### PR TITLE
New program structure

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,5 +19,6 @@ default = ["std"]
 std = ["math/std", "winter-utils/std"]
 
 [dependencies]
+crypto = { package = "winter-crypto", version = "0.2", default-features = false }
 math = { package = "winter-math", version = "0.2", default-features = false }
 winter-utils = { package = "winter-utils", version = "0.2", default-features = false }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,8 @@ pub mod utils;
 mod trace_state;
 pub use trace_state::TraceState;
 
+pub mod v1;
+
 // GLOBAL CONSTANTS
 // ================================================================================================
 

--- a/core/src/v1/mod.rs
+++ b/core/src/v1/mod.rs
@@ -1,0 +1,1 @@
+pub mod program;

--- a/core/src/v1/program/blocks/call_block.rs
+++ b/core/src/v1/program/blocks/call_block.rs
@@ -1,0 +1,47 @@
+use super::{fmt, Digest, Hasher, Rp62_248};
+
+// CALL BLOCK
+// ================================================================================================
+/// A code block describing a function call.
+///
+/// When the VM executes a Call block, it simply executes the code of the underlying function.
+/// Thus, to execute a function call, the VM must have access to the function's body, otherwise,
+/// the execution fails.
+///
+/// Hash of a Call block is computed by hashing a concatenation of the function's body hash with
+/// zero.
+/// TODO: update hashing methodology to make it different from Loop block.
+#[derive(Clone, Debug)]
+pub struct Call {
+    hash: Digest,
+    fn_hash: Digest,
+}
+
+impl Call {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new [Call] block instantiated with the specified function body hash.
+    pub fn new(fn_hash: Digest) -> Self {
+        let hash = Rp62_248::merge(&[fn_hash, Digest::default()]);
+        Self { hash, fn_hash }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a hash of this code block.
+    pub fn hash(&self) -> Digest {
+        self.hash
+    }
+
+    /// Returns a hash of the function to be called by this block.
+    pub fn fn_hash(&self) -> Digest {
+        self.fn_hash
+    }
+}
+
+impl fmt::Display for Call {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "call.{:?}", self.fn_hash) // TODO
+    }
+}

--- a/core/src/v1/program/blocks/join_block.rs
+++ b/core/src/v1/program/blocks/join_block.rs
@@ -1,0 +1,42 @@
+use super::{fmt, CodeBlock, Digest, Hasher, Rp62_248};
+
+// JOIN BLOCKS
+// ================================================================================================
+/// A code block used to combine two other code blocks.
+///
+/// When the VM executes a Join block, it executes joined blocks in sequence one after the other.
+///
+/// Hash of a Join block is computed by hashing a concatenation of the hashes of joined blocks.
+/// TODO: update hashing methodology to make it different from Split block.
+#[derive(Clone, Debug)]
+pub struct Join {
+    body: Box<[CodeBlock; 2]>,
+    hash: Digest,
+}
+
+impl Join {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new [Join] block instantiated with the specified code blocks.
+    pub fn new(body: [CodeBlock; 2]) -> Self {
+        let hash = Rp62_248::merge(&[body[0].hash(), body[1].hash()]);
+        Self {
+            body: Box::new(body),
+            hash,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a hash of this code block.
+    pub fn hash(&self) -> Digest {
+        self.hash
+    }
+}
+
+impl fmt::Display for Join {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "block {} {} end", self.body[0], self.body[1])
+    }
+}

--- a/core/src/v1/program/blocks/loop_block.rs
+++ b/core/src/v1/program/blocks/loop_block.rs
@@ -1,0 +1,46 @@
+use super::{fmt, CodeBlock, Digest, Hasher, Rp62_248};
+
+// LOOP BLOCK
+// ================================================================================================
+/// A code block used to describe condition-based iterative execution.
+///
+/// When the VM encounters a Loop block, executes the loop's body if the top of the stack is `1`,
+/// and skips the block if the top of the stack is `0`. If the top of the stack is neither `0` nor
+/// `1`, the program fails. Once the loop body is fully executed, the VM checks the top of the
+/// stack again. If the top of the stack is `1`, the loop is executed again, if it is `0`, the VM
+/// stops executing the loop and moves to the next block. Thus, the body of the loop is executed
+/// while the top of the stack remains `1` at the end of each loop iteration.
+///
+/// Hash of a Loop block is computed by hashing a concatenation of the loop's body hash with zero.
+#[derive(Clone, Debug)]
+pub struct Loop {
+    body: Box<CodeBlock>,
+    hash: Digest,
+}
+
+impl Loop {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new [Loop] bock instantiated with the specified body.
+    pub fn new(body: CodeBlock) -> Self {
+        let hash = Rp62_248::merge(&[body.hash(), Digest::default()]);
+        Self {
+            body: Box::new(body),
+            hash,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a hash of this code block.
+    pub fn hash(&self) -> Digest {
+        self.hash
+    }
+}
+
+impl fmt::Display for Loop {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "while {} end", self.body)
+    }
+}

