### PR TITLE
ci: switch checkout action to v4

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -36,7 +36,7 @@ jobs:
     name: Build documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
 
       # Installation from source takes a fair while, so we install the binaries directly instead.
       - name: Install mdbook and plugins

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
       - name: Build for no-std
         run: |
           rustup update --no-self-update ${{ matrix.toolchain }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Check for changes in changelog

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     name: clippy nightly on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
       - name: Clippy
         run: |
           rustup update --no-self-update nightly
@@ -24,7 +24,7 @@ jobs:
     name: rustfmt check nightly on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
       - name: Rustfmt
         run: |
           rustup update --no-self-update nightly
@@ -35,7 +35,7 @@ jobs:
     name: doc stable on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
       - name: Build docs
         run: |
           rustup update --no-self-update


### PR DESCRIPTION
Replaced every `actions/checkout@main` reference with
`actions/checkout@v4`.

GitHub recommends pinning to a major version tag instead of the default
branch for better stability, security, and compatibility with future
updates.

[Reference](https://github.com/actions/checkout#usage)