### PR TITLE
fix: incorrect debug help commands

### DIFF
--- a/miden/src/cli/debug/executor.rs
+++ b/miden/src/cli/debug/executor.rs
@@ -205,8 +205,6 @@ impl DebugExecutor {
             b -> back\n\
             r -> rewind\n\
             p -> print\n\
-            m -> mem\n\
-            s -> stack\n\
             l -> clock\n\
             q -> quit\n\
             h -> help\n\


### PR DESCRIPTION
Fixes: #1750 

To verify, run:
```
cargo run --bin miden --features="executable" -- debug --input "./miden/masm-examples/fib/fib.inputs" "./miden/masm-examples/fib/fib.masm"
```
and then `help`

Output:
```
The following mappings are also available:
n -> next
c -> continue
b -> back
r -> rewind
p -> print
l -> clock
q -> quit
h -> help
? -> help
```