### PR TITLE
docs: fix invalid URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 #### First off, thanks for taking the time to contribute!
 
-You can find a detailed explanation of main project concepts in [docs](https://0xpolygonmiden.github.io/miden-vm/).
+You can find a detailed explanation of main project concepts in [docs](https://0xmiden.github.io/miden-vm/).
 
 We want to make contributing to this project as easy and transparent as possible, whether it's:
 

--- a/air/README.md
+++ b/air/README.md
@@ -4,14 +4,14 @@ This crate contains *algebraic intermediate representation* (AIR) of Miden VM ex
 AIR is a STARK-specific format of describing a computation. It consists of defining a set of constraints expressed as low-degree polynomials. Miden prover evaluates these polynomials over an execution trace produced by Miden processor and includes the results in the execution proof. To verify the proof, the verifier checks that the constraints are evaluated correctly against the execution trace committed to by the prover.
 
 Internally, Miden VM AIR is separated into several components:
-* AIR for the [decoder](https://0xpolygonmiden.github.io/miden-vm/design/decoder/main.html), which is responsible for decoding instructions and managing control flow.
-* AIR for the [stack](https://0xpolygonmiden.github.io/miden-vm/design/stack/main.html), which is responsible for executing instructions against the operand stack.
-* AIR for the [range checker](https://0xpolygonmiden.github.io/miden-vm/design/range.html), which is responsible for checking if field elements contain values smaller than $2^{16}$.
-* AIR for the [chiplets module](https://0xpolygonmiden.github.io/miden-vm/design/chiplets/main.html), which contains specialized circuits responsible for handling complex computations (e.g., hashing) as well as random access memory.
+* AIR for the [decoder](https://0xmiden.github.io/miden-vm/design/decoder/main.html), which is responsible for decoding instructions and managing control flow.
+* AIR for the [stack](https://0xmiden.github.io/miden-vm/design/stack/main.html), which is responsible for executing instructions against the operand stack.
+* AIR for the [range checker](https://0xmiden.github.io/miden-vm/design/range.html), which is responsible for checking if field elements contain values smaller than $2^{16}$.
+* AIR for the [chiplets module](https://0xmiden.github.io/miden-vm/design/chiplets/main.html), which contains specialized circuits responsible for handling complex computations (e.g., hashing) as well as random access memory.
 
 These different components are tied together using multiset checks similar to the ones used in [PLONK](https://hackmd.io/@relgabizon/ByFgSDA7D).
 
-All AIR constraints for Miden VM are described in detail in the [design](https://0xpolygonmiden.github.io/miden-vm/design/main.html) section of Miden VM documentation.
+All AIR constraints for Miden VM are described in detail in the [design](https://0xmiden.github.io/miden-vm/design/main.html) section of Miden VM documentation.
 
 If you'd like to learn more about AIR, the following blog posts from StarkWare are an excellent resource:
 

--- a/assembly/README.md
+++ b/assembly/README.md
@@ -2,7 +2,7 @@
 
 This crate contains Miden assembler.
 
-The purpose of the assembler is to compile/assemble [Miden Assembly (MASM)](https://0xpolygonmiden.github.io/miden-vm/user_docs/assembly/main.html)
+The purpose of the assembler is to compile/assemble [Miden Assembly (MASM)](https://0xmiden.github.io/miden-vm/user_docs/assembly/main.html)
 source code into a Miden VM program (represented by `Program` struct). The program
 can then be executed on Miden VM [processor](../processor).
 

--- a/core/README.md
+++ b/core/README.md
@@ -3,7 +3,7 @@ This crate contains core components used by Miden VM. These components include:
 
 * Miden VM instruction set, defined in the [Operation](/../main/core/src/operations/mod.rs) struct.
 * Miden VM program kernel, defined in [Kernel](/../main/core/src/program/mod.rs) struct which contains a set of roots of kernel routines.
-* Miden VM program structure, defined in [Program](/../main/core/src/program/mod.rs) struct and described [here](https://0xpolygonmiden.github.io/miden-vm/design/programs.html).
+* Miden VM program structure, defined in [Program](/../main/core/src/program/mod.rs) struct and described [here](https://0xmiden.github.io/miden-vm/design/programs.html).
 * Miden VM program metadata, defined in [ProgramInfo](/../main/core/src/program/info.rs) struct which contains a program's MAST root and the kernel used by the program.
 * Input and output containers for Miden VM programs, defined in [StackInputs](/../main/core/src/stack/inputs.rs) and [StackOutputs](/../main/core/src/stack/outputs.rs) structs.
 * Constants describing the shape of the VM's execution trace.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 # Miden docs
-This crate contains source files and assets for [Miden VM documentation](https://0xpolygonmiden.github.io/miden-vm/).
+This crate contains source files and assets for [Miden VM documentation](https://0xmiden.github.io/miden-vm/).
 
 All doc files are written in Markdown and are converted into an online book using [mdBook](https://github.com/rust-lang/mdBook) utility.
 

--- a/docs/src/intro/usage.md
+++ b/docs/src/intro/usage.md
@@ -121,7 +121,7 @@ You can use the run command with `--debug` parameter to enable debugging with th
 
 ### Inputs
 
-As described [here](https://0xpolygonmiden.github.io/miden-vm/intro/overview.html#inputs-and-outputs) the Miden VM can consume public and secret inputs.
+As described [here](https://0xmiden.github.io/miden-vm/intro/overview.html#inputs-and-outputs) the Miden VM can consume public and secret inputs.
 
 - Public inputs:
   - `operand_stack` - can be supplied to the VM to initialize the stack with the desired values before a program starts executing. If the number of provided input values is less than 16, the input stack will be padded with zeros to the length of 16. The maximum number of the stack inputs is limited by 16 values, providing more than 16 values will cause an error.

--- a/miden/README.md
+++ b/miden/README.md
@@ -4,17 +4,17 @@ This crate aggregates all components of the Miden VM in a single place. Specific
 
 ## Basic concepts
 
-An in-depth description of Miden VM is available in the full Miden VM [documentation](https://0xpolygonmiden.github.io/miden-vm/). In this section we cover only the basics to make the included examples easier to understand.
+An in-depth description of Miden VM is available in the full Miden VM [documentation](https://0xmiden.github.io/miden-vm/). In this section we cover only the basics to make the included examples easier to understand.
 
 ### Writing programs
 
 Our goal is to make Miden VM an easy compilation target for high-level languages such as Rust, Move, Sway, and others. We believe it is important to let people write programs in the languages of their choice. However, compilers to help with this have not been developed yet. Thus, for now, the primary way to write programs for Miden VM is to use [Miden assembly](../assembly).
 
-Miden assembler compiles assembly source code in a [program MAST](https://0xpolygonmiden.github.io/miden-vm/design/programs.html), which is represented by a `Program` struct. It is possible to construct a `Program` struct manually, but we don't recommend this approach because it is tedious, error-prone, and requires an in-depth understanding of VM internals. All examples throughout these docs use assembly syntax.
+Miden assembler compiles assembly source code in a [program MAST](https://0xmiden.github.io/miden-vm/design/programs.html), which is represented by a `Program` struct. It is possible to construct a `Program` struct manually, but we don't recommend this approach because it is tedious, error-prone, and requires an in-depth understanding of VM internals. All examples throughout these docs use assembly syntax.
 
 #### Program hash
 
-All Miden programs can be reduced to a single 32-byte value, called program hash. Once a `Program` object is constructed, you can access this hash via `Program::hash()` method. This hash value is used by a verifier when they verify program execution. This ensures that the verifier verifies execution of a specific program (e.g. a program which the prover had committed to previously). The methodology for computing program hash is described [here](https://0xpolygonmiden.github.io/miden-vm/design/programs.html#program-hash-computation).
+All Miden programs can be reduced to a single 32-byte value, called program hash. Once a `Program` object is constructed, you can access this hash via `Program::hash()` method. This hash value is used by a verifier when they verify program execution. This ensures that the verifier verifies execution of a specific program (e.g. a program which the prover had committed to previously). The methodology for computing program hash is described [here](https://0xmiden.github.io/miden-vm/design/programs.html#program-hash-computation).
 
 ### Inputs / outputs
 

--- a/miden/src/repl/mod.rs
+++ b/miden/src/repl/mod.rs
@@ -22,7 +22,7 @@ use crate::utils::print_mem_address;
 //
 // Miden Instructions
 // All Miden instructions mentioned in the
-// [Miden Assembly section](https://0xpolygonmiden.github.io/miden-vm/user_docs/assembly/main.html)
+// [Miden Assembly section](https://0xmiden.github.io/miden-vm/user_docs/assembly/main.html)
 // are valid.
 // One can either input instructions one by one or multiple instructions in one input.
 // For example, the below two commands will result in the same output.

--- a/processor/README.md
+++ b/processor/README.md
@@ -56,7 +56,7 @@ These components are connected via two buses:
 * The range-checker bus, which links stack and chiplets modules with the range-checker.
 * The chiplet bus, which links stack and the decoder with the chiplets module.
 
-A much more in-depth description of Miden VM design is available [here](https://0xpolygonmiden.github.io/miden-vm/design/main.html).
+A much more in-depth description of Miden VM design is available [here](https://0xmiden.github.io/miden-vm/design/main.html).
 
 ## Crate features
 Miden processor can be compiled with the following features:


### PR DESCRIPTION
# Summery

Changes invalid URLs in repository.

# Description

Links include in the "0xpolygonmiden.github.io" is invalid. Every "0xpolygonmiden.github.io" is changed to "0xmiden.github.io".

This pr motivated from https://github.com/0xMiden/miden-vm/pull/1798#issue-3040463729