### PR TITLE
Implement `Diagnostics` for `ExecutionError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - [BREAKING] Improve processor errors for memory and calls (#1717)
 - Implement a new fast processor that doesn't generate a trace (#1668)
 - `ProcessState::get_stack_state()` now only returns the state of the active context (#1753)
+- Improve processor error diagnostics (#1765)
 
 ## 0.12.0 (2025-01-22)
 

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -1,10 +1,10 @@
-use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
+use alloc::{collections::BTreeMap, string::ToString, sync::Arc, vec::Vec};
 
 use basic_block_builder::BasicBlockOrDecorators;
 use mast_forest_builder::MastForestBuilder;
 use module_graph::{ProcedureWrapper, WrappedModule};
 use vm_core::{
-    DecoratorList, Felt, Kernel, Operation, Program, WORD_SIZE,
+    AssemblyOp, Decorator, DecoratorList, Felt, Kernel, Operation, Program, WORD_SIZE,
     crypto::hash::RpoDigest,
     debuginfo::SourceSpan,
     mast::{DecoratorId, MastNodeId},
@@ -626,7 +626,7 @@ impl Assembler {
                     }
                 },
 
-                Op::If { then_blk, else_blk, .. } => {
+                Op::If { then_blk, else_blk, span } => {
                     if let Some(basic_block_id) = block_builder.make_basic_block()? {
                         body_node_ids.push(basic_block_id);
                     }
@@ -650,6 +650,23 @@ impl Assembler {
                         block_builder
                             .mast_forest_builder_mut()
                             .append_before_enter(split_node_id, &decorator_ids)
+                    }
+
+                    // Add an assembly operation decorator to the if node in debug mode.
+                    if self.in_debug_mode() {
+                        let location = proc_ctx.source_manager().location(*span).ok();
+                        let context_name = proc_ctx.name().to_string();
+                        let num_cycles = 0;
+                        let op = "if.true".to_string();
+                        let should_break = false;
+                        let op =
+                            AssemblyOp::new(location, context_name, num_cycles, op, should_break);
+                        let decorator_id = block_builder
+                            .mast_forest_builder_mut()
+                            .ensure_decorator(Decorator::AsmOp(op))?;
+                        block_builder
+                            .mast_forest_builder_mut()
+                            .append_before_enter(split_node_id, &[decorator_id]);
                     }
 
                     body_node_ids.push(split_node_id);
@@ -687,7 +704,7 @@ impl Assembler {
                     }
                 },
 
-                Op::While { body, .. } => {
+                Op::While { body, span } => {
                     if let Some(basic_block_id) = block_builder.make_basic_block()? {
                         body_node_ids.push(basic_block_id);
                     }
@@ -705,6 +722,23 @@ impl Assembler {
                         block_builder
                             .mast_forest_builder_mut()
                             .append_before_enter(loop_node_id, &decorator_ids)
+                    }
+
+                    // Add an assembly operation decorator to the loop node in debug mode.
+                    if self.in_debug_mode() {
+                        let location = proc_ctx.source_manager().location(*span).ok();
+                        let context_name = proc_ctx.name().to_string();
+                        let num_cycles = 0;
+                        let op = "while.true".to_string();
+                        let should_break = false;
+                        let op =
+                            AssemblyOp::new(location, context_name, num_cycles, op, should_break);
+                        let decorator_id = block_builder
+                            .mast_forest_builder_mut()
+                            .ensure_decorator(Decorator::AsmOp(op))?;
+                        block_builder
+                            .mast_forest_builder_mut()
+                            .append_before_enter(loop_node_id, &[decorator_id]);
                     }
 
                     body_node_ids.push(loop_node_id);

--- a/miden/tests/integration/exec.rs
+++ b/miden/tests/integration/exec.rs
@@ -30,7 +30,10 @@ fn advice_map_loaded_before_execution() {
     ) {
         Ok(_) => panic!("Expected error"),
         Err(e) => {
-            assert_matches!(e, prover::ExecutionError::AdviceMapKeyNotFound(_));
+            assert_matches!(
+                e,
+                prover::ExecutionError::AdviceMapKeyNotFound { key: _, label: _, source_file: _ }
+            );
         },
     }
 

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -66,7 +66,10 @@ fn faulty_condition_from_loop() {
         end";
 
     let test = build_test!(source, &[10]);
-    expect_exec_error_matches!(test, ExecutionError::NotBinaryValue(_));
+    expect_exec_error_matches!(
+        test,
+        ExecutionError::NotBinaryValueOp { label: _, source_file: _, value: _ }
+    );
 }
 
 #[test]

--- a/miden/tests/integration/flow_control/mod.rs
+++ b/miden/tests/integration/flow_control/mod.rs
@@ -68,7 +68,7 @@ fn faulty_condition_from_loop() {
     let test = build_test!(source, &[10]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotBinaryValueOp { label: _, source_file: _, value: _ }
+        ExecutionError::NotBinaryValueLoop { label: _, source_file: _, value: _ }
     );
 }
 

--- a/miden/tests/integration/operations/decorators/asmop.rs
+++ b/miden/tests/integration/operations/decorators/asmop.rs
@@ -718,6 +718,11 @@ fn asmop_conditional_execution_test() {
     //if branch
     let test = build_debug_test!(source, &[1, 1]);
     let path = test.source.name();
+    let if_branch_loc = Some(Location {
+        path: path.clone(),
+        start: 42.into(),
+        end: 150.into(),
+    });
     let eq_loc = Some(Location {
         path: path.clone(),
         start: 27.into(),
@@ -795,7 +800,16 @@ fn asmop_conditional_execution_test() {
         },
         VmStatePartial {
             clk: RowIndex::from(6),
-            asmop: None,
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new(
+                    if_branch_loc,
+                    "#exec::#main".to_string(),
+                    0,
+                    "if.true".to_string(),
+                    false,
+                ),
+                1,
+            )),
             op: Some(Operation::Split),
         },
         VmStatePartial {
@@ -946,6 +960,11 @@ fn asmop_conditional_execution_test() {
     //else branch
     let test = build_debug_test!(source, &[1, 0]);
     let path = test.source.name();
+    let else_branch_loc = Some(Location {
+        path: path.clone(),
+        start: 42.into(),
+        end: 150.into(),
+    });
     let eq_loc = Some(Location {
         path: path.clone(),
         start: 27.into(),
@@ -1023,7 +1042,16 @@ fn asmop_conditional_execution_test() {
         },
         VmStatePartial {
             clk: RowIndex::from(6),
-            asmop: None,
+            asmop: Some(AsmOpInfo::new(
+                AssemblyOp::new(
+                    else_branch_loc,
+                    "#exec::#main".to_string(),
+                    0,
+                    "if.true".to_string(),
+                    false,
+                ),
+                1,
+            )),
             op: Some(Operation::Split),
         },
         VmStatePartial {

--- a/miden/tests/integration/operations/decorators/mod.rs
+++ b/miden/tests/integration/operations/decorators/mod.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use processor::{
-    AdviceProvider, ExecutionError, Host, MastForest, MemAdviceProvider, ProcessState,
+    AdviceProvider, ErrorContext, ExecutionError, Host, MastForest, MemAdviceProvider, ProcessState,
 };
-use vm_core::DebugOptions;
+use vm_core::{DebugOptions, mast::MastNodeExt};
 
 mod advice;
 mod asmop;
@@ -40,7 +40,12 @@ impl<A: AdviceProvider> Host for TestHost<A> {
         &mut self.adv_provider
     }
 
-    fn on_event(&mut self, _process: ProcessState, event_id: u32) -> Result<(), ExecutionError> {
+    fn on_event(
+        &mut self,
+        _process: ProcessState,
+        event_id: u32,
+        _err_ctx: &ErrorContext<impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
         self.event_handler.push(event_id);
         Ok(())
     }

--- a/miden/tests/integration/operations/field_ops.rs
+++ b/miden/tests/integration/operations/field_ops.rs
@@ -321,7 +321,7 @@ fn pow2_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::FailedAssertion{clk, err_code, err_msg }
+        ExecutionError::FailedAssertion{clk, err_code, err_msg, label: _, source_file: _ }
         if clk == RowIndex::from(17) && err_code == 0 && err_msg.is_none()
     );
 }
@@ -353,7 +353,7 @@ fn exp_bits_length_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::FailedAssertion{clk, err_code, err_msg }
+        ExecutionError::FailedAssertion{clk, err_code, err_msg, label: _, source_file: _ }
         if clk == RowIndex::from(19) && err_code == 0 && err_msg.is_none()
     );
 

--- a/miden/tests/integration/operations/field_ops.rs
+++ b/miden/tests/integration/operations/field_ops.rs
@@ -407,7 +407,7 @@ fn ilog2_fail() {
     let test = build_op_test!(asm_op, &[0]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::LogArgumentZero(row_idx) if row_idx == RowIndex::from(2)
+        ExecutionError::LogArgumentZero{ clk: row_idx, label: _, source_file: _ } if row_idx == RowIndex::from(2)
     );
 }
 

--- a/miden/tests/integration/operations/field_ops.rs
+++ b/miden/tests/integration/operations/field_ops.rs
@@ -213,7 +213,10 @@ fn div_fail() {
 
     // --- test divide by zero --------------------------------------------------------------------
     let test = build_op_test!(asm_op, &[1, 0]);
-    expect_exec_error_matches!(test, ExecutionError::DivideByZero(row_idx) if row_idx == RowIndex::from(2));
+    expect_exec_error_matches!(
+        test,
+        ExecutionError::DivideByZero{ clk:value, label: _, source_file: _ } if value == RowIndex::from(2)
+    );
 }
 
 #[test]
@@ -279,7 +282,7 @@ fn inv_fail() {
 
     // --- test no inv on 0 -----------------------------------------------------------------------
     let test = build_op_test!(asm_op, &[0]);
-    expect_exec_error_matches!(test, ExecutionError::DivideByZero(row_idx) if row_idx == RowIndex::from(2));
+    expect_exec_error_matches!(test, ExecutionError::DivideByZero{clk: row_idx, label: _, source_file: _ } if row_idx == RowIndex::from(2));
 
     let asm_op = "inv.1";
 

--- a/miden/tests/integration/operations/field_ops.rs
+++ b/miden/tests/integration/operations/field_ops.rs
@@ -434,7 +434,7 @@ fn not_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotBinaryValue(value) if value == Felt::new(2_u64)
+        ExecutionError::NotBinaryValueOp{value, label: _, source_file: _ } if value == Felt::new(2_u64)
     );
 }
 
@@ -463,19 +463,19 @@ fn and_fail() {
     let test = build_op_test!(asm_op, &[2, 3]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotBinaryValue(value) if value == Felt::new(3_u64)
+        ExecutionError::NotBinaryValueOp{value, label: _, source_file: _ } if value == Felt::new(3_u64)
     );
 
     let test = build_op_test!(asm_op, &[2, 0]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotBinaryValue(value) if value == Felt::new(2_u64)
+        ExecutionError::NotBinaryValueOp{value, label: _, source_file: _ } if value == Felt::new(2_u64)
     );
 
     let test = build_op_test!(asm_op, &[0, 2]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotBinaryValue(value) if value == Felt::new(2_u64)
+        ExecutionError::NotBinaryValueOp{value, label: _, source_file: _ } if value == Felt::new(2_u64)
     );
 }
 
@@ -505,20 +505,20 @@ fn or_fail() {
     let test = build_op_test!(asm_op, &[2, 3]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotBinaryValue(value) if value == expected_value
+        ExecutionError::NotBinaryValueOp{value, label: _, source_file: _ } if value == expected_value
     );
 
     let expected_value = Felt::new(2);
     let test = build_op_test!(asm_op, &[2, 0]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotBinaryValue(value) if value == expected_value
+        ExecutionError::NotBinaryValueOp{value, label: _, source_file: _ } if value == expected_value
     );
 
     let test = build_op_test!(asm_op, &[0, 2]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotBinaryValue(value) if value == expected_value
+        ExecutionError::NotBinaryValueOp{value, label: _, source_file: _ } if value == expected_value
     );
 }
 
@@ -548,19 +548,19 @@ fn xor_fail() {
     let test = build_op_test!(asm_op, &[2, 3]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotBinaryValue(value) if value == expected_value
+        ExecutionError::NotBinaryValueOp{value, label: _, source_file: _ } if value == expected_value
     );
 
     let test = build_op_test!(asm_op, &[2, 0]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotBinaryValue(value) if value == expected_value
+        ExecutionError::NotBinaryValueOp{value, label: _, source_file: _ } if value == expected_value
     );
 
     let test = build_op_test!(asm_op, &[0, 2]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotBinaryValue(value) if value == expected_value
+        ExecutionError::NotBinaryValueOp{value, label: _, source_file: _ } if value == expected_value
     );
 }
 

--- a/miden/tests/integration/operations/io_ops/adv_ops.rs
+++ b/miden/tests/integration/operations/io_ops/adv_ops.rs
@@ -34,7 +34,7 @@ fn adv_push_invalid() {
     let test = build_op_test!("adv_push.1");
     expect_exec_error_matches!(
         test,
-        ExecutionError::AdviceStackReadFailed(row_idx) if row_idx == RowIndex::from(2)
+        ExecutionError::AdviceStackReadFailed{row: row_idx, label: _, source_file: _ } if row_idx == RowIndex::from(2)
     );
 }
 
@@ -58,7 +58,7 @@ fn adv_loadw_invalid() {
     let test = build_op_test!("adv_loadw", &[0, 0, 0, 0]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::AdviceStackReadFailed(row_idx) if row_idx == RowIndex::from(2)
+        ExecutionError::AdviceStackReadFailed{row: row_idx, label: _, source_file: _ } if row_idx == RowIndex::from(2)
     );
 }
 

--- a/miden/tests/integration/operations/sys_ops.rs
+++ b/miden/tests/integration/operations/sys_ops.rs
@@ -24,7 +24,7 @@ fn assert_with_code() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::FailedAssertion{ clk, err_code, err_msg }
+        ExecutionError::FailedAssertion{ clk, err_code, err_msg, label: _, source_file: _ }
         if clk == RowIndex::from(2) && err_code == 123_u32 && err_msg.is_none()
     );
 }
@@ -37,7 +37,7 @@ fn assert_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::FailedAssertion{ clk, err_code, err_msg }
+        ExecutionError::FailedAssertion{ clk, err_code, err_msg, label: _, source_file: _ }
         if clk == RowIndex::from(2) && err_code == 0 && err_msg.is_none()
     );
 }
@@ -61,7 +61,7 @@ fn assert_eq_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::FailedAssertion{ clk, err_code, err_msg }
+        ExecutionError::FailedAssertion{ clk, err_code, err_msg, label: _, source_file: _ }
         if clk == RowIndex::from(3) && err_code == 0_u32 && err_msg.is_none()
     );
 
@@ -69,7 +69,7 @@ fn assert_eq_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::FailedAssertion{ clk, err_code, err_msg }
+        ExecutionError::FailedAssertion{ clk, err_code, err_msg, label: _, source_file: _ }
         if clk == RowIndex::from(3) && err_code == 0_u32 && err_msg.is_none()
     );
 }

--- a/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -443,7 +443,7 @@ fn u32div_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::DivideByZero(value) if value == RowIndex::from(2)
+        ExecutionError::DivideByZero{ clk:value, label: _, source_file: _ } if value == RowIndex::from(2)
     );
 }
 
@@ -485,7 +485,7 @@ fn u32mod_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::DivideByZero(value) if value == RowIndex::from(2)
+        ExecutionError::DivideByZero{ clk:value, label: _, source_file: _ } if value == RowIndex::from(2)
     );
 }
 
@@ -532,7 +532,7 @@ fn u32divmod_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::DivideByZero(value) if value == RowIndex::from(2)
+        ExecutionError::DivideByZero{ clk:value, label: _, source_file: _ } if value == RowIndex::from(2)
     );
 }
 

--- a/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/bitwise_ops.rs
@@ -81,14 +81,14 @@ fn u32and_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(U32_BOUND) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(U32_BOUND) && err_code == ZERO
     );
 
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(U32_BOUND) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(U32_BOUND) && err_code == ZERO
     );
 }
 
@@ -164,14 +164,14 @@ fn u32or_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(U32_BOUND) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(U32_BOUND) && err_code == ZERO
     );
 
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(U32_BOUND) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(U32_BOUND) && err_code == ZERO
     );
 }
 
@@ -246,14 +246,14 @@ fn u32xor_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(U32_BOUND) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(U32_BOUND) && err_code == ZERO
     );
 
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(U32_BOUND) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(U32_BOUND) && err_code == ZERO
     );
 }
 

--- a/miden/tests/integration/operations/u32_ops/conversion_ops.rs
+++ b/miden/tests/integration/operations/u32_ops/conversion_ops.rs
@@ -103,7 +103,7 @@ fn u32assert_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(equal) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(equal) && err_code == ZERO
     );
 
     // --- test when a > 2^32 ---------------------------------------------------------------------
@@ -111,7 +111,7 @@ fn u32assert_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(larger) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(larger) && err_code == ZERO
     );
 }
 
@@ -142,7 +142,7 @@ fn u32assert2_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(value_b) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(value_b) && err_code == ZERO
     );
 
     // -------- Case 2: a > 2^32 and b < 2^32 ---------------------------------------------------
@@ -152,7 +152,7 @@ fn u32assert2_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(value_a) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(value_a) && err_code == ZERO
     );
 
     // --------- Case 3: a < 2^32 and b > 2^32 --------------------------------------------------
@@ -162,7 +162,7 @@ fn u32assert2_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(value_b) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(value_b) && err_code == ZERO
     );
 }
 
@@ -188,7 +188,7 @@ fn u32assertw_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(U32_BOUND) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(U32_BOUND) && err_code == ZERO
     );
 }
 

--- a/miden/tests/integration/operations/u32_ops/mod.rs
+++ b/miden/tests/integration/operations/u32_ops/mod.rs
@@ -16,7 +16,7 @@ pub fn test_input_out_of_bounds(asm_op: &str) {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(U32_BOUND) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(U32_BOUND) && err_code == ZERO
     );
 }
 
@@ -34,7 +34,7 @@ pub fn test_inputs_out_of_bounds(asm_op: &str, input_count: usize) {
 
         expect_exec_error_matches!(
             test,
-            ExecutionError::NotU32Value(value, err_code) if value == Felt::new(U32_BOUND) && err_code == ZERO
+            ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(U32_BOUND) && err_code == ZERO
         );
     }
 }

--- a/processor/src/chiplets/bitwise/mod.rs
+++ b/processor/src/chiplets/bitwise/mod.rs
@@ -4,8 +4,10 @@ use miden_air::trace::chiplets::bitwise::{
     A_COL_IDX, A_COL_RANGE, B_COL_IDX, B_COL_RANGE, BITWISE_AND, BITWISE_XOR, OUTPUT_COL_IDX,
     PREV_OUTPUT_COL_IDX, TRACE_WIDTH,
 };
+use vm_core::mast::MastNodeExt;
 
 use super::{ExecutionError, Felt, TraceFragment, ZERO, utils::get_trace_len};
+use crate::ErrorContext;
 
 #[cfg(test)]
 mod tests;
@@ -83,9 +85,14 @@ impl Bitwise {
     ///
     /// This also adds 8 rows to the internal execution trace table required for computing the
     /// operation.
-    pub fn u32and(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
-        let a = assert_u32(a)?.as_int();
-        let b = assert_u32(b)?.as_int();
+    pub fn u32and(
+        &mut self,
+        a: Felt,
+        b: Felt,
+        err_ctx: &ErrorContext<impl MastNodeExt>,
+    ) -> Result<Felt, ExecutionError> {
+        let a = assert_u32(a, err_ctx)?.as_int();
+        let b = assert_u32(b, err_ctx)?.as_int();
         let mut result = 0u64;
 
         // append 8 rows to the trace, each row computing bitwise AND in 4 bit limbs starting with
@@ -118,9 +125,14 @@ impl Bitwise {
     ///
     /// This also adds 8 rows to the internal execution trace table required for computing the
     /// operation.
-    pub fn u32xor(&mut self, a: Felt, b: Felt) -> Result<Felt, ExecutionError> {
-        let a = assert_u32(a)?.as_int();
-        let b = assert_u32(b)?.as_int();
+    pub fn u32xor(
+        &mut self,
+        a: Felt,
+        b: Felt,
+        err_ctx: &ErrorContext<impl MastNodeExt>,
+    ) -> Result<Felt, ExecutionError> {
+        let a = assert_u32(a, err_ctx)?.as_int();
+        let b = assert_u32(b, err_ctx)?.as_int();
         let mut result = 0u64;
 
         // append 8 rows to the trace, each row computing bitwise XOR in 4 bit limbs starting with
@@ -201,10 +213,13 @@ impl Default for Bitwise {
 // HELPER FUNCTIONS
 // --------------------------------------------------------------------------------------------
 
-pub fn assert_u32(value: Felt) -> Result<Felt, ExecutionError> {
+pub fn assert_u32(
+    value: Felt,
+    err_ctx: &ErrorContext<impl MastNodeExt>,
+) -> Result<Felt, ExecutionError> {
     let val_u64 = value.as_int();
     if val_u64 > u32::MAX.into() {
-        Err(ExecutionError::NotU32Value(value, ZERO))
+        Err(ExecutionError::not_u32_value(value, ZERO, err_ctx))
     } else {
         Ok(value)
     }

--- a/processor/src/chiplets/bitwise/tests.rs
+++ b/processor/src/chiplets/bitwise/tests.rs
@@ -8,6 +8,7 @@ use test_utils::rand::rand_value;
 use vm_core::ZERO;
 
 use super::{Bitwise, Felt, TraceFragment};
+use crate::ErrorContext;
 
 #[test]
 fn bitwise_init() {
@@ -22,7 +23,7 @@ fn bitwise_and() {
     let a = rand_u32();
     let b = rand_u32();
 
-    let result = bitwise.u32and(a, b).unwrap();
+    let result = bitwise.u32and(a, b, &ErrorContext::default()).unwrap();
     assert_eq!(a.as_int() & b.as_int(), result.as_int());
 
     // --- check generated trace ----------------------------------------------
@@ -65,7 +66,7 @@ fn bitwise_xor() {
     let a = rand_u32();
     let b = rand_u32();
 
-    let result = bitwise.u32xor(a, b).unwrap();
+    let result = bitwise.u32xor(a, b, &ErrorContext::default()).unwrap();
     assert_eq!(a.as_int() ^ b.as_int(), result.as_int());
 
     // --- check generated trace ----------------------------------------------
@@ -109,15 +110,15 @@ fn bitwise_multiple() {
     let b = [rand_u32(), rand_u32(), rand_u32()];
 
     // first operation: AND
-    let result0 = bitwise.u32and(a[0], b[0]).unwrap();
+    let result0 = bitwise.u32and(a[0], b[0], &ErrorContext::default()).unwrap();
     assert_eq!(a[0].as_int() & b[0].as_int(), result0.as_int());
 
     // second operation: XOR
-    let result1 = bitwise.u32xor(a[1], b[1]).unwrap();
+    let result1 = bitwise.u32xor(a[1], b[1], &ErrorContext::default()).unwrap();
     assert_eq!(a[1].as_int() ^ b[1].as_int(), result1.as_int());
 
     // third operation: AND
-    let result2 = bitwise.u32and(a[2], b[2]).unwrap();
+    let result2 = bitwise.u32and(a[2], b[2], &ErrorContext::default()).unwrap();
     assert_eq!(a[2].as_int() & b[2].as_int(), result2.as_int());
 
     // --- check generated trace ----------------------------------------------

--- a/processor/src/chiplets/kernel_rom/tests.rs
+++ b/processor/src/chiplets/kernel_rom/tests.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 
 use super::{Felt, Kernel, KernelRom, ONE, TRACE_WIDTH, TraceFragment, Word, ZERO};
+use crate::ErrorContext;
 
 // CONSTANTS
 // ================================================================================================
@@ -17,10 +18,13 @@ fn kernel_rom_invalid_access() {
     let mut rom = KernelRom::new(kernel);
 
     // accessing procedure which is in the kernel should be fine
-    assert!(rom.access_proc(PROC1_HASH.into()).is_ok());
+    assert!(rom.access_proc(PROC1_HASH.into(), &ErrorContext::default()).is_ok());
 
     // accessing procedure which is not in the kernel should return an error
-    assert!(rom.access_proc([ZERO, ONE, ZERO, ONE].into()).is_err());
+    assert!(
+        rom.access_proc([ZERO, ONE, ZERO, ONE].into(), &ErrorContext::default())
+            .is_err()
+    );
 }
 
 #[test]
@@ -61,11 +65,11 @@ fn kernel_rom_with_access() {
     let mut rom = KernelRom::new(kernel);
 
     // generate 5 access: 3 for proc1 and 2 for proc2
-    rom.access_proc(PROC1_HASH.into()).unwrap();
-    rom.access_proc(PROC2_HASH.into()).unwrap();
-    rom.access_proc(PROC1_HASH.into()).unwrap();
-    rom.access_proc(PROC1_HASH.into()).unwrap();
-    rom.access_proc(PROC2_HASH.into()).unwrap();
+    rom.access_proc(PROC1_HASH.into(), &ErrorContext::default()).unwrap();
+    rom.access_proc(PROC2_HASH.into(), &ErrorContext::default()).unwrap();
+    rom.access_proc(PROC1_HASH.into(), &ErrorContext::default()).unwrap();
+    rom.access_proc(PROC1_HASH.into(), &ErrorContext::default()).unwrap();
+    rom.access_proc(PROC2_HASH.into(), &ErrorContext::default()).unwrap();
 
     let expected_trace_len = 5;
     assert_eq!(expected_trace_len, rom.trace_len());

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -142,8 +142,16 @@ pub enum ExecutionError {
         source_file: Option<Arc<SourceFile>>,
         depth: Felt,
     },
-    #[error("provided node index {value} is out of bounds for a merkle tree node at depth {depth}")]
-    InvalidMerkleTreeNodeIndex { depth: Felt, value: Felt },
+    #[error("provided node index {index} is out of bounds for a merkle tree node at depth {depth}")]
+    #[diagnostic()]
+    InvalidMerkleTreeNodeIndex {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        depth: Felt,
+        index: Felt,
+    },
     #[error("attempted to calculate integer logarithm with zero argument at clock cycle {0}")]
     LogArgumentZero(RowIndex),
     #[error("malformed signature key: {0}")]
@@ -267,6 +275,15 @@ impl ExecutionError {
     ) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::InvalidMerkleTreeDepth { label, source_file, depth }
+    }
+
+    pub fn invalid_merkle_tree_node_index(
+        depth: Felt,
+        index: Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::InvalidMerkleTreeNodeIndex { label, source_file, depth, index }
     }
 
     pub fn invalid_stack_depth_on_return(

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -298,9 +298,15 @@ pub enum ExecutionError {
         preimage_len: usize,
     },
     #[error("syscall failed: procedure with root {hex} was not found in the kernel",
-      hex = to_hex(.0.as_bytes())
+      hex = to_hex(proc_root.as_bytes())
     )]
-    SyscallTargetNotInKernel(Digest),
+    SyscallTargetNotInKernel {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        proc_root: Digest,
+    },
 }
 
 impl From<Ext2InttError> for ExecutionError {
@@ -503,6 +509,14 @@ impl ExecutionError {
     ) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::SmtNodePreImageNotValid { label, source_file, node, preimage_len }
+    }
+
+    pub fn syscall_target_not_in_kernel(
+        proc_root: Digest,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::SyscallTargetNotInKernel { label, source_file, proc_root }
     }
 }
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -198,6 +198,10 @@ pub enum ExecutionError {
       root = to_hex(root.as_bytes()),
     )]
     MerklePathVerificationFailed {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
         value: Word,
         index: Felt,
         root: Digest,
@@ -360,6 +364,25 @@ impl ExecutionError {
     ) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::MalformedSignatureKey { label, source_file, key_type }
+    }
+
+    pub fn merkle_path_verification_failed(
+        value: Word,
+        index: Felt,
+        root: Digest,
+        err_code: u32,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+
+        Self::MerklePathVerificationFailed {
+            label,
+            source_file,
+            value,
+            index,
+            root,
+            err_code,
+        }
     }
 
     pub fn merkle_store_lookup_failed(

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -161,8 +161,15 @@ pub enum ExecutionError {
         source_file: Option<Arc<SourceFile>>,
         clk: RowIndex,
     },
-    #[error("malformed signature key: {0}")]
-    MalformedSignatureKey(&'static str),
+    #[error("malformed signature key: {key_type}")]
+    #[diagnostic(help("the secret key associated with the provided public key is malformed"))]
+    MalformedSignatureKey {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        key_type: &'static str,
+    },
     #[error(
         "MAST forest in host indexed by procedure root {root_digest} doesn't contain that root"
     )]
@@ -325,6 +332,14 @@ impl ExecutionError {
     pub fn log_argument_zero(clk: RowIndex, err_ctx: &ErrorContext<'_, impl MastNodeExt>) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::LogArgumentZero { label, source_file, clk }
+    }
+
+    pub fn malformed_signature_key(
+        key_type: &'static str,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::MalformedSignatureKey { label, source_file, key_type }
     }
 
     pub fn merkle_store_lookup_failed(

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -55,7 +55,12 @@ pub enum ExecutionError {
         None => "".into()
       }
     )]
+    #[diagnostic()]
     FailedAssertion {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
         clk: RowIndex,
         err_code: u32,
         err_msg: Option<String>,
@@ -148,6 +153,23 @@ impl From<Ext2InttError> for ExecutionError {
 }
 
 impl ExecutionError {
+    pub fn failed_assertion(
+        clk: RowIndex,
+        err_code: u32,
+        err_msg: Option<String>,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+
+        Self::FailedAssertion {
+            label,
+            source_file,
+            clk,
+            err_code,
+            err_msg,
+        }
+    }
+
     pub fn invalid_stack_depth_on_return(
         depth: usize,
         err_ctx: &ErrorContext<'_, impl MastNodeExt>,

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, string::String, sync::Arc};
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use core::error::Error;
 
 use miden_air::RowIndex;
@@ -32,8 +32,15 @@ pub enum ExecutionError {
         source_file: Option<Arc<SourceFile>>,
         key: Word,
     },
-    #[error("value for key {} already present in the advice map", to_hex(Felt::elements_as_bytes(.0)))]
-    AdviceMapKeyAlreadyPresent(Word),
+    #[error("value for key {} already present in the advice map when loading MAST forest", to_hex(Felt::elements_as_bytes(.key)))]
+    #[diagnostic(help(
+        "previous values at key were '{prev_values:?}'. Operation would have replaced them with '{new_values:?}'",
+    ))]
+    AdviceMapKeyAlreadyPresent {
+        key: Word,
+        prev_values: Vec<Felt>,
+        new_values: Vec<Felt>,
+    },
     #[error("advice stack read failed at step {0}")]
     AdviceStackReadFailed(RowIndex),
     #[error("illegal use of instruction {0} while inside a syscall")]

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -152,8 +152,15 @@ pub enum ExecutionError {
         depth: Felt,
         index: Felt,
     },
-    #[error("attempted to calculate integer logarithm with zero argument at clock cycle {0}")]
-    LogArgumentZero(RowIndex),
+    #[error("attempted to calculate integer logarithm with zero argument at clock cycle {clk}")]
+    #[diagnostic()]
+    LogArgumentZero {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        clk: RowIndex,
+    },
     #[error("malformed signature key: {0}")]
     MalformedSignatureKey(&'static str),
     #[error(
@@ -292,6 +299,11 @@ impl ExecutionError {
     ) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::InvalidStackDepthOnReturn { label, source_file, depth }
+    }
+
+    pub fn log_argument_zero(clk: RowIndex, err_ctx: &ErrorContext<'_, impl MastNodeExt>) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::LogArgumentZero { label, source_file, clk }
     }
 }
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -187,7 +187,14 @@ pub enum ExecutionError {
     #[error("advice provider Merkle store backend lookup failed")]
     MerkleStoreLookupFailed(#[source] MerkleError),
     #[error("advice provider Merkle store backend merge failed")]
-    MerkleStoreMergeFailed(#[source] MerkleError),
+    MerkleStoreMergeFailed {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        #[source]
+        err: MerkleError,
+    },
     #[error("advice provider Merkle store backend update failed")]
     MerkleStoreUpdateFailed(#[source] MerkleError),
     #[error("an operation expected a binary value, but received {0}")]
@@ -304,6 +311,15 @@ impl ExecutionError {
     pub fn log_argument_zero(clk: RowIndex, err_ctx: &ErrorContext<'_, impl MastNodeExt>) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::LogArgumentZero { label, source_file, clk }
+    }
+
+    /// Note: This error currently never occurs, since `MerkleStore::merge_roots()` never fails.
+    pub fn merkle_store_merge_failed(
+        err: MerkleError,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::MerkleStoreMergeFailed { label, source_file, err }
     }
 }
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -173,7 +173,13 @@ pub enum ExecutionError {
     #[error(
         "MAST forest in host indexed by procedure root {root_digest} doesn't contain that root"
     )]
-    MalformedMastForestInHost { root_digest: Digest },
+    MalformedMastForestInHost {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        root_digest: Digest,
+    },
     #[error("node id {node_id} does not exist in MAST forest")]
     MastNodeNotFoundInForest { node_id: MastNodeId },
     #[error(transparent)]
@@ -338,6 +344,14 @@ impl ExecutionError {
     pub fn log_argument_zero(clk: RowIndex, err_ctx: &ErrorContext<'_, impl MastNodeExt>) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::LogArgumentZero { label, source_file, clk }
+    }
+
+    pub fn malfored_mast_forest_in_host(
+        root_digest: Digest,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::MalformedMastForestInHost { label, source_file, root_digest }
     }
 
     pub fn malformed_signature_key(

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -281,10 +281,16 @@ pub enum ExecutionError {
     #[error("smt node {node_hex} not found", node_hex = to_hex(Felt::elements_as_bytes(.0)))]
     SmtNodeNotFound(Word),
     #[error("expected pre-image length of node {node_hex} to be a multiple of 8 but was {preimage_len}",
-      node_hex = to_hex(Felt::elements_as_bytes(.0)),
-      preimage_len = .1
+      node_hex = to_hex(Felt::elements_as_bytes(node)),
     )]
-    SmtNodePreImageNotValid(Word, usize),
+    SmtNodePreImageNotValid {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        node: Word,
+        preimage_len: usize,
+    },
     #[error("syscall failed: procedure with root {hex} was not found in the kernel",
       hex = to_hex(.0.as_bytes())
     )]
@@ -477,6 +483,15 @@ impl ExecutionError {
     ) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::NotU32Value { label, source_file, value, err_code }
+    }
+
+    pub fn smt_node_preimage_not_valid(
+        node: Word,
+        preimage_len: usize,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::SmtNodePreImageNotValid { label, source_file, node, preimage_len }
     }
 }
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -180,7 +180,13 @@ pub enum ExecutionError {
     #[diagnostic(transparent)]
     MemoryError(MemoryError),
     #[error("no MAST forest contains the procedure with root digest {root_digest}")]
-    NoMastForestWithProcedure { root_digest: Digest },
+    NoMastForestWithProcedure {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        root_digest: Digest,
+    },
     #[error("merkle path verification failed for value {value} at index {index} in the Merkle tree with root {root} (error code: {err_code})", 
       value = to_hex(Felt::elements_as_bytes(value)),
       root = to_hex(root.as_bytes()),
@@ -365,6 +371,14 @@ impl ExecutionError {
     ) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::MerkleStoreUpdateFailed { label, source_file, err }
+    }
+
+    pub fn no_mast_forest_with_procedure(
+        root_digest: Digest,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::NoMastForestWithProcedure { label, source_file, root_digest }
     }
 }
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -196,7 +196,14 @@ pub enum ExecutionError {
         err: MerkleError,
     },
     #[error("advice provider Merkle store backend update failed")]
-    MerkleStoreUpdateFailed(#[source] MerkleError),
+    MerkleStoreUpdateFailed {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        #[source]
+        err: MerkleError,
+    },
     #[error("an operation expected a binary value, but received {0}")]
     NotBinaryValue(Felt),
     #[error("an operation expected a u32 value, but received {0} (error code: {1})")]
@@ -320,6 +327,14 @@ impl ExecutionError {
     ) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::MerkleStoreMergeFailed { label, source_file, err }
+    }
+
+    pub fn merkle_store_update_failed(
+        err: MerkleError,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::MerkleStoreUpdateFailed { label, source_file, err }
     }
 }
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -184,8 +184,15 @@ pub enum ExecutionError {
         root: Digest,
         err_code: u32,
     },
-    #[error("advice provider Merkle store backend lookup failed")]
-    MerkleStoreLookupFailed(#[source] MerkleError),
+    #[error("failed to lookup value in Merkle store")]
+    MerkleStoreLookupFailed {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        #[source]
+        err: MerkleError,
+    },
     #[error("advice provider Merkle store backend merge failed")]
     MerkleStoreMergeFailed {
         #[label]
@@ -318,6 +325,14 @@ impl ExecutionError {
     pub fn log_argument_zero(clk: RowIndex, err_ctx: &ErrorContext<'_, impl MastNodeExt>) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::LogArgumentZero { label, source_file, clk }
+    }
+
+    pub fn merkle_store_lookup_failed(
+        err: MerkleError,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::MerkleStoreLookupFailed { label, source_file, err }
     }
 
     /// Note: This error currently never occurs, since `MerkleStore::merge_roots()` never fails.

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -134,7 +134,14 @@ pub enum ExecutionError {
     #[error(
         "provided merkle tree {depth} is out of bounds and cannot be represented as an unsigned 8-bit integer"
     )]
-    InvalidMerkleTreeDepth { depth: Felt },
+    #[diagnostic()]
+    InvalidMerkleTreeDepth {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        depth: Felt,
+    },
     #[error("provided node index {value} is out of bounds for a merkle tree node at depth {depth}")]
     InvalidMerkleTreeNodeIndex { depth: Felt, value: Felt },
     #[error("attempted to calculate integer logarithm with zero argument at clock cycle {0}")]
@@ -252,6 +259,14 @@ impl ExecutionError {
             err_code,
             err_msg,
         }
+    }
+
+    pub fn invalid_merkle_tree_depth(
+        depth: Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::InvalidMerkleTreeDepth { label, source_file, depth }
     }
 
     pub fn invalid_stack_depth_on_return(

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -234,8 +234,35 @@ pub enum ExecutionError {
         #[source]
         err: MerkleError,
     },
-    #[error("an operation expected a binary value, but received {0}")]
-    NotBinaryValue(Felt),
+    #[error("if statement expected a binary value on top of the stack, but got {value}")]
+    #[diagnostic()]
+    NotBinaryValueIf {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        value: Felt,
+    },
+    #[error("operation expected a binary value, but got {value}")]
+    #[diagnostic()]
+    NotBinaryValueOp {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        value: Felt,
+    },
+    #[error("loop condition must be a binary value, but got {value}")]
+    #[diagnostic(help(
+        "this could happen either when first entering the loop, or any subsequent iteration"
+    ))]
+    NotBinaryValueLoop {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        value: Felt,
+    },
     #[error("an operation expected a u32 value, but received {0} (error code: {1})")]
     NotU32Value(Felt, Felt),
     #[error("stack should have at most {MIN_STACK_DEPTH} elements at the end of program execution, but had {} elements", MIN_STACK_DEPTH + .0)]
@@ -416,6 +443,24 @@ impl ExecutionError {
     ) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::NoMastForestWithProcedure { label, source_file, root_digest }
+    }
+
+    pub fn not_binary_value_if(value: Felt, err_ctx: &ErrorContext<'_, impl MastNodeExt>) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::NotBinaryValueIf { label, source_file, value }
+    }
+
+    pub fn not_binary_value_op(value: Felt, err_ctx: &ErrorContext<'_, impl MastNodeExt>) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::NotBinaryValueOp { label, source_file, value }
+    }
+
+    pub fn not_binary_value_loop(
+        value: Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::NotBinaryValueLoop { label, source_file, value }
     }
 }
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -278,8 +278,14 @@ pub enum ExecutionError {
     ProgramAlreadyExecuted,
     #[error("proof generation failed")]
     ProverError(#[source] ProverError),
-    #[error("smt node {node_hex} not found", node_hex = to_hex(Felt::elements_as_bytes(.0)))]
-    SmtNodeNotFound(Word),
+    #[error("smt node {node_hex} not found", node_hex = to_hex(Felt::elements_as_bytes(node)))]
+    SmtNodeNotFound {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        node: Word,
+    },
     #[error("expected pre-image length of node {node_hex} to be a multiple of 8 but was {preimage_len}",
       node_hex = to_hex(Felt::elements_as_bytes(node)),
     )]
@@ -483,6 +489,11 @@ impl ExecutionError {
     ) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::NotU32Value { label, source_file, value, err_code }
+    }
+
+    pub fn smt_node_not_found(node: Word, err_ctx: &ErrorContext<'_, impl MastNodeExt>) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::SmtNodeNotFound { label, source_file, node }
     }
 
     pub fn smt_node_preimage_not_valid(

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -263,8 +263,15 @@ pub enum ExecutionError {
         source_file: Option<Arc<SourceFile>>,
         value: Felt,
     },
-    #[error("an operation expected a u32 value, but received {0} (error code: {1})")]
-    NotU32Value(Felt, Felt),
+    #[error("operation expected a u32 value, but got {value} (error code: {err_code})")]
+    NotU32Value {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        value: Felt,
+        err_code: Felt,
+    },
     #[error("stack should have at most {MIN_STACK_DEPTH} elements at the end of program execution, but had {} elements", MIN_STACK_DEPTH + .0)]
     OutputStackOverflow(usize),
     #[error("a program has already been executed in this process")]
@@ -461,6 +468,15 @@ impl ExecutionError {
     ) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::NotBinaryValueLoop { label, source_file, value }
+    }
+
+    pub fn not_u32_value(
+        value: Felt,
+        err_code: Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::NotU32Value { label, source_file, value, err_code }
     }
 }
 

--- a/processor/src/fast/crypto_ops.rs
+++ b/processor/src/fast/crypto_ops.rs
@@ -44,12 +44,13 @@ impl FastProcessor {
         // verify the path
         match path.verify(index.as_int(), node.into(), &root.into()) {
             Ok(_) => Ok(()),
-            Err(_) => Err(ExecutionError::MerklePathVerificationFailed {
-                value: node,
+            Err(_) => Err(ExecutionError::merkle_path_verification_failed(
+                node,
                 index,
-                root: root.into(),
+                root.into(),
                 err_code,
-            }),
+                &ErrorContext::default(),
+            )),
         }
     }
 
@@ -78,12 +79,13 @@ impl FastProcessor {
 
         // verify that the old node is consistent with the Merkle path
         if path.verify(index.as_int(), old_node.into(), &old_root.into()).is_err() {
-            return Err(ExecutionError::MerklePathVerificationFailed {
-                value: old_node,
+            return Err(ExecutionError::merkle_path_verification_failed(
+                old_node,
                 index,
-                root: old_root.into(),
-                err_code: 0,
-            });
+                old_root.into(),
+                0,
+                &ErrorContext::default(),
+            ));
         }
 
         // Replace the old node value with computed new root; everything else remains the same.

--- a/processor/src/fast/field_ops.rs
+++ b/processor/src/fast/field_ops.rs
@@ -1,6 +1,7 @@
 use vm_core::{Felt, FieldElement, ONE, ZERO};
 
 use super::{ExecutionError, FastProcessor, assert_binary};
+use crate::ErrorContext;
 
 const TWO: Felt = Felt::new(2);
 
@@ -26,7 +27,10 @@ impl FastProcessor {
     pub fn op_inv(&mut self, op_idx: usize) -> Result<(), ExecutionError> {
         let top = self.stack_get_mut(0);
         if (*top) == ZERO {
-            return Err(ExecutionError::DivideByZero(self.clk + op_idx));
+            return Err(ExecutionError::divide_by_zero(
+                self.clk + op_idx,
+                &ErrorContext::default(),
+            ));
         }
         *top = top.inv();
         Ok(())

--- a/processor/src/fast/field_ops.rs
+++ b/processor/src/fast/field_ops.rs
@@ -1,7 +1,7 @@
 use vm_core::{Felt, FieldElement, ONE, ZERO};
 
-use super::{ExecutionError, FastProcessor, assert_binary};
-use crate::ErrorContext;
+use super::{ExecutionError, FastProcessor};
+use crate::{ErrorContext, operations::utils::assert_binary};
 
 const TWO: Felt = Felt::new(2);
 
@@ -70,7 +70,7 @@ impl FastProcessor {
         } else if *top == ONE {
             *top = ZERO;
         } else {
-            return Err(ExecutionError::NotBinaryValue(*top));
+            return Err(ExecutionError::not_binary_value_op(*top, &ErrorContext::default()));
         }
         Ok(())
     }

--- a/processor/src/fast/io_ops.rs
+++ b/processor/src/fast/io_ops.rs
@@ -1,7 +1,7 @@
 use vm_core::Word;
 
 use super::{DOUBLE_WORD_SIZE, ExecutionError, FastProcessor, Felt, WORD_SIZE_FELT};
-use crate::{AdviceProvider, Host, ProcessState};
+use crate::{AdviceProvider, ErrorContext, Host, ProcessState};
 
 impl FastProcessor {
     /// Analogous to `Process::op_push`.
@@ -12,7 +12,9 @@ impl FastProcessor {
 
     /// Analogous to `Process::op_advpop`.
     pub fn op_advpop(&mut self, op_idx: usize, host: &mut impl Host) -> Result<(), ExecutionError> {
-        let value = host.advice_provider_mut().pop_stack(ProcessState::new_fast(self, op_idx))?;
+        let value = host
+            .advice_provider_mut()
+            .pop_stack(ProcessState::new_fast(self, op_idx), &ErrorContext::default())?;
         self.increment_stack_size();
         self.stack_write(0, value);
         Ok(())
@@ -26,7 +28,7 @@ impl FastProcessor {
     ) -> Result<(), ExecutionError> {
         let word: Word = host
             .advice_provider_mut()
-            .pop_stack_word(ProcessState::new_fast(self, op_idx))?;
+            .pop_stack_word(ProcessState::new_fast(self, op_idx), &ErrorContext::default())?;
         self.stack_write_word(0, &word);
 
         Ok(())
@@ -111,7 +113,7 @@ impl FastProcessor {
         // pop two words from the advice stack
         let words = host
             .advice_provider_mut()
-            .pop_stack_dword(ProcessState::new_fast(self, op_idx))?;
+            .pop_stack_dword(ProcessState::new_fast(self, op_idx), &ErrorContext::default())?;
 
         // write the words to memory
         self.memory.write_word(self.ctx, addr_first_word, self.clk + op_idx, words[0])?;

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -559,9 +559,12 @@ impl FastProcessor {
         match program.find_procedure_root(callee_hash.into()) {
             Some(callee_id) => self.execute_mast_node(callee_id, program, kernel, host)?,
             None => {
-                let mast_forest = host
-                    .get_mast_forest(&callee_hash.into())
-                    .ok_or_else(|| ExecutionError::DynamicNodeNotFound(callee_hash.into()))?;
+                let mast_forest = host.get_mast_forest(&callee_hash.into()).ok_or_else(|| {
+                    ExecutionError::dynamic_node_not_found(
+                        callee_hash.into(),
+                        &ErrorContext::default(),
+                    )
+                })?;
 
                 // We limit the parts of the program that can be called externally to procedure
                 // roots, even though MAST doesn't have that restriction.

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -569,7 +569,10 @@ impl FastProcessor {
                 // We limit the parts of the program that can be called externally to procedure
                 // roots, even though MAST doesn't have that restriction.
                 let root_id = mast_forest.find_procedure_root(callee_hash.into()).ok_or(
-                    ExecutionError::MalformedMastForestInHost { root_digest: callee_hash.into() },
+                    ExecutionError::malfored_mast_forest_in_host(
+                        callee_hash.into(),
+                        &ErrorContext::default(),
+                    ),
                 )?;
 
                 self.execute_mast_node(root_id, &mast_forest, kernel, host)?

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -16,7 +16,7 @@ use vm_core::{
 
 use crate::{
     ContextId, ExecutionError, FMP_MIN, Host, ProcessState, SYSCALL_FMP_MIN, errors::ErrorContext,
-    operations::utils::assert_binary, utils::resolve_external_node,
+    utils::resolve_external_node,
 };
 
 mod memory;
@@ -414,7 +414,7 @@ impl FastProcessor {
         } else if condition == ZERO {
             self.execute_mast_node(split_node.on_false(), program, kernel, host)
         } else {
-            Err(ExecutionError::NotBinaryValue(condition))
+            Err(ExecutionError::not_binary_value_if(condition, &ErrorContext::default()))
         };
 
         // Corresponds to the row inserted for the END operation added to the trace.
@@ -462,7 +462,7 @@ impl FastProcessor {
         if condition == ZERO {
             Ok(())
         } else {
-            Err(ExecutionError::NotBinaryValue(condition))
+            Err(ExecutionError::not_binary_value_loop(condition, &ErrorContext::default()))
         }
     }
 

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -492,7 +492,10 @@ impl FastProcessor {
         if call_node.is_syscall() {
             // check if the callee is in the kernel
             if !kernel.contains_proc(callee_hash) {
-                return Err(ExecutionError::SyscallTargetNotInKernel(callee_hash));
+                return Err(ExecutionError::syscall_target_not_in_kernel(
+                    callee_hash,
+                    &ErrorContext::default(),
+                ));
             }
 
             // set the system registers to the syscall context

--- a/processor/src/fast/stack_ops.rs
+++ b/processor/src/fast/stack_ops.rs
@@ -1,7 +1,7 @@
 use vm_core::{WORD_SIZE, ZERO};
 
 use super::FastProcessor;
-use crate::ExecutionError;
+use crate::{ErrorContext, ExecutionError};
 
 impl FastProcessor {
     /// Analogous to `Process::op_pad`.
@@ -109,7 +109,12 @@ impl FastProcessor {
             1 => {
                 self.stack_swap(0, 1);
             },
-            _ => return Err(ExecutionError::NotBinaryValue(condition)),
+            _ => {
+                return Err(ExecutionError::not_binary_value_op(
+                    condition,
+                    &ErrorContext::default(),
+                ));
+            },
         }
 
         Ok(())
@@ -130,7 +135,12 @@ impl FastProcessor {
                 self.stack_swap(2, 6);
                 self.stack_swap(3, 7);
             },
-            _ => return Err(ExecutionError::NotBinaryValue(condition)),
+            _ => {
+                return Err(ExecutionError::not_binary_value_op(
+                    condition,
+                    &ErrorContext::default(),
+                ));
+            },
         }
 
         Ok(())

--- a/processor/src/fast/sys_ops.rs
+++ b/processor/src/fast/sys_ops.rs
@@ -2,16 +2,9 @@ use vm_core::{ZERO, sys_events::SystemEvent};
 
 use super::{ExecutionError, FastProcessor, ONE};
 use crate::{
-    FMP_MIN, Host, ProcessState,
     operations::sys_ops::sys_event_handlers::{
-        HDWORD_TO_MAP_WITH_DOMAIN_DOMAIN_OFFSET, copy_map_value_to_adv_stack,
-        copy_merkle_node_to_adv_stack, insert_hdword_into_adv_map, insert_hperm_into_adv_map,
-        insert_mem_values_into_adv_map, merge_merkle_nodes, push_ext2_intt_result,
-        push_ext2_inv_result, push_falcon_mod_result, push_ilog2, push_leading_ones,
-        push_leading_zeros, push_smtpeek_result, push_trailing_ones, push_trailing_zeros,
-        push_u64_div_result,
-    },
-    system::FMP_MAX,
+        copy_map_value_to_adv_stack, copy_merkle_node_to_adv_stack, insert_hdword_into_adv_map, insert_hperm_into_adv_map, insert_mem_values_into_adv_map, merge_merkle_nodes, push_ext2_intt_result, push_ext2_inv_result, push_falcon_mod_result, push_ilog2, push_leading_ones, push_leading_zeros, push_smtpeek_result, push_trailing_ones, push_trailing_zeros, push_u64_div_result, HDWORD_TO_MAP_WITH_DOMAIN_DOMAIN_OFFSET
+    }, system::FMP_MAX, ErrorContext, Host, ProcessState, FMP_MIN
 };
 
 impl FastProcessor {
@@ -23,7 +16,7 @@ impl FastProcessor {
         host: &mut impl Host,
     ) -> Result<(), ExecutionError> {
         if self.stack_get(0) != ONE {
-            return Err(host.on_assert_failed(ProcessState::new_fast(self, op_idx), err_code));
+            return Err(host.on_assert_failed(ProcessState::new_fast(self, op_idx), err_code, &ErrorContext::default()));
         }
 
         self.decrement_stack_size();
@@ -90,7 +83,7 @@ impl FastProcessor {
         if let Some(system_event) = SystemEvent::from_event_id(event_id) {
             self.handle_system_event(system_event, op_idx, host)
         } else {
-            host.on_event(ProcessState::new_fast(self, op_idx), event_id)
+            host.on_event(ProcessState::new_fast(self, op_idx), event_id, &ErrorContext::default())
         }
     }
 
@@ -108,24 +101,24 @@ impl FastProcessor {
         match system_event {
             SystemEvent::MerkleNodeMerge => merge_merkle_nodes(advice_provider, process_state),
             SystemEvent::MerkleNodeToStack => {
-                copy_merkle_node_to_adv_stack(advice_provider, process_state)
+                copy_merkle_node_to_adv_stack(advice_provider, process_state, &ErrorContext::default())
             },
             SystemEvent::MapValueToStack => {
-                copy_map_value_to_adv_stack(advice_provider, process_state, false)
+                copy_map_value_to_adv_stack(advice_provider, process_state, false, &ErrorContext::default())
             },
             SystemEvent::MapValueToStackN => {
-                copy_map_value_to_adv_stack(advice_provider, process_state, true)
+                copy_map_value_to_adv_stack(advice_provider, process_state, true, &ErrorContext::default())
             },
-            SystemEvent::U64Div => push_u64_div_result(advice_provider, process_state),
-            SystemEvent::FalconDiv => push_falcon_mod_result(advice_provider, process_state),
-            SystemEvent::Ext2Inv => push_ext2_inv_result(advice_provider, process_state),
-            SystemEvent::Ext2Intt => push_ext2_intt_result(advice_provider, process_state),
-            SystemEvent::SmtPeek => push_smtpeek_result(advice_provider, process_state),
-            SystemEvent::U32Clz => push_leading_zeros(advice_provider, process_state),
-            SystemEvent::U32Ctz => push_trailing_zeros(advice_provider, process_state),
-            SystemEvent::U32Clo => push_leading_ones(advice_provider, process_state),
-            SystemEvent::U32Cto => push_trailing_ones(advice_provider, process_state),
-            SystemEvent::ILog2 => push_ilog2(advice_provider, process_state),
+            SystemEvent::U64Div => push_u64_div_result(advice_provider, process_state, &ErrorContext::default()),
+            SystemEvent::FalconDiv => push_falcon_mod_result(advice_provider, process_state, &ErrorContext::default()),
+            SystemEvent::Ext2Inv => push_ext2_inv_result(advice_provider, process_state, &ErrorContext::default()),
+            SystemEvent::Ext2Intt => push_ext2_intt_result(advice_provider, process_state, &ErrorContext::default()),
+            SystemEvent::SmtPeek => push_smtpeek_result(advice_provider, process_state, &ErrorContext::default()),
+            SystemEvent::U32Clz => push_leading_zeros(advice_provider, process_state, &ErrorContext::default()),
+            SystemEvent::U32Ctz => push_trailing_zeros(advice_provider, process_state, &ErrorContext::default()),
+            SystemEvent::U32Clo => push_leading_ones(advice_provider, process_state, &ErrorContext::default()),
+            SystemEvent::U32Cto => push_trailing_ones(advice_provider, process_state, &ErrorContext::default()),
+            SystemEvent::ILog2 => push_ilog2(advice_provider, process_state, &ErrorContext::default()),
 
             SystemEvent::MemToMap => insert_mem_values_into_adv_map(advice_provider, process_state),
             SystemEvent::HdwordToMap => {

--- a/processor/src/fast/sys_ops.rs
+++ b/processor/src/fast/sys_ops.rs
@@ -2,9 +2,16 @@ use vm_core::{ZERO, sys_events::SystemEvent};
 
 use super::{ExecutionError, FastProcessor, ONE};
 use crate::{
+    ErrorContext, FMP_MIN, Host, ProcessState,
     operations::sys_ops::sys_event_handlers::{
-        copy_map_value_to_adv_stack, copy_merkle_node_to_adv_stack, insert_hdword_into_adv_map, insert_hperm_into_adv_map, insert_mem_values_into_adv_map, merge_merkle_nodes, push_ext2_intt_result, push_ext2_inv_result, push_falcon_mod_result, push_ilog2, push_leading_ones, push_leading_zeros, push_smtpeek_result, push_trailing_ones, push_trailing_zeros, push_u64_div_result, HDWORD_TO_MAP_WITH_DOMAIN_DOMAIN_OFFSET
-    }, system::FMP_MAX, ErrorContext, Host, ProcessState, FMP_MIN
+        HDWORD_TO_MAP_WITH_DOMAIN_DOMAIN_OFFSET, copy_map_value_to_adv_stack,
+        copy_merkle_node_to_adv_stack, insert_hdword_into_adv_map, insert_hperm_into_adv_map,
+        insert_mem_values_into_adv_map, merge_merkle_nodes, push_ext2_intt_result,
+        push_ext2_inv_result, push_falcon_mod_result, push_ilog2, push_leading_ones,
+        push_leading_zeros, push_smtpeek_result, push_trailing_ones, push_trailing_zeros,
+        push_u64_div_result,
+    },
+    system::FMP_MAX,
 };
 
 impl FastProcessor {
@@ -16,7 +23,11 @@ impl FastProcessor {
         host: &mut impl Host,
     ) -> Result<(), ExecutionError> {
         if self.stack_get(0) != ONE {
-            return Err(host.on_assert_failed(ProcessState::new_fast(self, op_idx), err_code, &ErrorContext::default()));
+            return Err(host.on_assert_failed(
+                ProcessState::new_fast(self, op_idx),
+                err_code,
+                &ErrorContext::default(),
+            ));
         }
 
         self.decrement_stack_size();
@@ -99,26 +110,56 @@ impl FastProcessor {
         let advice_provider = host.advice_provider_mut();
         let process_state = ProcessState::new_fast(self, op_idx);
         match system_event {
-            SystemEvent::MerkleNodeMerge => merge_merkle_nodes(advice_provider, process_state),
-            SystemEvent::MerkleNodeToStack => {
-                copy_merkle_node_to_adv_stack(advice_provider, process_state, &ErrorContext::default())
+            SystemEvent::MerkleNodeMerge => {
+                merge_merkle_nodes(advice_provider, process_state, &ErrorContext::default())
             },
-            SystemEvent::MapValueToStack => {
-                copy_map_value_to_adv_stack(advice_provider, process_state, false, &ErrorContext::default())
+            SystemEvent::MerkleNodeToStack => copy_merkle_node_to_adv_stack(
+                advice_provider,
+                process_state,
+                &ErrorContext::default(),
+            ),
+            SystemEvent::MapValueToStack => copy_map_value_to_adv_stack(
+                advice_provider,
+                process_state,
+                false,
+                &ErrorContext::default(),
+            ),
+            SystemEvent::MapValueToStackN => copy_map_value_to_adv_stack(
+                advice_provider,
+                process_state,
+                true,
+                &ErrorContext::default(),
+            ),
+            SystemEvent::U64Div => {
+                push_u64_div_result(advice_provider, process_state, &ErrorContext::default())
             },
-            SystemEvent::MapValueToStackN => {
-                copy_map_value_to_adv_stack(advice_provider, process_state, true, &ErrorContext::default())
+            SystemEvent::FalconDiv => {
+                push_falcon_mod_result(advice_provider, process_state, &ErrorContext::default())
             },
-            SystemEvent::U64Div => push_u64_div_result(advice_provider, process_state, &ErrorContext::default()),
-            SystemEvent::FalconDiv => push_falcon_mod_result(advice_provider, process_state, &ErrorContext::default()),
-            SystemEvent::Ext2Inv => push_ext2_inv_result(advice_provider, process_state, &ErrorContext::default()),
-            SystemEvent::Ext2Intt => push_ext2_intt_result(advice_provider, process_state, &ErrorContext::default()),
-            SystemEvent::SmtPeek => push_smtpeek_result(advice_provider, process_state, &ErrorContext::default()),
-            SystemEvent::U32Clz => push_leading_zeros(advice_provider, process_state, &ErrorContext::default()),
-            SystemEvent::U32Ctz => push_trailing_zeros(advice_provider, process_state, &ErrorContext::default()),
-            SystemEvent::U32Clo => push_leading_ones(advice_provider, process_state, &ErrorContext::default()),
-            SystemEvent::U32Cto => push_trailing_ones(advice_provider, process_state, &ErrorContext::default()),
-            SystemEvent::ILog2 => push_ilog2(advice_provider, process_state, &ErrorContext::default()),
+            SystemEvent::Ext2Inv => {
+                push_ext2_inv_result(advice_provider, process_state, &ErrorContext::default())
+            },
+            SystemEvent::Ext2Intt => {
+                push_ext2_intt_result(advice_provider, process_state, &ErrorContext::default())
+            },
+            SystemEvent::SmtPeek => {
+                push_smtpeek_result(advice_provider, process_state, &ErrorContext::default())
+            },
+            SystemEvent::U32Clz => {
+                push_leading_zeros(advice_provider, process_state, &ErrorContext::default())
+            },
+            SystemEvent::U32Ctz => {
+                push_trailing_zeros(advice_provider, process_state, &ErrorContext::default())
+            },
+            SystemEvent::U32Clo => {
+                push_leading_ones(advice_provider, process_state, &ErrorContext::default())
+            },
+            SystemEvent::U32Cto => {
+                push_trailing_ones(advice_provider, process_state, &ErrorContext::default())
+            },
+            SystemEvent::ILog2 => {
+                push_ilog2(advice_provider, process_state, &ErrorContext::default())
+            },
 
             SystemEvent::MemToMap => insert_mem_values_into_adv_map(advice_provider, process_state),
             SystemEvent::HdwordToMap => {

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -231,7 +231,10 @@ fn test_syscall_fail() {
     let err = processor.execute(&program, &mut host).unwrap_err();
 
     // Check that the error is due to the syscall target not being in the kernel
-    assert_matches!(err, ExecutionError::SyscallTargetNotInKernel(_));
+    assert_matches!(
+        err,
+        ExecutionError::SyscallTargetNotInKernel { label: _, source_file: _, proc_root: _ }
+    );
 }
 
 #[test]

--- a/processor/src/fast/u32_ops.rs
+++ b/processor/src/fast/u32_ops.rs
@@ -35,13 +35,25 @@ impl FastProcessor {
 
             // Check that a, b, and c are u32 values.
             if a > u32::MAX as u64 {
-                return Err(ExecutionError::NotU32Value(Felt::new(a), ZERO));
+                return Err(ExecutionError::not_u32_value(
+                    Felt::new(a),
+                    ZERO,
+                    &ErrorContext::default(),
+                ));
             }
             if b > u32::MAX as u64 {
-                return Err(ExecutionError::NotU32Value(Felt::new(b), ZERO));
+                return Err(ExecutionError::not_u32_value(
+                    Felt::new(b),
+                    ZERO,
+                    &ErrorContext::default(),
+                ));
             }
             if c > u32::MAX as u64 {
-                return Err(ExecutionError::NotU32Value(Felt::new(c), ZERO));
+                return Err(ExecutionError::not_u32_value(
+                    Felt::new(c),
+                    ZERO,
+                    &ErrorContext::default(),
+                ));
             }
             let result = Felt::new(a + b + c);
             split_element(result)
@@ -83,13 +95,25 @@ impl FastProcessor {
 
             // Check that a, b, and c are u32 values.
             if b > u32::MAX as u64 {
-                return Err(ExecutionError::NotU32Value(Felt::new(a), ZERO));
+                return Err(ExecutionError::not_u32_value(
+                    Felt::new(a),
+                    ZERO,
+                    &ErrorContext::default(),
+                ));
             }
             if a > u32::MAX as u64 {
-                return Err(ExecutionError::NotU32Value(Felt::new(b), ZERO));
+                return Err(ExecutionError::not_u32_value(
+                    Felt::new(b),
+                    ZERO,
+                    &ErrorContext::default(),
+                ));
             }
             if c > u32::MAX as u64 {
-                return Err(ExecutionError::NotU32Value(Felt::new(c), ZERO));
+                return Err(ExecutionError::not_u32_value(
+                    Felt::new(c),
+                    ZERO,
+                    &ErrorContext::default(),
+                ));
             }
             let result = Felt::new(a * b + c);
             split_element(result)
@@ -147,10 +171,18 @@ impl FastProcessor {
 
         // Check that a and b are u32 values.
         if b > u32::MAX as u64 {
-            return Err(ExecutionError::NotU32Value(Felt::new(b), ZERO));
+            return Err(ExecutionError::not_u32_value(
+                Felt::new(b),
+                ZERO,
+                &ErrorContext::default(),
+            ));
         }
         if a > u32::MAX as u64 {
-            return Err(ExecutionError::NotU32Value(Felt::new(a), ZERO));
+            return Err(ExecutionError::not_u32_value(
+                Felt::new(a),
+                ZERO,
+                &ErrorContext::default(),
+            ));
         }
 
         let result = f(a, b);
@@ -180,10 +212,18 @@ impl FastProcessor {
 
         // Check that a and b are u32 values.
         if a > u32::MAX as u64 {
-            return Err(ExecutionError::NotU32Value(Felt::new(a), ZERO));
+            return Err(ExecutionError::not_u32_value(
+                Felt::new(a),
+                ZERO,
+                &ErrorContext::default(),
+            ));
         }
         if b > u32::MAX as u64 {
-            return Err(ExecutionError::NotU32Value(Felt::new(b), ZERO));
+            return Err(ExecutionError::not_u32_value(
+                Felt::new(b),
+                ZERO,
+                &ErrorContext::default(),
+            ));
         }
 
         let result = Felt::new(f(a, b));
@@ -209,10 +249,18 @@ impl FastProcessor {
 
         // Check that a and b are u32 values.
         if first_old > u32::MAX as u64 {
-            return Err(ExecutionError::NotU32Value(Felt::new(first_old), Felt::from(err_code)));
+            return Err(ExecutionError::not_u32_value(
+                Felt::new(first_old),
+                Felt::from(err_code),
+                &ErrorContext::default(),
+            ));
         }
         if second_old > u32::MAX as u64 {
-            return Err(ExecutionError::NotU32Value(Felt::new(second_old), Felt::from(err_code)));
+            return Err(ExecutionError::not_u32_value(
+                Felt::new(second_old),
+                Felt::from(err_code),
+                &ErrorContext::default(),
+            ));
         }
 
         let (first_new, second_new) = f(first_old, second_old)?;

--- a/processor/src/fast/u32_ops.rs
+++ b/processor/src/fast/u32_ops.rs
@@ -1,7 +1,7 @@
 use vm_core::{Felt, ZERO};
 
 use super::FastProcessor;
-use crate::{ExecutionError, utils::split_element};
+use crate::{ErrorContext, ExecutionError, utils::split_element};
 
 impl FastProcessor {
     /// Analogous to `Process::op_u32split`.
@@ -107,7 +107,7 @@ impl FastProcessor {
         let clk = self.clk + op_idx;
         self.u32_pop2_applyfn_push_results(0, |first, second| {
             if first == 0 {
-                return Err(ExecutionError::DivideByZero(clk));
+                return Err(ExecutionError::divide_by_zero(clk, &ErrorContext::default()));
             }
 
             // a/b = n*q + r for some n>=0 and 0<=r<b

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -3,9 +3,10 @@ use alloc::vec::Vec;
 use vm_core::{
     Felt,
     crypto::{hash::RpoDigest, merkle::MerklePath},
+    mast::MastNodeExt,
 };
 
-use crate::{ExecutionError, ProcessState, Word};
+use crate::{ErrorContext, ExecutionError, ProcessState, Word};
 
 mod inputs;
 pub use inputs::AdviceInputs;
@@ -70,7 +71,11 @@ pub trait AdviceProvider: Sized {
     ///
     /// # Errors
     /// Returns an error if the value specified by the advice source cannot be obtained.
-    fn push_stack(&mut self, source: AdviceSource) -> Result<(), ExecutionError>;
+    fn push_stack(
+        &mut self,
+        source: AdviceSource,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError>;
 
     // ADVICE MAP
     // --------------------------------------------------------------------------------------------

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -115,8 +115,13 @@ pub trait AdviceProvider: Sized {
     /// - The specified depth is either zero or greater than the depth of the Merkle tree identified
     ///   by the specified root.
     /// - Value of the node at the specified depth and index is not known to this advice provider.
-    fn get_tree_node(&self, root: Word, depth: &Felt, index: &Felt)
-    -> Result<Word, ExecutionError>;
+    fn get_tree_node(
+        &self,
+        root: Word,
+        depth: &Felt,
+        index: &Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Word, ExecutionError>;
 
     /// Returns a path to a node at the specified depth and index in a Merkle tree with the
     /// specified root.
@@ -132,6 +137,7 @@ pub trait AdviceProvider: Sized {
         root: Word,
         depth: &Felt,
         index: &Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<MerklePath, ExecutionError>;
 
     /// Reconstructs a path from the root until a leaf or empty node and returns its depth.
@@ -147,6 +153,7 @@ pub trait AdviceProvider: Sized {
         root: Word,
         tree_depth: &Felt,
         index: &Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<u8, ExecutionError>;
 
     /// Updates a node at the specified depth and index in a Merkle tree with the specified root;
@@ -168,6 +175,7 @@ pub trait AdviceProvider: Sized {
         depth: &Felt,
         index: &Felt,
         value: Word,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<(MerklePath, Word), ExecutionError>;
 
     /// Creates a new Merkle tree in the advice provider by combining Merkle trees with the
@@ -178,5 +186,10 @@ pub trait AdviceProvider: Sized {
     ///
     /// It is not checked whether a Merkle tree for either of the specified roots can be found in
     /// this advice provider.
-    fn merge_roots(&mut self, lhs: Word, rhs: Word) -> Result<Word, ExecutionError>;
+    fn merge_roots(
+        &mut self,
+        lhs: Word,
+        rhs: Word,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Word, ExecutionError>;
 }

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -46,7 +46,11 @@ pub trait AdviceProvider: Sized {
     ///
     /// # Errors
     /// Returns an error if the advice stack is empty.
-    fn pop_stack(&mut self, process: ProcessState) -> Result<Felt, ExecutionError>;
+    fn pop_stack(
+        &mut self,
+        process: ProcessState,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Felt, ExecutionError>;
 
     /// Pops a word (4 elements) from the advice stack and returns it.
     ///
@@ -55,7 +59,11 @@ pub trait AdviceProvider: Sized {
     ///
     /// # Errors
     /// Returns an error if the advice stack does not contain a full word.
-    fn pop_stack_word(&mut self, process: ProcessState) -> Result<Word, ExecutionError>;
+    fn pop_stack_word(
+        &mut self,
+        process: ProcessState,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Word, ExecutionError>;
 
     /// Pops a double word (8 elements) from the advice stack and returns them.
     ///
@@ -65,7 +73,11 @@ pub trait AdviceProvider: Sized {
     ///
     /// # Errors
     /// Returns an error if the advice stack does not contain two words.
-    fn pop_stack_dword(&mut self, process: ProcessState) -> Result<[Word; 2], ExecutionError>;
+    fn pop_stack_dword(
+        &mut self,
+        process: ProcessState,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<[Word; 2], ExecutionError>;
 
     /// Pushes the value(s) specified by the source onto the advice stack.
     ///

--- a/processor/src/host/advice/providers.rs
+++ b/processor/src/host/advice/providers.rs
@@ -201,7 +201,7 @@ where
         self.store
             .set_node(root.into(), node_index, value.into())
             .map(|root| (root.path, root.root.into()))
-            .map_err(ExecutionError::MerkleStoreUpdateFailed)
+            .map_err(|err| ExecutionError::merkle_store_update_failed(err, err_ctx))
     }
 
     fn merge_roots(

--- a/processor/src/host/advice/providers.rs
+++ b/processor/src/host/advice/providers.rs
@@ -213,7 +213,7 @@ where
         self.store
             .merge_roots(lhs.into(), rhs.into())
             .map(|v| v.into())
-            .map_err(ExecutionError::MerkleStoreMergeFailed)
+            .map_err(|err| ExecutionError::merkle_store_merge_failed(err, err_ctx))
     }
 }
 

--- a/processor/src/host/advice/providers.rs
+++ b/processor/src/host/advice/providers.rs
@@ -149,6 +149,7 @@ where
         root: Word,
         depth: &Felt,
         index: &Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<Word, ExecutionError> {
         let index = NodeIndex::from_elements(depth, index).map_err(|_| {
             ExecutionError::InvalidMerkleTreeNodeIndex { depth: *depth, value: *index }
@@ -164,6 +165,7 @@ where
         root: Word,
         depth: &Felt,
         index: &Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<MerklePath, ExecutionError> {
         let index = NodeIndex::from_elements(depth, index).map_err(|_| {
             ExecutionError::InvalidMerkleTreeNodeIndex { depth: *depth, value: *index }
@@ -179,6 +181,7 @@ where
         root: Word,
         tree_depth: &Felt,
         index: &Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<u8, ExecutionError> {
         let tree_depth = u8::try_from(tree_depth.as_int())
             .map_err(|_| ExecutionError::InvalidMerkleTreeDepth { depth: *tree_depth })?;
@@ -193,6 +196,7 @@ where
         depth: &Felt,
         index: &Felt,
         value: Word,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<(MerklePath, Word), ExecutionError> {
         let node_index = NodeIndex::from_elements(depth, index).map_err(|_| {
             ExecutionError::InvalidMerkleTreeNodeIndex { depth: *depth, value: *index }
@@ -203,7 +207,12 @@ where
             .map_err(ExecutionError::MerkleStoreUpdateFailed)
     }
 
-    fn merge_roots(&mut self, lhs: Word, rhs: Word) -> Result<Word, ExecutionError> {
+    fn merge_roots(
+        &mut self,
+        lhs: Word,
+        rhs: Word,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Word, ExecutionError> {
         self.store
             .merge_roots(lhs.into(), rhs.into())
             .map(|v| v.into())
@@ -286,24 +295,34 @@ impl AdviceProvider for MemAdviceProvider {
         self.provider.get_mapped_values(key)
     }
 
-    fn get_tree_node(&self, root: Word, depth: &Felt, index: &Felt) -> Result<Word, ExecutionError> {
-        self.provider.get_tree_node(root, depth, index)
+    fn get_tree_node(&self, root: Word, depth: &Felt, index: &Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Word, ExecutionError> {
+        self.provider.get_tree_node(root, depth, index, err_ctx)
     }
 
-    fn get_merkle_path(&self, root: Word, depth: &Felt, index: &Felt) -> Result<MerklePath, ExecutionError> {
-        self.provider.get_merkle_path(root, depth, index)
+    fn get_merkle_path(&self, root: Word, depth: &Felt, index: &Felt, 
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<MerklePath, ExecutionError> {
+        self.provider.get_merkle_path(root, depth, index, err_ctx)
     }
 
-    fn get_leaf_depth(&self, root: Word, tree_depth: &Felt, index: &Felt) -> Result<u8, ExecutionError> {
-        self.provider.get_leaf_depth(root, tree_depth, index)
+    fn get_leaf_depth(&self, root: Word, tree_depth: &Felt, index: &Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<u8, ExecutionError> {
+        self.provider.get_leaf_depth(root, tree_depth, index, err_ctx)
     }
 
-    fn update_merkle_node(&mut self, root: Word, depth: &Felt, index: &Felt, value: Word) -> Result<(MerklePath, Word), ExecutionError> {
-        self.provider.update_merkle_node(root, depth, index, value)
+    fn update_merkle_node(&mut self, root: Word, depth: &Felt, index: &Felt, value: Word,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(MerklePath, Word), ExecutionError> {
+        self.provider.update_merkle_node(root, depth, index, value, err_ctx)
     }
 
-    fn merge_roots(&mut self, lhs: Word, rhs: Word) -> Result<Word, ExecutionError> {
-        self.provider.merge_roots(lhs, rhs)
+    fn merge_roots(&mut self, lhs: Word, rhs: Word,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Word, ExecutionError> {
+        self.provider.merge_roots(lhs, rhs, err_ctx)
     }
 }
 
@@ -398,24 +417,34 @@ impl AdviceProvider for RecAdviceProvider {
         self.provider.get_mapped_values(key)
     }
 
-    fn get_tree_node(&self, root: Word, depth: &Felt, index: &Felt) -> Result<Word, ExecutionError> {
-        self.provider.get_tree_node(root, depth, index)
+    fn get_tree_node(&self, root: Word, depth: &Felt, index: &Felt,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Word, ExecutionError> {
+        self.provider.get_tree_node(root, depth, index, err_ctx)
     }
 
-    fn get_merkle_path(&self, root: Word, depth: &Felt, index: &Felt) -> Result<MerklePath, ExecutionError> {
-        self.provider.get_merkle_path(root, depth, index)
+    fn get_merkle_path(&self, root: Word, depth: &Felt, index: &Felt, 
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<MerklePath, ExecutionError> {
+        self.provider.get_merkle_path(root, depth, index, err_ctx)
     }
 
-    fn get_leaf_depth(&self, root: Word, tree_depth: &Felt, index: &Felt) -> Result<u8, ExecutionError> {
-        self.provider.get_leaf_depth(root, tree_depth, index)
+    fn get_leaf_depth(&self, root: Word, tree_depth: &Felt, index: &Felt, 
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<u8, ExecutionError> {
+        self.provider.get_leaf_depth(root, tree_depth, index, err_ctx)
     }
 
-    fn update_merkle_node(&mut self, root: Word, depth: &Felt, index: &Felt, value: Word) -> Result<(MerklePath, Word), ExecutionError> {
-        self.provider.update_merkle_node(root, depth, index, value)
+    fn update_merkle_node(&mut self, root: Word, depth: &Felt, index: &Felt, value: Word,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(MerklePath, Word), ExecutionError> {
+        self.provider.update_merkle_node(root, depth, index, value, err_ctx)
     }
 
-    fn merge_roots(&mut self, lhs: Word, rhs: Word) -> Result<Word, ExecutionError> {
-        self.provider.merge_roots(lhs, rhs)
+    fn merge_roots(&mut self, lhs: Word, rhs: Word,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Word, ExecutionError> {
+        self.provider.merge_roots(lhs, rhs, err_ctx)
     }
 }
 

--- a/processor/src/host/advice/providers.rs
+++ b/processor/src/host/advice/providers.rs
@@ -184,7 +184,7 @@ where
         err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<u8, ExecutionError> {
         let tree_depth = u8::try_from(tree_depth.as_int())
-            .map_err(|_| ExecutionError::InvalidMerkleTreeDepth { depth: *tree_depth })?;
+            .map_err(|_| ExecutionError::invalid_merkle_tree_depth(*tree_depth, err_ctx))?;
         self.store
             .get_leaf_depth(root.into(), tree_depth, index.as_int())
             .map_err(ExecutionError::MerkleStoreLookupFailed)

--- a/processor/src/host/advice/providers.rs
+++ b/processor/src/host/advice/providers.rs
@@ -62,13 +62,23 @@ where
     // ADVICE STACK
     // --------------------------------------------------------------------------------------------
 
-    fn pop_stack(&mut self, process: ProcessState) -> Result<Felt, ExecutionError> {
-        self.stack.pop().ok_or(ExecutionError::AdviceStackReadFailed(process.clk()))
+    fn pop_stack(
+        &mut self,
+        process: ProcessState,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Felt, ExecutionError> {
+        self.stack
+            .pop()
+            .ok_or(ExecutionError::advice_stack_read_failed(process.clk(), err_ctx))
     }
 
-    fn pop_stack_word(&mut self, process: ProcessState) -> Result<Word, ExecutionError> {
+    fn pop_stack_word(
+        &mut self,
+        process: ProcessState,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Word, ExecutionError> {
         if self.stack.len() < 4 {
-            return Err(ExecutionError::AdviceStackReadFailed(process.clk()));
+            return Err(ExecutionError::advice_stack_read_failed(process.clk(), err_ctx));
         }
 
         let idx = self.stack.len() - 4;
@@ -80,9 +90,13 @@ where
         Ok(result)
     }
 
-    fn pop_stack_dword(&mut self, process: ProcessState) -> Result<[Word; 2], ExecutionError> {
-        let word0 = self.pop_stack_word(process)?;
-        let word1 = self.pop_stack_word(process)?;
+    fn pop_stack_dword(
+        &mut self,
+        process: ProcessState,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<[Word; 2], ExecutionError> {
+        let word0 = self.pop_stack_word(process, err_ctx)?;
+        let word1 = self.pop_stack_word(process, err_ctx)?;
 
         Ok([word0, word1])
     }
@@ -242,16 +256,22 @@ impl MemAdviceProvider {
 /// TODO: potentially do this via a macro.
 #[rustfmt::skip]
 impl AdviceProvider for MemAdviceProvider {
-    fn pop_stack(&mut self, process: ProcessState)-> Result<Felt, ExecutionError> {
-        self.provider.pop_stack(process)
+    fn pop_stack(&mut self, process: ProcessState,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    )-> Result<Felt, ExecutionError> {
+        self.provider.pop_stack(process, err_ctx)
     }
 
-    fn pop_stack_word(&mut self, process: ProcessState) -> Result<Word, ExecutionError> {
-        self.provider.pop_stack_word(process)
+    fn pop_stack_word(&mut self, process: ProcessState,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Word, ExecutionError> {
+        self.provider.pop_stack_word(process, err_ctx)
     }
 
-    fn pop_stack_dword(&mut self, process: ProcessState) -> Result<[Word; 2], ExecutionError> {
-        self.provider.pop_stack_dword(process)
+    fn pop_stack_dword(&mut self, process: ProcessState,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<[Word; 2], ExecutionError> {
+        self.provider.pop_stack_dword(process, err_ctx)
     }
 
     fn push_stack(&mut self, source: AdviceSource, err_ctx: &ErrorContext<impl MastNodeExt>) -> Result<(), ExecutionError> {
@@ -348,16 +368,22 @@ impl RecAdviceProvider {
 /// TODO: potentially do this via a macro.
 #[rustfmt::skip]
 impl AdviceProvider for RecAdviceProvider {
-    fn pop_stack(&mut self, process: ProcessState) -> Result<Felt, ExecutionError> {
-        self.provider.pop_stack(process)
+    fn pop_stack(&mut self, process: ProcessState,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Felt, ExecutionError> {
+        self.provider.pop_stack(process,err_ctx)
     }
 
-    fn pop_stack_word(&mut self, process: ProcessState) -> Result<Word, ExecutionError> {
-        self.provider.pop_stack_word(process)
+    fn pop_stack_word(&mut self, process: ProcessState, 
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<Word, ExecutionError> {
+        self.provider.pop_stack_word(process,err_ctx)
     }
 
-    fn pop_stack_dword(&mut self, process: ProcessState) -> Result<[Word; 2], ExecutionError> {
-        self.provider.pop_stack_dword(process)
+    fn pop_stack_dword(&mut self, process: ProcessState,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<[Word; 2], ExecutionError> {
+        self.provider.pop_stack_dword(process, err_ctx)
     }
 
     fn push_stack(&mut self, source: AdviceSource, err_ctx: &ErrorContext<impl MastNodeExt>) -> Result<(), ExecutionError> {

--- a/processor/src/host/advice/providers.rs
+++ b/processor/src/host/advice/providers.rs
@@ -156,7 +156,7 @@ where
         self.store
             .get_node(root.into(), index)
             .map(|v| v.into())
-            .map_err(ExecutionError::MerkleStoreLookupFailed)
+            .map_err(|err| ExecutionError::merkle_store_lookup_failed(err, err_ctx))
     }
 
     fn get_merkle_path(
@@ -171,7 +171,7 @@ where
         self.store
             .get_path(root.into(), index)
             .map(|value| value.path)
-            .map_err(ExecutionError::MerkleStoreLookupFailed)
+            .map_err(|err| ExecutionError::merkle_store_lookup_failed(err, err_ctx))
     }
 
     fn get_leaf_depth(
@@ -185,7 +185,7 @@ where
             .map_err(|_| ExecutionError::invalid_merkle_tree_depth(*tree_depth, err_ctx))?;
         self.store
             .get_leaf_depth(root.into(), tree_depth, index.as_int())
-            .map_err(ExecutionError::MerkleStoreLookupFailed)
+            .map_err(|err| ExecutionError::merkle_store_lookup_failed(err, err_ctx))
     }
 
     fn update_merkle_node(

--- a/processor/src/host/advice/providers.rs
+++ b/processor/src/host/advice/providers.rs
@@ -151,9 +151,8 @@ where
         index: &Felt,
         err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<Word, ExecutionError> {
-        let index = NodeIndex::from_elements(depth, index).map_err(|_| {
-            ExecutionError::InvalidMerkleTreeNodeIndex { depth: *depth, value: *index }
-        })?;
+        let index = NodeIndex::from_elements(depth, index)
+            .map_err(|_| ExecutionError::invalid_merkle_tree_node_index(*depth, *index, err_ctx))?;
         self.store
             .get_node(root.into(), index)
             .map(|v| v.into())
@@ -167,9 +166,8 @@ where
         index: &Felt,
         err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<MerklePath, ExecutionError> {
-        let index = NodeIndex::from_elements(depth, index).map_err(|_| {
-            ExecutionError::InvalidMerkleTreeNodeIndex { depth: *depth, value: *index }
-        })?;
+        let index = NodeIndex::from_elements(depth, index)
+            .map_err(|_| ExecutionError::invalid_merkle_tree_node_index(*depth, *index, err_ctx))?;
         self.store
             .get_path(root.into(), index)
             .map(|value| value.path)
@@ -198,9 +196,8 @@ where
         value: Word,
         err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<(MerklePath, Word), ExecutionError> {
-        let node_index = NodeIndex::from_elements(depth, index).map_err(|_| {
-            ExecutionError::InvalidMerkleTreeNodeIndex { depth: *depth, value: *index }
-        })?;
+        let node_index = NodeIndex::from_elements(depth, index)
+            .map_err(|_| ExecutionError::invalid_merkle_tree_node_index(*depth, *index, err_ctx))?;
         self.store
             .set_node(root.into(), node_index, value.into())
             .map(|root| (root.path, root.root.into()))

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -188,7 +188,11 @@ impl<A: AdviceProvider> DefaultHost<A> {
         for (digest, values) in mast_forest.advice_map().iter() {
             if let Some(stored_values) = self.advice_provider().get_mapped_values(digest) {
                 if stored_values != values {
-                    return Err(ExecutionError::AdviceMapKeyAlreadyPresent(digest.into()));
+                    return Err(ExecutionError::AdviceMapKeyAlreadyPresent {
+                        key: digest.into(),
+                        prev_values: stored_values.to_vec(),
+                        new_values: values.clone(),
+                    });
                 }
             } else {
                 self.advice_provider_mut().insert_into_map(digest.into(), values.clone());

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -48,7 +48,12 @@ pub trait Host {
     // --------------------------------------------------------------------------------------------
 
     /// Handles the event emitted from the VM.
-    fn on_event(&mut self, _process: ProcessState, _event_id: u32) -> Result<(), ExecutionError> {
+    fn on_event(
+        &mut self,
+        _process: ProcessState,
+        _event_id: u32,
+        _err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
         #[cfg(feature = "std")]
         std::println!(
             "Event with id {} emitted at step {} in context {}",
@@ -119,8 +124,13 @@ where
         H::on_debug(self, process, options)
     }
 
-    fn on_event(&mut self, process: ProcessState, event_id: u32) -> Result<(), ExecutionError> {
-        H::on_event(self, process, event_id)
+    fn on_event(
+        &mut self,
+        process: ProcessState,
+        event_id: u32,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
+        H::on_event(self, process, event_id, err_ctx)
     }
 
     fn on_trace(&mut self, process: ProcessState, trace_id: u32) -> Result<(), ExecutionError> {
@@ -219,7 +229,12 @@ impl<A: AdviceProvider> Host for DefaultHost<A> {
         self.store.get(node_digest)
     }
 
-    fn on_event(&mut self, _process: ProcessState, _event_id: u32) -> Result<(), ExecutionError> {
+    fn on_event(
+        &mut self,
+        _process: ProcessState,
+        _event_id: u32,
+        _err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
         #[cfg(feature = "std")]
         std::println!(
             "Event with id {} emitted at step {} in context {}",

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -9,7 +9,6 @@ extern crate std;
 use alloc::{sync::Arc, vec::Vec};
 use core::fmt::{Display, LowerHex};
 
-use errors::ErrorContext;
 use fast::FastProcessor;
 use miden_air::trace::{
     CHIPLETS_WIDTH, DECODER_TRACE_WIDTH, MIN_TRACE_LEN, RANGE_CHECK_TRACE_WIDTH, STACK_TRACE_WIDTH,
@@ -68,7 +67,7 @@ use trace::TraceFragment;
 pub use trace::{ChipletsLengths, ExecutionTrace, NUM_RAND_ROWS, TraceLenSummary};
 
 mod errors;
-pub use errors::{ExecutionError, Ext2InttError};
+pub use errors::{ErrorContext, ExecutionError, Ext2InttError};
 
 pub mod utils;
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -499,9 +499,9 @@ impl Process {
         match program.find_procedure_root(callee_hash.into()) {
             Some(callee_id) => self.execute_mast_node(callee_id, program, host)?,
             None => {
-                let mast_forest = host
-                    .get_mast_forest(&callee_hash.into())
-                    .ok_or_else(|| ExecutionError::DynamicNodeNotFound(callee_hash.into()))?;
+                let mast_forest = host.get_mast_forest(&callee_hash.into()).ok_or_else(|| {
+                    ExecutionError::dynamic_node_not_found(callee_hash.into(), &error_ctx)
+                })?;
 
                 // We limit the parts of the program that can be called externally to procedure
                 // roots, even though MAST doesn't have that restriction.

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -307,7 +307,11 @@ impl Process {
         for (digest, values) in program.mast_forest().advice_map().iter() {
             if let Some(stored_values) = host.advice_provider().get_mapped_values(digest) {
                 if stored_values != values {
-                    return Err(ExecutionError::AdviceMapKeyAlreadyPresent(digest.into()));
+                    return Err(ExecutionError::AdviceMapKeyAlreadyPresent {
+                        key: digest.into(),
+                        prev_values: stored_values.to_vec(),
+                        new_values: values.clone(),
+                    });
                 }
             } else {
                 host.advice_provider_mut().insert_into_map(digest.into(), values.clone());

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -519,7 +519,10 @@ impl Process {
                 // We limit the parts of the program that can be called externally to procedure
                 // roots, even though MAST doesn't have that restriction.
                 let root_id = mast_forest.find_procedure_root(callee_hash.into()).ok_or(
-                    ExecutionError::MalformedMastForestInHost { root_digest: callee_hash.into() },
+                    ExecutionError::malfored_mast_forest_in_host(
+                        callee_hash.into(),
+                        &ErrorContext::default(),
+                    ),
                 )?;
 
                 self.execute_mast_node(root_id, &mast_forest, host)?
@@ -897,7 +900,8 @@ fn add_error_ctx_to_external_error(
         Ok(_) => Ok(()),
         // Add context information to any errors coming from executing an `ExternalNode`
         Err(err) => match err {
-            ExecutionError::NoMastForestWithProcedure { label, source_file: _, root_digest } => {
+            ExecutionError::NoMastForestWithProcedure { label, source_file: _, root_digest }
+            | ExecutionError::MalformedMastForestInHost { label, source_file: _, root_digest } => {
                 if label == SourceSpan::UNKNOWN {
                     let err_with_ctx =
                         ExecutionError::no_mast_forest_with_procedure(root_digest, &err_ctx);

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -476,7 +476,8 @@ impl Process {
             let callee = program.get_node_by_id(call_node.callee()).ok_or_else(|| {
                 ExecutionError::MastNodeNotFoundInForest { node_id: call_node.callee() }
             })?;
-            self.chiplets.kernel_rom.access_proc(callee.digest())?;
+            let err_ctx = ErrorContext::new(program, call_node, self.source_manager.clone());
+            self.chiplets.kernel_rom.access_proc(callee.digest(), &err_ctx)?;
         }
         let err_ctx = ErrorContext::new(program, call_node, self.source_manager.clone());
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -408,7 +408,8 @@ impl Process {
         } else if condition == ZERO {
             self.execute_mast_node(node.on_false(), program, host)?;
         } else {
-            return Err(ExecutionError::NotBinaryValue(condition));
+            let err_ctx = ErrorContext::new(program, node, self.source_manager.clone());
+            return Err(ExecutionError::not_binary_value_if(condition, &err_ctx));
         }
 
         self.end_split_node(node, host)
@@ -440,7 +441,8 @@ impl Process {
             }
 
             if self.stack.peek() != ZERO {
-                return Err(ExecutionError::NotBinaryValue(self.stack.peek()));
+                let err_ctx = ErrorContext::new(program, node, self.source_manager.clone());
+                return Err(ExecutionError::not_binary_value_loop(self.stack.peek(), &err_ctx));
             }
 
             // end the LOOP block and drop the condition from the stack
@@ -450,7 +452,8 @@ impl Process {
             // already dropped when we started the LOOP block
             self.end_loop_node(node, false, host)
         } else {
-            Err(ExecutionError::NotBinaryValue(condition))
+            let err_ctx = ErrorContext::new(program, node, self.source_manager.clone());
+            Err(ExecutionError::not_binary_value_loop(condition, &err_ctx))
         }
     }
 

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -91,12 +91,13 @@ impl Process {
         if root != computed_root {
             // If the hasher chiplet doesn't compute the same root (using the same path),
             // then it means that `node` is not the value currently in the tree at `index`
-            return Err(ExecutionError::MerklePathVerificationFailed {
-                value: node,
+            return Err(ExecutionError::merkle_path_verification_failed(
+                node,
                 index,
-                root: root.into(),
+                root.into(),
                 err_code,
-            });
+                err_ctx,
+            ));
         }
 
         // The same state is copied over to the next clock cycle with no changes.

--- a/processor/src/operations/crypto_ops.rs
+++ b/processor/src/operations/crypto_ops.rs
@@ -1,5 +1,7 @@
+use vm_core::mast::MastNodeExt;
+
 use super::{ExecutionError, Operation, Process};
-use crate::{AdviceProvider, Host};
+use crate::{AdviceProvider, ErrorContext, Host};
 
 // CRYPTOGRAPHIC OPERATIONS
 // ================================================================================================
@@ -67,6 +69,7 @@ impl Process {
         &mut self,
         err_code: u32,
         host: &mut impl Host,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<(), ExecutionError> {
         // read node value, depth, index and root value from the stack
         let node = [self.stack.get(3), self.stack.get(2), self.stack.get(1), self.stack.get(0)];
@@ -76,7 +79,7 @@ impl Process {
 
         // get a Merkle path from the advice provider for the specified root and node index.
         // the path is expected to be of the specified depth.
-        let path = host.advice_provider_mut().get_merkle_path(root, &depth, &index)?;
+        let path = host.advice_provider_mut().get_merkle_path(root, &depth, &index, err_ctx)?;
 
         // use hasher to compute the Merkle root of the path
         let (addr, computed_root) = self.chiplets.hasher.build_merkle_root(node, &path, index);
@@ -134,7 +137,11 @@ impl Process {
     ///
     /// # Panics
     /// Panics if the computed old root does not match the input root provided via the stack.
-    pub(super) fn op_mrupdate(&mut self, host: &mut impl Host) -> Result<(), ExecutionError> {
+    pub(super) fn op_mrupdate(
+        &mut self,
+        host: &mut impl Host,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
         // read old node value, depth, index, tree root and new node values from the stack
         let old_node = [self.stack.get(3), self.stack.get(2), self.stack.get(1), self.stack.get(0)];
         let depth = self.stack.get(4);
@@ -149,7 +156,7 @@ impl Process {
         // whole sub-tree to this node.
         let (path, _) = host
             .advice_provider_mut()
-            .update_merkle_node(old_root, &depth, &index, new_node)?;
+            .update_merkle_node(old_root, &depth, &index, new_node, err_ctx)?;
 
         assert_eq!(path.len(), depth.as_int() as usize);
 

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -1,6 +1,6 @@
 use vm_core::{ONE, Operation, ZERO, mast::MastNodeExt};
 
-use super::{ExecutionError, Felt, FieldElement, Process, utils::assert_binary};
+use super::{ExecutionError, Felt, FieldElement, Process, utils::assert_binary_with_ctx};
 use crate::ErrorContext;
 
 // FIELD OPERATIONS
@@ -78,8 +78,8 @@ impl Process {
         &mut self,
         err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<(), ExecutionError> {
-        let b = assert_binary(self.stack.get(0), err_ctx)?;
-        let a = assert_binary(self.stack.get(1), err_ctx)?;
+        let b = assert_binary_with_ctx(self.stack.get(0), err_ctx)?;
+        let a = assert_binary_with_ctx(self.stack.get(1), err_ctx)?;
         if a == ONE && b == ONE {
             self.stack.set(0, ONE);
         } else {
@@ -99,8 +99,8 @@ impl Process {
         &mut self,
         err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<(), ExecutionError> {
-        let b = assert_binary(self.stack.get(0), err_ctx)?;
-        let a = assert_binary(self.stack.get(1), err_ctx)?;
+        let b = assert_binary_with_ctx(self.stack.get(0), err_ctx)?;
+        let a = assert_binary_with_ctx(self.stack.get(1), err_ctx)?;
         if a == ONE || b == ONE {
             self.stack.set(0, ONE);
         } else {
@@ -119,7 +119,7 @@ impl Process {
         &mut self,
         err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Result<(), ExecutionError> {
-        let a = assert_binary(self.stack.get(0), err_ctx)?;
+        let a = assert_binary_with_ctx(self.stack.get(0), err_ctx)?;
         self.stack.set(0, ONE - a);
         self.stack.copy_state(1);
         Ok(())

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -74,9 +74,12 @@ impl Process {
     /// # Errors
     /// Returns an error if either of the two elements on the top of the stack is not a binary
     /// value.
-    pub(super) fn op_and(&mut self) -> Result<(), ExecutionError> {
-        let b = assert_binary(self.stack.get(0))?;
-        let a = assert_binary(self.stack.get(1))?;
+    pub(super) fn op_and(
+        &mut self,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
+        let b = assert_binary(self.stack.get(0), err_ctx)?;
+        let a = assert_binary(self.stack.get(1), err_ctx)?;
         if a == ONE && b == ONE {
             self.stack.set(0, ONE);
         } else {
@@ -92,9 +95,12 @@ impl Process {
     /// # Errors
     /// Returns an error if either of the two elements on the top of the stack is not a binary
     /// value.
-    pub(super) fn op_or(&mut self) -> Result<(), ExecutionError> {
-        let b = assert_binary(self.stack.get(0))?;
-        let a = assert_binary(self.stack.get(1))?;
+    pub(super) fn op_or(
+        &mut self,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
+        let b = assert_binary(self.stack.get(0), err_ctx)?;
+        let a = assert_binary(self.stack.get(1), err_ctx)?;
         if a == ONE || b == ONE {
             self.stack.set(0, ONE);
         } else {
@@ -109,8 +115,11 @@ impl Process {
     ///
     /// # Errors
     /// Returns an error if the value on the top of the stack is not a binary value.
-    pub(super) fn op_not(&mut self) -> Result<(), ExecutionError> {
-        let a = assert_binary(self.stack.get(0))?;
+    pub(super) fn op_not(
+        &mut self,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
+        let a = assert_binary(self.stack.get(0), err_ctx)?;
         self.stack.set(0, ONE - a);
         self.stack.copy_state(1);
         Ok(())

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -1,6 +1,7 @@
-use vm_core::{ONE, Operation, ZERO};
+use vm_core::{ONE, Operation, ZERO, mast::MastNodeExt};
 
 use super::{ExecutionError, Felt, FieldElement, Process, utils::assert_binary};
+use crate::ErrorContext;
 
 // FIELD OPERATIONS
 // ================================================================================================
@@ -42,10 +43,13 @@ impl Process {
     ///
     /// # Errors
     /// Returns an error if the value on the top of the stack is ZERO.
-    pub(super) fn op_inv(&mut self) -> Result<(), ExecutionError> {
+    pub(super) fn op_inv(
+        &mut self,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
         let a = self.stack.get(0);
         if a == ZERO {
-            return Err(ExecutionError::DivideByZero(self.system.clk()));
+            return Err(ExecutionError::divide_by_zero(self.system.clk(), err_ctx));
         }
 
         self.stack.set(0, a.inv());

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -232,7 +232,7 @@ impl Process {
         let addr_second_word = addr_first_word + Felt::from(WORD_SIZE as u32);
 
         // pop two words from the advice stack
-        let words = host.advice_provider_mut().pop_stack_dword(self.into())?;
+        let words = host.advice_provider_mut().pop_stack_dword(self.into(), error_ctx)?;
 
         // write the words memory
         self.chiplets
@@ -272,8 +272,12 @@ impl Process {
     ///
     /// # Errors
     /// Returns an error if the advice stack is empty.
-    pub(super) fn op_advpop(&mut self, host: &mut impl Host) -> Result<(), ExecutionError> {
-        let value = host.advice_provider_mut().pop_stack(self.into())?;
+    pub(super) fn op_advpop(
+        &mut self,
+        host: &mut impl Host,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
+        let value = host.advice_provider_mut().pop_stack(self.into(), err_ctx)?;
         self.stack.set(0, value);
         self.stack.shift_right(0);
         Ok(())
@@ -284,8 +288,12 @@ impl Process {
     ///
     /// # Errors
     /// Returns an error if the advice stack contains fewer than four elements.
-    pub(super) fn op_advpopw(&mut self, host: &mut impl Host) -> Result<(), ExecutionError> {
-        let word: Word = host.advice_provider_mut().pop_stack_word(self.into())?;
+    pub(super) fn op_advpopw(
+        &mut self,
+        host: &mut impl Host,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
+        let word: Word = host.advice_provider_mut().pop_stack_word(self.into(), err_ctx)?;
 
         self.stack.set(0, word[3]);
         self.stack.set(1, word[2]);

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -562,6 +562,7 @@ mod tests {
 
     #[test]
     fn op_pipe() {
+        let err_ctx = ErrorContext::default();
         let mut host = DefaultHost::default();
         let mut process = Process::new_dummy_with_decoder_helpers_and_empty_stack();
 
@@ -572,7 +573,9 @@ mod tests {
         let word2_felts: Word = word2.to_elements().try_into().unwrap();
         for element in word2_felts.iter().rev().chain(word1_felts.iter().rev()).copied() {
             // reverse the word order, since elements are pushed onto the advice stack.
-            host.advice_provider_mut().push_stack(AdviceSource::Value(element)).unwrap();
+            host.advice_provider_mut()
+                .push_stack(AdviceSource::Value(element), &err_ctx)
+                .unwrap();
         }
 
         // arrange the stack such that:

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -98,16 +98,16 @@ impl Process {
 
             // ----- u32 operations ---------------------------------------------------------------
             Operation::U32split => self.op_u32split()?,
-            Operation::U32add => self.op_u32add()?,
-            Operation::U32add3 => self.op_u32add3()?,
-            Operation::U32sub => self.op_u32sub()?,
-            Operation::U32mul => self.op_u32mul()?,
-            Operation::U32madd => self.op_u32madd()?,
+            Operation::U32add => self.op_u32add(error_ctx)?,
+            Operation::U32add3 => self.op_u32add3(error_ctx)?,
+            Operation::U32sub => self.op_u32sub(error_ctx)?,
+            Operation::U32mul => self.op_u32mul(error_ctx)?,
+            Operation::U32madd => self.op_u32madd(error_ctx)?,
             Operation::U32div => self.op_u32div(error_ctx)?,
 
-            Operation::U32and => self.op_u32and()?,
-            Operation::U32xor => self.op_u32xor()?,
-            Operation::U32assert2(err_code) => self.op_u32assert2(err_code)?,
+            Operation::U32and => self.op_u32and(error_ctx)?,
+            Operation::U32xor => self.op_u32xor(error_ctx)?,
+            Operation::U32assert2(err_code) => self.op_u32assert2(err_code, error_ctx)?,
 
             // ----- stack manipulation -----------------------------------------------------------
             Operation::Pad => self.op_pad()?,

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -168,8 +168,8 @@ impl Process {
 
             // ----- cryptographic operations -----------------------------------------------------
             Operation::HPerm => self.op_hperm()?,
-            Operation::MpVerify(err_code) => self.op_mpverify(err_code, host)?,
-            Operation::MrUpdate => self.op_mrupdate(host)?,
+            Operation::MpVerify(err_code) => self.op_mpverify(err_code, host, error_ctx)?,
+            Operation::MrUpdate => self.op_mrupdate(host, error_ctx)?,
             Operation::FriE2F4 => self.op_fri_ext2fold4()?,
             Operation::HornerBase => self.op_horner_eval_base(error_ctx)?,
             Operation::HornerExt => self.op_horner_eval_ext(error_ctx)?,

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -84,9 +84,9 @@ impl Process {
             Operation::Inv => self.op_inv(error_ctx)?,
             Operation::Incr => self.op_incr()?,
 
-            Operation::And => self.op_and()?,
-            Operation::Or => self.op_or()?,
-            Operation::Not => self.op_not()?,
+            Operation::And => self.op_and(error_ctx)?,
+            Operation::Or => self.op_or(error_ctx)?,
+            Operation::Not => self.op_not(error_ctx)?,
 
             Operation::Eq => self.op_eq()?,
             Operation::Eqz => self.op_eqz()?,
@@ -148,8 +148,8 @@ impl Process {
             Operation::MovDn7 => self.op_movdn(7)?,
             Operation::MovDn8 => self.op_movdn(8)?,
 
-            Operation::CSwap => self.op_cswap()?,
-            Operation::CSwapW => self.op_cswapw()?,
+            Operation::CSwap => self.op_cswap(error_ctx)?,
+            Operation::CSwapW => self.op_cswapw(error_ctx)?,
 
             // ----- input / output ---------------------------------------------------------------
             Operation::Push(value) => self.op_push(value)?,

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -81,7 +81,7 @@ impl Process {
             Operation::Add => self.op_add()?,
             Operation::Neg => self.op_neg()?,
             Operation::Mul => self.op_mul()?,
-            Operation::Inv => self.op_inv()?,
+            Operation::Inv => self.op_inv(error_ctx)?,
             Operation::Incr => self.op_incr()?,
 
             Operation::And => self.op_and()?,
@@ -103,7 +103,7 @@ impl Process {
             Operation::U32sub => self.op_u32sub()?,
             Operation::U32mul => self.op_u32mul()?,
             Operation::U32madd => self.op_u32madd()?,
-            Operation::U32div => self.op_u32div()?,
+            Operation::U32div => self.op_u32div(error_ctx)?,
 
             Operation::U32and => self.op_u32and()?,
             Operation::U32xor => self.op_u32xor()?,

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -51,7 +51,7 @@ impl Process {
         match op {
             // ----- system operations ------------------------------------------------------------
             Operation::Noop => self.stack.copy_state(0),
-            Operation::Assert(err_code) => self.op_assert(err_code, host)?,
+            Operation::Assert(err_code) => self.op_assert(err_code, host, error_ctx)?,
 
             Operation::FmpAdd => self.op_fmpadd()?,
             Operation::FmpUpdate => self.op_fmpupdate()?,

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -60,7 +60,7 @@ impl Process {
             Operation::Caller => self.op_caller()?,
 
             Operation::Clk => self.op_clk()?,
-            Operation::Emit(event_id) => self.op_emit(event_id, host)?,
+            Operation::Emit(event_id) => self.op_emit(event_id, host, error_ctx)?,
 
             // ----- flow control operations ------------------------------------------------------
             // control flow operations are never executed directly

--- a/processor/src/operations/mod.rs
+++ b/processor/src/operations/mod.rs
@@ -154,8 +154,8 @@ impl Process {
             // ----- input / output ---------------------------------------------------------------
             Operation::Push(value) => self.op_push(value)?,
 
-            Operation::AdvPop => self.op_advpop(host)?,
-            Operation::AdvPopW => self.op_advpopw(host)?,
+            Operation::AdvPop => self.op_advpop(host, error_ctx)?,
+            Operation::AdvPopW => self.op_advpopw(host, error_ctx)?,
 
             Operation::MLoadW => self.op_mloadw(error_ctx)?,
             Operation::MStoreW => self.op_mstorew(error_ctx)?,

--- a/processor/src/operations/stack_ops.rs
+++ b/processor/src/operations/stack_ops.rs
@@ -1,5 +1,7 @@
+use vm_core::mast::MastNodeExt;
+
 use super::{ExecutionError, MIN_STACK_DEPTH, Process};
-use crate::ZERO;
+use crate::{ErrorContext, ZERO};
 
 impl Process {
     // STACK MANIPULATION
@@ -228,7 +230,10 @@ impl Process {
     ///
     /// # Errors
     /// Returns an error if the top element of the stack is neither 0 nor 1.
-    pub(super) fn op_cswap(&mut self) -> Result<(), ExecutionError> {
+    pub(super) fn op_cswap(
+        &mut self,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
         let c = self.stack.get(0);
         let b = self.stack.get(1);
         let a = self.stack.get(2);
@@ -242,7 +247,7 @@ impl Process {
                 self.stack.set(0, a);
                 self.stack.set(1, b);
             },
-            _ => return Err(ExecutionError::NotBinaryValue(c)),
+            _ => return Err(ExecutionError::not_binary_value_op(c, err_ctx)),
         }
 
         self.stack.shift_left(3);
@@ -254,7 +259,10 @@ impl Process {
     ///
     /// # Errors
     /// Returns an error if the top element of the stack is neither 0 nor 1.
-    pub(super) fn op_cswapw(&mut self) -> Result<(), ExecutionError> {
+    pub(super) fn op_cswapw(
+        &mut self,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
         let c = self.stack.get(0);
         let b0 = self.stack.get(1);
         let b1 = self.stack.get(2);
@@ -286,7 +294,7 @@ impl Process {
                 self.stack.set(6, b2);
                 self.stack.set(7, b3);
             },
-            _ => return Err(ExecutionError::NotBinaryValue(c)),
+            _ => return Err(ExecutionError::not_binary_value_op(c, err_ctx)),
         }
 
         self.stack.shift_left(9);

--- a/processor/src/operations/sys_ops/mod.rs
+++ b/processor/src/operations/sys_ops/mod.rs
@@ -122,7 +122,12 @@ impl Process {
     // --------------------------------------------------------------------------------------------
 
     /// Forwards the emitted event id to the host.
-    pub(super) fn op_emit<H>(&mut self, event_id: u32, host: &mut H) -> Result<(), ExecutionError>
+    pub(super) fn op_emit<H>(
+        &mut self,
+        event_id: u32,
+        host: &mut H,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError>
     where
         H: Host,
     {
@@ -131,9 +136,9 @@ impl Process {
 
         // If it's a system event, handle it directly. Otherwise, forward it to the host.
         if let Some(system_event) = SystemEvent::from_event_id(event_id) {
-            self.handle_system_event(system_event, host)
+            self.handle_system_event(system_event, host, err_ctx)
         } else {
-            host.on_event(self.into(), event_id)
+            host.on_event(self.into(), event_id, err_ctx)
         }
     }
 }

--- a/processor/src/operations/sys_ops/mod.rs
+++ b/processor/src/operations/sys_ops/mod.rs
@@ -1,4 +1,4 @@
-use vm_core::{Felt, Operation, sys_events::SystemEvent};
+use vm_core::{Felt, Operation, mast::MastNodeExt, sys_events::SystemEvent};
 
 use super::{
     super::{
@@ -7,7 +7,7 @@ use super::{
     },
     ExecutionError, Process,
 };
-use crate::Host;
+use crate::{Host, errors::ErrorContext};
 pub(crate) mod sys_event_handlers;
 
 // SYSTEM OPERATIONS
@@ -18,12 +18,17 @@ impl Process {
     ///
     /// # Errors
     /// Returns an error if the popped value is not ONE.
-    pub(super) fn op_assert<H>(&mut self, err_code: u32, host: &mut H) -> Result<(), ExecutionError>
+    pub(super) fn op_assert<H>(
+        &mut self,
+        err_code: u32,
+        host: &mut H,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError>
     where
         H: Host,
     {
         if self.stack.get(0) != ONE {
-            return Err(host.on_assert_failed(self.into(), err_code));
+            return Err(host.on_assert_failed(self.into(), err_code, err_ctx));
         }
         self.stack.shift_left(1);
         Ok(())

--- a/processor/src/operations/sys_ops/sys_event_handlers.rs
+++ b/processor/src/operations/sys_ops/sys_event_handlers.rs
@@ -332,10 +332,10 @@ pub fn push_u64_div_result(
 
         // Ensure the divisor is a pair of u32 values
         if divisor_hi > u32::MAX.into() {
-            return Err(ExecutionError::NotU32Value(Felt::new(divisor_hi), ZERO));
+            return Err(ExecutionError::not_u32_value(Felt::new(divisor_hi), ZERO, err_ctx));
         }
         if divisor_lo > u32::MAX.into() {
-            return Err(ExecutionError::NotU32Value(Felt::new(divisor_lo), ZERO));
+            return Err(ExecutionError::not_u32_value(Felt::new(divisor_lo), ZERO, err_ctx));
         }
 
         let divisor = (divisor_hi << 32) + divisor_lo;
@@ -353,10 +353,10 @@ pub fn push_u64_div_result(
 
         // Ensure the dividend is a pair of u32 values
         if dividend_hi > u32::MAX.into() {
-            return Err(ExecutionError::NotU32Value(Felt::new(dividend_hi), ZERO));
+            return Err(ExecutionError::not_u32_value(Felt::new(dividend_hi), ZERO, err_ctx));
         }
         if dividend_lo > u32::MAX.into() {
-            return Err(ExecutionError::NotU32Value(Felt::new(dividend_lo), ZERO));
+            return Err(ExecutionError::not_u32_value(Felt::new(dividend_lo), ZERO, err_ctx));
         }
 
         (dividend_hi << 32) + dividend_lo
@@ -760,7 +760,7 @@ fn push_transformed_stack_top<A: AdviceProvider>(
     let stack_top: u32 = stack_top
         .as_int()
         .try_into()
-        .map_err(|_| ExecutionError::NotU32Value(stack_top, ZERO))?;
+        .map_err(|_| ExecutionError::not_u32_value(stack_top, ZERO, err_ctx))?;
     let transformed_stack_top = f(stack_top);
     advice_provider.push_stack(AdviceSource::Value(transformed_stack_top), err_ctx)?;
     Ok(())

--- a/processor/src/operations/sys_ops/sys_event_handlers.rs
+++ b/processor/src/operations/sys_ops/sys_event_handlers.rs
@@ -775,7 +775,7 @@ fn get_smt_leaf_preimage<A: AdviceProvider>(
 
     let kv_pairs = advice_provider
         .get_mapped_values(&node_bytes)
-        .ok_or(ExecutionError::SmtNodeNotFound(node))?;
+        .ok_or(ExecutionError::smt_node_not_found(node, err_ctx))?;
 
     if kv_pairs.len() % WORD_SIZE * 2 != 0 {
         return Err(ExecutionError::smt_node_preimage_not_valid(node, kv_pairs.len(), err_ctx));

--- a/processor/src/operations/sys_ops/sys_event_handlers.rs
+++ b/processor/src/operations/sys_ops/sys_event_handlers.rs
@@ -642,7 +642,7 @@ pub fn push_ilog2(
 ) -> Result<(), ExecutionError> {
     let n = process.get_stack_item(0).as_int();
     if n == 0 {
-        return Err(ExecutionError::LogArgumentZero(process.clk()));
+        return Err(ExecutionError::log_argument_zero(process.clk(), err_ctx));
     }
     let ilog2 = Felt::from(n.ilog2());
     advice_provider.push_stack(AdviceSource::Value(ilog2), err_ctx)?;

--- a/processor/src/operations/sys_ops/sys_event_handlers.rs
+++ b/processor/src/operations/sys_ops/sys_event_handlers.rs
@@ -338,7 +338,7 @@ pub fn push_u64_div_result(
         let divisor = (divisor_hi << 32) + divisor_lo;
 
         if divisor == 0 {
-            return Err(ExecutionError::DivideByZero(process.clk()));
+            return Err(ExecutionError::divide_by_zero(process.clk(), err_ctx));
         }
 
         divisor
@@ -438,7 +438,7 @@ pub fn push_ext2_inv_result(
 
     let element = QuadFelt::new(coef0, coef1);
     if element == QuadFelt::ZERO {
-        return Err(ExecutionError::DivideByZero(process.clk()));
+        return Err(ExecutionError::divide_by_zero(process.clk(), err_ctx));
     }
     let result = element.inv().to_base_elements();
 

--- a/processor/src/operations/sys_ops/sys_event_handlers.rs
+++ b/processor/src/operations/sys_ops/sys_event_handlers.rs
@@ -688,7 +688,7 @@ pub fn push_smtpeek_result(
         // the specified key
         advice_provider.push_stack(AdviceSource::Word(Smt::EMPTY_VALUE), err_ctx)?;
     } else {
-        let leaf_preimage = get_smt_leaf_preimage(advice_provider, node)?;
+        let leaf_preimage = get_smt_leaf_preimage(advice_provider, node, err_ctx)?;
 
         for (key_in_leaf, value_in_leaf) in leaf_preimage {
             if key == key_in_leaf {
@@ -769,6 +769,7 @@ fn push_transformed_stack_top<A: AdviceProvider>(
 fn get_smt_leaf_preimage<A: AdviceProvider>(
     advice_provider: &A,
     node: Word,
+    err_ctx: &ErrorContext<'_, impl MastNodeExt>,
 ) -> Result<Vec<(Word, Word)>, ExecutionError> {
     let node_bytes = RpoDigest::from(node);
 
@@ -777,7 +778,7 @@ fn get_smt_leaf_preimage<A: AdviceProvider>(
         .ok_or(ExecutionError::SmtNodeNotFound(node))?;
 
     if kv_pairs.len() % WORD_SIZE * 2 != 0 {
-        return Err(ExecutionError::SmtNodePreImageNotValid(node, kv_pairs.len()));
+        return Err(ExecutionError::smt_node_preimage_not_valid(node, kv_pairs.len(), err_ctx));
     }
 
     Ok(kv_pairs

--- a/processor/src/operations/u32_ops.rs
+++ b/processor/src/operations/u32_ops.rs
@@ -1,8 +1,10 @@
+use vm_core::mast::MastNodeExt;
+
 use super::{
     super::utils::{split_element, split_u32_into_u16},
     ExecutionError, Felt, FieldElement, Operation, Process,
 };
-use crate::ZERO;
+use crate::{ErrorContext, ZERO};
 
 const U32_MAX: u64 = u32::MAX as u64;
 
@@ -147,12 +149,15 @@ impl Process {
     ///
     /// # Errors
     /// Returns an error if the divisor is ZERO.
-    pub(super) fn op_u32div(&mut self) -> Result<(), ExecutionError> {
+    pub(super) fn op_u32div(
+        &mut self,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
         let b = require_u32_operand!(self.stack, 0).as_int();
         let a = require_u32_operand!(self.stack, 1).as_int();
 
         if b == 0 {
-            return Err(ExecutionError::DivideByZero(self.system.clk()));
+            return Err(ExecutionError::divide_by_zero(self.system.clk(), err_ctx));
         }
 
         let q = a / b;

--- a/processor/src/operations/utils.rs
+++ b/processor/src/operations/utils.rs
@@ -5,12 +5,21 @@ use crate::{ErrorContext, ONE, ZERO};
 
 /// TODO: add docs
 #[inline(always)]
-pub fn assert_binary(
+pub fn assert_binary_with_ctx(
     value: Felt,
     err_ctx: &ErrorContext<'_, impl MastNodeExt>,
 ) -> Result<Felt, ExecutionError> {
     if value != ZERO && value != ONE {
         Err(ExecutionError::not_binary_value_op(value, err_ctx))
+    } else {
+        Ok(value)
+    }
+}
+
+#[inline(always)]
+pub fn assert_binary(value: Felt) -> Result<Felt, ExecutionError> {
+    if value != ZERO && value != ONE {
+        Err(ExecutionError::not_binary_value_op(value, &ErrorContext::default()))
     } else {
         Ok(value)
     }

--- a/processor/src/operations/utils.rs
+++ b/processor/src/operations/utils.rs
@@ -1,11 +1,16 @@
+use vm_core::mast::MastNodeExt;
+
 use super::{ExecutionError, Felt};
-use crate::{ONE, ZERO};
+use crate::{ErrorContext, ONE, ZERO};
 
 /// TODO: add docs
 #[inline(always)]
-pub fn assert_binary(value: Felt) -> Result<Felt, ExecutionError> {
+pub fn assert_binary(
+    value: Felt,
+    err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+) -> Result<Felt, ExecutionError> {
     if value != ZERO && value != ONE {
-        Err(ExecutionError::NotBinaryValue(value))
+        Err(ExecutionError::not_binary_value_op(value, err_ctx))
     } else {
         Ok(value)
     }

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -155,6 +155,51 @@ fn test_diagnostic_divide_by_zero_2() {
     );
 }
 
+// DynamicNodeNotFound
+// ------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_diagnostic_dynamic_node_not_found_1() {
+    let source = "
+        begin
+            trace.2 dynexec
+        end";
+
+    let build_test = build_test_by_mode!(true, source, &[]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "failed to execute the dynamic code block provided by the stack with root 0x0000000000000000000000000000000000000000000000000000000000000000; the block could not be found",
+        regex!(r#",-\[test[\d]+:3:21\]"#),
+        " 2 |         begin",
+        " 3 |             trace.2 dynexec",
+        "   :                     ^^^^^^^",
+        " 4 |         end",
+        "   `----"
+    );
+}
+
+#[test]
+fn test_diagnostic_dynamic_node_not_found_2() {
+    let source = "
+        begin
+            trace.2 dyncall
+        end";
+
+    let build_test = build_test_by_mode!(true, source, &[]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "failed to execute the dynamic code block provided by the stack with root 0x0000000000000000000000000000000000000000000000000000000000000000; the block could not be found",
+        regex!(r#",-\[test[\d]+:3:21\]"#),
+        " 2 |         begin",
+        " 3 |             trace.2 dyncall",
+        "   :                     ^^^^^^^",
+        " 4 |         end",
+        "   `----"
+    );
+}
+
 // FailedAssertion
 // ------------------------------------------------------------------------------------------------
 

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -369,7 +369,7 @@ fn test_diagnostic_invalid_stack_depth_on_return_dyncall() {
 
 #[test]
 fn test_diagnostic_log_argument_zero() {
-    // returning from a function with non-empty overflow table should result in an error
+    // taking the log of 0 should result in an error
     let source = "
         begin
             trace.2 ilog2    

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -86,6 +86,30 @@ fn test_diagnostic_advice_map_key_not_found_2() {
     );
 }
 
+// AdviceStackReadFailed
+// ------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_diagnostic_advice_stack_read_failed() {
+    let source = "
+        begin
+            swap adv_push.1 trace.2
+        end";
+
+    let build_test = build_test_by_mode!(true, source, &[1, 2]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "advice stack read failed at clock cycle 2",
+        regex!(r#",-\[test[\d]+:3:18\]"#),
+        " 2 |         begin",
+        " 3 |             swap adv_push.1 trace.2",
+        "   :                  ^^^^^^^^^^",
+        " 4 |         end",
+        "   `----"
+    );
+}
+
 // FailedAssertion
 // ------------------------------------------------------------------------------------------------
 

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -209,9 +209,8 @@ fn test_diagnostic_dynamic_node_not_found_2() {
 // FailedAssertion
 // ------------------------------------------------------------------------------------------------
 
-// TODO(plafer): re-enable this and fix after `assert*` lexing is fixed
 #[test]
-#[ignore]
+#[ignore = "https://github.com/0xMiden/miden-vm/issues/1764"]
 fn test_diagnostic_failed_assertion() {
     let source = "
         begin
@@ -235,9 +234,8 @@ fn test_diagnostic_failed_assertion() {
     );
 }
 
-// TODO(plafer): finish the diagnostic when the lexer is fixed
 #[test]
-#[ignore]
+#[ignore = "https://github.com/0xMiden/miden-vm/issues/1764"]
 fn test_diagnostic_merkle_path_verification_failed() {
     let source = "
         begin

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -3,6 +3,54 @@ use test_utils::build_test_by_mode;
 
 use super::*;
 
+// AdviceMapKeyNotFound
+// ------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_diagnostic_advice_map_key_not_found_1() {
+    let source = "
+        begin
+            swap swap trace.2 adv.push_mapval
+        end";
+
+    let build_test = build_test_by_mode!(true, source, &[1, 2]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "value for key 00000000000000000000000000000000ffffffff00000000feffffff01000000 not present in the advice map",
+        regex!(r#",-\[test[\d]+:3:31\]"#),
+        " 2 |         begin",
+        " 3 |             swap swap trace.2 adv.push_mapval",
+        "   :                               ^^^^^^^^^^^^^^^",
+        "4 |         end",
+        "   `----"
+    );
+}
+
+#[test]
+fn test_diagnostic_advice_map_key_not_found_2() {
+    let source = "
+        begin
+            swap swap trace.2 adv.push_mapvaln
+        end";
+
+    let build_test = build_test_by_mode!(true, source, &[1, 2]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "value for key 00000000000000000000000000000000ffffffff00000000feffffff01000000 not present in the advice map",
+        regex!(r#",-\[test[\d]+:3:31\]"#),
+        " 2 |         begin",
+        " 3 |             swap swap trace.2 adv.push_mapvaln",
+        "   :                               ^^^^^^^^^^^^^^^^",
+        "4 |         end",
+        "   `----"
+    );
+}
+
+// FailedAssertion
+// ------------------------------------------------------------------------------------------------
+
 // TODO(plafer): re-enable this and fix after `assert*` lexing is fixed
 #[test]
 #[ignore]

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -110,6 +110,51 @@ fn test_diagnostic_advice_stack_read_failed() {
     );
 }
 
+// DivideByZero
+// ------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_diagnostic_divide_by_zero_1() {
+    let source = "
+        begin
+            trace.2 div
+        end";
+
+    let build_test = build_test_by_mode!(true, source, &[]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "division by zero at clock cycle 1",
+        regex!(r#",-\[test[\d]+:3:21\]"#),
+        " 2 |         begin",
+        " 3 |             trace.2 div",
+        "   :                     ^^^",
+        " 4 |         end",
+        "   `----"
+    );
+}
+
+#[test]
+fn test_diagnostic_divide_by_zero_2() {
+    let source = "
+        begin
+            trace.2 u32div
+        end";
+
+    let build_test = build_test_by_mode!(true, source, &[]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "division by zero at clock cycle 1",
+        regex!(r#",-\[test[\d]+:3:21\]"#),
+        " 2 |         begin",
+        " 3 |             trace.2 u32div",
+        "   :                     ^^^^^^",
+        " 4 |         end",
+        "   `----"
+    );
+}
+
 // FailedAssertion
 // ------------------------------------------------------------------------------------------------
 

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -238,7 +238,7 @@ fn test_diagnostic_invalid_merkle_tree_node_index() {
         begin
             mtree_get
         end";
-    
+
     let depth = 4;
     let index = 16;
 
@@ -315,6 +315,31 @@ fn test_diagnostic_invalid_stack_depth_on_return_dyncall() {
         "   :             ^^^|^^^",
         "   :                `-- when returning from this call site",
         " 9 |         end",
+        "   `----"
+    );
+}
+
+// LogArgumentZero
+// ------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_diagnostic_log_argument_zero() {
+    // returning from a function with non-empty overflow table should result in an error
+    let source = "
+        begin
+            trace.2 ilog2    
+        end";
+
+    let build_test = build_test_by_mode!(true, source, &[]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "attempted to calculate integer logarithm with zero argument at clock cycle 1",
+        regex!(r#",-\[test[\d]+:3:21\]"#),
+        " 2 |         begin",
+        " 3 |             trace.2 ilog2",
+        "   :                     ^^^^^",
+        " 4 |         end",
         "   `----"
     );
 }

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -229,6 +229,33 @@ fn test_diagnostic_failed_assertion() {
     );
 }
 
+// InvalidMerkleTreeNodeIndex
+// ------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_diagnostic_invalid_merkle_tree_node_index() {
+    let source = "
+        begin
+            mtree_get
+        end";
+    
+    let depth = 4;
+    let index = 16;
+
+    let build_test = build_test_by_mode!(true, source, &[index, depth]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "provided node index 16 is out of bounds for a merkle tree node at depth 4",
+        regex!(r#",-\[test[\d]+:3:13\]"#),
+        " 2 |         begin",
+        " 3 |             mtree_get",
+        "   :             ^^^^^^^^^",
+        " 4 |         end",
+        "   `----"
+    );
+}
+
 // InvalidStackDepthOnReturn
 // ------------------------------------------------------------------------------------------------
 

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -755,3 +755,49 @@ fn test_diagnostic_not_binary_value_binary_ops() {
         "   `----"
     );
 }
+
+// NotU32Value
+// -------------------------------------------------------------------------------------------------
+
+#[test]
+fn test_diagnostic_not_u32_value() {
+    // u32and
+    let source = "
+        begin
+            u32and trace.2
+        end";
+
+    let big_value = u32::MAX as u64 + 1_u64;
+    let build_test = build_test_by_mode!(true, source, &[big_value]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "operation expected a u32 value, but got 4294967296",
+        regex!(r#",-\[test[\d]+:3:13\]"#),
+        " 2 |         begin",
+        " 3 |             u32and trace.2",
+        "   :             ^^^^^^",
+        " 4 |         end",
+        "   `----"
+    );
+
+    // u32madd
+    let source = "
+        begin
+            u32overflowing_add3 trace.2
+        end";
+
+    let big_value = u32::MAX as u64 + 1_u64;
+    let build_test = build_test_by_mode!(true, source, &[big_value]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "operation expected a u32 value, but got 4294967296",
+        regex!(r#",-\[test[\d]+:3:13\]"#),
+        " 2 |         begin",
+        " 3 |             u32overflowing_add3 trace.2",
+        "   :             ^^^^^^^^^^^^^^^^^^^",
+        " 4 |         end",
+        "   `----"
+    );
+}

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -3,6 +3,32 @@ use test_utils::build_test_by_mode;
 
 use super::*;
 
+// TODO(plafer): re-enable this and fix after `assert*` lexing is fixed
+#[test]
+#[ignore]
+fn test_diagnostic_failed_assertion() {
+    let source = "
+        begin
+            push.1.2
+            assertz
+            push.3.4
+        end";
+
+    let build_test = build_test_by_mode!(true, source, &[1, 2]);
+    let err = build_test.execute().expect_err("expected error");
+    assert_diagnostic_lines!(
+        err,
+        "when returning from a call or dyncall, stack depth must be 16, but was 17",
+        regex!(r#",-\[test[\d]+:7:21\]"#),
+        " 6 |         begin",
+        " 7 |             trace.2 call.foo",
+        "   :                     ^^^^|^^^",
+        "   :                         `-- when returning from this call site",
+        " 8 |         end",
+        "   `----"
+    );
+}
+
 // InvalidStackDepthOnReturn
 // ------------------------------------------------------------------------------------------------
 

--- a/processor/src/utils.rs
+++ b/processor/src/utils.rs
@@ -66,9 +66,9 @@ pub(crate) fn resolve_external_node(
 
     // We limit the parts of the program that can be called externally to procedure
     // roots, even though MAST doesn't have that restriction.
-    let root_id = mast_forest
-        .find_procedure_root(node_digest)
-        .ok_or(ExecutionError::MalformedMastForestInHost { root_digest: node_digest })?;
+    let root_id = mast_forest.find_procedure_root(node_digest).ok_or(
+        ExecutionError::malfored_mast_forest_in_host(node_digest, &ErrorContext::default()),
+    )?;
 
     // if the node that we got by looking up an external reference is also an External
     // node, we are about to enter into an infinite loop - so, return an error

--- a/processor/src/utils.rs
+++ b/processor/src/utils.rs
@@ -6,7 +6,7 @@ use vm_core::mast::{ExternalNode, MastForest, MastNodeId};
 pub use vm_core::utils::*;
 
 use super::Felt;
-use crate::{ExecutionError, Host};
+use crate::{ErrorContext, ExecutionError, Host};
 
 // HELPER FUNCTIONS
 // ================================================================================================
@@ -57,9 +57,12 @@ pub(crate) fn resolve_external_node(
     host: &mut impl Host,
 ) -> Result<(MastNodeId, Arc<MastForest>), ExecutionError> {
     let node_digest = external_node.digest();
-    let mast_forest = host
-        .get_mast_forest(&node_digest)
-        .ok_or(ExecutionError::NoMastForestWithProcedure { root_digest: node_digest })?;
+    let mast_forest =
+        host.get_mast_forest(&node_digest)
+            .ok_or(ExecutionError::no_mast_forest_with_procedure(
+                node_digest,
+                &ErrorContext::default(),
+            ))?;
 
     // We limit the parts of the program that can be called externally to procedure
     // roots, even though MAST doesn't have that restriction.

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -158,7 +158,7 @@ fn test_falcon512_probabilistic_product_failure() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::FailedAssertion{ clk, err_code, err_msg }
+        ExecutionError::FailedAssertion{clk, err_code, err_msg, label: _, source_file: _ }
         if clk == RowIndex::from(3182) && err_code == 0 && err_msg.is_none()
     );
 }

--- a/stdlib/tests/crypto/rpo.rs
+++ b/stdlib/tests/crypto/rpo.rs
@@ -19,7 +19,7 @@ fn test_invalid_end_addr() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::FailedAssertion{ clk, err_code, err_msg }
+        ExecutionError::FailedAssertion{ clk, err_code, err_msg , label: _, source_file: _ }
         if clk == RowIndex::from(18) && err_code == 0 && err_msg.is_none()
     );
 }

--- a/stdlib/tests/math/u64_mod.rs
+++ b/stdlib/tests/math/u64_mod.rs
@@ -448,7 +448,15 @@ fn ensure_div_doesnt_crash() {
     let err = test.execute();
     match err {
         Ok(_) => panic!("expected an error"),
-        Err(err) => assert_matches!(err, ExecutionError::NotU32Value(_, _)),
+        Err(err) => assert_matches!(
+            err,
+            ExecutionError::NotU32Value {
+                label: _,
+                source_file: _,
+                value: _,
+                err_code: _
+            }
+        ),
     }
 
     // 2. dividend limbs not u32
@@ -460,7 +468,15 @@ fn ensure_div_doesnt_crash() {
     let err = test.execute();
     match err {
         Ok(_) => panic!("expected an error"),
-        Err(err) => assert_matches!(err, ExecutionError::NotU32Value(_, _)),
+        Err(err) => assert_matches!(
+            err,
+            ExecutionError::NotU32Value {
+                label: _,
+                source_file: _,
+                value: _,
+                err_code: _
+            }
+        ),
     }
 }
 
@@ -559,7 +575,7 @@ fn checked_and_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(a0) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(a0) && err_code == ZERO
     );
 }
 
@@ -601,7 +617,7 @@ fn checked_or_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(a0) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(a0) && err_code == ZERO
     );
 }
 
@@ -643,7 +659,7 @@ fn checked_xor_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Value(value, err_code) if value == Felt::new(a0) && err_code == ZERO
+        ExecutionError::NotU32Value{ value, err_code, label: _, source_file: _ } if value == Felt::new(a0) && err_code == ZERO
     );
 }
 

