### PR TITLE
Reduce the size of the `AssemblyError` enum

### DIFF
--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -148,13 +148,10 @@ impl Air for ProcessorAir {
     // ASSERTIONS
     // --------------------------------------------------------------------------------------------
 
-    #[allow(clippy::vec_init_then_push)]
     fn get_assertions(&self) -> Vec<Assertion<Felt>> {
-        let mut result = Vec::new();
-
         // --- set assertions for the first step --------------------------------------------------
         // first value of clk is 0
-        result.push(Assertion::single(CLK_COL_IDX, 0, ZERO));
+        let mut result = vec![Assertion::single(CLK_COL_IDX, 0, ZERO)];
 
         if IS_FULL_CONSTRAINT_SET {
             // first value of fmp is 2^30

--- a/assembly/src/assembler/mast_forest_builder.rs
+++ b/assembly/src/assembler/mast_forest_builder.rs
@@ -229,8 +229,8 @@ impl MastForestBuilder {
                 !mismatched_locals || core::cmp::min(cached_locals, procedure_locals) == 0;
             if !is_valid {
                 return Err(AssemblyError::ConflictingDefinitions {
-                    first: cached.fully_qualified_name().clone(),
-                    second: procedure.fully_qualified_name().clone(),
+                    first: cached.fully_qualified_name().clone().into(),
+                    second: procedure.fully_qualified_name().clone().into(),
                 });
             }
         }

--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -457,7 +457,7 @@ impl Assembler {
                     let proc = self.module_graph.get_procedure_unsafe(node);
                     nodes.push(format!("{}::{}", module, proc.name()));
                 }
-                AssemblyError::Cycle { nodes }
+                AssemblyError::Cycle { nodes: nodes.into() }
             })?
             .into_iter()
             .filter(|&gid| self.module_graph.get_procedure_unsafe(gid).is_ast())
@@ -854,7 +854,7 @@ impl Assembler {
                     return Err(AssemblyError::InvalidSysCallTarget {
                         span,
                         source_file: current_source_file,
-                        callee: proc.fully_qualified_name().clone(),
+                        callee: proc.fully_qualified_name().clone().into(),
                     });
                 }
                 let maybe_kernel_path = proc.path();
@@ -863,7 +863,7 @@ impl Assembler {
                     .ok_or_else(|| AssemblyError::InvalidSysCallTarget {
                         span,
                         source_file: current_source_file.clone(),
-                        callee: proc.fully_qualified_name().clone(),
+                        callee: proc.fully_qualified_name().clone().into(),
                     })
                     .and_then(|module| {
                         // Note: this module is guaranteed to be of AST variant, since we have the
@@ -875,7 +875,7 @@ impl Assembler {
                             Err(AssemblyError::InvalidSysCallTarget {
                                 span,
                                 source_file: current_source_file.clone(),
-                                callee: proc.fully_qualified_name().clone(),
+                                callee: proc.fully_qualified_name().clone().into(),
                             })
                         }
                     })?;

--- a/assembly/src/assembler/module_graph/mod.rs
+++ b/assembly/src/assembler/module_graph/mod.rs
@@ -477,7 +477,7 @@ impl ModuleGraph {
                 let proc = self.get_procedure_unsafe(node);
                 nodes.push(format!("{}::{}", module, proc.name()));
             }
-            AssemblyError::Cycle { nodes }
+            AssemblyError::Cycle { nodes: nodes.into() }
         })?;
 
         Ok(())

--- a/assembly/src/assembler/module_graph/name_resolver.rs
+++ b/assembly/src/assembler/module_graph/name_resolver.rs
@@ -226,7 +226,8 @@ impl<'a> NameResolver<'a> {
                             self.graph.source_manager.get(caller.span.source_id()).ok(),
                         )
                         .with_labeled_span(caller.span, "unable to resolve this name locally"),
-                ],
+                ]
+                .into(),
             }),
         }
     }
@@ -326,7 +327,7 @@ impl<'a> NameResolver<'a> {
                                 .source_manager
                                 .get(current_caller.span.source_id())
                                 .ok(),
-                            callee: current_callee.into_owned(),
+                            callee: current_callee.into_owned().into(),
                         });
                     }
                     break Ok(id);