--- a/core/src/v1/program/blocks/mod.rs
+++ b/core/src/v1/program/blocks/mod.rs
@@ -1,0 +1,97 @@
+use super::{Digest, ElementHasher, Hasher, Operation, Rp62_248};
+use core::fmt;
+
+mod call_block;
+mod join_block;
+mod loop_block;
+mod proxy_block;
+mod span_block;
+mod split_block;
+
+pub use call_block::Call;
+pub use join_block::Join;
+pub use loop_block::Loop;
+pub use proxy_block::Proxy;
+pub use span_block::Span;
+pub use split_block::Split;
+
+// PROGRAM BLOCK
+// ================================================================================================
+/// TODO: add comments
+#[derive(Clone, Debug)]
+pub enum CodeBlock {
+    Span(Span),
+    Join(Join),
+    Split(Split),
+    Loop(Loop),
+    Call(Call),
+    Proxy(Proxy),
+}
+
+impl CodeBlock {
+    // CONSTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a new Span block instantiated with the provided operations.
+    pub fn new_span(operations: Vec<Operation>) -> Self {
+        Self::Span(Span::new(operations))
+    }
+
+    /// TODO: add comments
+    pub fn new_join(blocks: [CodeBlock; 2]) -> Self {
+        Self::Join(Join::new(blocks))
+    }
+
+    /// TODO: add comments
+    pub fn new_split(t_branch: CodeBlock, f_branch: CodeBlock) -> Self {
+        Self::Split(Split::new(t_branch, f_branch))
+    }
+
+    /// TODO: add comments
+    pub fn new_loop(body: CodeBlock) -> Self {
+        Self::Loop(Loop::new(body))
+    }
+
+    /// TODO: add comments
+    pub fn new_call(code_hash: Digest) -> Self {
+        Self::Call(Call::new(code_hash))
+    }
+
+    /// TODO: add comments
+    pub fn new_proxy(code_hash: Digest) -> Self {
+        Self::Proxy(Proxy::new(code_hash))
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns true if this code block is a [Span] block.
+    pub fn is_span(&self) -> bool {
+        matches!(self, CodeBlock::Span(_))
+    }
+
+    /// Returns a hash of this code block.
+    pub fn hash(&self) -> Digest {
+        match self {
+            CodeBlock::Span(block) => block.hash(),
+            CodeBlock::Join(block) => block.hash(),
+            CodeBlock::Split(block) => block.hash(),
+            CodeBlock::Loop(block) => block.hash(),
+            CodeBlock::Call(block) => block.hash(),
+            CodeBlock::Proxy(block) => block.hash(),
+        }
+    }
+}
+
+impl fmt::Display for CodeBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CodeBlock::Span(block) => write!(f, "{}", block),
+            CodeBlock::Join(block) => write!(f, "{}", block),
+            CodeBlock::Split(block) => write!(f, "{}", block),
+            CodeBlock::Loop(block) => write!(f, "{}", block),
+            CodeBlock::Call(block) => write!(f, "{}", block),
+            CodeBlock::Proxy(block) => write!(f, "{}", block),
+        }
+    }
+}