--- a/test-utils/src/host.rs
+++ b/test-utils/src/host.rs
@@ -91,7 +91,7 @@ pub fn push_falcon_signature(
         .ok_or(ExecutionError::advice_map_key_not_found(pub_key, err_ctx))?;
 
     let result = falcon_sign(pk_sk, msg)
-        .ok_or_else(|| ExecutionError::MalformedSignatureKey("RPO Falcon512"))?;
+        .ok_or_else(|| ExecutionError::malformed_signature_key("RPO Falcon512", err_ctx))?;
 
     for r in result {
         advice_provider.push_stack(AdviceSource::Value(r), err_ctx)?;

--- a/test-utils/src/host.rs
+++ b/test-utils/src/host.rs
@@ -1,8 +1,11 @@
 use alloc::sync::Arc;
 
-use processor::{AdviceProvider, AdviceSource, DefaultHost, MastForest, ProcessState};
+use processor::{
+    AdviceProvider, AdviceSource, DefaultHost, ErrorContext, MastForest, ProcessState,
+};
 use prover::{ExecutionError, Host, MemAdviceProvider};
 use stdlib::{EVENT_FALCON_SIG_TO_STACK, falcon_sign};
+use vm_core::mast::MastNodeExt;
 
 pub struct TestHost(DefaultHost<MemAdviceProvider>);
 
@@ -43,10 +46,15 @@ impl Host for TestHost {
         self.0.get_mast_forest(node_digest)
     }
 
-    fn on_event(&mut self, process: ProcessState, event_id: u32) -> Result<(), ExecutionError> {
+    fn on_event(
+        &mut self,
+        process: ProcessState,
+        event_id: u32,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Result<(), ExecutionError> {
         if event_id == EVENT_FALCON_SIG_TO_STACK {
             let advice_provider = self.advice_provider_mut();
-            push_falcon_signature(advice_provider, process)
+            push_falcon_signature(advice_provider, process, err_ctx)
         } else {
             Ok(())
         }
@@ -73,19 +81,20 @@ impl Host for TestHost {
 pub fn push_falcon_signature(
     advice_provider: &mut impl AdviceProvider,
     process: ProcessState,
+    err_ctx: &ErrorContext<'_, impl MastNodeExt>,
 ) -> Result<(), ExecutionError> {
     let pub_key = process.get_stack_word(0);
     let msg = process.get_stack_word(1);
 
     let pk_sk = advice_provider
         .get_mapped_values(&pub_key.into())
-        .ok_or(ExecutionError::AdviceMapKeyNotFound(pub_key))?;
+        .ok_or(ExecutionError::advice_map_key_not_found(pub_key, err_ctx))?;
 
     let result = falcon_sign(pk_sk, msg)
         .ok_or_else(|| ExecutionError::MalformedSignatureKey("RPO Falcon512"))?;
 
     for r in result {
-        advice_provider.push_stack(AdviceSource::Value(r))?;
+        advice_provider.push_stack(AdviceSource::Value(r), err_ctx)?;
     }
     Ok(())
 }


### PR DESCRIPTION
Closes #1712

Note that the fast processor doesn't use diagnostics (yet at least), so `ErrorContext::default()` is used everywhere.

There are also 2 tests that are `#[ignore]`'d, due to #1764. Ideally we would fix #1764 and reinstate those tests before merging this PR.