### PR TITLE
Add kernel procedures digests reduction using auxiliary randomness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [BREAKING] Make `Assembler::source_manager()` be `Send + Sync` (#1822)
 - Simplify and optimize the recursive verifier (#1801).
 - Simplify auxiliary randomness generation (#1810).
+- Add handling of variable length public inputs to the recursive verifier (#1813).
 
 #### Fixes
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -270,8 +270,11 @@ impl ToElements for ProgramInfo {
         result.extend_from_slice(self.program_hash.as_elements());
 
         // append kernel procedure hash elements
+        // we reverse the digests in order to make reducing them using auxiliary randomness easier
         for proc_hash in self.kernel.proc_hashes() {
-            result.extend_from_slice(proc_hash.as_elements());
+            let mut digest = proc_hash.as_elements().to_vec();
+            digest.reverse();
+            result.extend_from_slice(&digest);
         }
         result
     }

--- a/stdlib/asm/crypto/fri/helper.masm
+++ b/stdlib/asm/crypto/fri/helper.masm
@@ -126,8 +126,11 @@ end
 #! Output: [...]
 #!
 #! Cycles:
-#!  1- Remainder of size 32: 1633
-#!  2- Remainder of size 64: 3109
+#!
+#!  1- Remainder polynomial of degree less
+#!     than 64: 157
+#!  2- Remainder polynomial of degree less
+#!     than 128: 191
 export.load_and_verify_remainder
     # Load remainder commitment and save it at `TMP1`
     padw

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -32,6 +32,9 @@ const.NUM_INPUTS_CIRCUIT=232
 # Number of evaluation gates in the constraint evaluation circuit
 const.NUM_EVAL_GATES_CIRCUIT=88
 
+# Op label for kernel procedures table messages
+const.KERNEL_OP_LABEL=0
+
 # MEMORY POINTERS
 # =================================================================================================
 
@@ -479,3 +482,10 @@ end
 export.aux_rand_nd_ptr
     push.AUX_RAND_ND_PTR
 end
+<<<<<<< HEAD
+=======
+
+export.kernel_proc_table_op_label
+    push.KERNEL_OP_LABEL
+end
+>>>>>>> 567fc1a2 (update the computation of unique kernel digests hash to include a domain separator)

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -36,14 +36,20 @@ const.NUM_EVAL_GATES_CIRCUIT=88
 # =================================================================================================
 
 # Trace domain generator
-const.TRACE_DOMAIN_GENERATOR_PTR=4294799999
+const.TRACE_DOMAIN_GENERATOR_PTR=4294799998
+
+# Variable length public inputs address
+const.VARIABLE_LEN_PUBLIC_INPUTS_ADDRESS_PTR=4294799999
 
 # Public inputs address
 const.PUBLIC_INPUTS_ADDRESS_PTR=4294800000
 
 # Random elements
-# There are are currently 16 ExtFelt for a total of 32 Felt. Thus the number of memory slots required is 32.
-const.AUX_RAND_ELEM_PTR=4294899968
+# We use 2 extension field elements for a total of 4 base field elements.
+const.AUX_RAND_ELEM_PTR=4294899996
+# This will hold the non-deterministically loaded 2 random challenges, which will be
+# checked for correctness once we receive the commitment to the auxiliary trace.
+const.AUX_RAND_ND_PTR=4294800004
 
 # OOD Frames
 # (80 + 8) * 2 * 2 Felt for current and next trace rows and 8 * 2 Felt for constraint composition
@@ -153,7 +159,8 @@ const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 #   +------------------------------------------+-------------------------+
 #   | TRACE_DOMAIN_GENERATOR_PTR               |       4294799999        |
 #   | PUBLIC_INPUTS_ADDRESS_PTR                |       4294800000        |
-#   | AUX_RAND_ELEM_PTR                        |       4294899968        |
+#   | AUX_RAND_ND_PTR                          |       4294800004        |
+#   | AUX_RAND_ELEM_PTR                        |       4294899996        |
 #   | OOD_TRACE_CURRENT_PTR                    |       4294900000        |
 #   | OOD_TRACE_NEXT_PTR                       |       4294900162        |
 #   | OOD_CONSTRAINT_EVALS_PTR                 |       4294900324        |
@@ -192,6 +199,10 @@ const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 
 export.public_inputs_address_ptr
     push.PUBLIC_INPUTS_ADDRESS_PTR
+end
+
+export.variable_length_public_inputs_address_ptr
+    push.VARIABLE_LEN_PUBLIC_INPUTS_ADDRESS_PTR
 end
 
 export.ood_trace_current_ptr
@@ -463,4 +474,8 @@ end
 
 export.get_arithmetic_circuit_eval_number_eval_gates
     push.NUM_EVAL_GATES_CIRCUIT
+end
+
+export.aux_rand_nd_ptr
+    push.AUX_RAND_ND_PTR
 end

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -482,10 +482,7 @@ end
 export.aux_rand_nd_ptr
     push.AUX_RAND_ND_PTR
 end
-<<<<<<< HEAD
-=======
 
 export.kernel_proc_table_op_label
     push.KERNEL_OP_LABEL
 end
->>>>>>> 567fc1a2 (update the computation of unique kernel digests hash to include a domain separator)

--- a/stdlib/asm/crypto/stark/public_inputs.masm
+++ b/stdlib/asm/crypto/stark/public_inputs.masm
@@ -222,62 +222,86 @@ proc.reduce_kernel_digests
     padw exec.constants::aux_rand_nd_ptr mem_loadw
     # => [alpha1, alpha0, beta1, beta0, digests_ptr, ...]
 
-    # We will keep [alpha0, alpha1, prod_acc0, prod_acc1] on the stack so that we can compute the final result
-    movup.2 drop
-    movup.2 drop
-    push.1
-    push.0
-    # => [prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, ...]
+    # We will keep [beta0, beta1, alpha0 + op_label, alpha1] on the stack so that we can compute
+    # the final result, where op_label is a unique label to domain separate the interaction with
+    # the chiplets` bus.
+    # The final result is then computed as:
+    #
+    #   alpha + op_label * beta^0 + beta * (r_0 * beta^0 + r_1 * beta^1 + r_2 * beta^2 + r_3 * beta^3)
+    swap
+    exec.constants::kernel_proc_table_op_label
+    add
+    swap
+    # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, ...]
 
     # Push the `horner_eval_ext` accumulator
     push.0.0
-    # => [acc1, acc0, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, ...]
+    # => [acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, ...]
 
     # Push the pointer to the evaluation point beta
     exec.constants::aux_rand_nd_ptr
-    # => [beta_ptr, acc1, acc0, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, ...]
+    # => [beta_ptr, acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0,  digests_ptr, ...]
 
     # Get the pointer to kernel procedures digests
     movup.7
-    # => [digests_ptr, beta_ptr, acc1, acc0, prod_acc1, prod_acc0, alpha1, alpha0, ...]
+    # => [digests_ptr, beta_ptr, acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0,  ...]
 
     # Set up the stack for `mem_stream` + `horner_eval_ext`
     swapw
     padw push.0.0.0
-    # => [0, 0, 0, Y, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, acc1, acc0, ...]
+    # => [0, 0, 0, Y, alpha1, alpha0 + op_label, beta1, beta0,  digests_ptr, beta_ptr, acc1, acc0, ...]
     # where `Y` is a garbage word.
 
-    exec.constants::get_num_kernel_procedures
+    # Store the accumulator to compute the grand product 
+    push.1
+    exec.constants::tmp3 mem_store
+    push.0
+    exec.constants::tmp4 mem_store
 
+
+    exec.constants::get_num_kernel_procedures
     exec.constants::tmp1 mem_storew
     dup
     push.0
     neq
 
     while.true
-
         mem_stream
         horner_eval_ext
-        # => [Y, Y, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, acc1, acc0, ...]
+        # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, acc1, acc0, ...]
 
         swapdw
-        # => [prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, acc1, acc0, Y, Y, ...]
+        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, acc1, acc0, Y, Y, ...]
 
-        movup.7 dup.4 add
-        # => [alpha0 + acc0, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, acc1, Y, Y, ...]
+        movup.7 movup.7
+        # => [acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
         
-        movup.7 dup.4 add
-        # => [alpha1 + acc1, alpha0 + acc0, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, Y, Y, ...]
+        dup.5 dup.5
+        # => [beta1, beta0, acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+        ext2mul
+        # => [tmp1', tmp0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        dup.3 dup.3
+        ext2add
+        # => [term1', term0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        exec.constants::tmp3 mem_load
+        exec.constants::tmp4 mem_load
+        # => [prod_acc1, prod_acc0, term1', term0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
 
         ext2mul
-        # => [prod_acc1', prod_acc0', alpha1, alpha0, digests_ptr, beta_ptr, Y, Y, ...]
+        # => [prod_acc1', prod_acc0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+    
+        exec.constants::tmp4 mem_store
+        exec.constants::tmp3 mem_store
+        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
 
         push.0 movdn.6
         push.0 movdn.6
-        # => [prod_acc1', prod_acc0', alpha1, alpha0, digests_ptr, beta_ptr, 0, 0, Y, Y, ...]
+        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, Y, Y, ...]
 
         swapdw
-        # => [Y, Y, prod_acc1', prod_acc0', alpha1, alpha0, digests_ptr, beta_ptr, 0, 0, ...]
+        # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, ...]
 
         exec.constants::tmp1 mem_loadw sub.1
         exec.constants::tmp1 mem_storew
@@ -286,16 +310,15 @@ proc.reduce_kernel_digests
         push.0
         neq
     end
-    # => [Y, Y, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, acc1, acc0, ...]
-    dropw dropw
-    swapw
-    # => [digests_ptr, beta_ptr, acc1, acc0, prod_acc1, prod_acc0, alpha1, alpha0, ...]
-    movdn.7
-    # => [beta_ptr, acc1, acc0, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, ...]
+    # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, ...]
+    dropw dropw dropw
+    # => [digests_ptr, beta_ptr, 0, 0, ...]
+    movdn.3
     drop drop drop
-    # => [prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, ...]
-    movup.2 drop
-    movup.2 drop
+    # => [digests_ptr, ...]
+
+    exec.constants::tmp3 mem_load
+    exec.constants::tmp4 mem_load
     # => [prod_acc1, prod_acc0, digests_ptr, ...]
 end
 

--- a/stdlib/asm/crypto/stark/public_inputs.masm
+++ b/stdlib/asm/crypto/stark/public_inputs.masm
@@ -1,5 +1,70 @@
 use.std::crypto::stark::constants
 use.std::crypto::hashes::rpo
+use.std::crypto::stark::random_coin
+
+
+#! Processes the public inputs.
+#! 
+#! This involves:
+#!
+#! 1. Loading from the advice stack the fixed-length public inputs and storing them in memory
+#! starting from the address pointed to by `public_inputs_address_ptr`.
+#! 2. Loading from the advice stack the variable-length public inputs, storing them temporarily
+#! in memory, and then reducing them to an element in the challenge field using the auxiliary
+#! randomness. This reduced value is then used to impose a boundary condition on the relevant
+#! auxiliary column. 
+#!
+#! Note that the public inputs are stored as extension field elements.
+#! Note also that, while loading the above, we compute the hash of the public inputs. The hashing
+#! starts with capacity registers of the hash function set to `C` that is the result of hashing
+#! the proof context.
+#!
+#! The output D, that is the digest of the above hashing, is then used in order to reseed
+#! the random coin.
+#!
+#! It is worth noting that:
+#!
+#! 1. Only the fixed-length public inputs are stored for the lifetime of the verification procedure.
+#!    The variable-length public inputs are stored temporarily, as this simplifies the task of
+#!    reducing them using the auxiliary randomness. On the other hand, the resulting values from
+#!    the aforementioned reductions are stored right after the fixed-length public inputs. These
+#!    are stored in word-aligned manner and padded with zeros if needed.
+#! 2. The public inputs address is computed in such a way so as we end up with the following
+#!    memory layout:
+#!
+#!    [..., a_0...a_{m-1}, b_0...b_{n-1}, alpha0, alpha1, beta0, beta1, OOD-evaluations-start, ...]
+#!
+#!    where:
+#!
+#!    1. [a_0...a_{m-1}] are the fixed-length public inputs stored as extension field elements. This
+#!       section is word-aligned.
+#!    2. [b_0...b_{n-1}] are the results of reducing the variable length public inputs using
+#!       auxiliary randomness. This section is word-aligned.
+#!    3. [alpha0, alpha1, beta0, beta1] is the auxiliary randomness.
+#!    4. `OOD-evaluations-start` is the first field element of the section containing the OOD
+#!       evaluations.
+#!
+#!
+#! Input: [C, ...]
+#! Output: [...]
+export.process_public_inputs
+    # 1) Compute the address where the public inputs will be stored and stores it.
+    #    This also computes the address where the reduced variable-length public inputs will be stored.
+    exec.compute_and_store_public_inputs_address
+    # => [C, ...]
+
+    # 2) Load the public inputs.
+    #    This will also hash them so that we can absorb them in the transcript.
+    exec.load
+    # => [D, ...]
+
+    # 3) Absorb into the transcript
+    exec.random_coin::reseed
+    # => [...]
+
+    # 4) Reduce the variable-length public inputs using randomness.
+    exec.reduce_variable_length_public_inputs
+end
 
 
 #! Loads from the advice stack the public inputs and stores them in memory starting from address
@@ -11,7 +76,6 @@ use.std::crypto::hashes::rpo
 #!
 #! Input: [C, ...]
 #! Output: [D, ...]
-#! Cycles: ~ xx + xx * number_kernel_procedures
 export.load
     # Load the public inputs from the advice provider.
     # The public inputs are made up of:
@@ -23,7 +87,7 @@ export.load
     # While loading the public inputs, we also absorb them in the Fiat-Shamir transcript.
 
     # 1) Load the input and output operand stacks
-    exec.compute_and_store_public_inputs_address
+    exec.constants::public_inputs_address_ptr mem_load
     movdn.4
     padw padw
     repeat.4
@@ -38,6 +102,9 @@ export.load
     add.1
 
     # 3) Load the program hash and kernel procedures digests.
+    #    Note that while we are saving the kernel procedures to memory, this is only done so that
+    #    we can later reduce the kernel procedures digests using randomness.
+    #    The memory region that will (temporarily) hold these digests will be later on over-written.
     #    We need one call to the RPO permutation per 2 digests, thus we compute the division
     #    with remainder of the number of digests by 2. If the remainder is 1 then we need
     #    to pad with the zero word, while we do not need to pad otherwise.
@@ -90,6 +157,148 @@ export.load
     movup.4 drop
 end
 
+#! Reduces the variable-length public inputs using the auxiliary randomness.
+#!
+#! The procedure non-deterministically loads the auxiliary randomness from the advice tape and
+#! stores it at `aux_rand_nd_ptr` so that it can be later checked for correctness. After this,
+#! the procedure uses the auxiliary randomness in order to reduce the variable-length public
+#! inputs to a single element in the challenge field. The resulting values are then stored
+#! contiguously after the fixed-length public inputs.
+#!
+#! Currently, the only variable-length public inputs are the kernel procedure digests.
+proc.reduce_variable_length_public_inputs
+    # 1) Load the auxiliary randomness i.e., alpha and beta
+    #    We store them as [beta0, beta1, alpha0, alpha1] since `horner_eval_ext` requires memory
+    #    word-alignment.
+    adv_push.4
+    exec.constants::aux_rand_nd_ptr mem_storew
+    # => [alpha1, alpha0, beta1, beta0, ...]
+    dropw
+    # => [...]
+
+    # 2) Get the pointer to the variable-length public inputs.
+    #    This is also the pointer to the first address at which we will store the results of
+    #    the reductions.
+    exec.constants::variable_length_public_inputs_address_ptr mem_load
+    dup
+    # => [next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...] where
+    # `next_var_len_pub_inputs_ptr` points to the next chunk of variable public inputs to be reduced,
+    # and `var_len_pub_inputs_res_ptr` points to the next available memory location where the result
+    # of the reduction can be stored.
+    # Note that, as mentioned in the top of this module, the variable-length public inputs are only
+    # stored temporarily and they will be over-written by, among other data, the result of reducing
+    # the variable public inputs. 
+
+    # 3) Reduce the variable-length public inputs.
+    #    These include:
+    #    a) Kernel procedure digests.
+    exec.reduce_kernel_digests
+    # => [res1, res0, next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...]
+
+    # 4) Store the results of the reductions.
+    #    This is stored in a word-aligned manner with zero padding if needed.
+    push.0.0
+    # => [0, 0, res1, res0, next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...]
+    dup.5 add.4 swap.6
+    mem_storew
+    dropw
+    # => [next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...]
+    
+    # 5) Clean up the stack.
+    drop drop
+    # => [...]
+end
+
+#! Reduces the kernel procedures digests using auxiliary randomness.
+#!
+#! Input: [digests_ptr, ...]
+#! Output: [res1, res0, next_ptr, ...]
+#!
+#! where:
+#!  1. `digests_ptr` is a pointer to the kernel procedures digests, and
+#!  2. `res = (res0, res1)` is the resulting reduced value.
+proc.reduce_kernel_digests
+    # Load alpha
+    padw exec.constants::aux_rand_nd_ptr mem_loadw
+    # => [alpha1, alpha0, beta1, beta0, digests_ptr, ...]
+
+    # We will keep [alpha0, alpha1, prod_acc0, prod_acc1] on the stack so that we can compute the final result
+    movup.2 drop
+    movup.2 drop
+    push.1
+    push.0
+    # => [prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, ...]
+
+    # Push the `horner_eval_ext` accumulator
+    push.0.0
+    # => [acc1, acc0, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, ...]
+
+    # Push the pointer to the evaluation point beta
+    exec.constants::aux_rand_nd_ptr
+    # => [beta_ptr, acc1, acc0, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, ...]
+
+    # Get the pointer to kernel procedures digests
+    movup.7
+    # => [digests_ptr, beta_ptr, acc1, acc0, prod_acc1, prod_acc0, alpha1, alpha0, ...]
+
+    # Set up the stack for `mem_stream` + `horner_eval_ext`
+    swapw
+    padw push.0.0.0
+    # => [0, 0, 0, Y, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, acc1, acc0, ...]
+    # where `Y` is a garbage word.
+
+    exec.constants::get_num_kernel_procedures
+
+    exec.constants::tmp1 mem_storew
+    dup
+    push.0
+    neq
+
+    while.true
+
+        mem_stream
+        horner_eval_ext
+        # => [Y, Y, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, acc1, acc0, ...]
+
+        swapdw
+        # => [prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, acc1, acc0, Y, Y, ...]
+
+        movup.7 dup.4 add
+        # => [alpha0 + acc0, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, acc1, Y, Y, ...]
+        
+        movup.7 dup.4 add
+        # => [alpha1 + acc1, alpha0 + acc0, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        ext2mul
+        # => [prod_acc1', prod_acc0', alpha1, alpha0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        push.0 movdn.6
+        push.0 movdn.6
+        # => [prod_acc1', prod_acc0', alpha1, alpha0, digests_ptr, beta_ptr, 0, 0, Y, Y, ...]
+
+        swapdw
+        # => [Y, Y, prod_acc1', prod_acc0', alpha1, alpha0, digests_ptr, beta_ptr, 0, 0, ...]
+
+        exec.constants::tmp1 mem_loadw sub.1
+        exec.constants::tmp1 mem_storew
+
+        dup
+        push.0
+        neq
+    end
+    # => [Y, Y, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, beta_ptr, acc1, acc0, ...]
+    dropw dropw
+    swapw
+    # => [digests_ptr, beta_ptr, acc1, acc0, prod_acc1, prod_acc0, alpha1, alpha0, ...]
+    movdn.7
+    # => [beta_ptr, acc1, acc0, prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, ...]
+    drop drop drop
+    # => [prod_acc1, prod_acc0, alpha1, alpha0, digests_ptr, ...]
+    movup.2 drop
+    movup.2 drop
+    # => [prod_acc1, prod_acc0, digests_ptr, ...]
+end
+
 #! Computes the address where the public inputs are to be stored and returns it.
 #!
 #! In order to be able to call `arithmetic_circuit_eval`, we need to layout the inputs to
@@ -103,7 +312,7 @@ end
 #! from the address where the OOD are stored.
 #!
 #! Input: [...]
-#! Output: [ptr, ...]
+#! Output: [...]
 proc.compute_and_store_public_inputs_address
 
     # 1) Get a pointer to where OOD evaluations are stored
@@ -117,16 +326,20 @@ proc.compute_and_store_public_inputs_address
     # 2. the digest of the program,
     # 3. the digests of procedures making up the kernel.
     #
-    # In total, we need to allocate 16 * 2 * 2 + 4 * 2 + num_ker_proc * 4 * 2
+    # In total, we need to allocate 16 * 2 * 2 + 4 * 2
     # We also need to allocate space for the auxiliary randomness, i.e., 2 * 2
-    sub.76
-    exec.constants::get_num_kernel_procedures
-    mul.8
-    sub
+    # We also need to allocate space for the result of reducing the kernel procedures using
+    # the auxiliary randomness, i.e., 2.
+    # We round up to the next multiple of 4 in order to guarantee memory word-alignment.
+    sub.80
 
     # 3) Store the address of public inputs
     dup
     exec.constants::public_inputs_address_ptr mem_store
+
+    # 4) Store the address of the variable length public inputs
+    add.72
+    exec.constants::variable_length_public_inputs_address_ptr mem_store
 end
 
 #! Loads 4 base field elements from the advice stack and saves them as extension field elements.

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -284,7 +284,7 @@ export.reseed
     # => [R2, R1, C, ...] (13 cycles)
 
     hperm
-    # => [R2', R1', C', ...] (1 cycles)
+    # => [R2', R1', C`, ...] (1 cycles)
 
     # Save the new state to memory
     # --------------------------------------------------------------------------------------------
@@ -307,14 +307,26 @@ end
 #! More specifically, we draw two challenges, alpha and beta. This means that our multi-set hash function
 #! has the form `h(m) = alpha + \sum_{i=0}^{|m| - 1} m_i * beta^i` for a message `m`.
 #!
+#! As these random challenges have already been used non-deterministically in prior computations, we
+#! also check that the generated challenges matche the non-deterministically provided one.
+#!
 #! Input: [...]
 #! Output: [...]
-#! Cycles: 12
+#! Cycles: 20
 export.generate_aux_randomness
     padw exec.constants::r1_ptr mem_loadw
     exec.constants::aux_rand_elem_ptr mem_storew
     #=> [beta1, beta0, alpha1, alpha0, ...]
-    dropw
+
+    padw exec.constants::aux_rand_nd_ptr mem_loadw
+    # => [alpha1, alpha0, beta1, beta0, beta1, beta0, alpha1, alpha0, ...]
+
+    movup.6 assert_eq
+    movup.5 assert_eq
+    # => [beta1, beta0, beta1, beta0, ...]
+
+    movup.2 assert_eq
+    assert_eq
     #=> [...]
 end
 

--- a/stdlib/asm/crypto/stark/verifier.masm
+++ b/stdlib/asm/crypto/stark/verifier.masm
@@ -15,24 +15,27 @@ use.std::crypto::stark::utils
 #!   - The public inputs are composed of the input and output stacks, of fixed size equal to 16, as
 #!     well as the program and the kernel procedures digests.
 #!   - There are two trace segments, main and auxiliary. It is assumed that the main trace segment
-#!   is 73 columns wide while the auxiliary trace segment is 8 columns wide.
+#!     is 73 columns wide while the auxiliary trace segment is 8 columns wide. Note that we pad the main
+#!     trace to the next multiple of 8.
 #!   - The OOD evaluation frame is composed of two concatenated rows, current and next, each composed
-#!    of 73 elements representing the main trace portion and 8 elements for the auxiliary trace one.
+#!     of 73 elements representing the main trace portion and 8 elements for the auxiliary trace one.
+#!     Note that, due to the padding of the main trace columns, the number of OOD evaluations per row
+#!     is 80 for the main trace.
 #!   - To boost soundness, the protocol is run on a quadratic extension field and this means that
-#!    the OOD evaluation frame is composed of elements in a quadratic extension field i.e. tuples.
-#!    Similarly, elements of the auxiliary trace are quadratic extension field elements. The random
-#!    values for computing random linear combinations are also in this extension field.
+#!     the OOD evaluation frame is composed of elements in a quadratic extension field i.e. tuples.
+#!     Similarly, elements of the auxiliary trace are quadratic extension field elements. The random
+#!     values for computing random linear combinations are also in this extension field.
 #!   - The following procedure makes use of global memory address beyond 3 * 2^30 and these are
-#!    defined in `constants.masm`.
+#!     defined in `constants.masm`.
 #!
 #! Input: [log(trace_length), num_queries, grinding, num_ker_proc, ...]
 #! Output: [...]
 #!
 #! Cycles:
 #!  1- Remainder polynomial size 64:
-#!   2015 + num_queries * (512 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
+#!   2515 + num_queries * (512 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
 #!  2- Remainder polynomial size 128:
-#!   2040 + num_queries * (541 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
+#!   2540 + num_queries * (541 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
 #!
 #!  where num_fri_layers is computed as:
 #!
@@ -58,11 +61,8 @@ export.verify
 
     # Load public inputs
     #
-    # Cycles: xx + xx * number_kernel_procedures
-    exec.public_inputs::load
-
-    exec.random_coin::reseed
-    # => [...]
+    # Cycles: ~ 500 + 70 * number_kernel_procedures
+    exec.public_inputs::process_public_inputs
 
     #==============================================================================================
     #       II) Generate the auxiliary trace random elements

--- a/stdlib/tests/crypto/stark/mod.rs
+++ b/stdlib/tests/crypto/stark/mod.rs
@@ -12,7 +12,7 @@ use test_utils::{
     proptest::proptest, prove,
 };
 use verifier_recursive::{VerifierData, generate_advice_inputs};
-use vm_core::Word;
+use vm_core::{Felt, Word};
 
 mod verifier_recursive;
 
@@ -20,14 +20,13 @@ mod verifier_recursive;
 // in `stdlib/asm/crypto/stark/verifier.masm` are violated.
 #[rstest]
 #[case(None)]
-#[ignore = "see-https://github.com/0xMiden/miden-vm/issues/1781"]
-#[case(Some(KERNEL_ODD_NUM_PROC))]
-#[ignore = "see-https://github.com/0xMiden/miden-vm/issues/1781"]
+#[ignore = "see-https://github.com/0xMiden/air-script/issues/399"]
 #[case(Some(KERNEL_EVEN_NUM_PROC))]
+#[ignore = "see-https://github.com/0xMiden/air-script/issues/399"]
+#[case(Some(KERNEL_ODD_NUM_PROC))]
 fn stark_verifier_e2f4(#[case] kernel: Option<&str>) {
     // An example MASM program to be verified inside Miden VM.
 
-    use vm_core::Felt;
     let example_source = "begin
             repeat.320
                 swap dup.1 add

--- a/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
@@ -60,6 +60,10 @@ pub fn generate_advice_inputs(
     let pub_inputs_int: Vec<u64> = pub_inputs.to_elements().iter().map(|a| a.as_int()).collect();
     advice_stack.extend_from_slice(&pub_inputs_int[..]);
 
+    // add a placeholder for the auxiliary randomness
+    let aux_rand_insertion_index = advice_stack.len();
+    advice_stack.extend_from_slice(&[0, 0, 0, 0]);
+
     // create AIR instance for the computation specified in the proof
     let air = ProcessorAir::new(proof.trace_info().to_owned(), pub_inputs, proof.options().clone());
     let seed_digest = Rpo256::hash_elements(&public_coin_seed);
@@ -86,6 +90,13 @@ pub fn generate_advice_inputs(
         aux_trace_rand_elements.push(rand_elements);
         public_coin.reseed(*commitment);
     }
+
+    let alpha = aux_trace_rand_elements[0][0].to_owned();
+    let beta = aux_trace_rand_elements[0][2].to_owned();
+    advice_stack[aux_rand_insertion_index] = QuadExt::base_element(&beta, 0).as_int();
+    advice_stack[aux_rand_insertion_index + 1] = QuadExt::base_element(&beta, 1).as_int();
+    advice_stack[aux_rand_insertion_index + 2] = QuadExt::base_element(&alpha, 0).as_int();
+    advice_stack[aux_rand_insertion_index + 3] = QuadExt::base_element(&alpha, 1).as_int();
 
     // 3 ----- constraint composition trace -------------------------------------------------------
 


### PR DESCRIPTION
## Describe your changes

Adds the infrastructure to handle variable length public inputs in the recursive verifier.

The idea is to provide the randomness-reduced value of the variable length public inputs as an input to the ACE circuit.
Although the only variable-length public inputs in the case of the recursive verifier are the kernel procedures digests, the code in this PR tries to be a bit more general to accommodate more general settings.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'