### PR TITLE
Simplify auxiliary randomness generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [BREAKING] Make `Assembler::source_manager()` be `Send + Sync` (#1822)
 - Simplify and optimize the recursive verifier (#1801).
 - Simplify auxiliary randomness generation (#1810).
+- Add handling of variable length public inputs to the recursive verifier (#1813).
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Remove `idx` column from Kernel ROM chiplet and use chiplet bus for initialization. (#1818)
 - [BREAKING] Make `Assembler::source_manager()` be `Send + Sync` (#1822)
 - Simplify and optimize the recursive verifier (#1801).
+- Simplify auxiliary randomness generation (#1810).
 
 #### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,8 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "winter-air"
-version = "0.12.1"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48a9ee4b14f192be4b0f253d6cc6241844664d6d6684819b6d9b074f4b85af14"
 dependencies = [
  "libm",
  "winter-crypto",
@@ -2949,7 +2950,8 @@ dependencies = [
 [[package]]
 name = "winter-crypto"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32247cde9f43e5bbd05362caa7274608790ea69b14f7c81cd509aae7127c5ff2"
 dependencies = [
  "blake3",
  "sha3",
@@ -2960,7 +2962,8 @@ dependencies = [
 [[package]]
 name = "winter-fri"
 version = "0.12.2"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b346b0eea2292986a1193bfc70dd2dbcdbb6adb3e5110b71d18c6f1077df10"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -2970,7 +2973,8 @@ dependencies = [
 [[package]]
 name = "winter-math"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "326dfe4bfa4072b7c909133a88f8807820d3e49e5dfd246f67981771f74a0ed3"
 dependencies = [
  "winter-utils",
 ]
@@ -2978,7 +2982,8 @@ dependencies = [
 [[package]]
 name = "winter-maybe-async"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa132be74e602b707f1dab5a69c38496445e54ee940e7c281c02b15007241bd"
 dependencies = [
  "quote",
  "syn",
@@ -2986,8 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "winter-prover"
-version = "0.12.2"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e1ad2747c0f67f3aab25c2753cb7ee321e06722dd1f011344faeee7e2828a4"
 dependencies = [
  "tracing",
  "winter-air",
@@ -3001,7 +3007,8 @@ dependencies = [
 [[package]]
 name = "winter-rand-utils"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6321741f063344258c80f0c0255a559ded99bc17fe99fab9577f2460065ddf"
 dependencies = [
  "rand 0.8.5",
  "winter-utils",
@@ -3010,15 +3017,17 @@ dependencies = [
 [[package]]
 name = "winter-utils"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d47518e6931955dcac73a584cacb04550b82ab2f45c72880cbbbdbe13adb63c"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "winter-verifier"
-version = "0.12.2"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a980cd314dddc2f4c9cdbc77127e6390238bb8b7541b6f627541ca35223f8ff"
 dependencies = [
  "winter-air",
  "winter-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,8 +2950,7 @@ dependencies = [
 [[package]]
 name = "winter-crypto"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32247cde9f43e5bbd05362caa7274608790ea69b14f7c81cd509aae7127c5ff2"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "blake3",
  "sha3",
@@ -2962,8 +2961,7 @@ dependencies = [
 [[package]]
 name = "winter-fri"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b346b0eea2292986a1193bfc70dd2dbcdbb6adb3e5110b71d18c6f1077df10"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -2973,8 +2971,7 @@ dependencies = [
 [[package]]
 name = "winter-math"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326dfe4bfa4072b7c909133a88f8807820d3e49e5dfd246f67981771f74a0ed3"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "winter-utils",
 ]
@@ -2982,8 +2979,7 @@ dependencies = [
 [[package]]
 name = "winter-maybe-async"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa132be74e602b707f1dab5a69c38496445e54ee940e7c281c02b15007241bd"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "quote",
  "syn",
@@ -3007,8 +3003,7 @@ dependencies = [
 [[package]]
 name = "winter-rand-utils"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6321741f063344258c80f0c0255a559ded99bc17fe99fab9577f2460065ddf"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "rand 0.8.5",
  "winter-utils",
@@ -3017,8 +3012,7 @@ dependencies = [
 [[package]]
 name = "winter-utils"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d47518e6931955dcac73a584cacb04550b82ab2f45c72880cbbbdbe13adb63c"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "rayon",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,14 @@ overflow-checks = true
 
 [workspace.dependencies]
 thiserror = { version = "2.0", default-features = false }
+
+[patch.crates-io]
+winter-air = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-air" }
+winter-crypto = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-crypto" }
+winter-prover = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-prover" }
+winter-verifier = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-verifier" }
+winter-math = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-math" }
+winter-fri = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-fri" }
+winter-maybe-async = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-maybe-async" }
+winter-utils = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-utils" }
+winter-rand-utils = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-rand-utils" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,14 +37,3 @@ overflow-checks = true
 
 [workspace.dependencies]
 thiserror = { version = "2.0", default-features = false }
-
-[patch.crates-io]
-winter-air = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-air" }
-winter-crypto = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-crypto" }
-winter-prover = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-prover" }
-winter-verifier = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-verifier" }
-winter-math = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-math" }
-winter-fri = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-fri" }
-winter-maybe-async = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-maybe-async" }
-winter-utils = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-utils" }
-winter-rand-utils = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-rand-utils" }

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -270,8 +270,11 @@ impl ToElements for ProgramInfo {
         result.extend_from_slice(self.program_hash.as_elements());
 
         // append kernel procedure hash elements
+        // we reverse the digests in order to make reducing them using auxiliary randomness easier
         for proc_hash in self.kernel.proc_hashes() {
-            result.extend_from_slice(proc_hash.as_elements());
+            let mut digest = proc_hash.as_elements().to_vec();
+            digest.reverse();
+            result.extend_from_slice(&digest);
         }
         result
     }

--- a/stdlib/asm/crypto/fri/helper.masm
+++ b/stdlib/asm/crypto/fri/helper.masm
@@ -126,8 +126,11 @@ end
 #! Output: [...]
 #!
 #! Cycles:
-#!  1- Remainder of size 32: 1633
-#!  2- Remainder of size 64: 3109
+#!
+#!  1- Remainder polynomial of degree less
+#!     than 64: 157
+#!  2- Remainder polynomial of degree less
+#!     than 128: 191
 export.load_and_verify_remainder
     # Load remainder commitment and save it at `TMP1`
     padw

--- a/stdlib/asm/crypto/fri/helper.masm
+++ b/stdlib/asm/crypto/fri/helper.masm
@@ -7,7 +7,7 @@ use.std::crypto::stark::constants
 #!
 #! Input: [...]
 #! Output: [num_fri_layers, ...]
-#! Cycles: 77
+#! Cycles: 45
 export.generate_fri_parameters
     # Load FRI verifier data
     padw exec.constants::get_lde_domain_info_word
@@ -90,6 +90,7 @@ export.load_fri_layer_commitments
         sub.2
         swap
         exec.constants::tmp1 mem_storew
+        # => [lde_size / 4, log2(lde_size) - 2, lde_generator, 0, a1, a0, num_layers, ptr_layer + 4, y, y, ...]
 
         # Move the pointer higher up the stack
         movup.2 drop
@@ -129,7 +130,7 @@ end
 #!  2- Remainder of size 64: 3109
 export.load_and_verify_remainder
     # Load remainder commitment and save it at `TMP1`
-    push.0.0.0.0
+    padw
     adv_loadw
     exec.constants::tmp1 mem_storew
     #=> [COM, ...]

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -32,18 +32,27 @@ const.NUM_INPUTS_CIRCUIT=232
 # Number of evaluation gates in the constraint evaluation circuit
 const.NUM_EVAL_GATES_CIRCUIT=88
 
+# Op label for kernel procedures table messages
+const.KERNEL_OP_LABEL=0
+
 # MEMORY POINTERS
 # =================================================================================================
 
 # Trace domain generator
-const.TRACE_DOMAIN_GENERATOR_PTR=4294799999
+const.TRACE_DOMAIN_GENERATOR_PTR=4294799998
+
+# Variable length public inputs address
+const.VARIABLE_LEN_PUBLIC_INPUTS_ADDRESS_PTR=4294799999
 
 # Public inputs address
 const.PUBLIC_INPUTS_ADDRESS_PTR=4294800000
 
 # Random elements
-# There are are currently 16 ExtFelt for a total of 32 Felt. Thus the number of memory slots required is 32.
-const.AUX_RAND_ELEM_PTR=4294899968
+# We use 2 extension field elements for a total of 4 base field elements.
+const.AUX_RAND_ELEM_PTR=4294899996
+# This will hold the non-deterministically loaded 2 random challenges, which will be
+# checked for correctness once we receive the commitment to the auxiliary trace.
+const.AUX_RAND_ND_PTR=4294800004
 
 # OOD Frames
 # (80 + 8) * 2 * 2 Felt for current and next trace rows and 8 * 2 Felt for constraint composition
@@ -153,7 +162,8 @@ const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 #   +------------------------------------------+-------------------------+
 #   | TRACE_DOMAIN_GENERATOR_PTR               |       4294799999        |
 #   | PUBLIC_INPUTS_ADDRESS_PTR                |       4294800000        |
-#   | AUX_RAND_ELEM_PTR                        |       4294899968        |
+#   | AUX_RAND_ND_PTR                          |       4294800004        |
+#   | AUX_RAND_ELEM_PTR                        |       4294899996        |
 #   | OOD_TRACE_CURRENT_PTR                    |       4294900000        |
 #   | OOD_TRACE_NEXT_PTR                       |       4294900162        |
 #   | OOD_CONSTRAINT_EVALS_PTR                 |       4294900324        |
@@ -192,6 +202,10 @@ const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 
 export.public_inputs_address_ptr
     push.PUBLIC_INPUTS_ADDRESS_PTR
+end
+
+export.variable_length_public_inputs_address_ptr
+    push.VARIABLE_LEN_PUBLIC_INPUTS_ADDRESS_PTR
 end
 
 export.ood_trace_current_ptr
@@ -463,4 +477,12 @@ end
 
 export.get_arithmetic_circuit_eval_number_eval_gates
     push.NUM_EVAL_GATES_CIRCUIT
+end
+
+export.aux_rand_nd_ptr
+    push.AUX_RAND_ND_PTR
+end
+
+export.kernel_proc_table_op_label
+    push.KERNEL_OP_LABEL
 end

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -103,6 +103,8 @@ const.COMPOSITION_POLY_COM_PTR=4294813208
 # Instant-specific constants
 const.LDE_DOMAIN_INFO_PTR=4294813212
 const.LDE_DOMAIN_GEN_PTR=4294813213
+const.LDE_DOMAIN_LOG_SIZE_PTR=4294813214
+const.LDE_DOMAIN_SIZE_PTR=4294813215
 const.Z_PTR=4294813216
 const.NUM_QUERIES_PTR=4294813220
 const.REMAINDER_POLY_SIZE_PTR=4294813221
@@ -164,6 +166,9 @@ const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 #   | AUX_TRACE_COM_PTR                        |       4294913204        |
 #   | COMPOSITION_POLY_COM_PTR                 |       4294913208        |
 #   | LDE_DOMAIN_INFO_PTR                      |       4294913212        |
+#   | LDE_DOMAIN_GEN_PTR                       |       4294913213        |
+#   | LDE_DOMAIN_LOG_SIZE_PTR                  |       4294913214        |
+#   | LDE_DOMAIN_SIZE_PTR                      |       4294913215        |
 #   | Z_PTR                                    |       4294913216        |
 #   | NUM_QUERIES_PTR                          |       4294913220        |
 #   | TRACE_LENGTH_PTR                         |       4294913224        |
@@ -391,6 +396,22 @@ end
 
 export.get_fri_queries_address
     push.FRI_QUERIES_ADDRESS_PTR mem_load
+end
+
+export.set_lde_domain_size
+    push.LDE_DOMAIN_SIZE_PTR mem_store
+end
+
+export.get_lde_domain_size
+    push.LDE_DOMAIN_SIZE_PTR mem_load
+end
+
+export.set_lde_domain_log_size
+    push.LDE_DOMAIN_LOG_SIZE_PTR mem_store 
+end
+
+export.get_lde_domain_log_size
+    push.LDE_DOMAIN_LOG_SIZE_PTR mem_load
 end
 
 export.set_trace_length

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -7,7 +7,7 @@ const.DOMAIN_OFFSET=7
 const.DOMAIN_OFFSET_INV=2635249152773512046
 
 # Number of random extension field coefficients related to the auxiliary trace (i.e. the alphas)
-const.NUM_AUX_TRACE_COEFS=16
+const.NUM_AUX_TRACE_COEFS=2
 
 # Number of constraints, both boundary and transitional
 # Note: If the full set of all implemented constraints is used then this should be set to 226

--- a/stdlib/asm/crypto/stark/public_inputs.masm
+++ b/stdlib/asm/crypto/stark/public_inputs.masm
@@ -1,5 +1,70 @@
 use.std::crypto::stark::constants
 use.std::crypto::hashes::rpo
+use.std::crypto::stark::random_coin
+
+
+#! Processes the public inputs.
+#! 
+#! This involves:
+#!
+#! 1. Loading from the advice stack the fixed-length public inputs and storing them in memory
+#! starting from the address pointed to by `public_inputs_address_ptr`.
+#! 2. Loading from the advice stack the variable-length public inputs, storing them temporarily
+#! in memory, and then reducing them to an element in the challenge field using the auxiliary
+#! randomness. This reduced value is then used to impose a boundary condition on the relevant
+#! auxiliary column. 
+#!
+#! Note that the public inputs are stored as extension field elements.
+#! Note also that, while loading the above, we compute the hash of the public inputs. The hashing
+#! starts with capacity registers of the hash function set to `C` that is the result of hashing
+#! the proof context.
+#!
+#! The output D, that is the digest of the above hashing, is then used in order to reseed
+#! the random coin.
+#!
+#! It is worth noting that:
+#!
+#! 1. Only the fixed-length public inputs are stored for the lifetime of the verification procedure.
+#!    The variable-length public inputs are stored temporarily, as this simplifies the task of
+#!    reducing them using the auxiliary randomness. On the other hand, the resulting values from
+#!    the aforementioned reductions are stored right after the fixed-length public inputs. These
+#!    are stored in word-aligned manner and padded with zeros if needed.
+#! 2. The public inputs address is computed in such a way so as we end up with the following
+#!    memory layout:
+#!
+#!    [..., a_0...a_{m-1}, b_0...b_{n-1}, alpha0, alpha1, beta0, beta1, OOD-evaluations-start, ...]
+#!
+#!    where:
+#!
+#!    1. [a_0...a_{m-1}] are the fixed-length public inputs stored as extension field elements. This
+#!       section is word-aligned.
+#!    2. [b_0...b_{n-1}] are the results of reducing the variable length public inputs using
+#!       auxiliary randomness. This section is word-aligned.
+#!    3. [alpha0, alpha1, beta0, beta1] is the auxiliary randomness.
+#!    4. `OOD-evaluations-start` is the first field element of the section containing the OOD
+#!       evaluations.
+#!
+#!
+#! Input: [C, ...]
+#! Output: [...]
+export.process_public_inputs
+    # 1) Compute the address where the public inputs will be stored and stores it.
+    #    This also computes the address where the reduced variable-length public inputs will be stored.
+    exec.compute_and_store_public_inputs_address
+    # => [C, ...]
+
+    # 2) Load the public inputs.
+    #    This will also hash them so that we can absorb them in the transcript.
+    exec.load
+    # => [D, ...]
+
+    # 3) Absorb into the transcript
+    exec.random_coin::reseed
+    # => [...]
+
+    # 4) Reduce the variable-length public inputs using randomness.
+    exec.reduce_variable_length_public_inputs
+end
 
 
 #! Loads from the advice stack the public inputs and stores them in memory starting from address
@@ -11,7 +76,6 @@ use.std::crypto::hashes::rpo
 #!
 #! Input: [C, ...]
 #! Output: [D, ...]
-#! Cycles: ~ xx + xx * number_kernel_procedures
 export.load
     # Load the public inputs from the advice provider.
     # The public inputs are made up of:
@@ -23,7 +87,7 @@ export.load
     # While loading the public inputs, we also absorb them in the Fiat-Shamir transcript.
 
     # 1) Load the input and output operand stacks
-    exec.compute_and_store_public_inputs_address
+    exec.constants::public_inputs_address_ptr mem_load
     movdn.4
     padw padw
     repeat.4
@@ -38,6 +102,9 @@ export.load
     add.1
 
     # 3) Load the program hash and kernel procedures digests.
+    #    Note that while we are saving the kernel procedures to memory, this is only done so that
+    #    we can later reduce the kernel procedures digests using randomness.
+    #    The memory region that will (temporarily) hold these digests will be later on over-written.
     #    We need one call to the RPO permutation per 2 digests, thus we compute the division
     #    with remainder of the number of digests by 2. If the remainder is 1 then we need
     #    to pad with the zero word, while we do not need to pad otherwise.
@@ -90,6 +157,171 @@ export.load
     movup.4 drop
 end
 
+#! Reduces the variable-length public inputs using the auxiliary randomness.
+#!
+#! The procedure non-deterministically loads the auxiliary randomness from the advice tape and
+#! stores it at `aux_rand_nd_ptr` so that it can be later checked for correctness. After this,
+#! the procedure uses the auxiliary randomness in order to reduce the variable-length public
+#! inputs to a single element in the challenge field. The resulting values are then stored
+#! contiguously after the fixed-length public inputs.
+#!
+#! Currently, the only variable-length public inputs are the kernel procedure digests.
+proc.reduce_variable_length_public_inputs
+    # 1) Load the auxiliary randomness i.e., alpha and beta
+    #    We store them as [beta0, beta1, alpha0, alpha1] since `horner_eval_ext` requires memory
+    #    word-alignment.
+    adv_push.4
+    exec.constants::aux_rand_nd_ptr mem_storew
+    # => [alpha1, alpha0, beta1, beta0, ...]
+    dropw
+    # => [...]
+
+    # 2) Get the pointer to the variable-length public inputs.
+    #    This is also the pointer to the first address at which we will store the results of
+    #    the reductions.
+    exec.constants::variable_length_public_inputs_address_ptr mem_load
+    dup
+    # => [next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...] where
+    # `next_var_len_pub_inputs_ptr` points to the next chunk of variable public inputs to be reduced,
+    # and `var_len_pub_inputs_res_ptr` points to the next available memory location where the result
+    # of the reduction can be stored.
+    # Note that, as mentioned in the top of this module, the variable-length public inputs are only
+    # stored temporarily and they will be over-written by, among other data, the result of reducing
+    # the variable public inputs. 
+
+    # 3) Reduce the variable-length public inputs.
+    #    These include:
+    #    a) Kernel procedure digests.
+    exec.reduce_kernel_digests
+    # => [res1, res0, next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...]
+
+    # 4) Store the results of the reductions.
+    #    This is stored in a word-aligned manner with zero padding if needed.
+    push.0.0
+    # => [0, 0, res1, res0, next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...]
+    dup.5 add.4 swap.6
+    mem_storew
+    dropw
+    # => [next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...]
+    
+    # 5) Clean up the stack.
+    drop drop
+    # => [...]
+end
+
+#! Reduces the kernel procedures digests using auxiliary randomness.
+#!
+#! Input: [digests_ptr, ...]
+#! Output: [res1, res0, next_ptr, ...]
+#!
+#! where:
+#!  1. `digests_ptr` is a pointer to the kernel procedures digests, and
+#!  2. `res = (res0, res1)` is the resulting reduced value.
+proc.reduce_kernel_digests
+    # Load alpha
+    padw exec.constants::aux_rand_nd_ptr mem_loadw
+    # => [alpha1, alpha0, beta1, beta0, digests_ptr, ...]
+
+    # We will keep [beta0, beta1, alpha0 + op_label, alpha1] on the stack so that we can compute
+    # the final result, where op_label is a unique label to domain separate the interaction with
+    # the chiplets` bus.
+    # The final result is then computed as:
+    #
+    #   alpha + op_label * beta^0 + beta * (r_0 * beta^0 + r_1 * beta^1 + r_2 * beta^2 + r_3 * beta^3)
+    swap
+    exec.constants::kernel_proc_table_op_label
+    add
+    swap
+    # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, ...]
+
+    # Push the `horner_eval_ext` accumulator
+    push.0.0
+    # => [acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, ...]
+
+    # Push the pointer to the evaluation point beta
+    exec.constants::aux_rand_nd_ptr
+    # => [beta_ptr, acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0,  digests_ptr, ...]
+
+    # Get the pointer to kernel procedures digests
+    movup.7
+    # => [digests_ptr, beta_ptr, acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0,  ...]
+
+    # Set up the stack for `mem_stream` + `horner_eval_ext`
+    swapw
+    padw push.0.0.0
+    # => [0, 0, 0, Y, alpha1, alpha0 + op_label, beta1, beta0,  digests_ptr, beta_ptr, acc1, acc0, ...]
+    # where `Y` is a garbage word.
+
+    # Store the accumulator to compute the grand product 
+    push.1
+    exec.constants::tmp3 mem_store
+    push.0
+    exec.constants::tmp4 mem_store
+
+
+    exec.constants::get_num_kernel_procedures
+    exec.constants::tmp1 mem_storew
+    dup
+    push.0
+    neq
+
+    while.true
+        mem_stream
+        horner_eval_ext
+        # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, acc1, acc0, ...]
+
+        swapdw
+        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, acc1, acc0, Y, Y, ...]
+
+        movup.7 movup.7
+        # => [acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+        
+        dup.5 dup.5
+        # => [beta1, beta0, acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+        ext2mul
+        # => [tmp1', tmp0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        dup.3 dup.3
+        ext2add
+        # => [term1', term0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        exec.constants::tmp3 mem_load
+        exec.constants::tmp4 mem_load
+        # => [prod_acc1, prod_acc0, term1', term0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        ext2mul
+        # => [prod_acc1', prod_acc0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+    
+        exec.constants::tmp4 mem_store
+        exec.constants::tmp3 mem_store
+        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        push.0 movdn.6
+        push.0 movdn.6
+        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, Y, Y, ...]
+
+        swapdw
+        # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, ...]
+
+        exec.constants::tmp1 mem_loadw sub.1
+        exec.constants::tmp1 mem_storew
+
+        dup
+        push.0
+        neq
+    end
+    # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, ...]
+    dropw dropw dropw
+    # => [digests_ptr, beta_ptr, 0, 0, ...]
+    movdn.3
+    drop drop drop
+    # => [digests_ptr, ...]
+
+    exec.constants::tmp3 mem_load
+    exec.constants::tmp4 mem_load
+    # => [prod_acc1, prod_acc0, digests_ptr, ...]
+end
+
 #! Computes the address where the public inputs are to be stored and returns it.
 #!
 #! In order to be able to call `arithmetic_circuit_eval`, we need to layout the inputs to
@@ -103,7 +335,7 @@ end
 #! from the address where the OOD are stored.
 #!
 #! Input: [...]
-#! Output: [ptr, ...]
+#! Output: [...]
 proc.compute_and_store_public_inputs_address
 
     # 1) Get a pointer to where OOD evaluations are stored
@@ -117,16 +349,20 @@ proc.compute_and_store_public_inputs_address
     # 2. the digest of the program,
     # 3. the digests of procedures making up the kernel.
     #
-    # In total, we need to allocate 16 * 2 * 2 + 4 * 2 + num_ker_proc * 4 * 2
+    # In total, we need to allocate 16 * 2 * 2 + 4 * 2
     # We also need to allocate space for the auxiliary randomness, i.e., 2 * 2
-    sub.76
-    exec.constants::get_num_kernel_procedures
-    mul.8
-    sub
+    # We also need to allocate space for the result of reducing the kernel procedures using
+    # the auxiliary randomness, i.e., 2.
+    # We round up to the next multiple of 4 in order to guarantee memory word-alignment.
+    sub.80
 
     # 3) Store the address of public inputs
     dup
     exec.constants::public_inputs_address_ptr mem_store
+
+    # 4) Store the address of the variable length public inputs
+    add.72
+    exec.constants::variable_length_public_inputs_address_ptr mem_store
 end
 
 #! Loads 4 base field elements from the advice stack and saves them as extension field elements.

--- a/stdlib/asm/crypto/stark/public_inputs.masm
+++ b/stdlib/asm/crypto/stark/public_inputs.masm
@@ -118,8 +118,8 @@ proc.compute_and_store_public_inputs_address
     # 3. the digests of procedures making up the kernel.
     #
     # In total, we need to allocate 16 * 2 * 2 + 4 * 2 + num_ker_proc * 4 * 2
-    # We also need to allocate space for the auxiliary randomness, i.e., 16 * 2
-    sub.104
+    # We also need to allocate space for the auxiliary randomness, i.e., 2 * 2
+    sub.76
     exec.constants::get_num_kernel_procedures
     mul.8
     sub

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -2,7 +2,6 @@
 
 use.std::crypto::stark::constants
 use.std::crypto::stark::utils
-use.std::crypto::hashes::rpo
 
 #! Helper procedure to compute addition of two words component-wise.
 #! Input: [b3, b2, b1, b0, a3, a2, a1, a0]
@@ -44,6 +43,15 @@ export.get_rate_1
     padw exec.constants::r1_ptr mem_loadw
 end
 
+#! Store the first half of the rate portion of the random coin state.
+#!
+#! Input: [R1, ...]
+#! Output: [...]
+#! Cycles: 6
+export.set_rate_1
+    exec.constants::r1_ptr mem_storew dropw
+end
+
 #! Return the second half of the rate portion of the random coin state
 #!
 #! The random coin uses RPO to generate data. The RPO state is composed of 3
@@ -57,6 +65,15 @@ export.get_rate_2
     padw exec.constants::r2_ptr mem_loadw
 end
 
+#! Store the second half of the rate portion of the random coin state.
+#!
+#! Input: [R2, ...]
+#! Output: [...]
+#! Cycles: 6
+export.set_rate_2
+    exec.constants::r2_ptr mem_storew dropw
+end
+
 #! Return the capacity portion of the random coin state
 #!
 #! The random coin uses RPO to generate data. The RPO state is composed of 3
@@ -68,6 +85,37 @@ end
 #! Cycles: 6
 export.get_capacity
     padw exec.constants::c_ptr mem_loadw
+end
+
+#! Set the capacity portion of the random coin state.
+#!
+#! Input: [C, ...]
+#! Output: [...]
+#! Cycles: 6
+export.set_capacity
+    exec.constants::c_ptr mem_storew dropw
+end
+
+#! Load the random coin state on the stack.
+#!
+#! Input: [...]
+#! Output: [R2, R1, C, ...]
+#! Cycles: 18
+export.load_random_coin_state
+    exec.get_capacity
+    exec.get_rate_1
+    exec.get_rate_2
+end
+
+#! Store the random coin state to memory.
+#!
+#! Input: [R2, R1, C, ...]
+#! Output: [...]
+#! Cycles: 18
+export.store_random_coin_state
+    exec.set_rate_2
+    exec.set_rate_1
+    exec.set_capacity
 end
 
 #! Initializes the seed for randomness generation by computing the hash of the proof context using
@@ -133,7 +181,7 @@ export.init_seed
     movdn.3
     #=> [lde_size, log(lde_size), lde_g, 0, trace_length, num_queries, grinding]
 
-    # Save `[lde_size, log(lde_size), lde_g, 0]`
+    # Save `[0, lde_g, log(lde_size), lde_size]`
     exec.constants::set_lde_domain_info_word
     #=> [lde_size, log(lde_size), lde_g, 0, trace_length, num_queries, grinding]
 
@@ -555,32 +603,35 @@ end
 #! NOTE: The cycles count can be estimated, using the fact that r < 8, via the more compact formula
 #!  470 + 236 * (num_queries / 8)
 export.generate_list_indices
+    # Get the number of querie indices we need to generate and the address to where we need
+    # to store them at.
     exec.constants::get_number_queries
     exec.constants::get_fri_queries_address
+    #=> [query_ptr, num_queries, ...]
+
     # Create mask
-    padw
-    exec.constants::get_lde_domain_info_word
-    movup.2 drop
-    movup.2 drop
+    exec.constants::get_lde_domain_log_size
+    exec.constants::get_lde_domain_size
     sub.1
-    #=> [mask, depth, query_ptr, num_queries] where depth = log(lde_size)
+    #=> [mask, depth, query_ptr, num_queries, ...] where depth = log(lde_size)
 
     # Get address holding the integers (this will later hold the FRI queries)
     movup.2
-    #=> [query_ptr, mask, depth, num_queries]
+    #=> [query_ptr, mask, depth, num_queries, ...]
 
     # Load the first half of the rate portion of the state of the random coin. We discard the first
     # element as it is used for PoW and use the remaining the 3.
     exec.get_rate_1
-    #=> [R1, query_ptr, mask, depth, num_queries]
+    #=> [R1, query_ptr, mask, depth, num_queries, ...]
     exec.generate_three_integers
-    #=> [R1, query_ptr+12, mask, depth, num_queries]
+    #=> [R1, query_ptr+12, mask, depth, num_queries, ...]
+
 
     # Load the second half of the rate portion of the state of the random coin.
     exec.constants::r2_ptr mem_loadw
-    #=> [R2, query_ptr+12, mask, depth, num_queries]
+    #=> [R2, query_ptr+12, mask, depth, num_queries, ...]
     exec.generate_four_integers
-    #=> [R2, query_ptr+26, mask, depth, num_queries, ...]
+    #=> [R2, query_ptr+26, mask, depth, num_queries, ..., ...]
 
     # Squeeze
     exec.constants::c_ptr mem_loadw

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -301,93 +301,20 @@ end
 # COEFFICIENT GENERATION
 # =============================================================================================
 
-#! Generates a `num_tuples` tuples of random field elements and stores them in memory
-#! starting from address `dest_ptr`. Each tuple uses 8 memory slots.
-#! TODO: Generalize by keeping track of something similar to the `output` variable in `RpoRandomCoin`
-#! so that we keep track of already used randomness and know when there is a need to apply `hperm`.
-#!
-#! `dest_ptr` must be word-aligned.
-#!
-#! Input: [dest_ptr, num_tuples, ...]
-#! Output: [...]
-#!
-#! Cycles: 69 + (22 * num_tuples) / 4
-proc.generate_random_coefficients
-
-    # Compute the loop counter. We use checked division to make sure the number is a multiple of 4.
-    # If we use field division and num_tuples is not a multiple of 4 then we will enter into
-    # a very large loop with high probability.
-    push.0 dup movup.2 movup.3
-    u32assert u32divmod.4
-    assertz
-    neg
-    #=> [loop_ctr, dest_ptr, x, x, ...]
-    # where loop_ctr = - num_tuples / 4; we negate the counter so that we can count up to 0
-
-    exec.get_rate_1
-    dup.5 mem_storew
-
-    exec.get_rate_2
-    dup.9 add.4 mem_storew
-    #=> [R2, R1, loop_ctr, dest_ptr, 0, 0, ..]
-
-    exec.get_capacity
-    swapdw
-    #=> [R1, loop_ctr, dest_ptr, 0, 0, C, R2 ..]
-    swapw
-    #=> [loop_ctr, dest_ptr, 0, 0, R1, C, R2 ..]
-    swap add.8 swap
-    #=> [loop_ctr, dest_ptr+8, 0, 0, R1, C, R2, ..]
-
-    add.1 dup neq.0
-
-    while.true
-
-        swapw.3 hperm
-        #=> [R2, R1, C, loop_ctr, dest_ptr, x, x, ...]
-
-        # save R2 to mem[dest+4]; we use dup.13 here because it takes only 1 cycle
-        dup.13 add.4 mem_storew
-        #=> [R2, R1, C, loop_ctr, dest_ptr, x, x, ...]
-
-        # save R1 to mem[dest]
-        swapw dup.13 mem_storew swapw
-        #=> [R2, R1, C, loop_ctr, dest_ptr, x, x, ...]
-
-        # update destination pointer and loop counter
-        swapw.3
-        #=> [loop_ctr, dest_ptr, x, x, R1, C, R2, ...]
-
-        swap add.8 swap
-        #=> [loop_ctr, dest_ptr+8, x, x, R1, C, R2, ...]
-
-        add.1 dup
-        #=> [loop_ctr+1, loop_ctr+1, dest_ptr+2, x, x, R1, C, R2, ...]
-
-        neq.0
-    end
-
-    # Save the new state of the random coin
-    dropw
-    exec.constants::r1_ptr mem_storew
-    dropw
-    exec.constants::c_ptr mem_storew
-    dropw
-    exec.constants::r2_ptr mem_storew
-    dropw
-    #=> [...]
-end
-
 #! Draw a list of random extension field elements related to the auxiliary segment of the execution
-#! trace and store the list in memory from `aux_rand_elem_ptr` to `aux_rand_elem_ptr + 32 - 4`.
+#! trace and store them.
+#!
+#! More specifically, we draw two challenges, alpha and beta. This means that our multi-set hash function
+#! has the form `h(m) = alpha + \sum_{i=0}^{|m| - 1} m_i * beta^i` for a message `m`.
 #!
 #! Input: [...]
 #! Output: [...]
-#! Cycles: 159
+#! Cycles: 12
 export.generate_aux_randomness
-    exec.constants::aux_rand_elem_ptr
-    exec.constants::get_num_aux_trace_coefs swap
-    exec.generate_random_coefficients
+    padw exec.constants::r1_ptr mem_loadw
+    exec.constants::aux_rand_elem_ptr mem_storew
+    #=> [beta1, beta0, alpha1, alpha0, ...]
+    dropw
     #=> [...]
 end
 

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -603,7 +603,7 @@ end
 #! NOTE: The cycles count can be estimated, using the fact that r < 8, via the more compact formula
 #!  470 + 236 * (num_queries / 8)
 export.generate_list_indices
-    # Get the number of querie indices we need to generate and the address to where we need
+    # Get the number of query indices we need to generate and the address to where we need
     # to store them at.
     exec.constants::get_number_queries
     exec.constants::get_fri_queries_address

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -284,7 +284,7 @@ export.reseed
     # => [R2, R1, C, ...] (13 cycles)
 
     hperm
-    # => [R2', R1', C', ...] (1 cycles)
+    # => [R2', R1', C`, ...] (1 cycles)
 
     # Save the new state to memory
     # --------------------------------------------------------------------------------------------
@@ -307,14 +307,26 @@ end
 #! More specifically, we draw two challenges, alpha and beta. This means that our multi-set hash function
 #! has the form `h(m) = alpha + \sum_{i=0}^{|m| - 1} m_i * beta^i` for a message `m`.
 #!
+#! As these random challenges have already been used non-deterministically in prior computations, we
+#! also check that the generated challenges matche the non-deterministically provided one.
+#!
 #! Input: [...]
 #! Output: [...]
-#! Cycles: 12
+#! Cycles: 20
 export.generate_aux_randomness
     padw exec.constants::r1_ptr mem_loadw
     exec.constants::aux_rand_elem_ptr mem_storew
     #=> [beta1, beta0, alpha1, alpha0, ...]
-    dropw
+
+    padw exec.constants::aux_rand_nd_ptr mem_loadw
+    # => [alpha1, alpha0, beta1, beta0, beta1, beta0, alpha1, alpha0, ...]
+
+    movup.6 assert_eq
+    movup.5 assert_eq
+    # => [beta1, beta0, beta1, beta0, ...]
+
+    movup.2 assert_eq
+    assert_eq
     #=> [...]
 end
 

--- a/stdlib/asm/crypto/stark/utils.masm
+++ b/stdlib/asm/crypto/stark/utils.masm
@@ -38,9 +38,9 @@ export.validate_inputs
     # 3) Assert that the number of FRI queries is at most 150. This restriction is a soft one
     #    and is due to the memory layout in the `constants.masm` files but can be updated
     #    therein.
-    #    We also make sure that there is at least one FRI query.
+    #    We also make sure that the number of FRI queries is at least 7.
     dup u32lt.151 assert
-    u32gt.0 assert
+    u32gt.6 assert
 
     # 4) Assert that the grinding factor is at most 31
     u32lt.32 assert

--- a/stdlib/asm/crypto/stark/verifier.masm
+++ b/stdlib/asm/crypto/stark/verifier.masm
@@ -30,9 +30,9 @@ use.std::crypto::stark::utils
 #!
 #! Cycles:
 #!  1- Remainder polynomial size 64:
-#!   2175 + num_queries * (512 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
+#!   2015 + num_queries * (512 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
 #!  2- Remainder polynomial size 128:
-#!   2200 + num_queries * (541 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
+#!   2040 + num_queries * (541 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
 #!
 #!  where num_fri_layers is computed as:
 #!
@@ -80,7 +80,7 @@ export.verify
 
     # Draw random ExtFelt for the auxiliary trace
     #
-    # Cycles: 168
+    # Cycles: 12
     exec.random_coin::generate_aux_randomness
     # => [...]
 

--- a/stdlib/asm/crypto/stark/verifier.masm
+++ b/stdlib/asm/crypto/stark/verifier.masm
@@ -15,24 +15,27 @@ use.std::crypto::stark::utils
 #!   - The public inputs are composed of the input and output stacks, of fixed size equal to 16, as
 #!     well as the program and the kernel procedures digests.
 #!   - There are two trace segments, main and auxiliary. It is assumed that the main trace segment
-#!   is 73 columns wide while the auxiliary trace segment is 8 columns wide.
+#!     is 73 columns wide while the auxiliary trace segment is 8 columns wide. Note that we pad the main
+#!     trace to the next multiple of 8.
 #!   - The OOD evaluation frame is composed of two concatenated rows, current and next, each composed
-#!    of 73 elements representing the main trace portion and 8 elements for the auxiliary trace one.
+#!     of 73 elements representing the main trace portion and 8 elements for the auxiliary trace one.
+#!     Note that, due to the padding of the main trace columns, the number of OOD evaluations per row
+#!     is 80 for the main trace.
 #!   - To boost soundness, the protocol is run on a quadratic extension field and this means that
-#!    the OOD evaluation frame is composed of elements in a quadratic extension field i.e. tuples.
-#!    Similarly, elements of the auxiliary trace are quadratic extension field elements. The random
-#!    values for computing random linear combinations are also in this extension field.
+#!     the OOD evaluation frame is composed of elements in a quadratic extension field i.e. tuples.
+#!     Similarly, elements of the auxiliary trace are quadratic extension field elements. The random
+#!     values for computing random linear combinations are also in this extension field.
 #!   - The following procedure makes use of global memory address beyond 3 * 2^30 and these are
-#!    defined in `constants.masm`.
+#!     defined in `constants.masm`.
 #!
 #! Input: [log(trace_length), num_queries, grinding, num_ker_proc, ...]
 #! Output: [...]
 #!
 #! Cycles:
 #!  1- Remainder polynomial size 64:
-#!   2015 + num_queries * (512 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
+#!   2515 + num_queries * (512 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
 #!  2- Remainder polynomial size 128:
-#!   2040 + num_queries * (541 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
+#!   2540 + num_queries * (541 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
 #!
 #!  where num_fri_layers is computed as:
 #!
@@ -58,11 +61,8 @@ export.verify
 
     # Load public inputs
     #
-    # Cycles: xx + xx * number_kernel_procedures
-    exec.public_inputs::load
-
-    exec.random_coin::reseed
-    # => [...]
+    # Cycles: ~ 500 + 70 * number_kernel_procedures
+    exec.public_inputs::process_public_inputs
 
     #==============================================================================================
     #       II) Generate the auxiliary trace random elements

--- a/stdlib/tests/crypto/stark/mod.rs
+++ b/stdlib/tests/crypto/stark/mod.rs
@@ -12,7 +12,7 @@ use test_utils::{
     proptest::proptest, prove,
 };
 use verifier_recursive::{VerifierData, generate_advice_inputs};
-use vm_core::Word;
+use vm_core::{Felt, Word};
 
 mod verifier_recursive;
 
@@ -20,14 +20,13 @@ mod verifier_recursive;
 // in `stdlib/asm/crypto/stark/verifier.masm` are violated.
 #[rstest]
 #[case(None)]
-#[ignore = "see-https://github.com/0xMiden/miden-vm/issues/1781"]
-#[case(Some(KERNEL_ODD_NUM_PROC))]
-#[ignore = "see-https://github.com/0xMiden/miden-vm/issues/1781"]
+#[ignore = "see-https://github.com/0xMiden/air-script/issues/399"]
 #[case(Some(KERNEL_EVEN_NUM_PROC))]
+#[ignore = "see-https://github.com/0xMiden/air-script/issues/399"]
+#[case(Some(KERNEL_ODD_NUM_PROC))]
 fn stark_verifier_e2f4(#[case] kernel: Option<&str>) {
     // An example MASM program to be verified inside Miden VM.
 
-    use vm_core::Felt;
     let example_source = "begin
             repeat.320
                 swap dup.1 add

--- a/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
@@ -60,6 +60,10 @@ pub fn generate_advice_inputs(
     let pub_inputs_int: Vec<u64> = pub_inputs.to_elements().iter().map(|a| a.as_int()).collect();
     advice_stack.extend_from_slice(&pub_inputs_int[..]);
 
+    // add a placeholder for the auxiliary randomness
+    let aux_rand_insertion_index = advice_stack.len();
+    advice_stack.extend_from_slice(&[0, 0, 0, 0]);
+
     // create AIR instance for the computation specified in the proof
     let air = ProcessorAir::new(proof.trace_info().to_owned(), pub_inputs, proof.options().clone());
     let seed_digest = Rpo256::hash_elements(&public_coin_seed);
@@ -86,6 +90,13 @@ pub fn generate_advice_inputs(
         aux_trace_rand_elements.push(rand_elements);
         public_coin.reseed(*commitment);
     }
+
+    let alpha = aux_trace_rand_elements[0][0].to_owned();
+    let beta = aux_trace_rand_elements[0][2].to_owned();
+    advice_stack[aux_rand_insertion_index] = QuadExt::base_element(&beta, 0).as_int();
+    advice_stack[aux_rand_insertion_index + 1] = QuadExt::base_element(&beta, 1).as_int();
+    advice_stack[aux_rand_insertion_index + 2] = QuadExt::base_element(&alpha, 0).as_int();
+    advice_stack[aux_rand_insertion_index + 3] = QuadExt::base_element(&alpha, 1).as_int();
 
     // 3 ----- constraint composition trace -------------------------------------------------------
 


### PR DESCRIPTION
## Describe your changes

This has the advantage of reducing the number of squeezes needed of the random oracle to generate the aux randomness to just one. This means that the only place where there is a complex squeezing/Duplex logic is in the query generation procedure.

This PR also includes testing to make sure that the query sampling procedure is robust.

This closes #920.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'