--- a/core/src/v1/program/blocks/proxy_block.rs
+++ b/core/src/v1/program/blocks/proxy_block.rs
@@ -1,0 +1,32 @@
+use super::{fmt, Digest};
+
+// PROXY BLOCK
+// ================================================================================================
+/// A code block used to conceal a part of a program.
+///
+/// Proxy blocks cannot be executed by the VM. They are used primarily to verify the integrity of
+/// a program's hash while keeping parts of the program secret.
+///
+/// Hash of a proxy block is not computed but is rathe defined at instantiation time.
+#[derive(Clone, Debug)]
+pub struct Proxy {
+    hash: Digest,
+}
+
+impl Proxy {
+    /// Returns a new [Proxy] block instantiated with the specified code hash.
+    pub fn new(code_hash: Digest) -> Self {
+        Self { hash: code_hash }
+    }
+
+    /// Returns a hash of this code block.
+    pub fn hash(&self) -> Digest {
+        self.hash
+    }
+}
+
+impl fmt::Display for Proxy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "proxy.{:?}", self.hash) // TODO: use hex, change formatting
+    }
+}

--- a/core/src/v1/program/blocks/span_block.rs
+++ b/core/src/v1/program/blocks/span_block.rs
@@ -1,0 +1,279 @@
+use super::{fmt, Digest, ElementHasher, Operation, Rp62_248};
+use math::{fields::f62::BaseElement, FieldElement};
+use winter_utils::flatten_slice_elements;
+
+// CONSTANTS
+// ================================================================================================
+
+/// Maximum number of operations per group.
+const GROUP_SIZE: usize = 9;
+
+/// Maximum number of groups per batch.
+const BATCH_SIZE: usize = 8;
+
+// SPAN BLOCK
+// ================================================================================================
+/// A code block used to describe a linear sequence of operations.
+///
+/// When the VM executes a Span block, it breaks the sequence of operations into batches and
+/// groups according to the following rules:
+/// - A group may contain up to 9 operations or a single immediate value.
+/// - A batch may contain up to 8 groups.
+/// - There is no limit on the number of batches contained within a single span.
+///
+/// Thus, for example, executing 8 pushes in a row will result in two operation batches:
+/// - The first batch will contain 8 groups, with the first group containing 7 push opcodes,
+///   and the remaining 7 groups containing immediate values for each of the push operations.
+/// - The second batch will contain 2 groups, with the first group containing a single push opcode,
+///   and the second group containing the immediate value for the last push operation.
+///
+/// If a sequence of operations does not have any operations which carry immediate values, then
+/// up to 72 operations can fit into a single batch.
+///
+/// From the user's perspective, all operations are executed in order, however, the VM may insert
+/// NOOPs to ensure proper alignment of all operations in the sequence.
+///
+/// TODO: describe how Span hash is computed.
+#[derive(Clone, Debug)]
+pub struct Span {
+    ops: Vec<Operation>,
+    hash: Digest,
+}
+
+impl Span {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new [Span] block instantiated with the specified operations.
+    ///
+    /// # Errors (TODO)
+    /// Returns an error if:
+    /// - `operations` vector is empty.
+    /// - `operations` vector contains any number of system operations.
+    pub fn new(operations: Vec<Operation>) -> Self {
+        assert!(!operations.is_empty()); // TODO: return error
+        let op_batches = batch_ops(&operations);
+        let hash = Rp62_248::hash_elements(flatten_slice_elements(&op_batches));
+        Self {
+            ops: operations,
+            hash,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a hash of this code block.
+    pub fn hash(&self) -> Digest {
+        self.hash
+    }
+}
+
+impl fmt::Display for Span {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "span {}", self.ops[0])?;
+        for op in self.ops.iter().skip(1) {
+            write!(f, " {}", op)?;
+        }
+        write!(f, " end")
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+
+fn batch_ops(ops: &[Operation]) -> Vec<[BaseElement; BATCH_SIZE]> {
+    // encodes a group of opcodes; up to 7 opcodes can fit into one group
+    let mut op_group = 0u64;
+
+    // index of the next opcode in the current group; valued range of values is [0, 8)
+    let mut op_idx = 0;
+
+    // indexes of the current group in the batch, and the next free group in the batch; these
+    // could be different by more than 1 if some operations in the batch carry immediate values.
+    let mut group_idx = 0;
+    let mut next_group_idx = 1;
+
+    // current batch of operations; each batch can contain a combination of op groups and immediate
+    // values; total number of slots in a batch is 8.
+    let mut batch = [BaseElement::ZERO; BATCH_SIZE];
+    let mut batches = Vec::<[BaseElement; BATCH_SIZE]>::new();
+
+    for op in ops {
+        // if the operation carries immediate value, process it first
+        if let Some(imm) = op.imm_value() {
+            // operation carrying an immediate value cannot be the first one in the group;
+            // so, we just add a noop in front of it
+            if op_idx == 0 {
+                op_group = Operation::Noop.op_code() as u64;
+                op_idx += 1;
+            }
+
+            // check if the batch has room for the immediate value, and if not start another batch
+            if next_group_idx == BATCH_SIZE {
+                batches.push(batch);
+                batch = [BaseElement::ZERO; BATCH_SIZE];
+                op_group = 0;
+                group_idx = 0;
+                next_group_idx = 1;
+                op_idx = 0;
+            }
+
+            // put the immediate value into the next available slot
+            batch[next_group_idx] = imm;
+            next_group_idx += 1;
+        }
+
+        // add the opcode to the group
+        op_group |= (op.op_code() as u64) << (Operation::OP_BITS * op_idx);
+        op_idx += 1;
+
+        // if the group is full, put it into the batch and start another group
+        if op_idx == GROUP_SIZE {
+            batch[group_idx] = BaseElement::new(op_group);
+            op_idx = 0;
+            op_group = 0;
+            group_idx = next_group_idx;
+            next_group_idx += 1;
+
+            // if the batch is full, start another batch
+            if next_group_idx == BATCH_SIZE {
+                batches.push(batch);
+                batch = [BaseElement::ZERO; BATCH_SIZE];
+                group_idx = 0;
+                next_group_idx = 1;
+            }
+        }
+    }
+
+    // make sure we finished processing the last batch
+    if group_idx != 0 || op_group != 0 {
+        if op_group != 0 {
+            batch[group_idx] = BaseElement::new(op_group);
+        }
+        batches.push(batch);
+    }
+
+    batches
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::{BaseElement, FieldElement, Operation, GROUP_SIZE};
+
+    #[test]
+    fn batch_ops() {
+        // one operation
+        let ops = [Operation::Add];
+        let batches = super::batch_ops(&ops);
+        assert_eq!(1, batches.len());
+        assert_eq!(BaseElement::from(Operation::Add.op_code()), batches[0][0]);
+        for &group in batches[0].iter().skip(1) {
+            assert_eq!(BaseElement::ZERO, group);
+        }
+
+        // two operations
+        let ops = [Operation::Add, Operation::Mul];
+        let batches = super::batch_ops(&ops);
+        assert_eq!(1, batches.len());
+        assert_eq!(build_group(&ops), batches[0][0]);
+        for &group in batches[0].iter().skip(1) {
+            assert_eq!(BaseElement::ZERO, group);
+        }
+
+        // one group with one immediate value
+        let ops = [Operation::Add, Operation::Push(BaseElement::new(12345678))];
+        let batches = super::batch_ops(&ops);
+        assert_eq!(1, batches.len());
+        let batch = batches[0];
+        assert_eq!(build_group(&ops), batch[0]);
+        assert_eq!(BaseElement::new(12345678), batch[1]);
+        for &group in batch.iter().skip(2) {
+            assert_eq!(BaseElement::ZERO, group);
+        }
+
+        // one group with 7 immediate values
+        let ops = [
+            Operation::Add,
+            Operation::Push(BaseElement::new(1)),
+            Operation::Push(BaseElement::new(2)),
+            Operation::Push(BaseElement::new(3)),
+            Operation::Push(BaseElement::new(4)),
+            Operation::Push(BaseElement::new(5)),
+            Operation::Push(BaseElement::new(6)),
+            Operation::Push(BaseElement::new(7)),
+        ];
+        let batches = super::batch_ops(&ops);
+        assert_eq!(1, batches.len());
+        let batch = batches[0];
+        assert_eq!(build_group(&ops), batch[0]);
+        for (i, &group) in batch.iter().enumerate().skip(1) {
+            assert_eq!(BaseElement::new(i as u64), group);
+        }
+
+        // two groups with 7 immediate values; the last push overflows to the second batch
+        let ops = [
+            Operation::Add,
+            Operation::Mul,
+            Operation::Add,
+            Operation::Push(BaseElement::new(1)),
+            Operation::Push(BaseElement::new(2)),
+            Operation::Push(BaseElement::new(3)),
+            Operation::Push(BaseElement::new(4)),
+            Operation::Push(BaseElement::new(5)),
+            Operation::Push(BaseElement::new(6)),
+            Operation::Push(BaseElement::new(7)),
+        ];
+        let batches = super::batch_ops(&ops);
+        assert_eq!(2, batches.len());
+        let batch0 = batches[0];
+        assert_eq!(build_group(&ops[..9]), batch0[0]);
+        for (i, &group) in batch0.iter().enumerate().skip(1).take(6) {
+            assert_eq!(BaseElement::new(i as u64), group);
+        }
+        assert_eq!(BaseElement::ZERO, batch0[7]);
+
+        let batch1 = batches[1];
+        assert_eq!(build_group(&[Operation::Noop, ops[9]]), batch1[0]);
+        assert_eq!(BaseElement::new(7), batch1[1]);
+        for &group in batch1.iter().skip(2) {
+            assert_eq!(BaseElement::ZERO, group);
+        }
+
+        // immediate values in-between groups
+        let ops = [
+            Operation::Add,
+            Operation::Mul,
+            Operation::Add,
+            Operation::Push(BaseElement::new(7)),
+            Operation::Add,
+            Operation::Add,
+            Operation::Push(BaseElement::new(11)),
+            Operation::Mul,
+            Operation::Mul,
+            Operation::Add,
+        ];
+
+        let batches = super::batch_ops(&ops);
+        assert_eq!(1, batches.len());
+        let batch = batches[0];
+        assert_eq!(build_group(&ops[..9]), batch[0]);
+        assert_eq!(BaseElement::new(7), batch[1]);
+        assert_eq!(BaseElement::new(11), batch[2]);
+        assert_eq!(build_group(&ops[9..]), batch[3]);
+    }
+
+    // TEST HELPERS
+    // --------------------------------------------------------------------------------------------
+
+    fn build_group(ops: &[Operation]) -> BaseElement {
+        assert!(ops.len() <= GROUP_SIZE);
+        let mut group = 0u64;
+        for (i, op) in ops.iter().enumerate() {
+            group |= (op.op_code() as u64) << (Operation::OP_BITS * i);
+        }
+        BaseElement::new(group)
+    }
+}

--- a/core/src/v1/program/blocks/split_block.rs
+++ b/core/src/v1/program/blocks/split_block.rs
@@ -1,0 +1,55 @@
+use super::{fmt, CodeBlock, Digest, Hasher, Rp62_248};
+
+// SPLIT BLOCK
+// ================================================================================================
+/// A code block used to describe conditional execution.
+///
+/// When the VM executes a Split bock, either the true branch or the false branch of the block is
+/// executed. Specifically, if the top of the stack is `1`, the true branch is executed, and if
+/// the top of the stack is `0`, the false branch is executed. If the top of the stack is neither
+/// `0` nor `1`, the program fails.
+///
+/// Hash of a Split block is computed by hashing a concatenation of the true and the false branch
+/// hashes.
+#[derive(Clone, Debug)]
+pub struct Split {
+    branches: Box<[CodeBlock; 2]>,
+    hash: Digest,
+}
+
+impl Split {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Returns a new [Split] block instantiated with the specified true and false branches.
+    pub fn new(t_branch: CodeBlock, f_branch: CodeBlock) -> Self {
+        let hash = Rp62_248::merge(&[t_branch.hash(), f_branch.hash()]);
+        Self {
+            branches: Box::new([t_branch, f_branch]),
+            hash,
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns a hash of this code block.
+    pub fn hash(&self) -> Digest {
+        self.hash
+    }
+
+    /// Returns a code block which is to be executed when the top of the stack is `1`.
+    pub fn on_true(&self) -> &CodeBlock {
+        &self.branches[0]
+    }
+
+    /// Returns a code block which is to be executed when the top of the stack is `0`.
+    pub fn on_false(&self) -> &CodeBlock {
+        &self.branches[1]
+    }
+}
+
+impl fmt::Display for Split {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "if {} else {} end", self.branches[0], self.branches[1])
+    }
+}

--- a/core/src/v1/program/mod.rs
+++ b/core/src/v1/program/mod.rs
@@ -1,0 +1,97 @@
+use core::fmt;
+use crypto::{hashers::Rp62_248, Digest as HasherDigest, ElementHasher, Hasher};
+use math::fields::f128::BaseElement;
+use std::collections::BTreeMap;
+
+pub mod blocks;
+use blocks::CodeBlock;
+
+mod operations;
+pub use operations::Operation;
+
+// TYPES ALIASES
+// ================================================================================================
+
+type Digest = <Rp62_248 as Hasher>::Digest;
+
+// SCRIPT
+// ================================================================================================
+/// A program which can be executed by the VM.
+///
+/// A script is a self-contained program which can be executed by the VM. A script has its own
+/// read-write memory, but has no storage and cannot define functions. When executed against a
+/// [Module], a script can call the module's functions, and via these functions modify the module's
+/// storage.
+#[derive(Clone, Debug)]
+pub struct Script {
+    root: CodeBlock,
+    hash: [u8; 32],
+}
+
+impl Script {
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    /// Constructs a new program from the specified code block.
+    pub fn new(root: CodeBlock) -> Self {
+        let hash = Rp62_248::merge(&[root.hash(), Digest::default()]);
+        Self {
+            root,
+            hash: hash.as_bytes(),
+        }
+    }
+
+    // PUBLIC ACCESSORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the root code block of this script.
+    pub fn root(&self) -> &CodeBlock {
+        &self.root
+    }
+
+    /// Returns a hash of this script.
+    pub fn hash(&self) -> &[u8; 32] {
+        &self.hash
+    }
+}
+
+impl fmt::Display for Script {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "begin {} end", self.root)
+    }
+}
+
+// MODULE
+// ================================================================================================
+/// TODO: add comments
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct Module {
+    functions: BTreeMap<Digest, CodeBlock>,
+    storage: Vec<u64>, // TODO: this should be a sparse Merkle tree
+}
+
+#[allow(dead_code)]
+impl Module {
+    pub fn new(_functions: BTreeMap<Digest, CodeBlock>) -> Self {
+        unimplemented!()
+    }
+
+    pub fn code_root(&self) -> Digest {
+        unimplemented!()
+    }
+
+    pub fn storage_root(&self) -> Digest {
+        unimplemented!()
+    }
+
+    pub fn get_function(&self, _hash: Digest) -> Option<&CodeBlock> {
+        //self.functions.get(&hash)
+        unimplemented!()
+    }
+
+    pub fn load(&self, _index: BaseElement) -> [BaseElement; 4] {
+        unimplemented!()
+    }
+
+    pub fn store(&self, _index: usize, _value: [BaseElement; 4]) {}
+}

