### PR TITLE
`OpBatch` refactor

### DIFF
--- a/assembly/src/assembler/mast_forest_builder.rs
+++ b/assembly/src/assembler/mast_forest_builder.rs
@@ -335,8 +335,10 @@ impl MastForestBuilder {
                 for &(op_idx, decorator) in basic_block_node.decorators() {
                     decorators.push((op_idx + operations.len(), decorator));
                 }
+                // Merge all operations except the NOOPs
                 for batch in basic_block_node.op_batches() {
-                    operations.extend_from_slice(batch.ops());
+                    operations
+                        .extend(batch.ops().iter().filter(|op| !matches!(op, Operation::Noop)));
                 }
             } else {
                 // if we don't want to merge this block, we flush the buffer of operations into a

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -194,7 +194,7 @@ fn basic_block_and_simple_if_true() -> TestResult {
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) noop end
+        basic_block push(2) push(3) noop noop end
         if.true
             basic_block add end
         else
@@ -210,7 +210,7 @@ end";
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) noop end
+        basic_block push(2) push(3) noop noop end
         if.true
             basic_block add end
         else
@@ -232,7 +232,7 @@ fn basic_block_and_simple_if_false() -> TestResult {
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) noop end
+        basic_block push(2) push(3) noop noop end
         if.true
             basic_block mul end
         else
@@ -248,7 +248,7 @@ end";
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) noop end
+        basic_block push(2) push(3) noop noop end
         if.true
             basic_block noop end
         else
@@ -505,7 +505,7 @@ fn multiple_constants_push() -> TestResult {
     );
     let expected = "\
 begin
-    basic_block push(21) push(64) push(44) push(72) noop end
+    basic_block push(21) push(64) push(44) push(72) noop noop noop noop end
 end";
     let program = context.assemble(source)?;
     assert_str_eq!(format!("{program}"), expected);
@@ -1666,6 +1666,9 @@ begin
         mpverify({code2})
         mpverify({code2})
         mpverify({code1})
+        noop
+        noop
+        noop
     end
 end"
     );
