### PR TITLE
docs: fix typo in "explicitly" spelling

### DIFF
--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -13,7 +13,7 @@ else
     if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
         >&2 echo "Changes should come with an entry in the \"CHANGELOG.md\" file. This behavior
 can be overridden by using the \"no changelog\" label, which is used for changes
-that are trivial / explicitely stated not to require a changelog entry."
+that are trivial / explicitly stated not to require a changelog entry."
         exit 1
     fi
 


### PR DESCRIPTION
spotted a small typo and fixed it - "explicitely" was misspelled, changed it to "explicitly".

nothing big, just keeping things tidy.