--- a/core/src/v1/program/operations.rs
+++ b/core/src/v1/program/operations.rs
@@ -1,0 +1,43 @@
+use core::fmt;
+use math::fields::f62::BaseElement;
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Operation {
+    Noop,
+    Push(BaseElement),
+    Add,
+    Mul,
+}
+
+impl Operation {
+    pub const OP_BITS: usize = 7;
+
+    /// Returns the opcode of this operation.
+    pub fn op_code(&self) -> u8 {
+        match self {
+            Self::Noop => 0b0000_0000,
+            Self::Push(_) => 0b0000_0001,
+            Self::Add => 0b0000_0010,
+            Self::Mul => 0b0000_0011,
+        }
+    }
+
+    /// Returns an immediate value carried by this operation.
+    pub fn imm_value(&self) -> Option<BaseElement> {
+        match self {
+            Self::Push(imm) => Some(*imm),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Operation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Noop => write!(f, "noop"),
+            Self::Push(value) => write!(f, "push.{}", value),
+            Self::Add => write!(f, "add"),
+            Self::Mul => write!(f, "mul"),
+        }
+    }
+}


### PR DESCRIPTION
This PR implements basic structures for v1 programs. Specifically:

- A program construct has been separated into `scripts` and `modules`.
- Names and semantics of some program blocks have been changed:
  - `Group` block is now `Join` block and is used to join exactly two other blocks.
  - `Switch` block is now `Split` block.
  - `Span` block now groups a linear sequence of operations into groups and batches.
- New program blocks have been added:
  - `Call` block to facilitate function calls.
  - `Proxy` block to conceal hidden parts of a program.