@@ -1729,17 +1732,17 @@ fn nested_control_blocks() -> TestResult {
 begin
     join
         join
-            basic_block push(2) push(3) noop end
+            basic_block push(2) push(3) noop noop end
             if.true
                 join
                     basic_block add end
                     while.true
-                        basic_block push(7) push(11) add end
+                        basic_block push(7) push(11) add noop end
                     end
                 end
             else
                 join
-                    basic_block mul push(8) push(8) noop end
+                    basic_block mul push(8) push(8) noop noop end
                     if.true
                         basic_block mul end
                     else
@@ -1820,7 +1823,7 @@ fn program_with_one_procedure() -> TestResult {
     let program = context.assemble(source)?;
     let expected = "\
 begin
-    basic_block push(2) push(3) add push(3) push(7) mul end
+    basic_block push(2) push(3) add push(3) push(7) mul noop noop noop end
 end";
     assert_str_eq!(format!("{program}"), expected);
     Ok(())
@@ -1849,12 +1852,14 @@ begin
         push(11)
         push(5)
         noop
+        noop
         push(3)
         push(7)
         mul
         add
         neg
         add
+        noop
     end
 end";
     assert_str_eq!(format!("{program}"), expected);
@@ -2099,7 +2104,7 @@ fn program_with_one_import_and_hex_call() -> TestResult {
 begin
     join
         join
-            basic_block push(4) push(3) noop end
+            basic_block push(4) push(3) noop noop end
             external.0xc2545da99d3a1f3f38d957c7893c44d78998d8ea8b11aba7e22c8c2b2a213dae
         end
         call.0x20234ee941e53a15886e733cc8e041198c6e90d2a16ea18ce1030e8c3596dd38
@@ -2236,7 +2241,7 @@ fn program_with_reexported_proc_in_same_library() -> TestResult {
 begin
     join
         join
-            basic_block push(4) push(3) noop end
+            basic_block push(4) push(3) noop noop end
             external.0xb9691da1d9b4b364aca0a0990e9f04c446a2faa622c8dd0d8831527dbec61393
         end
         external.0xcb08c107c81c582788cbf63c99f6b455e11b33bb98ca05fe1cfa17c087dfa8f1
@@ -2306,7 +2311,7 @@ fn program_with_reexported_proc_in_another_library() -> TestResult {
 begin
     join
         join
-            basic_block push(4) push(3) noop end
+            basic_block push(4) push(3) noop noop end
             external.0xb9691da1d9b4b364aca0a0990e9f04c446a2faa622c8dd0d8831527dbec61393
         end
         external.0xcb08c107c81c582788cbf63c99f6b455e11b33bb98ca05fe1cfa17c087dfa8f1
@@ -2562,12 +2567,12 @@ begin
                 join
                     basic_block add end
                     while.true
-                        basic_block push(7) push(11) add end
+                        basic_block push(7) push(11) add noop end
                     end
                 end
             else
                 join
-                    basic_block mul push(8) push(8) noop end
+                    basic_block mul push(8) push(8) noop noop end
                     if.true
                         basic_block mul end
                     else

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -194,7 +194,7 @@ fn basic_block_and_simple_if_true() -> TestResult {
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop end
         if.true
             basic_block add end
         else
@@ -210,7 +210,7 @@ end";
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop end
         if.true
             basic_block add end
         else
@@ -232,7 +232,7 @@ fn basic_block_and_simple_if_false() -> TestResult {
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop end
         if.true
             basic_block mul end
         else
@@ -248,7 +248,7 @@ end";
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop end
         if.true
             basic_block noop end
         else
@@ -485,7 +485,7 @@ fn simple_constant() -> TestResult {
     );
     let expected = "\
 begin
-    basic_block push(7) end
+    basic_block push(7) noop end
 end";
     let program = context.assemble(source)?;
     assert_str_eq!(format!("{program}"), expected);
@@ -505,7 +505,7 @@ fn multiple_constants_push() -> TestResult {
     );
     let expected = "\
 begin
-    basic_block push(21) push(64) push(44) push(72) end
+    basic_block push(21) push(64) push(44) push(72) noop end
 end";
     let program = context.assemble(source)?;
     assert_str_eq!(format!("{program}"), expected);
@@ -525,7 +525,7 @@ fn constant_numeric_expression() -> TestResult {
     );
     let expected = "\
 begin
-    basic_block push(26) end
+    basic_block push(26) noop end
 end";
     let program = context.assemble(source)?;
     assert_str_eq!(format!("{program}"), expected);
@@ -547,7 +547,7 @@ fn constant_alphanumeric_expression() -> TestResult {
     );
     let expected = "\
 begin
-    basic_block push(21) end
+    basic_block push(21) noop end
 end";
     let program = context.assemble(source)?;
     assert_str_eq!(format!("{program}"), expected);
@@ -567,7 +567,7 @@ fn constant_hexadecimal_value() -> TestResult {
     );
     let expected = "\
 begin
-    basic_block push(255) end
+    basic_block push(255) noop end
 end";
     let program = context.assemble(source)?;
     assert_str_eq!(format!("{program}"), expected);
@@ -587,7 +587,7 @@ fn constant_field_division() -> TestResult {
     );
     let expected = "\
 begin
-    basic_block push(2) end
+    basic_block push(2) noop end
 end";
     let program = context.assemble(source)?;
     assert_str_eq!(format!("{program}"), expected);
@@ -1074,15 +1074,15 @@ begin
     join
         trace(0)
         if.true
-            basic_block trace(1) push(42) trace(2) end
+            basic_block trace(1) push(42) trace(2) noop end
         else
-            basic_block trace(3) push(22) trace(3) end
+            basic_block trace(3) push(22) trace(3) noop end
         end
         trace(4)
         if.true
-            basic_block trace(1) push(42) trace(2) end
+            basic_block trace(1) push(42) trace(2) noop end
         else
-            basic_block trace(3) push(22) trace(3) end
+            basic_block trace(3) push(22) trace(3) noop end
         end
         trace(4)
     end
@@ -1228,9 +1228,9 @@ begin
         end
         trace(6)
         if.true
-            basic_block trace(7) push(42) trace(8) end
+            basic_block trace(7) push(42) trace(8) noop end
         else
-            basic_block trace(9) push(22) trace(10) end
+            basic_block trace(9) push(22) trace(10) noop end
         end
     end
     trace(11)
@@ -1729,7 +1729,7 @@ fn nested_control_blocks() -> TestResult {
 begin
     join
         join
-            basic_block push(2) push(3) end
+            basic_block push(2) push(3) noop end
             if.true
                 join
                     basic_block add end
@@ -1739,7 +1739,7 @@ begin
                 end
             else
                 join
-                    basic_block mul push(8) push(8) end
+                    basic_block mul push(8) push(8) noop end
                     if.true
                         basic_block mul end
                     else
@@ -1848,6 +1848,7 @@ begin
         mul
         push(11)
         push(5)
+        noop
         push(3)
         push(7)
         mul
@@ -2098,7 +2099,7 @@ fn program_with_one_import_and_hex_call() -> TestResult {
 begin
     join
         join
-            basic_block push(4) push(3) end
+            basic_block push(4) push(3) noop end
             external.0xc2545da99d3a1f3f38d957c7893c44d78998d8ea8b11aba7e22c8c2b2a213dae
         end
         call.0x20234ee941e53a15886e733cc8e041198c6e90d2a16ea18ce1030e8c3596dd38
@@ -2235,7 +2236,7 @@ fn program_with_reexported_proc_in_same_library() -> TestResult {
 begin
     join
         join
-            basic_block push(4) push(3) end
+            basic_block push(4) push(3) noop end
             external.0xb9691da1d9b4b364aca0a0990e9f04c446a2faa622c8dd0d8831527dbec61393
         end
         external.0xcb08c107c81c582788cbf63c99f6b455e11b33bb98ca05fe1cfa17c087dfa8f1
@@ -2305,7 +2306,7 @@ fn program_with_reexported_proc_in_another_library() -> TestResult {
 begin
     join
         join
-            basic_block push(4) push(3) end
+            basic_block push(4) push(3) noop end
             external.0xb9691da1d9b4b364aca0a0990e9f04c446a2faa622c8dd0d8831527dbec61393
         end
         external.0xcb08c107c81c582788cbf63c99f6b455e11b33bb98ca05fe1cfa17c087dfa8f1
@@ -2556,7 +2557,7 @@ fn comment_in_nested_control_blocks() -> TestResult {
 begin
     join
         join
-            basic_block pad incr push(2) end
+            basic_block pad incr push(2) noop end
             if.true
                 join
                     basic_block add end
@@ -2566,7 +2567,7 @@ begin
                 end
             else
                 join
-                    basic_block mul push(8) push(8) end
+                    basic_block mul push(8) push(8) noop end
                     if.true
                         basic_block mul end
                     else

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -15,7 +15,7 @@ use crate::crypto::hash::{Blake3_256, Blake3Digest, Digest};
 mod node;
 pub use node::{
     BasicBlockNode, CallNode, DynNode, ExternalNode, JoinNode, LoopNode, MastNode, MastNodeExt,
-    OP_BATCH_SIZE, OP_GROUP_SIZE, OpBatch, OperationOrDecorator, SplitNode,
+    OP_BATCH_SIZE, OP_GROUP_SIZE, OpBatch, OpBatchAccumulator, OperationOrDecorator, SplitNode,
 };
 use winter_utils::{ByteWriter, DeserializationError, Serializable};
 

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -11,8 +11,7 @@ use crate::{
 };
 
 mod op_batch;
-pub use op_batch::OpBatch;
-use op_batch::OpBatchAccumulator;
+pub use op_batch::{OpBatch, OpBatchAccumulator};
 
 use super::MastNodeExt;
 

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -403,21 +403,9 @@ fn batch_and_hash_ops(ops: Vec<Operation>) -> (Vec<OpBatch>, RpoDigest) {
 /// Groups the provided operations into batches as described in the docs for this module (i.e., up
 /// to 9 operations per group, and 8 groups per batch).
 fn batch_ops(ops: Vec<Operation>) -> Vec<OpBatch> {
-    let mut batches = Vec::<OpBatch>::new();
     let mut batch_acc = OpBatchAccumulator::new();
-
-    for op in ops {
-        if let Some(batch) = batch_acc.add_op(op) {
-            batches.push(batch);
-        }
-    }
-
-    // Make sure we finished processing the last batch.
-    if let Some(batch) = batch_acc.into_batch() {
-        batches.push(batch);
-    }
-
-    batches
+    batch_acc.add_ops(&ops);
+    batch_acc.into_batches()
 }
 
 /// Checks if a given decorators list is valid (only checked in debug mode)

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -23,7 +23,7 @@ mod tests;
 // ================================================================================================
 
 /// Maximum number of operations per group.
-pub const GROUP_SIZE: usize = 9;
+pub const OP_GROUP_SIZE: usize = 9;
 
 /// Maximum number of groups per batch.
 pub const BATCH_SIZE: usize = 8;
@@ -408,22 +408,13 @@ fn batch_ops(ops: Vec<Operation>) -> Vec<OpBatch> {
     let mut batch_acc = OpBatchAccumulator::new();
 
     for op in ops {
-        // If the operation cannot be accepted into the current accumulator, add the contents of
-        // the accumulator to the list of batches and start a new accumulator.
-        if !batch_acc.can_accept_op(op) {
-            let batch = batch_acc.into_batch();
-            batch_acc = OpBatchAccumulator::new();
-
+        if let Some(batch) = batch_acc.add_op(op) {
             batches.push(batch);
         }
-
-        // Add the operation to the accumulator.
-        batch_acc.add_op(op);
     }
 
     // Make sure we finished processing the last batch.
-    if !batch_acc.is_empty() {
-        let batch = batch_acc.into_batch();
+    if let Some(batch) = batch_acc.into_batch() {
         batches.push(batch);
     }
 

--- a/core/src/mast/node/basic_block_node/op_batch.rs
+++ b/core/src/mast/node/basic_block_node/op_batch.rs
@@ -51,7 +51,7 @@ impl OpBatch {
 // ================================================================================================
 
 /// An accumulator used in construction of operation batches.
-pub(super) struct OpBatchAccumulator {
+pub struct OpBatchAccumulator {
     /// A list of operations in this batch.
     ///
     /// This list is redundant with opcodes stored in the operation groups.

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -3,7 +3,8 @@ use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 pub use basic_block_node::{
-    BATCH_SIZE as OP_BATCH_SIZE, BasicBlockNode, OP_GROUP_SIZE, OpBatch, OpBatchAccumulator, OperationOrDecorator,
+    BATCH_SIZE as OP_BATCH_SIZE, BasicBlockNode, OP_GROUP_SIZE, OpBatch, OpBatchAccumulator,
+    OperationOrDecorator,
 };
 
 mod call_node;

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -3,7 +3,7 @@ use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 pub use basic_block_node::{
-    BATCH_SIZE as OP_BATCH_SIZE, BasicBlockNode, OP_GROUP_SIZE, OpBatch, OperationOrDecorator,
+    BATCH_SIZE as OP_BATCH_SIZE, BasicBlockNode, OP_GROUP_SIZE, OpBatch, OpBatchAccumulator, OperationOrDecorator,
 };
 
 mod call_node;

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -3,8 +3,7 @@ use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 pub use basic_block_node::{
-    BATCH_SIZE as OP_BATCH_SIZE, BasicBlockNode, GROUP_SIZE as OP_GROUP_SIZE, OpBatch,
-    OperationOrDecorator,
+    BATCH_SIZE as OP_BATCH_SIZE, BasicBlockNode, OP_GROUP_SIZE, OpBatch, OperationOrDecorator,
 };
 
 mod call_node;

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -954,13 +954,15 @@ fn get_num_groups_in_next_batch(num_groups_left: Felt) -> usize {
 /// Build an operation group from the specified list of operations.
 #[cfg(test)]
 pub fn build_op_group(ops: &[Operation]) -> Felt {
+    use vm_core::mast::OP_GROUP_SIZE;
+
     let mut group = 0u64;
     let mut i = 0;
     for op in ops.iter() {
         group |= (op.op_code() as u64) << (Operation::OP_BITS * i);
         i += 1;
     }
-    assert!(i <= super::OP_GROUP_SIZE, "too many ops");
+    assert!(i <= OP_GROUP_SIZE, "too many ops");
     Felt::new(group)
 }
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -180,6 +180,17 @@ pub enum ExecutionError {
         source_file: Option<Arc<SourceFile>>,
         root_digest: Digest,
     },
+    #[error("The op batch is malformed")]
+    #[diagnostic(help(
+        "The number of groups in the batch is {num_groups}, but needs to be a power of 2"
+    ))]
+    MalformedOpBatch {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        num_groups: usize,
+    },
     #[error("node id {node_id} does not exist in MAST forest")]
     MastNodeNotFoundInForest { node_id: MastNodeId },
     #[error(transparent)]
@@ -414,6 +425,14 @@ impl ExecutionError {
     pub fn log_argument_zero(clk: RowIndex, err_ctx: &ErrorContext<'_, impl MastNodeExt>) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::LogArgumentZero { label, source_file, clk }
+    }
+
+    pub fn malformed_op_batch(
+        num_groups: usize,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::MalformedOpBatch { label, source_file, num_groups }
     }
 
     pub fn malfored_mast_forest_in_host(

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -681,15 +681,13 @@ impl FastProcessor {
         program: &MastForest,
         host: &mut impl Host,
     ) -> Result<(), ExecutionError> {
-        let op_counts = batch.op_counts();
-        let mut op_idx_in_group = 0;
-        let mut group_idx = 0;
-        let mut next_group_idx = 1;
-
-        // round up the number of groups to be processed to the next power of two; we do this
-        // because the processor requires the number of groups to be either 1, 2, 4, or 8; if
-        // the actual number of groups is smaller, we'll pad the batch with NOOPs at the end
-        let num_batch_groups = batch.num_groups().next_power_of_two();
+        // Ensure the number of groups is a power of 2.
+        if !batch.num_groups().is_power_of_two() {
+            return Err(ExecutionError::malformed_op_batch(
+                batch.num_groups(),
+                &ErrorContext::default(),
+            ));
+        }
 
         // execute operations in the batch one by one
         for (op_idx_in_batch, op) in batch.ops().iter().enumerate() {
@@ -704,36 +702,7 @@ impl FastProcessor {
 
             // decode and execute the operation
             self.execute_op(op, batch_offset_in_block + op_idx_in_batch, program, host)?;
-
-            // if the operation carries an immediate value, the value is stored at the next group
-            // pointer; so, we advance the pointer to the following group
-            let has_imm = op.imm_value().is_some();
-            if has_imm {
-                next_group_idx += 1;
-            }
-
-            // determine if we've executed all non-decorator operations in a group
-            if op_idx_in_group == op_counts[group_idx] - 1 {
-                debug_assert!(
-                    !has_imm,
-                    "operation with immediate value at the end of an operation group"
-                );
-
-                // move to the next group and reset operation index
-                group_idx = next_group_idx;
-                next_group_idx += 1;
-                op_idx_in_group = 0;
-            } else {
-                op_idx_in_group += 1;
-            }
         }
-
-        // make sure we execute the required number of operation groups; this would happen when the
-        // actual number of operation groups was not a power of two. In this processor, this
-        // corresponds to incrementing the clock by the number of empty op groups (i.e. 1 NOOP
-        // executed per missing op group).
-
-        self.clk += (num_batch_groups - group_idx) as u32;
 
         Ok(())
     }

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -8,7 +8,7 @@ use vm_core::{
     WORD_SIZE, Word, ZERO,
     mast::{
         BasicBlockNode, CallNode, DynNode, ExternalNode, JoinNode, LoopNode, MastForest, MastNode,
-        MastNodeId, OP_GROUP_SIZE, OpBatch, SplitNode,
+        MastNodeId, OpBatch, SplitNode,
     },
     stack::MIN_STACK_DEPTH,
     utils::range,
@@ -714,17 +714,12 @@ impl FastProcessor {
 
             // determine if we've executed all non-decorator operations in a group
             if op_idx_in_group == op_counts[group_idx] - 1 {
-                // if we are at the end of the group, first check if the operation carries an
-                // immediate value
-                if has_imm {
-                    // an operation with an immediate value cannot be the last operation in a group
-                    // so, we need execute a NOOP after it. In this processor, we increment the
-                    // clock to account for the NOOP.
-                    debug_assert!(op_idx_in_group < OP_GROUP_SIZE - 1, "invalid op index");
-                    self.clk += 1_u32;
-                }
+                debug_assert!(
+                    !has_imm,
+                    "operation with immediate value at the end of an operation group"
+                );
 
-                // then, move to the next group and reset operation index
+                // move to the next group and reset operation index
                 group_idx = next_group_idx;
                 next_group_idx += 1;
                 op_idx_in_group = 0;

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -30,8 +30,7 @@ pub use vm_core::{
 use vm_core::{
     Decorator, DecoratorIterator, FieldElement, WORD_SIZE,
     mast::{
-        BasicBlockNode, CallNode, DynNode, JoinNode, LoopNode, MastNodeExt, OP_GROUP_SIZE, OpBatch,
-        SplitNode,
+        BasicBlockNode, CallNode, DynNode, JoinNode, LoopNode, MastNodeExt, OpBatch, SplitNode,
     },
 };
 pub use winter_prover::matrix::ColMatrix;
@@ -651,19 +650,12 @@ impl Process {
 
             // determine if we've executed all non-decorator operations in a group
             if op_idx == op_counts[group_idx] - 1 {
-                // if we are at the end of the group, first check if the operation carries an
-                // immediate value
-                if has_imm {
-                    // an operation with an immediate value cannot be the last operation in a group
-                    // so, we need execute a NOOP after it. the assert also makes sure that there
-                    // is enough room in the group to execute a NOOP (if there isn't, there is a
-                    // bug somewhere in the assembler)
-                    debug_assert!(op_idx < OP_GROUP_SIZE - 1, "invalid op index");
-                    self.decoder.execute_user_op(Operation::Noop, op_idx + 1);
-                    self.execute_op(Operation::Noop, program, host)?;
-                }
+                debug_assert!(
+                    !has_imm,
+                    "operation with immediate value at the end of an operation group"
+                );
 
-                // then, move to the next group and reset operation index
+                // move to the next group and reset operation index
                 group_idx = next_group_idx;
                 next_group_idx += 1;
                 op_idx = 0;

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -159,7 +159,7 @@ fn test_falcon512_probabilistic_product_failure() {
     expect_exec_error_matches!(
         test,
         ExecutionError::FailedAssertion{clk, err_code, err_msg, label: _, source_file: _ }
-        if clk == RowIndex::from(3182) && err_code == ZERO && err_msg.is_none()
+        if clk == RowIndex::from(3193) && err_code == ZERO && err_msg.is_none()
     );
 }
 

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -159,7 +159,7 @@ fn test_falcon512_probabilistic_product_failure() {
     expect_exec_error_matches!(
         test,
         ExecutionError::FailedAssertion{clk, err_code, err_msg, label: _, source_file: _ }
-        if clk == RowIndex::from(3193) && err_code == ZERO && err_msg.is_none()
+        if clk == RowIndex::from(3194) && err_code == ZERO && err_msg.is_none()
     );
 }
 


### PR DESCRIPTION
Closes #1815 

Inserts all the NOOPs due to op batch constraints at assembly-time rather than at runtime.

Left to do:
- Fix `DecoratorList` representation
  - The index associated with a decorator is in the list of operations *before* NOOPs are appended, and so are currently broken by this change
- Fix serialization/deserialization
- Think: return an error when group ends with an operation containing an immediate value?
  - keeping track of this will slow the fast processor down
- Check if some source spans are broken after we insert noops (so that the `op_idx` would be invalidated)