### PR TITLE
fix:add docs check workflow and script from miden-base

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,20 @@
+name: docs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  documented:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+      - name: Check for changes in the docs directory
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          NO_DOCS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no docs') }}
+        run: ./scripts/check-docs.sh "${{ inputs.docs }}"
+        shell: bash

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -uo pipefail
+
+DOCS_DIR="docs/"
+
+if [ "${NO_DOCS_LABEL}" = "true" ]; then
+    echo "\"no docs\" label has been set"
+    exit 0
+else
+    if git diff --quiet "origin/${BASE_REF}" -- "${DOCS_DIR}"; then
+        >&2 echo "Changes should be accompanied by documentation updates in the \"docs/\" directory.
+This behavior can be overridden by using the \"no docs\" label, which is used for changes
+that don't require documentation updates or are purely maintenance-related."
+        exit 1
+    fi
+
+    echo "The \"docs/\" directory has been updated."
+fi


### PR DESCRIPTION
Closes #1603 
This PR adds a workflow that checks for documentation updates in pull requests. 
If a PR does not include changes in the docs/ directory and does not have the "no docs" label, 
the workflow will fail to enforce documentation consistency.

The following files have been added by copying from the miden-base repository:
- .github/workflows/docs.yml
- scripts/check-docs.sh

This implements the feature requested in issue #1603.