@@ -344,7 +345,7 @@ impl<'a> NameResolver<'a> {
                                 RelatedLabel::advice("recursive alias")
                                     .with_source_file(self.graph.source_manager.get(caller.span.source_id()).ok())
                                     .with_labeled_span(caller.span, "as a result of resolving this procedure reference"),
-                            ],
+                            ].into(),
                         });
                     }
                     current_caller = Cow::Owned(CallerInfo {
@@ -381,7 +382,8 @@ impl<'a> NameResolver<'a> {
                                     current_callee.span(),
                                     "this name cannot be resolved",
                                 ),
-                        ],
+                        ]
+                        .into(),
                     });
                 },
                 None if matches!(current_caller.kind, InvokeKind::SysCall) => {
@@ -398,7 +400,7 @@ impl<'a> NameResolver<'a> {
                                         current_callee.span(),
                                         "this name cannot be resolved, because the assembler has an empty kernel",
                                     ),
-                            ]
+                            ].into()
                         });
                     } else {
                         // No such kernel procedure
@@ -413,7 +415,7 @@ impl<'a> NameResolver<'a> {
                                         current_callee.span(),
                                         "this name cannot be resolved",
                                     ),
-                            ]
+                            ].into()
                         });
                     }
                 },
@@ -440,7 +442,8 @@ impl<'a> NameResolver<'a> {
                                     current_callee.span(),
                                     "this name cannot be resolved",
                                 ),
-                        ],
+                        ]
+                        .into(),
                     });
                 },
             }

--- a/assembly/src/errors.rs
+++ b/assembly/src/errors.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc};
 
 use vm_core::mast::MastForestError;
 
@@ -14,7 +14,6 @@ use crate::{
 /// An error which can be generated while compiling a Miden assembly program into a MAST.
 #[derive(Debug, thiserror::Error, Diagnostic)]
 #[non_exhaustive]
-#[allow(clippy::large_enum_variant)]
 pub enum AssemblyError {
     #[error("there are no modules to analyze")]
     #[diagnostic()]
@@ -23,18 +22,18 @@ pub enum AssemblyError {
     #[diagnostic(help("see diagnostics for details"))]
     Failed {
         #[related]
-        labels: Vec<RelatedLabel>,
+        labels: Box<[RelatedLabel]>,
     },
-    #[error("found a cycle in the call graph, involving these procedures: {}", nodes.as_slice().join(", "))]
+    #[error("found a cycle in the call graph, involving these procedures: {}", nodes.join(", "))]
     #[diagnostic()]
-    Cycle { nodes: Vec<String> },
+    Cycle { nodes: Box<[String]> },
     #[error(
         "two procedures found with same mast root, but conflicting definitions ('{first}' and '{second}')"
     )]
     #[diagnostic()]
     ConflictingDefinitions {
-        first: QualifiedProcedureName,
-        second: QualifiedProcedureName,
+        first: Box<QualifiedProcedureName>,
+        second: Box<QualifiedProcedureName>,
     },
     #[error("duplicate definition found for module '{path}'")]
     #[diagnostic()]
@@ -61,7 +60,7 @@ pub enum AssemblyError {
         span: SourceSpan,
         #[source_code]
         source_file: Option<Arc<SourceFile>>,
-        callee: QualifiedProcedureName,
+        callee: Box<QualifiedProcedureName>,
     },
     #[error("invalid local word index: {local_addr}")]
     #[diagnostic(help("the index to a local word must be a multiple of 4"))]


### PR DESCRIPTION
A large enum used in several places can cause a negative runtime impact. In fact, this is so common that the community created several lints to prevent such a scenario.

- [large_enum_variant](https://rust-lang.github.io/rust-clippy/master/?groups=perf#large_enum_variant)
- [result_large_err](https://rust-lang.github.io/rust-clippy/master/?groups=perf#result_large_err)
- [variant_size_differences](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/types/static.VARIANT_SIZE_DIFFERENCES.html)

This PR cuts **64 bytes** from the `AssemblyError` enum through the use of dynamic allocation that doesn't change any intended behavior or any hot path. AFAICT, this strategy shouldn't be a problem because errors raise in rare exceptional cases.