### PR TITLE
Improve implementation of RPO-based random coin for the recursive verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Enhancements
 
 - Add kernel procedures digests as public inputs to the recursive verifier (#1724).
+- Improve implementation of RPO-based random coin for the recursive verifier (#1734).
 
 
 ## 0.13.2 (2025-04-02)

--- a/stdlib/asm/crypto/fri/helper.masm
+++ b/stdlib/asm/crypto/fri/helper.masm
@@ -7,52 +7,12 @@ use.std::crypto::stark::constants
 #!
 #! Input: [...]
 #! Output: [num_fri_layers, ...]
-#! Cycles: 77
+#!
+#! Cycles: 45
 export.generate_fri_parameters
     # Load FRI verifier data
     padw exec.constants::get_lde_domain_info_word
     #=> [lde_size, log(lde_size), lde_g, 0, ...] (6 cycles)
-
-    # Store temporarily in order to use it for FRI layer loading
-    exec.constants::tmp1 mem_storew
-
-    # Compute [gz1, gz0, z1, z0] using domain generator
-    # TODO: move to somewhere else
-    # ---------------------------------------------------------------------------------------------
-
-    # load z from memory
-    padw
-    exec.constants::z_ptr mem_loadw
-    #=> [(z1, z0)^n, z1, z0, lde_size, log2(lde_size), lde_g, 0, ...] (6 cycles)
-
-    # prepare stack
-    drop
-    drop
-    dup.1
-    dup.1
-    dup.6
-    drop
-    #=> [z1, z0, z1, z0, lde_size, log2(lde_size), lde_g, 0, ...] (6 cycles)
-
-    # Load `trace_g` from memory
-    exec.constants::get_trace_domain_generator
-    #=> [trace_g, z1, z0, z1, z0, lde_size, log2(lde_size), lde_g, 0, ...] (2 cycles)
-
-    # Compute `gz0` = `trace_g * z_0`
-    dup
-    movup.3
-    mul
-    #=> [gz0, trace_g, z1, z0, z1, z0, lde_size, log2(lde_size), lde_g, 0, ...] (3 cycles)
-
-    # Compute `gz1` = `trace_g * z_1`
-    swap.2
-    mul
-    #=> [gz1, gz0, z1, z0, lde_size, log2(lde_size), lde_g, 0, ...] (2 cycles)
-
-    # Save `[gz1, gz0, z1, z0]` and clean the stack
-    exec.constants::tmp1 mem_storew
-    dropw
-    #=> [lde_size, log2(lde_size), lde_g, 0, ...] (6 cycles)
 
     # Compute the number of FRI layers
     dup
@@ -86,21 +46,27 @@ end
 #!
 #! Input: [...]
 #! Output: [...]
-#! Cycles: 21 + 83 * num_fri_layers
+#!
+#! Cycles: 29 + 85 * num_fri_layers
 export.load_fri_layer_commitments
     # Address containing the first layer commitment
     push.0.0
-    push.0.0.0.0
     exec.constants::fri_com_ptr
     exec.constants::get_num_fri_layers
+    # => [num_layers, ptr_layer, y, y, ...]
+    
+    # We need to store the current FRI layer LDE domain size and its logarithm.
+    padw exec.constants::get_lde_domain_info_word 
+    exec.constants::tmp1 mem_storew swapw
     # => [num_layers, ptr_layer, y, y, Y, ...]
-
+    
     dup
     push.0
     neq
     while.true
-        swapw               # [Y, num_layers, ptr_layer, y, y, ...]
-        adv_loadw           # [COM, num_layers, ptr_layer, y, y, ...]
+        swapw
+        adv_loadw        
+        # => [COM, num_layers, ptr_layer, y, y, ...]
 
         # Save FRI layer commitment
         dup.5
@@ -113,34 +79,33 @@ export.load_fri_layer_commitments
         exec.random_coin::reseed
         # => [num_layers, ptr_layer + 4, y, y, ...]
 
-        push.0.0.0.0
-        exec.random_coin::get_rate_1
-        #=> [R1, ZERO, num_layers, ptr_layer + 4, y, y, ... ]
-        push.0.0
-        exec.constants::tmp1 mem_loadw
-        # => [lde_size, log2(lde_size), lde_generator, 0, a1, a0, Y, num_layers, ptr_layer + 4, y, y, ...]
+        # Generate FRI folding randomness
+        exec.random_coin::generate_random_challenge
+        #=> [a1, a0, num_layers, ptr_layer + 4, y, y, ... ]
 
-        # Compute and save to memory new lde_size and its new logarithm
+        # Compute and save to memory new lde_size and its logarithm
+        padw
+        exec.constants::tmp1 mem_loadw
+        # => [lde_size, log2(lde_size), lde_generator, 0, a1, a0, num_layers, ptr_layer + 4, y, y, ...]
         div.4
         swap
         sub.2
         swap
         exec.constants::tmp1 mem_storew
+        # => [lde_size / 4, log2(lde_size) - 2, lde_generator, 0, a1, a0, num_layers, ptr_layer + 4, y, y, ...]
 
         # Move the pointer higher up the stack
         movup.2 drop
         movup.2 drop
-        swapw
-        dropw
-        # => [lde_size, log2(lde_size), a1, a0, num_layers, ptr_layer + 4, y, y, Y, ...]
+        # => [lde_size / 4, log2(lde_size) - 2, a1, a0, num_layers, ptr_layer + 4, y, y, ...]
 
-        # Save [lde_size, log2(lde_size), a1, a0] in memory next to the layer commitment
+        # Save [a0, a1, log2(lde_size) - 2, lde_size / 4] in memory next to the layer commitment
         dup.5
         add.4
         swap.6
         mem_storew
         swapw
-        # => [num_layers, ptr_layer + 8, y, y, lde_size, log2(lde_size), a1, a0, Y]
+        # => [num_layers, ptr_layer + 8, y, y, lde_size / 4, log2(lde_size) - 2, a1, a0, ...]
 
         # Decrement the FRI layer counter
         sub.1
@@ -148,7 +113,7 @@ export.load_fri_layer_commitments
         push.0
         neq
     end
-    # => [Y, Y]
+    # => [Y, Y, ...]
     dropw
     dropw
     #=> [...]
@@ -165,8 +130,7 @@ end
 #!  2- Remainder of size 64: 3109
 export.load_and_verify_remainder
     # Load remainder commitment and save it at `TMP7`
-    push.0.0.0.0
-    adv_loadw
+    padw adv_loadw
     exec.constants::tmp1 mem_storew
     #=> [COM, ...]
 

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -16,6 +16,9 @@ const.NUM_CONSTRAINTS=226
 const.BLOWUP_FACTOR=8
 const.BLOWUP_FACTOR_LOG=3
 
+# Extension field degree
+const.EXTENSION_FIELD_DEGREE=2
+
 # MEMORY POINTERS
 # =================================================================================================
 
@@ -84,6 +87,8 @@ const.COMPOSITION_POLY_COM_PTR=4294813208
 # Instant-specific constants
 const.LDE_DOMAIN_INFO_PTR=4294813212
 const.LDE_DOMAIN_GEN_PTR=4294813213
+const.LDE_DOMAIN_LOG_SIZE_PTR=4294813214
+const.LDE_DOMAIN_SIZE_PTR=4294813215
 const.Z_PTR=4294813216
 const.NUM_QUERIES_PTR=4294813220
 const.REMAINDER_POLY_SIZE_PTR=4294813221
@@ -99,6 +104,7 @@ const.NUM_KERNEL_PROCEDURES_PTR=4294813233
 const.ZERO_WORD_PTR=4294813236
 
 # State of RPO-based random coin
+const.CURRENT_PTR=4294813243
 const.C_PTR=4294813244
 const.R1_PTR=4294813248
 const.R2_PTR=4294813252
@@ -160,6 +166,9 @@ const.ALPHA_POWER_85_1_PTR=4294903445
 #   | AUX_TRACE_COM_PTR                        |       4294913204        |
 #   | COMPOSITION_POLY_COM_PTR                 |       4294913208        |
 #   | LDE_DOMAIN_INFO_PTR                      |       4294913212        |
+#   | LDE_DOMAIN_SIZE_PTR                      |       4294913213        |
+#   | LDE_DOMAIN_LOG_SIZE_PTR                  |       4294913214        |
+#   | LDE_DOMAIN_SIZE_PTR                      |       4294913215        |
 #   | Z_PTR                                    |       4294913216        |
 #   | NUM_QUERIES_PTR                          |       4294913220        |
 #   | TRACE_LENGTH_PTR                         |       4294913224        |
@@ -251,6 +260,14 @@ end
 #! The word stored is `[z_0, z_1, z^n_0, z^n_1]`.
 export.z_ptr
     push.Z_PTR
+end
+
+export.set_rpo_current
+    push.CURRENT_PTR mem_store
+end
+
+export.get_rpo_current
+    push.CURRENT_PTR mem_load
 end
 
 #! Returns the pointer to the capacity word of the RPO-based random coin.
@@ -374,7 +391,7 @@ end
 
 #! Store details about the LDE domain.
 #!
-#! The info stored is `[lde_size, log(lde_size), lde_g, 0]`.
+#! The info stored is `[0, lde_g, log(lde_size), lde_size]`.
 export.set_lde_domain_info_word
     push.LDE_DOMAIN_INFO_PTR mem_storew
 end
@@ -492,4 +509,24 @@ end
 
 export.get_grinding_factor
     push.GRINDING_FACTOR_PTR mem_load
+end
+
+export.extension_field_degree
+    push.EXTENSION_FIELD_DEGREE
+end
+
+export.set_lde_domain_size
+    push.LDE_DOMAIN_SIZE_PTR mem_store
+end
+
+export.get_lde_domain_size
+    push.LDE_DOMAIN_SIZE_PTR mem_load
+end
+
+export.set_lde_domain_log_size
+    push.LDE_DOMAIN_LOG_SIZE_PTR mem_store 
+end
+
+export.get_lde_domain_log_size
+    push.LDE_DOMAIN_LOG_SIZE_PTR mem_load
 end

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -31,7 +31,7 @@ proc.add_two_words
     #=> [c3, c2, c1, c0]
 end
 
-#! Return the first half of the rate portion of the random coin state
+#! Return the first half of the rate portion of the random coin state.
 #!
 #! The random coin uses RPO to generate data. The RPO state is composed of 3
 #! words, 2 words for the rate, and 1 word for the capacity. This procedure
@@ -44,7 +44,16 @@ export.get_rate_1
     padw exec.constants::r1_ptr mem_loadw
 end
 
-#! Return the second half of the rate portion of the random coin state
+#! Store the first half of the rate portion of the random coin state.
+#!
+#! Input: [R1, ...]
+#! Output: [...]
+#! Cycles: 6
+export.set_rate_1
+    exec.constants::r1_ptr mem_storew dropw
+end
+
+#! Return the second half of the rate portion of the random coin state.
 #!
 #! The random coin uses RPO to generate data. The RPO state is composed of 3
 #! words, 2 words for the rate, and 1 word for the capacity. This procedure
@@ -57,7 +66,16 @@ export.get_rate_2
     padw exec.constants::r2_ptr mem_loadw
 end
 
-#! Return the capacity portion of the random coin state
+#! Store the second half of the rate portion of the random coin state.
+#!
+#! Input: [R2, ...]
+#! Output: [...]
+#! Cycles: 6
+export.set_rate_2
+    exec.constants::r2_ptr mem_storew dropw
+end
+
+#! Return the capacity portion of the random coin state.
 #!
 #! The random coin uses RPO to generate data. The RPO state is composed of 3
 #! words, 2 words for the rate, and 1 word for the capacity. This procedure
@@ -68,6 +86,37 @@ end
 #! Cycles: 6
 export.get_capacity
     padw exec.constants::c_ptr mem_loadw
+end
+
+#! Set the capacity portion of the random coin state.
+#!
+#! Input: [C, ...]
+#! Output: [...]
+#! Cycles: 6
+export.set_capacity
+    exec.constants::c_ptr mem_storew dropw
+end
+
+#! Load the random coin state on the stack.
+#!
+#! Input: [...]
+#! Output: [R2, R1, C, ...]
+#! Cycles: 18
+export.load_random_coin_state
+    exec.get_capacity
+    exec.get_rate_1
+    exec.get_rate_2
+end
+
+#! Store the random coin state to memory.
+#!
+#! Input: [R2, R1, C, ...]
+#! Output: [...]
+#! Cycles: 18
+export.store_random_coin_state
+    exec.set_rate_2
+    exec.set_rate_1
+    exec.set_capacity
 end
 
 #! Initializes the seed for randomness generation by computing the hash of the proof context using
@@ -100,6 +149,7 @@ export.init_seed
     push.6 swap.4 drop exec.constants::zero_zero_zero_six_word_ptr mem_storew
     push.7 swap.4 drop exec.constants::zero_zero_zero_seven_word_ptr mem_storew
     dropw
+    push.0 exec.constants::set_rpo_current
     #=> [log(trace_length), num_queries, grinding, num_ker_proc, ...]
 
     # Create the initial seed for randomness generation from proof context
@@ -135,7 +185,7 @@ export.init_seed
     movdn.3
     #=> [lde_size, log(lde_size), lde_g, 0, trace_length, num_queries, grinding]
 
-    # Save `[lde_size, log(lde_size), lde_g, 0]`
+    # Save `[0, lde_g, log(lde_size), lde_size]`
     exec.constants::set_lde_domain_info_word
     #=> [lde_size, log(lde_size), lde_g, 0, trace_length, num_queries, grinding]
 
@@ -223,6 +273,11 @@ end
 #! Ouput: [...]
 #! Cycles: 54
 export.reseed
+
+    # Reset the random coin buffer
+    # --------------------------------------------------------------------------------------------
+    push.0 exec.constants::set_rpo_current
+
     # Load previous state and update it
     # --------------------------------------------------------------------------------------------
     exec.get_rate_1
@@ -256,7 +311,7 @@ end
 
 #! Generates a `num_tuples` tuples of random field elements and stores them in memory
 #! starting from address `dest_ptr`. Each tuple uses 8 memory slots.
-#! TODO: Generalize by keeping track of something similar to the `output` variable in `RpoRandomCoin`
+#!
 #! so that we keep track of already used randomness and know when there is a need to apply `hperm`.
 #!
 #! `dest_ptr` must be word-aligned.
@@ -266,15 +321,31 @@ end
 #!
 #! Cycles: 69 + (22 * num_tuples) / 4
 proc.generate_random_coefficients
+    # Check that all field elements in the random coin buffer are available.
+    exec.constants::get_rpo_current assertz
 
-    # Compute the loop counter. We use checked division to make sure the number is a multiple of 4.
-    # If we use field division and num_tuples is not a multiple of 4 then we will enter into
-    # a very large loop with high probability.
-    push.0 dup movup.2 movup.3
-    u32assert u32divmod.4
-    assertz
+    # Compute the loop counter. We use division with remainder to get the number of loops.
+    # We use the remainder, in addition to determining the number of loops, to update
+    # the `current` field of the RPO-based random coin.
+    swap
+    u32assert2 u32divmod.4
+
+    # If the remainder is not zero then we add 1 to the quotient i.e., 1 more iteration of the loop
+    push.0 dup.1
+    # => [rem, 0, rem, quo, dst_ptr, ...]
+    neq
+    # => [(rem == 0), rem, quo, dst_ptr, ...]
+    movup.2 add swap
+    # => [rem, num_loops, dst_ptr, ...] where num_loops = quo + (rem == 0)
+
+    movdn.2
+    # => [num_loops, dst_ptr, rem, ...]
+    
+    push.0 movdn.2
+    # => [num_loops, dst_ptr, x, rem, ...]
+
     neg
-    #=> [loop_ctr, dest_ptr, x, x, ...]
+    #=> [loop_ctr, dest_ptr, x, rem, ...]
     # where loop_ctr = - num_tuples / 4; we negate the counter so that we can count up to 0
 
     exec.get_rate_1
@@ -282,46 +353,54 @@ proc.generate_random_coefficients
 
     exec.get_rate_2
     dup.9 add.4 mem_storew
-    #=> [R2, R1, loop_ctr, dest_ptr, 0, 0, ..]
+    #=> [R2, R1, loop_ctr, dest_ptr, rem, 0, ..]
 
     exec.get_capacity
     swapdw
-    #=> [R1, loop_ctr, dest_ptr, 0, 0, C, R2 ..]
+    #=> [R1, loop_ctr, dest_ptr, rem, 0, C, R2 ..]
     swapw
-    #=> [loop_ctr, dest_ptr, 0, 0, R1, C, R2 ..]
+    #=> [loop_ctr, dest_ptr, rem, 0, R1, C, R2 ..]
     swap add.8 swap
-    #=> [loop_ctr, dest_ptr+8, 0, 0, R1, C, R2, ..]
+    #=> [loop_ctr, dest_ptr+8, rem, 0, R1, C, R2, ..]
 
     add.1 dup neq.0
 
     while.true
 
         swapw.3 hperm
-        #=> [R2, R1, C, loop_ctr, dest_ptr, x, x, ...]
+        #=> [R2, R1, C, loop_ctr, dest_ptr, x, rem, ...]
 
         # save R2 to mem[dest+4]; we use dup.13 here because it takes only 1 cycle
         dup.13 add.4 mem_storew
-        #=> [R2, R1, C, loop_ctr, dest_ptr, x, x, ...]
+        #=> [R2, R1, C, loop_ctr, dest_ptr, x, rem, ...]
 
         # save R1 to mem[dest]
         swapw dup.13 mem_storew swapw
-        #=> [R2, R1, C, loop_ctr, dest_ptr, x, x, ...]
+        #=> [R2, R1, C, loop_ctr, dest_ptr, x, rem, ...]
 
         # update destination pointer and loop counter
         swapw.3
-        #=> [loop_ctr, dest_ptr, x, x, R1, C, R2, ...]
+        #=> [loop_ctr, dest_ptr, x, rem, R1, C, R2, ...]
 
         swap add.8 swap
-        #=> [loop_ctr, dest_ptr+8, x, x, R1, C, R2, ...]
+        #=> [loop_ctr, dest_ptr+8, x, rem, R1, C, R2, ...]
 
         add.1 dup
-        #=> [loop_ctr+1, loop_ctr+1, dest_ptr+2, x, x, R1, C, R2, ...]
+        #=> [loop_ctr+1, loop_ctr+1, dest_ptr+2, x, rem, R1, C, R2, ...]
 
         neq.0
     end
 
     # Save the new state of the random coin
-    dropw
+
+    ## 1) Update the `current` counter to store the number of used up field elements of the buffer.
+    ##    This is equal to `rem` times the degree of the extension field.
+    drop drop drop
+    exec.constants::extension_field_degree
+    mul
+    exec.constants::set_rpo_current
+
+    ## 2) Store the RPO state
     exec.constants::r1_ptr mem_storew
     dropw
     exec.constants::c_ptr mem_storew
@@ -331,15 +410,35 @@ proc.generate_random_coefficients
     #=> [...]
 end
 
+#! Draws a random challenge from the extension field elements.
+#!
+#! Input: [...]
+#! Output: [alpha1, alpha0, ...]
+#!
+#! Cycles: 17
+export.generate_random_challenge
+    # 1) Check that all field elements in the random coin buffer are available.
+    exec.constants::get_rpo_current
+    dup assertz
+
+    # 2) Update the number of used up field elements from the random coin buffer.
+    exec.constants::extension_field_degree add
+    exec.constants::set_rpo_current
+
+    # 3) Load the random challenge.
+    padw exec.constants::r1_ptr mem_loadw drop drop
+end
+
 #! Draw a list of random extension field elements related to the auxiliary segment of the execution
 #! trace and store the list in memory from `aux_rand_elem_ptr` to `aux_rand_elem_ptr + 32 - 4`.
 #!
 #! Input: [...]
 #! Output: [...]
+#!
 #! Cycles: 159
 export.generate_aux_randomness
+    exec.constants::get_num_aux_trace_coefs
     exec.constants::aux_rand_elem_ptr
-    exec.constants::get_num_aux_trace_coefs swap
     exec.generate_random_coefficients
     #=> [...]
 end
@@ -348,26 +447,26 @@ end
 #!
 #! Input: [...]
 #! Output: [...]
-#! Cycles: 13
-export.generate_constraint_composition_coefficients
-    exec.constants::composition_coef_ptr
-    padw exec.constants::r1_ptr mem_loadw
-    # => [y, y, alpha1, alpha0, compos_coef_ptr, ...] where y is a "garbage" value
-    movup.4 mem_storew dropw
-    #=> [...]
+#!
+#! Cycles: 25
+export.generate_constraint_composition_coefficient
+    exec.generate_random_challenge
+    push.0.0 
+    exec.constants::composition_coef_ptr mem_storew
+    dropw
 end
 
 #! Draw deep composition polynomial random coefficient and save it at `deep_rand_coef_ptr`.
 #!
 #! Input: [...]
 #! Output: [...]
-#! Cycles: 13
-export.generate_deep_composition_random_coefficients
-    exec.constants::deep_rand_coef_ptr
-    padw exec.constants::r1_ptr mem_loadw
-    # => [y, y, alpha1, alpha0, deep_rand_coef_ptr, ...] where y is a "garbage" value
-    movup.4 mem_storew dropw
-    #=> [...]
+#!
+#! Cycles: 25
+export.generate_deep_composition_random_coefficient
+    exec.generate_random_challenge
+    push.0.0
+    exec.constants::deep_rand_coef_ptr mem_storew
+    dropw
 end
 
 
@@ -381,19 +480,17 @@ end
 #! Input: [X, ...]
 #! Output: [...]
 #! Note: The top word on the stack is consumed by this procedure.
-#! Cycles: 21 + 10 * log(N)
+#! Cycles: 30 + 10 * log(N)
 export.generate_z_zN
-    # Load z (first two felts of the random coin state) and log trace length N
-    exec.constants::r1_ptr mem_loadw
-    drop drop
+    # Generate OOD challenge point z and load log trace length N
+    exec.generate_random_challenge
     exec.constants::get_trace_length_log
     # => [log(trace_len), z_1, z_0, ...]
 
-    dup.2 dup.2
-    # => [z_1, z_0, log(trace_len), z_1, z_0, ...]
-
     # Compute z^N using the fact that z^N = z^(2^log(N))
     # Loop starts with `i=log(trace_len)`
+    dup.2 dup.2
+    # => [z_1, z_0, log(trace_len), z_1, z_0, ...]
     push.1
     while.true
         dup.1 dup.1 ext2mul
@@ -544,32 +641,40 @@ end
 #! NOTE: The cycles count can be estimated, using the fact that r < 8, via the more compact formula
 #!  470 + 236 * (num_queries / 8)
 export.generate_list_indices
+    # Check that all field elements in the random coin buffer are available except for the first
+    # one. The first element in the buffer is not used as it is biased due to PoW.
+    exec.constants::get_rpo_current
+    push.1 assert_eq
+
+    # Get the number of querie indices we need to generate and the address to where we need
+    # to store them at.
     exec.constants::get_number_queries
     exec.constants::get_fri_queries_address
+    #=> [query_ptr, num_queries, ...]
+
     # Create mask
-    padw
-    exec.constants::get_lde_domain_info_word
-    movup.2 drop
-    movup.2 drop
+    exec.constants::get_lde_domain_log_size
+    exec.constants::get_lde_domain_size
     sub.1
-    #=> [mask, depth, query_ptr, num_queries] where depth = log(lde_size)
+    #=> [mask, depth, query_ptr, num_queries, ...] where depth = log(lde_size)
 
     # Get address holding the integers (this will later hold the FRI queries)
     movup.2
-    #=> [query_ptr, mask, depth, num_queries]
+    #=> [query_ptr, mask, depth, num_queries, ...]
 
     # Load the first half of the rate portion of the state of the random coin. We discard the first
     # element as it is used for PoW and use the remaining the 3.
     exec.get_rate_1
-    #=> [R1, query_ptr, mask, depth, num_queries]
+    #=> [R1, query_ptr, mask, depth, num_queries, ...]
     exec.generate_three_integers
-    #=> [R1, query_ptr+12, mask, depth, num_queries]
+    #=> [R1, query_ptr+12, mask, depth, num_queries, ...]
+
 
     # Load the second half of the rate portion of the state of the random coin.
     exec.constants::r2_ptr mem_loadw
-    #=> [R2, query_ptr+12, mask, depth, num_queries]
+    #=> [R2, query_ptr+12, mask, depth, num_queries, ...]
     exec.generate_four_integers
-    #=> [R2, query_ptr+26, mask, depth, num_queries, ...]
+    #=> [R2, query_ptr+26, mask, depth, num_queries, ..., ...]
 
     # Squeeze
     exec.constants::c_ptr mem_loadw
@@ -721,6 +826,15 @@ export.check_pow
     hperm
     #=> [R2, R1, C, mask, ...]
 
+    # We need to reset the RPO random coin buffer. We skip using the first field element as
+    # it is biased because of PoW.
+    # We first check that `current` is equal to 0.
+    exec.constants::get_rpo_current
+    assertz
+    # We skip using the first field element. 
+    push.1
+    exec.constants::set_rpo_current
+
     # Save the new random coin state
     exec.constants::r2_ptr mem_storew
     dropw
@@ -729,7 +843,7 @@ export.check_pow
     exec.constants::c_ptr mem_storew
     dropw
     drop drop drop
-    #=> [R10, mask]
+    #=> [R10, mask, ...]
 
     # Make sure the PoW is valid
     u32split

--- a/stdlib/asm/crypto/stark/utils.masm
+++ b/stdlib/asm/crypto/stark/utils.masm
@@ -38,9 +38,9 @@ export.validate_inputs
     # 3) Assert that the number of FRI queries is at most 150. This restriction is a soft one
     #    and is due to the memory layout in the `constants.masm` files but can be updated
     #    therein.
-    #    We also make sure that there is at least one FRI query.
+    #    We also make sure that the number of FRI queries is at least 7.
     dup u32lt.151 assert
-    u32gt.0 assert
+    u32gt.6 assert
 
     # 4) Assert that the grinding factor is at most 31
     u32lt.32 assert

--- a/stdlib/asm/crypto/stark/verifier.masm
+++ b/stdlib/asm/crypto/stark/verifier.masm
@@ -30,9 +30,9 @@ use.std::crypto::stark::utils
 #!
 #! Cycles:
 #!  1- Remainder polynomial size 64:
-#!   2175 + num_queries * (512 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
+#!   2215 + num_queries * (512 + num_fri_layers * 83) + 120 * num_fri_layers + 10 * log(trace_length)
 #!  2- Remainder polynomial size 128:
-#!   2200 + num_queries * (541 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
+#!   2240 + num_queries * (541 + num_fri_layers * 83) + 120 * num_fri_layers + 10 * log(trace_length)
 #!
 #!  where num_fri_layers is computed as:
 #!
@@ -93,11 +93,11 @@ export.verify
     # => [...]
 
     #==============================================================================================
-    #       III) Draw constraint composition coefficients
+    #       III) Draw constraint composition coefficient
     #==============================================================================================
 
-    # Cycles: 13
-    exec.random_coin::generate_constraint_composition_coefficients
+    # Cycles: 25
+    exec.random_coin::generate_constraint_composition_coefficient
     # => [...]
 
     #==============================================================================================
@@ -153,12 +153,12 @@ export.verify
     #==============================================================================================
 
     #============================================
-    #   1) Draw random coefficients for computing
+    #   1) Draw random coefficient for computing
     #       DEEP composition polynomial.
     #============================================
 
-    # Cycles: 14
-    exec.random_coin::generate_deep_composition_random_coefficients
+    # Cycles: 25
+    exec.random_coin::generate_deep_composition_random_coefficient
 
     #============================================
     #   2) Compute constants needed for computing
@@ -169,7 +169,7 @@ export.verify
     #       -   Number of FRI layers.
     #============================================
 
-    # Cycles: 77
+    # Cycles: 45
     exec.helper::generate_fri_parameters
     # => [...]
 
@@ -179,7 +179,7 @@ export.verify
     #      computing the degree respecting projection
     #============================================
 
-    # Cycles: 40 + 108 * num_fri_layers
+    # Cycles: 40 + 120 * num_fri_layers
     exec.helper::load_fri_layer_commitments
     # => [...]
 
@@ -218,6 +218,7 @@ export.verify
     # Cycles: 92 + 32.5 * num_queries
     exec.random_coin::generate_list_indices
     # => [...]
+
 
     # Compute deep composition polynomial queries
     #

--- a/stdlib/tests/crypto/stark/mod.rs
+++ b/stdlib/tests/crypto/stark/mod.rs
@@ -2,12 +2,17 @@ use std::sync::Arc;
 mod verifier_recursive;
 use assembly::{Assembler, DefaultSourceManager};
 use miden_air::{FieldExtension, HashFunction, PublicInputs};
-use processor::{DefaultHost, Program, ProgramInfo};
+use processor::{
+    DefaultHost, Program, ProgramInfo,
+    crypto::{RandomCoin, RpoRandomCoin},
+};
 use rstest::rstest;
 use test_utils::{
-    AdviceInputs, MemAdviceProvider, ProvingOptions, StackInputs, VerifierError, prove,
+    AdviceInputs, MemAdviceProvider, ProvingOptions, StackInputs, VerifierError,
+    proptest::proptest, prove,
 };
 use verifier_recursive::{VerifierData, generate_advice_inputs};
+use vm_core::Word;
 
 // Note: Changes to Miden VM may cause this test to fail when some of the assumptions documented
 // in `stdlib/asm/crypto/stark/verifier.masm` are violated.
@@ -93,6 +98,48 @@ pub fn generate_recursive_verifier_data(
     Ok(generate_advice_inputs(proof, pub_inputs).unwrap())
 }
 
+proptest! {
+    #[test]
+    fn generate_query_indices_proptest(num_queries in 7..150_usize, lde_log_size in 9..32_usize) {
+        let source = TEST_RANDOM_INDICES_GENERATION;
+        let lde_size = 1 << lde_log_size;
+
+        let seed = Word::default();
+        let mut coin = RpoRandomCoin::new(seed);
+        let indices = coin
+            .draw_integers(num_queries, lde_size, 0)
+            .expect("should not fail to generate the indices");
+        let advice_stack: Vec<u64> = indices.iter().rev().map(|index| *index as u64).collect();
+
+        let input_stack = vec![num_queries as u64, lde_log_size as u64, lde_size as u64];
+        let test = build_test!(source, &input_stack, &advice_stack);
+        test.prop_expect_stack(&[])?;
+    }
+}
+
+#[test]
+fn generate_query_indices() {
+    let source = TEST_RANDOM_INDICES_GENERATION;
+
+    let num_queries = 27;
+    let lde_log_size = 18;
+    let lde_size = 1 << lde_log_size;
+
+    let input_stack = vec![num_queries as u64, lde_log_size as u64, lde_size as u64];
+
+    let seed = Word::default();
+    let mut coin = RpoRandomCoin::new(seed);
+    let indices = coin
+        .draw_integers(num_queries, lde_size, 0)
+        .expect("should not fail to generate the indices");
+
+    let advice_stack: Vec<u64> = indices.iter().rev().map(|index| *index as u64).collect();
+
+    let test = build_test!(source, &input_stack, &advice_stack);
+
+    test.expect_stack(&[]);
+}
+
 const KERNEL_ODD_NUM_PROC: &str = r#"
         export.foo
             add
@@ -111,3 +158,63 @@ const KERNEL_EVEN_NUM_PROC: &str = r#"
         export.bar
             div
         end"#;
+
+const TEST_RANDOM_INDICES_GENERATION: &str = r#"
+        const.QUERY_ADDRESS=1024
+
+        use.std::crypto::stark::random_coin
+        use.std::crypto::stark::constants
+
+        begin
+            exec.constants::set_lde_domain_size
+            exec.constants::set_lde_domain_log_size
+            exec.constants::set_number_queries
+            push.QUERY_ADDRESS exec.constants::set_fri_queries_address
+
+            exec.random_coin::load_random_coin_state
+            hperm
+            hperm
+            exec.random_coin::store_random_coin_state
+            push.1 exec.constants::set_rpo_current
+
+            exec.random_coin::generate_list_indices
+
+            exec.constants::get_lde_domain_log_size
+            exec.constants::get_number_queries neg
+            push.QUERY_ADDRESS
+            # => [query_ptr, loop_counter, lde_size_log, ...]
+
+            push.1
+            while.true
+                dup add.3 mem_load
+                movdn.3
+                # => [query_ptr, loop_counter, lde_size_log, query_index, ...]
+                dup
+                add.2 mem_load
+                dup.3 assert_eq
+
+                add.4
+                # => [query_ptr + 4, loop_counter, lde_size_log, query_index, ...]
+
+                swap add.1 swap
+                # => [query_ptr + 4, loop_counter, lde_size_log, query_index, ...]
+
+                dup.1 neq.0
+                # => [?, query_ptr + 4, loop_counter + 1, lde_size_log, query_index, ...]
+                
+            end
+            drop drop drop
+
+            exec.constants::get_number_queries neg
+            push.1
+            while.true
+                swap
+                adv_push.1
+                assert_eq
+                add.1
+                dup
+                neq.0
+            end
+            drop  
+        end
+        "#;


### PR DESCRIPTION
Closes #920 based on [this](https://github.com/0xPolygonMiden/miden-vm/issues/920#issuecomment-2721309919) comment.

In summary, due to the fact that the Fiat-Shamir transcript is very structured (e.g., we always absorb a word and always squeeze a field element except for the auxiliary trace random values and the FRI queries), we can simplify/optimize the MASM implementation. This means that, in contrast to the Rust implementation, we don't rely on the `current` field of the RPO random coin to determine how to manage the state of the coin but we use it only in order to perform some sanity checks when absorbing and squeezing.
For generating the FRI queries, which is the last thing that happens from a transcript point of view, we add more through testing in order to make sure that the random queries generation procedure works as expected.

In the future, and if the transcript becomes more complicated e.g., addition of sum-check, then we can revisit both the Rust and MASM implementations.

The impact of the changes in this PR are an increase from `32786` to `32865` cycles for verifying an execution trace of length `1 << 20`.