### PR TITLE
fix: add diagnostics feature to default build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ help:
 BACKTRACE=RUST_BACKTRACE=1
 WARNINGS=RUSTDOCFLAGS="-D warnings"
 DEBUG_ASSERTIONS=RUSTFLAGS="-C debug-assertions"
-FEATURES_CONCURRENT_EXEC=--features concurrent,executable
+FEATURES_CONCURRENT_EXEC=--features concurrent,executable,diagnostics
 FEATURES_LOG_TREE=--features concurrent,executable,tracing-forest
 FEATURES_METAL_EXEC=--features concurrent,executable,metal,tracing-forest
-ALL_FEATURES_BUT_ASYNC=--features concurrent,executable,metal,testing,with-debug-info,internal
+ALL_FEATURES_BUT_ASYNC=--features concurrent,executable,metal,testing,with-debug-info,internal,diagnostics
 
 # -- linting --------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #1768

This PR updates the Makefile to include the `diagnostics` feature in the default build flags (`FEATURES_CONCURRENT_EXEC` and `ALL_FEATURES_BUT_ASYNC`).

Currently, none of the CI jobs or local builds enable the `diagnostics` feature by default. As a result, issues like the one fixed in #1767 are not caught by CI.

By adding `diagnostics` to the default features in the Makefile, we ensure that:
- All builds (`make build`)
- Tests (`make test`)
- Linting (`make clippy`)
- And other related tasks

will now include the `diagnostics` code both locally and in CI workflows.


