### PR TITLE
feat(test-utils): improve random seed generation entropy

### DIFF
--- a/test-utils/src/rand.rs
+++ b/test-utils/src/rand.rs
@@ -23,13 +23,24 @@ pub fn seeded_element(seed: &mut u64) -> Felt {
 
 /// Generate a bytes seed that can be used as input for rand_utils.
 ///
-/// Increments the argument.
+/// Increments the argument and generates a 32-byte seed by spreading
+/// the seed value across all bytes using a simple mixing function.
 fn generate_bytes_seed(seed: &mut u64) -> [u8; 32] {
     // increment the seed
     *seed = seed.wrapping_add(1);
+    let seed_value = *seed;
 
-    // generate a bytes seed
     let mut bytes = [0u8; 32];
-    bytes[..8].copy_from_slice(&seed.to_le_bytes());
+
+    // Fill first 8 bytes with the original seed
+    bytes[..8].copy_from_slice(&seed_value.to_le_bytes());
+
+    // Fill remaining bytes using a simple mixing function
+    for i in 1..4 {
+        let next_value = seed_value.wrapping_mul(0x517cc1b727220a95).wrapping_add(i as u64);
+        let start = i * 8;
+        bytes[start..start + 8].copy_from_slice(&next_value.to_le_bytes());
+    }
+
     bytes
 }


### PR DESCRIPTION
Enhance the generate_bytes_seed function in test utilities to provide better
entropy distribution across all 32 bytes of the seed. Previously, only the first
8 bytes contained meaningful data while the rest were zeros.

Changes made:
- Fill all 32 bytes with meaningful data instead of zeros
- Implement a simple mixing function using multiplication and addition
- Maintain deterministic behavior while improving distribution
- Use constant 0x517cc1b727220a95 as a multiplier for good bit mixing

This improvement provides better random number distribution for test cases
while maintaining backwards compatibility with existing tests.