### PR TITLE
chore(lint): add clippy-extra.sh for optional stricter linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ The project is organized into several crates like so:
 | [stdlib](stdlib)         | Contains Miden standard library. The goal of Miden standard library is to provide highly-optimized and battle-tested implementations of commonly-used primitives.                                                      |
 | [test-utils](test-utils) | Contains utilities for testing execution of Miden VM programs.                                                                                                                                                         |
 
+## Optional Clippy Checks
+
+To run additional Clippy lints (e.g. `pedantic`, `style`, `cargo`, etc.), you can use the following script:
+
+```bash
+./scripts/clippy-extra.sh
+```
+
+This script enables strict linting rules that are too verbose for regular development or CI. It is useful when you want to catch rare but potentially important issues such as missing documentation, unnecessary casts, or inefficient method usage.
+
 ## Performance
 
 The benchmarks below should be viewed only as a rough guide for expected future performance. The reasons for this are twofold:

--- a/scripts/clippy-extra.sh
+++ b/scripts/clippy-extra.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cargo clippy --workspace --all-targets --all-features \
+  -W clippy::pedantic \
+  -W clippy::style \
+  -W clippy::missing_docs \
+  -- -D warnings


### PR DESCRIPTION
## Describe your changes
Closes #1479 

This PR adds an optional script to run stricter Clippy lints across the codebase.

- Introduces `scripts/clippy-extra.sh` to enable additional checks (`pedantic`, `style`, `missing_docs`, etc.)
- The script is intended for contributors who want to proactively catch rare but useful warnings (e.g., unnecessary casts, missing `#[must_use]`, undocumented panics/errors, etc.)
- These checks are not enforced in CI to avoid developer friction, but the script provides an easy opt-in for manual use.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'