### PR TITLE
feat: simplify and optimize the recursive verifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Remove `idx` column from Kernel ROM chiplet and use chiplet bus for initialization. (#1818)
 - [BREAKING] Make `Assembler::source_manager()` be `Send + Sync` (#1822)
 - Simplify and optimize the recursive verifier (#1801).
+- Simplify auxiliary randomness generation (#1810).
+- Add handling of variable length public inputs to the recursive verifier (#1813).
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Improve error messages for some assembler instruction (#1785)
 - Remove `idx` column from Kernel ROM chiplet and use chiplet bus for initialization. (#1818)
 - [BREAKING] Make `Assembler::source_manager()` be `Send + Sync` (#1822)
+- Simplify and optimize the recursive verifier (#1801).
 
 #### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,7 +2950,8 @@ dependencies = [
 [[package]]
 name = "winter-crypto"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32247cde9f43e5bbd05362caa7274608790ea69b14f7c81cd509aae7127c5ff2"
 dependencies = [
  "blake3",
  "sha3",
@@ -2961,7 +2962,8 @@ dependencies = [
 [[package]]
 name = "winter-fri"
 version = "0.12.2"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b346b0eea2292986a1193bfc70dd2dbcdbb6adb3e5110b71d18c6f1077df10"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -2971,7 +2973,8 @@ dependencies = [
 [[package]]
 name = "winter-math"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "326dfe4bfa4072b7c909133a88f8807820d3e49e5dfd246f67981771f74a0ed3"
 dependencies = [
  "winter-utils",
 ]
@@ -2979,7 +2982,8 @@ dependencies = [
 [[package]]
 name = "winter-maybe-async"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa132be74e602b707f1dab5a69c38496445e54ee940e7c281c02b15007241bd"
 dependencies = [
  "quote",
  "syn",
@@ -3003,7 +3007,8 @@ dependencies = [
 [[package]]
 name = "winter-rand-utils"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6321741f063344258c80f0c0255a559ded99bc17fe99fab9577f2460065ddf"
 dependencies = [
  "rand 0.8.5",
  "winter-utils",
@@ -3012,7 +3017,8 @@ dependencies = [
 [[package]]
 name = "winter-utils"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d47518e6931955dcac73a584cacb04550b82ab2f45c72880cbbbdbe13adb63c"
 dependencies = [
  "rayon",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2936,8 +2936,9 @@ dependencies = [
 
 [[package]]
 name = "winter-air"
-version = "0.12.1"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48a9ee4b14f192be4b0f253d6cc6241844664d6d6684819b6d9b074f4b85af14"
 dependencies = [
  "libm",
  "winter-crypto",
@@ -2949,7 +2950,8 @@ dependencies = [
 [[package]]
 name = "winter-crypto"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32247cde9f43e5bbd05362caa7274608790ea69b14f7c81cd509aae7127c5ff2"
 dependencies = [
  "blake3",
  "sha3",
@@ -2960,7 +2962,8 @@ dependencies = [
 [[package]]
 name = "winter-fri"
 version = "0.12.2"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b346b0eea2292986a1193bfc70dd2dbcdbb6adb3e5110b71d18c6f1077df10"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -2970,7 +2973,8 @@ dependencies = [
 [[package]]
 name = "winter-math"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "326dfe4bfa4072b7c909133a88f8807820d3e49e5dfd246f67981771f74a0ed3"
 dependencies = [
  "winter-utils",
 ]
@@ -2978,7 +2982,8 @@ dependencies = [
 [[package]]
 name = "winter-maybe-async"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa132be74e602b707f1dab5a69c38496445e54ee940e7c281c02b15007241bd"
 dependencies = [
  "quote",
  "syn",
@@ -2986,8 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "winter-prover"
-version = "0.12.2"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e1ad2747c0f67f3aab25c2753cb7ee321e06722dd1f011344faeee7e2828a4"
 dependencies = [
  "tracing",
  "winter-air",
@@ -3001,7 +3007,8 @@ dependencies = [
 [[package]]
 name = "winter-rand-utils"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6321741f063344258c80f0c0255a559ded99bc17fe99fab9577f2460065ddf"
 dependencies = [
  "rand 0.8.5",
  "winter-utils",
@@ -3010,15 +3017,17 @@ dependencies = [
 [[package]]
 name = "winter-utils"
 version = "0.12.0"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d47518e6931955dcac73a584cacb04550b82ab2f45c72880cbbbdbe13adb63c"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "winter-verifier"
-version = "0.12.2"
-source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a980cd314dddc2f4c9cdbc77127e6390238bb8b7541b6f627541ca35223f8ff"
 dependencies = [
  "winter-air",
  "winter-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,8 +2950,7 @@ dependencies = [
 [[package]]
 name = "winter-crypto"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32247cde9f43e5bbd05362caa7274608790ea69b14f7c81cd509aae7127c5ff2"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "blake3",
  "sha3",
@@ -2962,8 +2961,7 @@ dependencies = [
 [[package]]
 name = "winter-fri"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b346b0eea2292986a1193bfc70dd2dbcdbb6adb3e5110b71d18c6f1077df10"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -2973,8 +2971,7 @@ dependencies = [
 [[package]]
 name = "winter-math"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326dfe4bfa4072b7c909133a88f8807820d3e49e5dfd246f67981771f74a0ed3"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "winter-utils",
 ]
@@ -2982,8 +2979,7 @@ dependencies = [
 [[package]]
 name = "winter-maybe-async"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa132be74e602b707f1dab5a69c38496445e54ee940e7c281c02b15007241bd"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "quote",
  "syn",
@@ -3007,8 +3003,7 @@ dependencies = [
 [[package]]
 name = "winter-rand-utils"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6321741f063344258c80f0c0255a559ded99bc17fe99fab9577f2460065ddf"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "rand 0.8.5",
  "winter-utils",
@@ -3017,8 +3012,7 @@ dependencies = [
 [[package]]
 name = "winter-utils"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d47518e6931955dcac73a584cacb04550b82ab2f45c72880cbbbdbe13adb63c"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "rayon",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2937,8 +2937,7 @@ dependencies = [
 [[package]]
 name = "winter-air"
 version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7fbdcaa53d220b84811199790c1dda77c025533cdd27715cf1625af2b4027a"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "libm",
  "winter-crypto",
@@ -2950,8 +2949,7 @@ dependencies = [
 [[package]]
 name = "winter-crypto"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32247cde9f43e5bbd05362caa7274608790ea69b14f7c81cd509aae7127c5ff2"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "blake3",
  "sha3",
@@ -2962,8 +2960,7 @@ dependencies = [
 [[package]]
 name = "winter-fri"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b346b0eea2292986a1193bfc70dd2dbcdbb6adb3e5110b71d18c6f1077df10"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "winter-crypto",
  "winter-math",
@@ -2973,8 +2970,7 @@ dependencies = [
 [[package]]
 name = "winter-math"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "326dfe4bfa4072b7c909133a88f8807820d3e49e5dfd246f67981771f74a0ed3"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "winter-utils",
 ]
@@ -2982,8 +2978,7 @@ dependencies = [
 [[package]]
 name = "winter-maybe-async"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaa132be74e602b707f1dab5a69c38496445e54ee940e7c281c02b15007241bd"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "quote",
  "syn",
@@ -2992,8 +2987,7 @@ dependencies = [
 [[package]]
 name = "winter-prover"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426be0767a25150af20a241a6ae46bad1bf2f7da86393d897e5ec9967124f760"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "tracing",
  "winter-air",
@@ -3007,8 +3001,7 @@ dependencies = [
 [[package]]
 name = "winter-rand-utils"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6321741f063344258c80f0c0255a559ded99bc17fe99fab9577f2460065ddf"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "rand 0.8.5",
  "winter-utils",
@@ -3017,8 +3010,7 @@ dependencies = [
 [[package]]
 name = "winter-utils"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d47518e6931955dcac73a584cacb04550b82ab2f45c72880cbbbdbe13adb63c"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "rayon",
 ]
@@ -3026,8 +3018,7 @@ dependencies = [
 [[package]]
 name = "winter-verifier"
 version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e340716f24960b7ff3713029149fe5e52f9c0dae152101528ec5847d92d73e4"
+source = "git+https://github.com/Al-Kindi-0/winterfell/?branch=al-open-quotient-at-gz#cc900892f442c6f36bb28ab105c5c7ff90cf013d"
 dependencies = [
  "winter-air",
  "winter-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,14 @@ overflow-checks = true
 
 [workspace.dependencies]
 thiserror = { version = "2.0", default-features = false }
+
+[patch.crates-io]
+winter-air = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-air" }
+winter-crypto = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-crypto" }
+winter-prover = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-prover" }
+winter-verifier = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-verifier" }
+winter-math = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-math" }
+winter-fri = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-fri" }
+winter-maybe-async = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-maybe-async" }
+winter-utils = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-utils" }
+winter-rand-utils = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-rand-utils" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,14 +37,3 @@ overflow-checks = true
 
 [workspace.dependencies]
 thiserror = { version = "2.0", default-features = false }
-
-[patch.crates-io]
-winter-air = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-air" }
-winter-crypto = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-crypto" }
-winter-prover = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-prover" }
-winter-verifier = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-verifier" }
-winter-math = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-math" }
-winter-fri = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-fri" }
-winter-maybe-async = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-maybe-async" }
-winter-utils = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-utils" }
-winter-rand-utils = {git = "https://github.com/Al-Kindi-0/winterfell/", branch = "al-open-quotient-at-gz", package = "winter-rand-utils" }

--- a/air/src/options.rs
+++ b/air/src/options.rs
@@ -51,8 +51,8 @@ impl ProvingOptions {
         FieldExtension::Quadratic,
         4,
         7,
-        BatchingMethod::Algebraic,
-        BatchingMethod::Algebraic,
+        BatchingMethod::Horner,
+        BatchingMethod::Horner,
     );
 
     /// Standard proof parameters for 128-bit conjectured security in recursive context.
@@ -63,8 +63,8 @@ impl ProvingOptions {
         FieldExtension::Cubic,
         4,
         7,
-        BatchingMethod::Algebraic,
-        BatchingMethod::Algebraic,
+        BatchingMethod::Horner,
+        BatchingMethod::Horner,
     );
 
     // CONSTRUCTORS
@@ -87,8 +87,8 @@ impl ProvingOptions {
             field_extension,
             fri_folding_factor,
             fri_remainder_max_degree,
-            BatchingMethod::Algebraic,
-            BatchingMethod::Algebraic,
+            BatchingMethod::Horner,
+            BatchingMethod::Horner,
         );
         let exec_options = ExecutionOptions::default();
         Self { exec_options, proof_options, hash_fn }

--- a/air/src/trace/mod.rs
+++ b/air/src/trace/mod.rs
@@ -1,5 +1,6 @@
 use core::ops::Range;
 
+use chiplets::hasher::RATE_LEN;
 use vm_core::utils::range;
 
 pub mod chiplets;
@@ -55,6 +56,7 @@ pub const CHIPLETS_WIDTH: usize = 20;
 pub const CHIPLETS_RANGE: Range<usize> = range(CHIPLETS_OFFSET, CHIPLETS_WIDTH);
 
 pub const TRACE_WIDTH: usize = CHIPLETS_OFFSET + CHIPLETS_WIDTH;
+pub const PADDED_TRACE_WIDTH: usize = TRACE_WIDTH.next_multiple_of(RATE_LEN);
 
 // AUXILIARY COLUMNS LAYOUT
 // ------------------------------------------------------------------------------------------------

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -270,8 +270,11 @@ impl ToElements for ProgramInfo {
         result.extend_from_slice(self.program_hash.as_elements());
 
         // append kernel procedure hash elements
+        // we reverse the digests in order to make reducing them using auxiliary randomness easier
         for proc_hash in self.kernel.proc_hashes() {
-            result.extend_from_slice(proc_hash.as_elements());
+            let mut digest = proc_hash.as_elements().to_vec();
+            digest.reverse();
+            result.extend_from_slice(&digest);
         }
         result
     }

--- a/stdlib/asm/crypto/fri/helper.masm
+++ b/stdlib/asm/crypto/fri/helper.masm
@@ -7,7 +7,7 @@ use.std::crypto::stark::constants
 #!
 #! Input: [...]
 #! Output: [num_fri_layers, ...]
-#! Cycles: 77
+#! Cycles: 45
 export.generate_fri_parameters
     # Load FRI verifier data
     padw exec.constants::get_lde_domain_info_word
@@ -90,6 +90,7 @@ export.load_fri_layer_commitments
         sub.2
         swap
         exec.constants::tmp1 mem_storew
+        # => [lde_size / 4, log2(lde_size) - 2, lde_generator, 0, a1, a0, num_layers, ptr_layer + 4, y, y, ...]
 
         # Move the pointer higher up the stack
         movup.2 drop
@@ -125,11 +126,14 @@ end
 #! Output: [...]
 #!
 #! Cycles:
-#!  1- Remainder of size 32: 1633
-#!  2- Remainder of size 64: 3109
+#!
+#!  1- Remainder polynomial of degree less
+#!     than 64: 157
+#!  2- Remainder polynomial of degree less
+#!     than 128: 191
 export.load_and_verify_remainder
     # Load remainder commitment and save it at `TMP1`
-    push.0.0.0.0
+    padw
     adv_loadw
     exec.constants::tmp1 mem_storew
     #=> [COM, ...]

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -135,7 +135,13 @@ const.TMP4=4294913268
 # coefficients over base field and the last batch of coefficients processed by `horner_eval_base`
 # contains only 7 instead of 8 coefficients, then we would have to multiply the accumulator
 # by the first power of alpha^{-1}.
-const.ALPHA_PTR=4294903600
+# Note that due to the fact that in all current applications of `horner_eval_base`, respectively
+# `horner_eval_ext`, the number of coefficients is a multiple of 8, respectively of 4, we do not
+# need any of the above powers.
+
+# Address to store the non-deterministically provided DEEP polynomial batching randomness
+const.ALPHA_DEEP_ND_PTR=4294903600
+# Address to store the fixed terms, accross all queries, of the DEEP queries.
 const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 
 
@@ -172,7 +178,7 @@ const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 #   | TMP2                                     |       4294913260        |
 #   | TMP3                                     |       4294913264        |
 #   | TMP4                                     |       4294913268        |
-#   | ALPHA_PTR                                |       4294903600        |
+#   | ALPHA_DEEP_ND_PTR                        |       4294903600        |
 #   | OOD_FIXED_TERM_HORNER_EVALS_PTR          |       4294903448        |
 #   +------------------------------------------+-------------------------+
 
@@ -253,8 +259,8 @@ export.zero_word_ptr
     push.ZERO_WORD_PTR
 end
 
-export.deep_rand_alpha_ptr
-    push.ALPHA_PTR
+export.deep_rand_alpha_nd_ptr
+    push.ALPHA_DEEP_ND_PTR
 end
 
 export.ood_fixed_term_horner_evaluations_ptr

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -7,7 +7,7 @@ const.DOMAIN_OFFSET=7
 const.DOMAIN_OFFSET_INV=2635249152773512046
 
 # Number of random extension field coefficients related to the auxiliary trace (i.e. the alphas)
-const.NUM_AUX_TRACE_COEFS=16
+const.NUM_AUX_TRACE_COEFS=2
 
 # Number of constraints, both boundary and transitional
 # Note: If the full set of all implemented constraints is used then this should be set to 226
@@ -32,18 +32,27 @@ const.NUM_INPUTS_CIRCUIT=232
 # Number of evaluation gates in the constraint evaluation circuit
 const.NUM_EVAL_GATES_CIRCUIT=88
 
+# Op label for kernel procedures table messages
+const.KERNEL_OP_LABEL=0
+
 # MEMORY POINTERS
 # =================================================================================================
 
 # Trace domain generator
-const.TRACE_DOMAIN_GENERATOR_PTR=4294799999
+const.TRACE_DOMAIN_GENERATOR_PTR=4294799998
+
+# Variable length public inputs address
+const.VARIABLE_LEN_PUBLIC_INPUTS_ADDRESS_PTR=4294799999
 
 # Public inputs address
 const.PUBLIC_INPUTS_ADDRESS_PTR=4294800000
 
 # Random elements
-# There are are currently 16 ExtFelt for a total of 32 Felt. Thus the number of memory slots required is 32.
-const.AUX_RAND_ELEM_PTR=4294899968
+# We use 2 extension field elements for a total of 4 base field elements.
+const.AUX_RAND_ELEM_PTR=4294899996
+# This will hold the non-deterministically loaded 2 random challenges, which will be
+# checked for correctness once we receive the commitment to the auxiliary trace.
+const.AUX_RAND_ND_PTR=4294800004
 
 # OOD Frames
 # (80 + 8) * 2 * 2 Felt for current and next trace rows and 8 * 2 Felt for constraint composition
@@ -103,6 +112,8 @@ const.COMPOSITION_POLY_COM_PTR=4294813208
 # Instant-specific constants
 const.LDE_DOMAIN_INFO_PTR=4294813212
 const.LDE_DOMAIN_GEN_PTR=4294813213
+const.LDE_DOMAIN_LOG_SIZE_PTR=4294813214
+const.LDE_DOMAIN_SIZE_PTR=4294813215
 const.Z_PTR=4294813216
 const.NUM_QUERIES_PTR=4294813220
 const.REMAINDER_POLY_SIZE_PTR=4294813221
@@ -151,7 +162,8 @@ const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 #   +------------------------------------------+-------------------------+
 #   | TRACE_DOMAIN_GENERATOR_PTR               |       4294799999        |
 #   | PUBLIC_INPUTS_ADDRESS_PTR                |       4294800000        |
-#   | AUX_RAND_ELEM_PTR                        |       4294899968        |
+#   | AUX_RAND_ND_PTR                          |       4294800004        |
+#   | AUX_RAND_ELEM_PTR                        |       4294899996        |
 #   | OOD_TRACE_CURRENT_PTR                    |       4294900000        |
 #   | OOD_TRACE_NEXT_PTR                       |       4294900162        |
 #   | OOD_CONSTRAINT_EVALS_PTR                 |       4294900324        |
@@ -164,6 +176,9 @@ const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 #   | AUX_TRACE_COM_PTR                        |       4294913204        |
 #   | COMPOSITION_POLY_COM_PTR                 |       4294913208        |
 #   | LDE_DOMAIN_INFO_PTR                      |       4294913212        |
+#   | LDE_DOMAIN_GEN_PTR                       |       4294913213        |
+#   | LDE_DOMAIN_LOG_SIZE_PTR                  |       4294913214        |
+#   | LDE_DOMAIN_SIZE_PTR                      |       4294913215        |
 #   | Z_PTR                                    |       4294913216        |
 #   | NUM_QUERIES_PTR                          |       4294913220        |
 #   | TRACE_LENGTH_PTR                         |       4294913224        |
@@ -187,6 +202,10 @@ const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 
 export.public_inputs_address_ptr
     push.PUBLIC_INPUTS_ADDRESS_PTR
+end
+
+export.variable_length_public_inputs_address_ptr
+    push.VARIABLE_LEN_PUBLIC_INPUTS_ADDRESS_PTR
 end
 
 export.ood_trace_current_ptr
@@ -393,6 +412,22 @@ export.get_fri_queries_address
     push.FRI_QUERIES_ADDRESS_PTR mem_load
 end
 
+export.set_lde_domain_size
+    push.LDE_DOMAIN_SIZE_PTR mem_store
+end
+
+export.get_lde_domain_size
+    push.LDE_DOMAIN_SIZE_PTR mem_load
+end
+
+export.set_lde_domain_log_size
+    push.LDE_DOMAIN_LOG_SIZE_PTR mem_store 
+end
+
+export.get_lde_domain_log_size
+    push.LDE_DOMAIN_LOG_SIZE_PTR mem_load
+end
+
 export.set_trace_length
     push.TRACE_LENGTH_PTR mem_store
 end
@@ -442,4 +477,12 @@ end
 
 export.get_arithmetic_circuit_eval_number_eval_gates
     push.NUM_EVAL_GATES_CIRCUIT
+end
+
+export.aux_rand_nd_ptr
+    push.AUX_RAND_ND_PTR
+end
+
+export.kernel_proc_table_op_label
+    push.KERNEL_OP_LABEL
 end

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -128,14 +128,6 @@ const.TMP2=4294913260
 const.TMP3=4294913264
 const.TMP4=4294913268
 
-# RPO state capacity portion initialization words. In theory, we need a variant for each possible 
-# remainder modulo 8 but in practice we only need the following:
-# TODO(Al): Remove because we will not need after padding trace
-const.ZERO_ZERO_ZERO_FOUR_PTR=4294913400
-const.ZERO_ZERO_ZERO_FIVE_PTR=4294913404
-const.ZERO_ZERO_ZERO_SIX_PTR=4294913408
-const.ZERO_ZERO_ZERO_SEVEN_PTR=4294913412
-
 # Addresses to store powers of the DEEP composition randomness needed during the computation of
 # the DEEP queries. Powers from 1 to 7 are needed to correct results of `horner_eval_*` when
 # the final batch of coefficients processed is not 8 in the case of `horner_eval_base` or
@@ -143,8 +135,8 @@ const.ZERO_ZERO_ZERO_SEVEN_PTR=4294913412
 # coefficients over base field and the last batch of coefficients processed by `horner_eval_base`
 # contains only 7 instead of 8 coefficients, then we would have to multiply the accumulator
 # by the first power of alpha^{-1}.
-const.ALPHA=4294903600
-const.OOD_HORNER_EVALS_PTR=4294903448
+const.ALPHA_PTR=4294903600
+const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 
 
 #   The following is a table summarizing the memory pointers used:
@@ -173,7 +165,6 @@ const.OOD_HORNER_EVALS_PTR=4294903448
 #   | GRINDING_FACTOR_PTR                      |       4294913232        |
 #   | NUM_KERNEL_PROCEDURES_PTR                |       4294913233        |
 #   | ZERO_WORD_PTR                            |       4294913236        |
-#   | ZERO_ZERO_ZERO_ONE_PTR                   |       4294913240        |
 #   | C_PTR                                    |       4294913244        |
 #   | R1_PTR                                   |       4294913248        |
 #   | R2_PTR                                   |       4294913252        |
@@ -181,12 +172,8 @@ const.OOD_HORNER_EVALS_PTR=4294903448
 #   | TMP2                                     |       4294913260        |
 #   | TMP3                                     |       4294913264        |
 #   | TMP4                                     |       4294913268        |
-#   | ZERO_ZERO_ZERO_FOUR_PTR                  |       4294913400        |
-#   | ZERO_ZERO_ZERO_FIVE_PTR                  |       4294913404        |
-#   | ZERO_ZERO_ZERO_SIX_PTR                   |       4294913408        |
-#   | ZERO_ZERO_ZERO_SEVEN_PTR                 |       4294913412        |
-#   | ALPHA                                    |       4294903600        |
-#   | OOD_HORNER_EVALS_PTR                     |       4294903448        |
+#   | ALPHA_PTR                                |       4294903600        |
+#   | OOD_FIXED_TERM_HORNER_EVALS_PTR          |       4294903448        |
 #   +------------------------------------------+-------------------------+
 
 # ACCESSORS
@@ -266,28 +253,12 @@ export.zero_word_ptr
     push.ZERO_WORD_PTR
 end
 
-export.zero_zero_zero_four_word_ptr
-    push.ZERO_ZERO_ZERO_FOUR_PTR
-end
-
-export.zero_zero_zero_five_word_ptr
-    push.ZERO_ZERO_ZERO_FIVE_PTR
-end
-
-export.zero_zero_zero_six_word_ptr
-    push.ZERO_ZERO_ZERO_SIX_PTR
-end
-
-export.zero_zero_zero_seven_word_ptr
-    push.ZERO_ZERO_ZERO_SEVEN_PTR
-end
-
 export.deep_rand_alpha_ptr
-    push.ALPHA
+    push.ALPHA_PTR
 end
 
-export.ood_horner_evaluations_ptr
-    push.OOD_HORNER_EVALS_PTR
+export.ood_fixed_term_horner_evaluations_ptr
+    push.OOD_FIXED_TERM_HORNER_EVALS_PTR
 end
 
 export.tmp1

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -46,20 +46,19 @@ const.PUBLIC_INPUTS_ADDRESS_PTR=4294800000
 const.AUX_RAND_ELEM_PTR=4294899968
 
 # OOD Frames
-# (73 + 8) * 2 * 2 Felt for current and next trace rows and 8 * 2 Felt for constraint composition
+# (80 + 8) * 2 * 2 Felt for current and next trace rows and 8 * 2 Felt for constraint composition
 # polynomials. Memory slots:
-# OOD_TRACE_CURRENT_PTR: (73 + 8) * 2 = 162
-# OOD_TRACE_NEXT_PTR: (73 + 8) * 2 = 162
+# OOD_TRACE_CURRENT_PTR: (80 + 8) * 2 = 176
+# OOD_TRACE_NEXT_PTR: (80 + 8) * 2 = 176
 # OOD_CONSTRAINT_EVALS_PTR: 8 * 2 = 16
 const.OOD_TRACE_CURRENT_PTR=4294900000
-const.OOD_TRACE_NEXT_PTR=4294900162
-const.OOD_CONSTRAINT_EVALS_PTR=4294900324
-const.AUXILIARY_ACE_INPUTS_PTR=4294900340
+const.OOD_TRACE_NEXT_PTR=4294900176
+const.OOD_CONSTRAINT_EVALS_PTR=4294900352
+const.AUXILIARY_ACE_INPUTS_PTR=4294900368
 
 # Current trace row
-# 73 Felt for main portion of trace, 8 * 2 Felt for auxiliary portion of trace and 8 * 2 Felt for
-# constraint composition polynomials. Since we store these with the padding to make each of the
-# three portions a multiple of 8, the number of slots required is 72 + 16 + 16 = 104
+# 80 Felt for main portion of trace, 8 * 2 Felt for auxiliary portion of trace and 8 * 2 Felt for
+# constraint composition polynomials, i.e., the number of slots required is 80 + 16 + 16 = 112
 const.CURRENT_TRACE_ROW_PTR=4294900400
 
 # Address to the randomness used in computing the constraint composition polynomial
@@ -131,6 +130,7 @@ const.TMP4=4294913268
 
 # RPO state capacity portion initialization words. In theory, we need a variant for each possible 
 # remainder modulo 8 but in practice we only need the following:
+# TODO(Al): Remove because we will not need after padding trace
 const.ZERO_ZERO_ZERO_FOUR_PTR=4294913400
 const.ZERO_ZERO_ZERO_FIVE_PTR=4294913404
 const.ZERO_ZERO_ZERO_SIX_PTR=4294913408
@@ -142,24 +142,8 @@ const.ZERO_ZERO_ZERO_SEVEN_PTR=4294913412
 # 4 in the case of `horner_eval_ext`. For example if we are evaluating a polynomial with
 # coefficients over base field and the last batch of coefficients processed by `horner_eval_base`
 # contains only 7 instead of 8 coefficients, then we would have to multiply the accumulator
-# by the first power of alpha.
-# We also need alpha^{77} and alpha^{85} which are used in the final computation used to recover
-# the evaluation of the original polynomial from the evaluation of its reversed version at alpha^{-1}.
-# Note that 77 = 71 + 7 - 1 and 85 = 71 + 7 + 8 - 1.
-const.ALPHA_INV=4294903600
-const.ALPHA_POWER_1_PTR=4294903400
-const.ALPHA_POWER_2_PTR=4294903404
-const.ALPHA_POWER_3_PTR=4294903408
-const.ALPHA_POWER_4_PTR=4294903412
-const.ALPHA_POWER_5_PTR=4294903416
-const.ALPHA_POWER_6_PTR=4294903420
-const.ALPHA_POWER_7_PTR=4294903424
-const.ALPHA_POWER_80_PTR=4294903440
-const.ALPHA_POWER_80_0_PTR=4294903440
-const.ALPHA_POWER_80_1_PTR=4294903441
-const.ALPHA_POWER_88_PTR=4294903444
-const.ALPHA_POWER_88_0_PTR=4294903444
-const.ALPHA_POWER_88_1_PTR=4294903445
+# by the first power of alpha^{-1}.
+const.ALPHA=4294903600
 const.OOD_HORNER_EVALS_PTR=4294903448
 
 
@@ -201,20 +185,7 @@ const.OOD_HORNER_EVALS_PTR=4294903448
 #   | ZERO_ZERO_ZERO_FIVE_PTR                  |       4294913404        |
 #   | ZERO_ZERO_ZERO_SIX_PTR                   |       4294913408        |
 #   | ZERO_ZERO_ZERO_SEVEN_PTR                 |       4294913412        |
-#   | ALPHA_INV                                |       4294903600        |
-#   | ALPHA_POWER_1_PTR                        |       4294903400        |
-#   | ALPHA_POWER_2_PTR                        |       4294903404        |
-#   | ALPHA_POWER_3_PTR                        |       4294903408        |
-#   | ALPHA_POWER_4_PTR                        |       4294903412        |
-#   | ALPHA_POWER_5_PTR                        |       4294903416        |
-#   | ALPHA_POWER_6_PTR                        |       4294903420        |
-#   | ALPHA_POWER_7_PTR                        |       4294903424        |
-#   | ALPHA_POWER_80_PTR                       |       4294903440        |
-#   | ALPHA_POWER_80_0_PTR                     |       4294903440        |
-#   | ALPHA_POWER_80_1_PTR                     |       4294903441        |
-#   | ALPHA_POWER_88_PTR                       |       4294903444        |
-#   | ALPHA_POWER_88_0_PTR                     |       4294903444        |
-#   | ALPHA_POWER_88_1_PTR                     |       4294903445        |
+#   | ALPHA                                    |       4294903600        |
 #   | OOD_HORNER_EVALS_PTR                     |       4294903448        |
 #   +------------------------------------------+-------------------------+
 
@@ -311,60 +282,8 @@ export.zero_zero_zero_seven_word_ptr
     push.ZERO_ZERO_ZERO_SEVEN_PTR
 end
 
-export.deep_rand_alpha_inv_ptr
-    push.ALPHA_INV
-end
-
-export.deep_rand_alpha_1_ptr
-    push.ALPHA_POWER_1_PTR
-end
-
-export.deep_rand_alpha_2_ptr
-    push.ALPHA_POWER_2_PTR
-end
-
-export.deep_rand_alpha_3_ptr
-    push.ALPHA_POWER_3_PTR
-end
-
-export.deep_rand_alpha_4_ptr
-    push.ALPHA_POWER_4_PTR
-end
-
-export.deep_rand_alpha_5_ptr
-    push.ALPHA_POWER_5_PTR
-end
-
-export.deep_rand_alpha_6_ptr
-    push.ALPHA_POWER_6_PTR
-end
-
-export.deep_rand_alpha_7_ptr
-    push.ALPHA_POWER_7_PTR
-end
-
-export.deep_rand_alpha_80_ptr
-    push.ALPHA_POWER_80_PTR
-end
-
-export.deep_rand_alpha_80_0_ptr
-    push.ALPHA_POWER_80_0_PTR
-end
-
-export.deep_rand_alpha_80_1_ptr
-    push.ALPHA_POWER_80_1_PTR
-end
-
-export.deep_rand_alpha_88_ptr
-    push.ALPHA_POWER_88_PTR
-end
-
-export.deep_rand_alpha_88_0_ptr
-    push.ALPHA_POWER_88_0_PTR
-end
-
-export.deep_rand_alpha_88_1_ptr
-    push.ALPHA_POWER_88_1_PTR
+export.deep_rand_alpha_ptr
+    push.ALPHA
 end
 
 export.ood_horner_evaluations_ptr

--- a/stdlib/asm/crypto/stark/deep_queries.masm
+++ b/stdlib/asm/crypto/stark/deep_queries.masm
@@ -4,11 +4,7 @@ use.std::crypto::stark::constants
 #! and computes the values of the DEEP code word at the index corresponding to the query.
 #!
 #! It takes a pointer to the current random query index and returns that index, together with
-#! the values 
-#!
-#! P^x(alpha) = (p_x_at_alpha_0, p_x_at_alpha_1) = \sum_{i=0}^{n+m} T_i * alpha^i 
-#!
-#! and 
+#! the value
 #!
 #! Q^x(alpha) = (q_x_at_alpha_0, q_x_at_alpha_1) = \sum_{i=0}^{n+m+l} T_i * alpha^i
 #!
@@ -21,7 +17,7 @@ use.std::crypto::stark::constants
 #! 3. alpha is the randomness used in order to build the DEEP polynomial.
 #!
 #! Input: [Y, query_ptr, ...]
-#! Output: [Y, q_x_at_alpha_1, q_x_at_alpha_0, p_x_at_alpha_1, p_x_at_alpha_0, index, query_ptr, ...]
+#! Output: [Y, q_x_at_alpha_1, q_x_at_alpha_0, q_x_at_alpha_1, q_x_at_alpha_0, index, query_ptr, ...]
 #!
 #! where:
 #! - Y is a "garbage" word.
@@ -55,32 +51,17 @@ proc.load_query_row
     ##    compute their hashing and the value of their random linear combination using powers of
     ##    a single random value alpha.
 
-    ### a) Load the first 64 columns in 8 batches of 8 base field elements
-    #exec.constants::zero_zero_zero_seven_word_ptr mem_loadw
-    push.1.0.0.0
+    ### a) Load the 80 columns in 10 batches of 8 base field elements
+    padw
     swapw
     padw
-    #=> [Y, Y, 0, 0, 0, 7, ptr, y, y, y]
-    repeat.9
+    #=> [Y, Y, 0, 0, 0, 0, ptr, y, y, y]
+    repeat.10
         adv_pipe
         horner_eval_base      
         hperm
     end
     #=> [Y, L, C, ptr_x, ptr_alpha_inv, acc1, acc0, depth, index, query_ptr, ...]
- 
-    ### b) Load the values of the last 7 main segment columns
-    movdnw.3
-    #adv_loadw
-    #=> [L, C, ptr_x, ptr_alpha_inv, acc1, acc0, Y, depth, index, query_ptr, ...]
-    adv_push.1
-    push.0.0.0
-    swapw
-    exec.constants::zero_word_ptr mem_loadw
-
-    ### c) Hash and combine using randomness the last 7 columns
-    horner_eval_base       
-    hperm
-    #=> [Y, D, C, ptr_x, ptr_alpha_inv, acc1, acc0, Y, depth, index, query_ptr, ...]
  
     ## 5) Load the leaf value we got using `mtree_get` and compare it against the hash
     ##    we just computed
@@ -92,48 +73,35 @@ proc.load_query_row
     movup.2
     assert_eq
     assert_eq
-    #=> [Y, ptr_x, ptr_alpha_inv, acc1, acc0, Y, depth, index, query_ptr, ...]
+    #=> [Y, ptr_x, ptr_alpha_inv, acc1, acc0, depth, index, query_ptr, ...]
 
-    ## 6) Adjust the accumulator
-    ##    Since the last batch to which we applied `horner_eval_base` was composed of 7 coefficients
-    ##    instead of 8, we have to multiply the accumulator by the inverse of the evaluation point.
-    ##    Since the evaluation point is alpha^{-1}, we thus need to multiply by alpha.
-    ##    In general, we have to multiply by alpha^num_missing_coefficients, where 
-    ##    `num_missing_coefficients` is in 1..=7
-    exec.constants::deep_rand_alpha_7_ptr mem_loadw
-    movup.7 movup.7
-    #=> [acc1, acc0, adj1, adj0, y, y, ptr_x, ptr_alpha_inv, Y, depth, index, query_ptr, ...]
-    ext2mul
-    movdn.5 movdn.5
-    #=> [y, y, ptr_x, ptr_alpha_inv, acc1, acc0, Y, depth, index, query_ptr, ...]
 
     # II) Process the auxiliary segment of the execution trace portion of the query
 
     ## 1) Load aux trace commitment and get leaf
-    push.0.0
     exec.constants::aux_trace_com_ptr mem_loadw
 
     ## 2) Get the leaf against the auxiliary trace commitment for the current query
-    dup.13
-    dup.13
+    dup.9
+    dup.9
     mtree_get
     exec.constants::tmp3 mem_storew
     adv.push_mapval
-    #=> [L, R, ptr_x, ptr_alpha_inv, acc1, acc0, Y, depth, index, query_ptr, ...]
+    #=> [L, R, ptr_x, ptr_alpha_inv, acc1, acc0, depth, index, query_ptr, ...]
 
     ## 3) Load the values of the auxiliary segment of the execution trace at the current query.
     
     ### a) Set up the stack
     exec.constants::zero_word_ptr mem_loadw
     swapw
-    movupw.3
+    padw
     #=> [Y, Y, C, ptr_x, ptr_alpha_inv, acc1, acc0, depth, index, query_ptr, ...]
 
     ### b) Load the first 4 columns as a batch of 4 quadratic extension field elements.
     repeat.2
-    adv_pipe
-    horner_eval_ext      
-    hperm
+        adv_pipe
+        horner_eval_ext      
+        hperm
     end
     #=> [Y, D, C, ptr_x, ptr_alpha_inv, acc1, acc0, depth, index, query_ptr, ...]
 
@@ -149,36 +117,19 @@ proc.load_query_row
     assert_eq
     #=> [Y, ptr_x, ptr_alpha_inv, acc1, acc0, depth, index, query_ptr, ...]
 
-    # III) Compute P^x(alpha).
-    #      This is the result of multiplying the current value of the accumulator by
-    #      alpha^(71 + 7 - 1) i.e., alpha^77.
-
-    ## 1) Load and multiply by alpha^80
-    #swapw
-    exec.constants::deep_rand_alpha_80_ptr mem_loadw
-    #=> [alpha80_1, alpha80_0, y, y, ptr_x, ptr_alpha_inv, acc1, acc0, depth, index, query_ptr, ...]
-    dup.7 dup.7
-    ext2mul
-    #=> [p_x_at_alpha_1, p_x_at_alpha_0, y, y, ptr_x, ptr_alpha_inv, acc1, acc0, depth, index, query_ptr, ...]
-
-    ## 2) Keep P^x(alpha) deeper on the stack
-    movdn.8
-    movdn.8
-    #=> [y, y, ptr_x, ptr_alpha_inv, acc1, acc0, depth, p_x_at_alpha_1, p_x_at_alpha_0, index, query_ptr, ...]
-
     # IV) Process the constraint trace portion of the query
 
     ## 1) Load the commitment to the constraint trace
-    push.0.0
     exec.constants::composition_poly_com_ptr mem_loadw
+    #=> [R, ptr_x, ptr_alpha_inv, acc1, acc0, depth, index, query_ptr, ...]
 
     ## 2) Get the leaf against the commitment
-    dup.11
+    dup.9
     movup.9
     mtree_get
     exec.constants::tmp3 mem_storew
     adv.push_mapval
-    #=>[L, R, ptr_x, ptr_alpha_inv, acc1, acc0, p_x_at_alpha_1, p_x_at_alpha_0, index, query_ptr, ...]
+    #=>[L, R, ptr_x, ptr_alpha_inv, acc1, acc0, index, query_ptr, ...]
 
     ## 3) Load the 8columns as quadratic extension field elements in batches of 4. 
     padw
@@ -188,7 +139,7 @@ proc.load_query_row
         horner_eval_ext        
         hperm
     end
-    #=> [Y, L, Y, ptr_x, ptr_alpha_inv, acc1, acc0, p_x_at_alpha_1, p_x_at_alpha_0, index, query_ptr, ...]
+    #=> [Y, L, Y, ptr_x, ptr_alpha_inv, acc1, acc0, index, query_ptr, ...]
 
     ## 4) Load the leaf value we got using `mtree_get` and compare it against the hash
     ##    we just computed
@@ -200,26 +151,14 @@ proc.load_query_row
     movup.2
     assert_eq
     assert_eq
-    #=> [Y, ptr_x, ptr_alpha_inv, acc1, acc0, p_x_at_alpha_1, p_x_at_alpha_0, index, query_ptr, ...]
+    #=> [Y, ptr_x, ptr_alpha_inv, acc1, acc0, index, query_ptr, ...]
 
-    # III) Compute Q^x(alpha).
-    #      This is the result of multiplying the current value of the accumulator by
-    #      alpha^(71 + 7 + 8 - 1) i.e., alpha^88.
-
-    ## 1) Load alpha^(71 + 7 + 8 - 1) i.e., alpha^88
+    ## 5) Re-order the stack
     swapw
     drop drop
-    exec.constants::deep_rand_alpha_88_0_ptr mem_load
-    exec.constants::deep_rand_alpha_88_1_ptr mem_load
-    #=> [alpha80_1, alpha80_0, acc1, acc0, Y, depth, index, query_ptr, ...]
-
-    ## 2) Multiply by alpha^88
-    ext2mul
-    #=> [q_x_at_alpha_1, q_x_at_alpha_0, Y, p_x_at_alpha_1, p_x_at_alpha_0, index, query_ptr, ...]
-
-    ## 3) Keep Q^x(alpha) deeper on the stack
-    movdn.5 movdn.5
-    #=> [Y, q_x_at_alpha_1, q_x_at_alpha_0, p_x_at_alpha_1, p_x_at_alpha_0, index, query_ptr, ...]
+    dup.1 dup.1
+    swapw
+    #=> [Y, q_x_at_alpha_1, q_x_at_alpha_0, q_x_at_alpha_1, q_x_at_alpha_0, index, query_ptr, ...]
 end
 
 #! Takes a query index and computes x := offset * domain_gen^index. It also computes the denominators
@@ -269,8 +208,8 @@ end
 #!
 #! where:
 #!
-#! 1. X is [q_x_at_alpha_1, q_x_at_alpha_0, p_x_at_alpha_1, p_x_at_alpha_0]
-#! 2. W is [p_gz_1, p_gz_0, q_z_1, q_z_0]
+#! 1. X is [q_x_at_alpha_1, q_x_at_alpha_0, q_x_at_alpha_1, q_x_at_alpha_0]
+#! 2. W is [q_gz_1, q_gz_0, q_z_1, q_z_0]
 #!
 #! Cycles: 62
 proc.divide_and_add
@@ -278,17 +217,17 @@ proc.divide_and_add
     #=> [X, Z, Y, W, query_ptr, ...]
     dupw.3
     #=> [W, X, Z, Y, query_ptr, ...]
-    #=> [p_gz_1, p_gz_0, q_z_1, q_z_0, q_x_at_alpha_1, q_x_at_alpha_0, p_x_at_alpha_1, p_x_at_alpha_0, Z, Y, query_ptr, ...]
+    #=> [q_gz_1, q_gz_0, q_z_1, q_z_0, q_x_at_alpha_1, q_x_at_alpha_0, q_x_at_alpha_1, q_x_at_alpha_0, Z, Y, query_ptr, ...]
 
     movup.5 movup.5
     movup.5 movup.5
-    #=> [q_z_1, q_z_0, q_x_at_alpha_1, q_x_at_alpha_0, p_gz_1, p_gz_0, p_x_at_alpha_1, p_x_at_alpha_0, Z, Y, query_ptr, ...]
+    #=> [q_z_1, q_z_0, q_x_at_alpha_1, q_x_at_alpha_0, p_gz_1, p_gz_0, q_x_at_alpha_1, q_x_at_alpha_0, Z, Y, query_ptr, ...]
 
     ext2add
-    #=> [num0_1, num0_0, p_gz_1, p_gz_0, p_x_at_alpha_1, p_x_at_alpha_0, Z, Y, query_ptr, ...]
+    #=> [num0_1, num0_0, p_gz_1, p_gz_0, q_x_at_alpha_1, q_x_at_alpha_0, Z, Y, query_ptr, ...]
 
     movdn.9 movdn.9
-    #=> [p_gz_1, p_gz_0, p_x_at_alpha_1, p_x_at_alpha_0, Z, num0_1, num0_0, Y, query_ptr, ...]
+    #=> [p_gz_1, p_gz_0, q_x_at_alpha_1, q_x_at_alpha_0, Z, num0_1, num0_0, Y, query_ptr, ...]
 
     ext2add
     #=> [num1_1, num1_0, Z, num0_1, num0_0, Y, query_ptr, ...]
@@ -316,8 +255,8 @@ export.compute_deep_composition_polynomial_queries
     # => [query_ptr, ...]
 
     padw exec.constants::ood_horner_evaluations_ptr mem_loadw
-    # => [p_gz_1, p_gz_0, q_z_1, q_z_0, query_ptr, ...]
-    # => [W, query_ptr, ...]
+    # => [q_gz_1, q_gz_0, q_z_1, q_z_0, query_ptr, ...]
+    # => [W, query_ptr, ...] where W is [q_gz_1, q_gz_0, q_z_1, q_z_0]
 
     # Get pointer to help test for the last query to be processed
     exec.constants::fri_com_ptr
@@ -328,7 +267,7 @@ export.compute_deep_composition_polynomial_queries
     # Store pointers to alpha_inv, memory region to store trace row for current query and a fresh
     # accumulator value i.e., (0, 0).
     push.0.0
-    exec.constants::deep_rand_alpha_inv_ptr
+    exec.constants::deep_rand_alpha_ptr
     exec.constants::current_trace_row_ptr
     exec.constants::tmp2 mem_storew
 

--- a/stdlib/asm/crypto/stark/deep_queries.masm
+++ b/stdlib/asm/crypto/stark/deep_queries.masm
@@ -254,7 +254,7 @@ export.compute_deep_composition_polynomial_queries
     exec.constants::get_fri_queries_address
     # => [query_ptr, ...]
 
-    padw exec.constants::ood_horner_evaluations_ptr mem_loadw
+    padw exec.constants::ood_fixed_term_horner_evaluations_ptr mem_loadw
     # => [q_gz_1, q_gz_0, q_z_1, q_z_0, query_ptr, ...]
     # => [W, query_ptr, ...] where W is [q_gz_1, q_gz_0, q_z_1, q_z_0]
 

--- a/stdlib/asm/crypto/stark/deep_queries.masm
+++ b/stdlib/asm/crypto/stark/deep_queries.masm
@@ -51,7 +51,7 @@ proc.load_query_row
     ##    compute their hashing and the value of their random linear combination using powers of
     ##    a single random value alpha.
 
-    ### a) Load the 80 columns in 10 batches of 8 base field elements
+    ### Load the 80 columns in 10 batches of 8 base field elements
     padw
     swapw
     padw
@@ -117,7 +117,7 @@ proc.load_query_row
     assert_eq
     #=> [Y, ptr_x, ptr_alpha_inv, acc1, acc0, depth, index, query_ptr, ...]
 
-    # IV) Process the constraint trace portion of the query
+    # III) Process the constraint trace portion of the query
 
     ## 1) Load the commitment to the constraint trace
     exec.constants::composition_poly_com_ptr mem_loadw
@@ -264,10 +264,10 @@ export.compute_deep_composition_polynomial_queries
     dup.5
     # => [query_ptr, query_end_ptr, W, query_ptr, ...]
 
-    # Store pointers to alpha_inv, memory region to store trace row for current query and a fresh
+    # Store pointers to alpha, memory region to store trace row for current query and a fresh
     # accumulator value i.e., (0, 0).
     push.0.0
-    exec.constants::deep_rand_alpha_ptr
+    exec.constants::deep_rand_alpha_nd_ptr
     exec.constants::current_trace_row_ptr
     exec.constants::tmp2 mem_storew
 

--- a/stdlib/asm/crypto/stark/ood_frames.masm
+++ b/stdlib/asm/crypto/stark/ood_frames.masm
@@ -23,7 +23,7 @@ use.std::crypto::stark::random_coin
 #! 4. alpha is the randomness used in order to build the DEEP polynomial.
 export.load_and_horner_eval_ood_frames
     # I) Load the random challenge used in computing the DEEP polynomial.
-    #    We use this challenge to compute the constant terms needed in the compuation of the DEEP queries.
+    #    We use this challenge to compute the constant terms needed in the computation of the DEEP queries.
     #    Although this challenge is generated only after all the OOD evaluations are received by the verifier,
     #    we use non-determinism to generate it before doing so. This is done so that we can hash, memory store
     #    and Horner evaluate in parallel.
@@ -34,8 +34,8 @@ export.load_and_horner_eval_ood_frames
 
     ## 2) Save the random challenge
     dup.1 dup.1
-    exec.constants::deep_rand_alpha_ptr mem_storew
-    # [Y, ...]
+    exec.constants::deep_rand_alpha_nd_ptr mem_storew
+    # => [Y, ...]
 
     # II) Compute Q^z(alpha)
     #     Note that there a few a goals which are in tension. Namely, we want to hash the execution trace OOD evaluations,
@@ -49,8 +49,10 @@ export.load_and_horner_eval_ood_frames
     ### a) Set up the initial accumulator and the pointers to alpha and a pointer to some memory region
     ###    to which we save the OOD.
     push.0.0
-    exec.constants::deep_rand_alpha_ptr
+    exec.constants::deep_rand_alpha_nd_ptr
     exec.constants::ood_trace_current_ptr
+    # => [ood_trace_current_ptr, deep_rand_alpha_ptr, 0, 0, Y, ...]
+    # => [U, Y, ...]
 
     ## 2) Process the fully aligned OOD `current` evaluations at z of the execution trace. 
     ##    Since there are (80 + 8 + 8) * 2 = 24 * 8 base field elements, there are 24 fully double-word aligned batches.

--- a/stdlib/asm/crypto/stark/ood_frames.masm
+++ b/stdlib/asm/crypto/stark/ood_frames.masm
@@ -4,22 +4,22 @@ use.std::crypto::stark::random_coin
 
 #! Loads the execution trace and the quotient trace evaluation frames.
 #! 
-#! This also computes P^gz(alpha) and Q^z(alpha) where:
+#! This also computes Q^z(alpha) and Q^gz(alpha) where:
 #!
-#! P^gz(alpha) = (p_gz_0, p_gz_1) = \sum_{i=0}^{n+m} T_i * alpha^i 
+#! Q^z(alpha) = (q_z_0, q_z_1) = \sum_{i=0}^{n+m+l} S_i * alpha^i
 #!
 #! and 
 #!
-#! Q^z(alpha) = (q_z_0, q_z_1) = \sum_{i=0}^{n+m+l} S_i * alpha^i
+#! Q^gz(alpha) = (q_gz_0, q_gz_1) = \sum_{i=0}^{n+m+l} T_i * alpha^i 
 #!
 #! where:
 #!
 #! 1. n, m and l are the widths of the main segment, auxiliary segment and constraint composition
 #!    traces, respectively.
-#! 2. T_i are the evaluations of columns in the main segment and auxiliary segments
-#!    at the the out-of-domain point gz.
-#! 3. S_i are the evaluations of columns in the main segment, auxiliary segment and constraint composition
+#! 2. S_i are the evaluations of columns in the main segment, auxiliary segment and constraint composition
 #!    at the the out-of-domain point z.
+#! 3. T_i are the evaluations of columns in the main segment, auxiliary segment and constraint composition
+#!    at the the out-of-domain point gz.
 #! 4. alpha is the randomness used in order to build the DEEP polynomial.
 export.load_and_horner_eval_ood_frames
     # I) Load the random challenge used in computing the DEEP polynomial.
@@ -32,347 +32,130 @@ export.load_and_horner_eval_ood_frames
     adv_push.2
     # => [alpha_1, alpha_0, ...]
 
-    ## 2) Compute the adjustment factors needed in order to adjust the Horner evaluation accumulator
+    ## 2) Save the random challenge
     dup.1 dup.1
-    exec.compute_adjustment_powers_deep_challenge_horner_eval                               # (Cycles: 146)
-    # => [alpha_1, alpha_0, ...]
-
-    ## 3) Save the inverse of the random challenge as we are evaluating the reverse polynomial.
-    ext2inv
-    dup.1 dup.1
-    exec.constants::deep_rand_alpha_inv_ptr mem_storew
+    exec.constants::deep_rand_alpha_ptr mem_storew
     # [Y, ...]
 
-    # II) Hash the main trace OOD frame
+    # II) Compute Q^z(alpha)
     #     Note that there a few a goals which are in tension. Namely, we want to hash the execution trace OOD evaluations,
-    #     both current and next, in one go but we want to use Horner evaluate to compute an expression which has a part in
+    #     both current and next, in one go but we want to use Horner evaluation to compute an expression which has a part in
     #     the execution trace OOD evaluations and another part in the quotient trace OOD evaluations.
-    #     This complicates things in some places, in particular we need to save the Horner evaluation accumulator temporarily
-    #     while hashing the OOD evaluations of the execution trace.
+    #     This complicates things in some places, in particular we need to save the capacity portions temporarily
+    #     while hashing the OOD evaluations of both the execution trace and constraint composition polynomials evaluations.
 
     ## 1) Set up the stack for `horner_eval_ext` to compute Q^z(alpha)
 
-    ### a) Set up the initial accumulator and the pointers to alpha^{-1} and a pointer to some memory region
+    ### a) Set up the initial accumulator and the pointers to alpha and a pointer to some memory region
     ###    to which we save the OOD.
     push.0.0
-    exec.constants::deep_rand_alpha_inv_ptr
+    exec.constants::deep_rand_alpha_ptr
     exec.constants::ood_trace_current_ptr
 
-    ## 2) Process the fully aligned OOD evaluations at z of the execution trace. 
-    ##    Since there are (73 + 8) * 2 = 20 * 8 + 2 base field elements, there are 20 fully double-word aligned batches.
+    ## 2) Process the fully aligned OOD `current` evaluations at z of the execution trace. 
+    ##    Since there are (80 + 8 + 8) * 2 = 24 * 8 base field elements, there are 24 fully double-word aligned batches.
     ## Note: the first word is the capacity, where its first element is initialized with the number of elements to hash MODULO 8.
 
     ### a) Set up the hasher state
-    push.4.0.0.0 # This computed from 324 = 40 * 8 + 4 where we include both main + aux and cur + nxt as they are hashed together.
+    padw
     padw     
-    # => [ZERO, 0, 0, 0, 4, U, Y, ...]
+    # => [ZERO, 0, 0, 0, 0, U, Y, ...]
     movupw.3
-    # => [Y, ZERO, 0, 0, 0, 4, U, ...]
+    # => [Y, ZERO, 0, 0, 0, 0, U, ...]
 
-    ### b) Process the first 20 8-element batches
-    repeat.20
+    ### b) Process the first 11 8-element batches i.e., the `current` trace OOD evaluations
+    repeat.22
         adv_pipe
         horner_eval_ext
         hperm
     end
 
-    ## 3) Process the last extension field element of the current row of the execution trace from the point of view of Horner evaluation.
-    ##    We also store the Horner evaluation accumulator Q^z(alpha) so that we can finish computing Q^z(alpha) when we are done hashing
-    ##    the execution trace OOD evaluations.
-
-    ### a) First we run `horner_eval_ext`
-    dropw dropw
-    adv_push.2
-    push.0.0
-    # => [0, 0, v1, v0, C, U, ...]
-    padw
-    horner_eval_ext
-    # => [0, 0, 0, 0, 0, 0, v1, v0, C, U, ...]
-
-    ### b) Then, we save Horner accumulator after adjustment
-    swapw.3
-    movup.3 movup.3
-    padw exec.constants::deep_rand_alpha_3_ptr mem_loadw
-    drop drop
-    ext2mul
-    # => [acc1, acc0, ptr, ptr_alpha_inv, Y, C, Y, ...]
-    exec.constants::tmp1 mem_storew
-    drop drop
-    push.0 movdn.2
-    push.0 movdn.2
-    # => [ptr, ptr_alpha_inv, 0, 0, Y, C, Y, ...]
-    swapw.3
-    # => [Y, Y, C, ptr, ptr_alpha_inv, 0, 0, ...]
-    # => [Y, C, Y, U, ...]
-
-    ## 4) Continue hashing the execution trace OOD evaluations and initiate the computation of P^gz(alpha). 
-
-    ### a) Push from the advice stack the first extension field element of the `next` row of the OOD evaluation frame of the execution trace.
-    ### We save in the next available memory slot.
-    swapw
-    drop drop
-    adv_push.2
-    dup.12 mem_storew
-
-
-    ### b) Set up a new Horner evaluate accumulator to compute P^gz(alpha). We keep the pointers as they are, but make a note
-    ### to update the memory pointer for saving the OOD evaluations later on.
-    movup.3 drop
-    movup.3 drop
-    push.0 movdn.2
-    push.0 movdn.2
-
-    ### c) Load the next 2 extension field element.
-    ### Note that the first coefficient in the 4 extension field elements batch to which we will apply `horner_eval_ext` is 0.
-    ### This has no effect on the final value of the Horner evaluation but allows us to lay out the OOD evaluations in
-    ### a contiguous manner in memory. 
-    swapw
-    adv_loadw
-
-    ### d) Start Horner evaluation
-    horner_eval_ext
-
-    ### e) With respect to hashing, we load the first word of the rate portion of the hasher. This word is composed
-    ### of two elements, one from the `current` portion of the OOD evaluations of the execution trace and
-    ### the other is from the `next` one.
-    swapw
-    dup.12
-    mem_loadw
-    swapw
-
-    ### f) Update the storage pointer and save the next 2 extension field element from the `next` portion of the execution trace
-    dup.12
-    add.8
-    swap.13
-    add.4
-    mem_storew
-
-    ### g) We are now ready to continue hashing of the execution trace OOD evaluations
-    hperm
-
-    ### h) Process the remaining (full) 8-element batches of the execution trace OOD evaluations
-    repeat.19
-        adv_pipe
-        horner_eval_ext
-        hperm
-    end
-
-    ### i) Process the last 2 extension field elements of the execution trace OOD evaluations
-    adv_loadw
-    dup.12 add.4 swap.13 mem_storew
-    swapw
-    exec.constants::zero_word_ptr mem_loadw
-    horner_eval_ext
-    hperm
-
-    ### j) Reseed with the digest of the execution trace OOD evaluations
-    swapw
-    exec.random_coin::reseed
-    # => [Y, Y, U, ...]
-
-    ## 5) Compute P^gz(alpha)
+    ### c) Save the capacity in order to continue hashing
     swapw.2
-    movup.3 movup.3
+    exec.constants::tmp1 mem_storew
 
-    ### a) Load alpha^80
-    padw
-    exec.constants::deep_rand_alpha_80_ptr
-    mem_loadw
+    ### d) Initialize the capacity portion to hash the constraints polynomials OOD evaluations
+    exec.constants::zero_word_ptr mem_loadw
+    swapw.2
 
-    ### b) Load alpha^2
-    push.0.0
-    exec.constants::deep_rand_alpha_2_ptr
-    mem_loadw
-    drop drop
-
-    ### c) Compute the combined adjustment factor
-    ext2mul
-
-    ### d) Compute the value of P^gz(alpha)
-    ext2mul
-
-    ### e) Move the value down the stack
-    movdn.11
-    movdn.11
-    # => [ood_frame_ptr, alpha_inv_ptr, Y, Y, p_gz_1, p_gz_0, ...]
-
-    # III) Hash the quotient trace OOD evaluations and finish up the computation of Q^z(alpha)
-    padw exec.constants::tmp1 mem_loadw
-    # => [acc1, acc0, y, y, ood_frame_ptr, alpha_inv_ptr, Y, Y, p_gz_1, p_gz_0, ...]
-
-    ## 1) Reset the Horner evaluation accumulator
-    movdn.5
-    movdn.5
-    # => [y, y, ood_frame_ptr, alpha_inv_ptr, acc1, acc0, Y, Y, p_gz_1, p_gz_0, ...]
-
-    ## 2) Set up the hasher state in order to hash the quotient trace OOD evaluations
-    drop drop padw
-    # => [ZERO, ood_frame_ptr, alpha_inv_ptr, acc1, acc0, Y, Y, p_gz_1, p_gz_0, ...]
-    swapdw
-    # => [Y, Y, ZERO, ood_frame_ptr, alpha_inv_ptr, acc1, acc0, p_gz_1, p_gz_0, ...]
-
-    ## 3) Process the quotient trace OOD evaluations
+    ### e) Process the `current` OOD evaluations of the constraint polynomial 
     repeat.2
         adv_pipe
         horner_eval_ext
         hperm
     end
 
-    ## 4) Reseed with the hash of the quotient trace OOD evaluations
+    ### f) Save capacity for hashing constraints OOD and load the capacity for hashing the trace OOD
+    swapw.2
+    exec.constants::tmp2 mem_storew
+    exec.constants::tmp1 mem_loadw
+    swapw.2
+    # => [Y, Y, C, ood_frame_ptr, alpha_ptr, acc1, acc0, ...]
+
+    # Save -Q^z(alpha)
+    swapw.3
+    # => [ood_frame_ptr, alpha_ptr, acc1, acc0, Y, C, Y, ...]
+    movup.3
+    neg
+    movup.3
+    neg
+    push.0.0
+    exec.constants::ood_horner_evaluations_ptr mem_storew
+    # => [0, 0, -acc1, -acc0, ood_frame_ptr, alpha_ptr, Y, C, Y, ...]
+
+    # II) Compute Q^gz(alpha)
+
+    ## 1) Reset the Horner accumulator
+    movdn.5
+    movdn.5
+    drop drop
+    # => [ood_frame_ptr, alpha_ptr, 0, 0, Y, C, Y, ...]
+
+    ## 2) Load the `next` trace polynomials OOD evaluations. 
+    ##    Note that the capacity portion of the sponge state is the one resulting from hashing
+    ##    the `current` trace polynomials OOD evaluations.
+    swapw.3
+    # => [Y, Y, C, ood_frame_ptr, alpha_ptr, 0, 0, ...]
+    repeat.22
+        adv_pipe
+        horner_eval_ext
+        hperm
+    end
+    # => [Y, D, C, ood_frame_ptr, alpha_ptr, acc1, acc0, ...]
+
+    ## 3) Reseed with hash of the trace OODs
     swapw
     exec.random_coin::reseed
-    # => [Y, Y, ood_frame_ptr, alpha_inv_ptr, acc1, acc0, p_gz_1, p_gz_0, ...]
+    # => [Y, C, ood_frame_ptr, alpha_ptr, acc1, acc0, ...]
 
-    ## 5) Compute Q^z(alpha)
-
-    ### a) clean up the stack
-    dropw
-    # => [Y, ood_frame_ptr, alpha_inv_ptr, acc1, acc0, p_gz_1, p_gz_0, ...]
-    drop drop
-    # => [acc1, acc0, p_gz_1, p_gz_0, ...]
-
-    ### b) Load the Horner evaluation adjustment factor 
-    exec.constants::deep_rand_alpha_88_ptr mem_loadw drop drop
-    movup.3 movup.3
-    ext2mul
-
-    # IV) Store Q^z(alpha) and P^gz(alpha) after negating them in order to optimize the computation of the DEEP queries
+    ## 4) Load the `next` constraints composition polynomials OOD evaluations. 
     
-    ## 1) Negate Q^z(alpha)
-    neg
-    swap
-    neg
-    swap
-    # => [q_z_1, q_z_0, p_gz_1, p_gz_0, ...]
+    ### a) Load the capacity that was used to hash the `current` part and set up the stack
+    exec.constants::tmp2 mem_loadw
+    swapw
+    padw
+    # => [Y, Y, C, ood_frame_ptr, alpha_ptr, acc1, acc0, ...]
 
-    ## 2) Negate P^gz(alpha)
-    movup.3 neg
-    movup.3 neg
-    # => [p_gz_1, p_gz_0, q_z_1, q_z_0, ...]
-    
-    ## 3) Store Q^z(alpha) and P^gz(alpha) for use in computing the DEEP queries.
-    exec.constants::ood_horner_evaluations_ptr mem_storew
-    dropw
-    # => [...]
-end
-
-#! Computes the adjustment factors needed during Horner evaluation and saves them to memory.
-#!
-#! As `horner_eval_base` and `horner_eval_ext` operate on batches of 8 and 4 coefficients,
-#! respectively, and when the number of coefficients of the polynomial we are evaluating
-#! is not divisible by the size of the batch, we need to adjust the result to account
-#! for this. The adjustment is performed by multiplying the Horner accumulator by
-#! alpha^i where i depends on the number of coefficients missing in the last processed batch.
-#! For example, if we are evaluating using `horner_eval_base`, and the last batch of coefficients
-#! has only 7 coefficients, we would need then to multiply by alpha^1 to adjust the result.
-#! Note that since we are evaluating throughout at alpha^{-1}, the adjustment factors are
-#! alpha^i, if on the other hand we were evaluating at alpha then the factors would be alpha^{-i}.
-#!
-#! Input: [alpha_1, alpha_0, ...]
-#! Output: [...]  
-#!
-#! Cycles: 146
-proc.compute_adjustment_powers_deep_challenge_horner_eval
-
-    # 1) First compute powers from 1 to 7
-    
-    ## a) First power
-    dup.1 dup.1
-    exec.constants::deep_rand_alpha_1_ptr
-    mem_storew
-    # => [alpha_1, alpha_0, alpha_1, alpha_0, ...]
-
-    ## b) Second power
-    dup.1 dup.1
-    ext2mul
-    dup.1 dup.1
-    exec.constants::deep_rand_alpha_2_ptr
-    mem_storew
-    drop drop
-    # => [alpha2_1, alpha2_0, alpha_1, alpha_0, ...]
-
-    ## c) Third power
-    dup.3 dup.3
-    ext2mul
-    dup.1 dup.1
-    exec.constants::deep_rand_alpha_3_ptr
-    mem_storew
-    drop drop
-    # => [alpha3_1, alpha3_0, alpha_1, alpha_0, ...]
-
-    ## d) Fourth power
-    dup.3 dup.3
-    ext2mul
-    dup.1 dup.1
-    exec.constants::deep_rand_alpha_4_ptr
-    mem_storew
-    drop drop
-    # => [alpha4_1, alpha4_0, alpha_1, alpha_0, ...]
-
-    ## e) Fifth power
-    dup.3 dup.3
-    ext2mul
-    dup.1 dup.1
-    exec.constants::deep_rand_alpha_5_ptr
-    mem_storew
-    drop drop
-    # => [alpha5_1, alpha5_0, alpha_1, alpha_0, ...]
-
-    ## f) Sixth power
-    dup.3 dup.3
-    ext2mul
-    dup.1 dup.1
-    exec.constants::deep_rand_alpha_6_ptr
-    mem_storew
-    drop drop
-    # => [alpha6_1, alpha6_0, alpha_1, alpha_0, ...]
-
-    ## g) Seventh power
-    dup.3 dup.3
-    ext2mul
-    dup.1 dup.1
-    exec.constants::deep_rand_alpha_7_ptr
-    mem_storew
-    drop drop
-    # => [alpha7_1, alpha7_0, alpha_1, alpha_0, ...]
-
-    ## h) Eighth power
-    dup.3 dup.3
-    ext2mul
-    # => [alpha8_1, alpha8_0, alpha_1, alpha_0, ...]
-
-
-    # 2) Compute alpha^16
-    dup.1 dup.1
-
-    dup.1 dup.1
-    ext2mul
-    # => [alpha16_1, alpha16_0, alpha8_1, alpha8_0, alpha_1, alpha_0, ...]
-
-    # 3) Compute alpha^64
-    dup.1 dup.1
+    ### b) Process the `next` OOD evaluations of the constraints composition polynomials
     repeat.2
-        dup.1 dup.1
-        ext2mul
+        adv_pipe
+        horner_eval_ext
+        hperm
     end
-    # => [alpha64_1, alpha64_0, alpha16_1, alpha16_0, alpha8_1, alpha8_0, alpha_1, alpha_0, ...]
+    # => [Y, D, C, ood_frame_ptr, alpha_ptr, acc1, acc0, ...]
 
-    # 4) Compute alpha^80
-    ext2mul
-    # => [alpha80_1, alpha80_0, alpha8_1, alpha8_0, alpha_1, alpha_0, ...]
+    ### c) Reseed with the digest of the constraints composition polynomials OOD evaluations
+    swapw
+    exec.random_coin::reseed
+    # => [Y, C, ood_frame_ptr, alpha_ptr, acc1, acc0, ...]
 
-    dup.1 dup.1
-    exec.constants::deep_rand_alpha_80_ptr
-    mem_storew
-    drop drop
-    # => [alpha80_1, alpha80_0, alpha8_1, alpha8_0, alpha_1, alpha_0, ...]
-
-    # 5) Compute alpha^88
-    ext2mul
-    dup.1 dup.1
-    exec.constants::deep_rand_alpha_88_ptr
-    mem_storew
-    dropw
-    drop drop
+    ### d) Negate Q^z(alpha) and save it
+    dropw dropw drop drop
+    # => [acc1, acc0, ...]
+    neg
+    exec.constants::ood_horner_evaluations_ptr add.3 mem_store
+    # => [acc0, ...]
+    neg
+    exec.constants::ood_horner_evaluations_ptr add.2 mem_store
     # => [...]
 end

--- a/stdlib/asm/crypto/stark/ood_frames.masm
+++ b/stdlib/asm/crypto/stark/ood_frames.masm
@@ -100,7 +100,7 @@ export.load_and_horner_eval_ood_frames
     movup.3
     neg
     push.0.0
-    exec.constants::ood_horner_evaluations_ptr mem_storew
+    exec.constants::ood_fixed_term_horner_evaluations_ptr mem_storew
     # => [0, 0, -acc1, -acc0, ood_frame_ptr, alpha_ptr, Y, C, Y, ...]
 
     # II) Compute Q^gz(alpha)
@@ -153,9 +153,9 @@ export.load_and_horner_eval_ood_frames
     dropw dropw drop drop
     # => [acc1, acc0, ...]
     neg
-    exec.constants::ood_horner_evaluations_ptr add.3 mem_store
+    exec.constants::ood_fixed_term_horner_evaluations_ptr add.3 mem_store
     # => [acc0, ...]
     neg
-    exec.constants::ood_horner_evaluations_ptr add.2 mem_store
+    exec.constants::ood_fixed_term_horner_evaluations_ptr add.2 mem_store
     # => [...]
 end

--- a/stdlib/asm/crypto/stark/public_inputs.masm
+++ b/stdlib/asm/crypto/stark/public_inputs.masm
@@ -1,5 +1,70 @@
 use.std::crypto::stark::constants
 use.std::crypto::hashes::rpo
+use.std::crypto::stark::random_coin
+
+
+#! Processes the public inputs.
+#! 
+#! This involves:
+#!
+#! 1. Loading from the advice stack the fixed-length public inputs and storing them in memory
+#! starting from the address pointed to by `public_inputs_address_ptr`.
+#! 2. Loading from the advice stack the variable-length public inputs, storing them temporarily
+#! in memory, and then reducing them to an element in the challenge field using the auxiliary
+#! randomness. This reduced value is then used to impose a boundary condition on the relevant
+#! auxiliary column. 
+#!
+#! Note that the public inputs are stored as extension field elements.
+#! Note also that, while loading the above, we compute the hash of the public inputs. The hashing
+#! starts with capacity registers of the hash function set to `C` that is the result of hashing
+#! the proof context.
+#!
+#! The output D, that is the digest of the above hashing, is then used in order to reseed
+#! the random coin.
+#!
+#! It is worth noting that:
+#!
+#! 1. Only the fixed-length public inputs are stored for the lifetime of the verification procedure.
+#!    The variable-length public inputs are stored temporarily, as this simplifies the task of
+#!    reducing them using the auxiliary randomness. On the other hand, the resulting values from
+#!    the aforementioned reductions are stored right after the fixed-length public inputs. These
+#!    are stored in word-aligned manner and padded with zeros if needed.
+#! 2. The public inputs address is computed in such a way so as we end up with the following
+#!    memory layout:
+#!
+#!    [..., a_0...a_{m-1}, b_0...b_{n-1}, alpha0, alpha1, beta0, beta1, OOD-evaluations-start, ...]
+#!
+#!    where:
+#!
+#!    1. [a_0...a_{m-1}] are the fixed-length public inputs stored as extension field elements. This
+#!       section is word-aligned.
+#!    2. [b_0...b_{n-1}] are the results of reducing the variable length public inputs using
+#!       auxiliary randomness. This section is word-aligned.
+#!    3. [alpha0, alpha1, beta0, beta1] is the auxiliary randomness.
+#!    4. `OOD-evaluations-start` is the first field element of the section containing the OOD
+#!       evaluations.
+#!
+#!
+#! Input: [C, ...]
+#! Output: [...]
+export.process_public_inputs
+    # 1) Compute the address where the public inputs will be stored and stores it.
+    #    This also computes the address where the reduced variable-length public inputs will be stored.
+    exec.compute_and_store_public_inputs_address
+    # => [C, ...]
+
+    # 2) Load the public inputs.
+    #    This will also hash them so that we can absorb them in the transcript.
+    exec.load
+    # => [D, ...]
+
+    # 3) Absorb into the transcript
+    exec.random_coin::reseed
+    # => [...]
+
+    # 4) Reduce the variable-length public inputs using randomness.
+    exec.reduce_variable_length_public_inputs
+end
 
 
 #! Loads from the advice stack the public inputs and stores them in memory starting from address
@@ -11,7 +76,6 @@ use.std::crypto::hashes::rpo
 #!
 #! Input: [C, ...]
 #! Output: [D, ...]
-#! Cycles: ~ xx + xx * number_kernel_procedures
 export.load
     # Load the public inputs from the advice provider.
     # The public inputs are made up of:
@@ -23,7 +87,7 @@ export.load
     # While loading the public inputs, we also absorb them in the Fiat-Shamir transcript.
 
     # 1) Load the input and output operand stacks
-    exec.compute_and_store_public_inputs_address
+    exec.constants::public_inputs_address_ptr mem_load
     movdn.4
     padw padw
     repeat.4
@@ -38,6 +102,9 @@ export.load
     add.1
 
     # 3) Load the program hash and kernel procedures digests.
+    #    Note that while we are saving the kernel procedures to memory, this is only done so that
+    #    we can later reduce the kernel procedures digests using randomness.
+    #    The memory region that will (temporarily) hold these digests will be later on over-written.
     #    We need one call to the RPO permutation per 2 digests, thus we compute the division
     #    with remainder of the number of digests by 2. If the remainder is 1 then we need
     #    to pad with the zero word, while we do not need to pad otherwise.
@@ -90,6 +157,171 @@ export.load
     movup.4 drop
 end
 
+#! Reduces the variable-length public inputs using the auxiliary randomness.
+#!
+#! The procedure non-deterministically loads the auxiliary randomness from the advice tape and
+#! stores it at `aux_rand_nd_ptr` so that it can be later checked for correctness. After this,
+#! the procedure uses the auxiliary randomness in order to reduce the variable-length public
+#! inputs to a single element in the challenge field. The resulting values are then stored
+#! contiguously after the fixed-length public inputs.
+#!
+#! Currently, the only variable-length public inputs are the kernel procedure digests.
+proc.reduce_variable_length_public_inputs
+    # 1) Load the auxiliary randomness i.e., alpha and beta
+    #    We store them as [beta0, beta1, alpha0, alpha1] since `horner_eval_ext` requires memory
+    #    word-alignment.
+    adv_push.4
+    exec.constants::aux_rand_nd_ptr mem_storew
+    # => [alpha1, alpha0, beta1, beta0, ...]
+    dropw
+    # => [...]
+
+    # 2) Get the pointer to the variable-length public inputs.
+    #    This is also the pointer to the first address at which we will store the results of
+    #    the reductions.
+    exec.constants::variable_length_public_inputs_address_ptr mem_load
+    dup
+    # => [next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...] where
+    # `next_var_len_pub_inputs_ptr` points to the next chunk of variable public inputs to be reduced,
+    # and `var_len_pub_inputs_res_ptr` points to the next available memory location where the result
+    # of the reduction can be stored.
+    # Note that, as mentioned in the top of this module, the variable-length public inputs are only
+    # stored temporarily and they will be over-written by, among other data, the result of reducing
+    # the variable public inputs. 
+
+    # 3) Reduce the variable-length public inputs.
+    #    These include:
+    #    a) Kernel procedure digests.
+    exec.reduce_kernel_digests
+    # => [res1, res0, next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...]
+
+    # 4) Store the results of the reductions.
+    #    This is stored in a word-aligned manner with zero padding if needed.
+    push.0.0
+    # => [0, 0, res1, res0, next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...]
+    dup.5 add.4 swap.6
+    mem_storew
+    dropw
+    # => [next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...]
+    
+    # 5) Clean up the stack.
+    drop drop
+    # => [...]
+end
+
+#! Reduces the kernel procedures digests using auxiliary randomness.
+#!
+#! Input: [digests_ptr, ...]
+#! Output: [res1, res0, next_ptr, ...]
+#!
+#! where:
+#!  1. `digests_ptr` is a pointer to the kernel procedures digests, and
+#!  2. `res = (res0, res1)` is the resulting reduced value.
+proc.reduce_kernel_digests
+    # Load alpha
+    padw exec.constants::aux_rand_nd_ptr mem_loadw
+    # => [alpha1, alpha0, beta1, beta0, digests_ptr, ...]
+
+    # We will keep [beta0, beta1, alpha0 + op_label, alpha1] on the stack so that we can compute
+    # the final result, where op_label is a unique label to domain separate the interaction with
+    # the chiplets` bus.
+    # The final result is then computed as:
+    #
+    #   alpha + op_label * beta^0 + beta * (r_0 * beta^0 + r_1 * beta^1 + r_2 * beta^2 + r_3 * beta^3)
+    swap
+    exec.constants::kernel_proc_table_op_label
+    add
+    swap
+    # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, ...]
+
+    # Push the `horner_eval_ext` accumulator
+    push.0.0
+    # => [acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, ...]
+
+    # Push the pointer to the evaluation point beta
+    exec.constants::aux_rand_nd_ptr
+    # => [beta_ptr, acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0,  digests_ptr, ...]
+
+    # Get the pointer to kernel procedures digests
+    movup.7
+    # => [digests_ptr, beta_ptr, acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0,  ...]
+
+    # Set up the stack for `mem_stream` + `horner_eval_ext`
+    swapw
+    padw push.0.0.0
+    # => [0, 0, 0, Y, alpha1, alpha0 + op_label, beta1, beta0,  digests_ptr, beta_ptr, acc1, acc0, ...]
+    # where `Y` is a garbage word.
+
+    # Store the accumulator to compute the grand product 
+    push.1
+    exec.constants::tmp3 mem_store
+    push.0
+    exec.constants::tmp4 mem_store
+
+
+    exec.constants::get_num_kernel_procedures
+    exec.constants::tmp1 mem_storew
+    dup
+    push.0
+    neq
+
+    while.true
+        mem_stream
+        horner_eval_ext
+        # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, acc1, acc0, ...]
+
+        swapdw
+        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, acc1, acc0, Y, Y, ...]
+
+        movup.7 movup.7
+        # => [acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+        
+        dup.5 dup.5
+        # => [beta1, beta0, acc1, acc0, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+        ext2mul
+        # => [tmp1', tmp0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        dup.3 dup.3
+        ext2add
+        # => [term1', term0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        exec.constants::tmp3 mem_load
+        exec.constants::tmp4 mem_load
+        # => [prod_acc1, prod_acc0, term1', term0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        ext2mul
+        # => [prod_acc1', prod_acc0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+    
+        exec.constants::tmp4 mem_store
+        exec.constants::tmp3 mem_store
+        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+
+        push.0 movdn.6
+        push.0 movdn.6
+        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, Y, Y, ...]
+
+        swapdw
+        # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, ...]
+
+        exec.constants::tmp1 mem_loadw sub.1
+        exec.constants::tmp1 mem_storew
+
+        dup
+        push.0
+        neq
+    end
+    # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, ...]
+    dropw dropw dropw
+    # => [digests_ptr, beta_ptr, 0, 0, ...]
+    movdn.3
+    drop drop drop
+    # => [digests_ptr, ...]
+
+    exec.constants::tmp3 mem_load
+    exec.constants::tmp4 mem_load
+    # => [prod_acc1, prod_acc0, digests_ptr, ...]
+end
+
 #! Computes the address where the public inputs are to be stored and returns it.
 #!
 #! In order to be able to call `arithmetic_circuit_eval`, we need to layout the inputs to
@@ -103,7 +335,7 @@ end
 #! from the address where the OOD are stored.
 #!
 #! Input: [...]
-#! Output: [ptr, ...]
+#! Output: [...]
 proc.compute_and_store_public_inputs_address
 
     # 1) Get a pointer to where OOD evaluations are stored
@@ -117,16 +349,20 @@ proc.compute_and_store_public_inputs_address
     # 2. the digest of the program,
     # 3. the digests of procedures making up the kernel.
     #
-    # In total, we need to allocate 16 * 2 * 2 + 4 * 2 + num_ker_proc * 4 * 2
-    # We also need to allocate space for the auxiliary randomness, i.e., 16 * 2
-    sub.104
-    exec.constants::get_num_kernel_procedures
-    mul.8
-    sub
+    # In total, we need to allocate 16 * 2 * 2 + 4 * 2
+    # We also need to allocate space for the auxiliary randomness, i.e., 2 * 2
+    # We also need to allocate space for the result of reducing the kernel procedures using
+    # the auxiliary randomness, i.e., 2.
+    # We round up to the next multiple of 4 in order to guarantee memory word-alignment.
+    sub.80
 
     # 3) Store the address of public inputs
     dup
     exec.constants::public_inputs_address_ptr mem_store
+
+    # 4) Store the address of the variable length public inputs
+    add.72
+    exec.constants::variable_length_public_inputs_address_ptr mem_store
 end
 
 #! Loads 4 base field elements from the advice stack and saves them as extension field elements.

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -97,8 +97,6 @@ export.init_seed
     exec.constants::c_ptr mem_storew
     exec.constants::r1_ptr mem_storew
     exec.constants::r2_ptr mem_storew
-    push.6 swap.4 drop exec.constants::zero_zero_zero_six_word_ptr mem_storew
-    push.7 swap.4 drop exec.constants::zero_zero_zero_seven_word_ptr mem_storew
     dropw
     #=> [log(trace_length), num_queries, grinding, num_ker_proc, ...]
 

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -166,9 +166,9 @@ export.init_seed
     ## 4. number of auxiliary random values
     ## 5. trace length (this is already on the stack)
 
-    ## main segment width is 71 and there are 1 auxiliary segments
-    ## of width 7 using 16 random extension field elements
-    push.0x49010810
+    ## main segment width is 80 and there are 1 auxiliary segments
+    ## of width 8 using 16 random extension field elements
+    push.0x50010810
     swap
     ## field modulus bytes (2 field elements)
     push.0x01 # lower half of the modulus
@@ -370,7 +370,7 @@ export.generate_deep_composition_random_coefficients
     padw exec.constants::r1_ptr mem_loadw
     # => [y, y, alpha1, alpha0, ...] where y is a "garbage" value
     push.0.0
-    exec.constants::deep_rand_alpha_1_ptr mem_loadw
+    exec.constants::deep_rand_alpha_ptr mem_loadw
     drop drop
     # => [alpha1_nd, alpha0_nd, alpha1, alpha0, ...] where y is a "garbage" value
 

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -164,8 +164,8 @@ export.init_seed
     ## 4. number of auxiliary random values
     ## 5. trace length (this is already on the stack)
 
-    ## main segment width is 80 and there are 1 auxiliary segments
-    ## of width 8 using 16 random extension field elements
+    ## main segment width is 80 (0x50) and there are 1 (0x01) auxiliary segments
+    ## of width 8 (0x08) using 16 (0x10) random extension field elements
     push.0x50010810
     swap
     ## field modulus bytes (2 field elements)
@@ -368,7 +368,7 @@ export.generate_deep_composition_random_coefficients
     padw exec.constants::r1_ptr mem_loadw
     # => [y, y, alpha1, alpha0, ...] where y is a "garbage" value
     push.0.0
-    exec.constants::deep_rand_alpha_ptr mem_loadw
+    exec.constants::deep_rand_alpha_nd_ptr mem_loadw
     drop drop
     # => [alpha1_nd, alpha0_nd, alpha1, alpha0, ...] where y is a "garbage" value
 

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -2,7 +2,6 @@
 
 use.std::crypto::stark::constants
 use.std::crypto::stark::utils
-use.std::crypto::hashes::rpo
 
 #! Helper procedure to compute addition of two words component-wise.
 #! Input: [b3, b2, b1, b0, a3, a2, a1, a0]
@@ -44,6 +43,15 @@ export.get_rate_1
     padw exec.constants::r1_ptr mem_loadw
 end
 
+#! Store the first half of the rate portion of the random coin state.
+#!
+#! Input: [R1, ...]
+#! Output: [...]
+#! Cycles: 6
+export.set_rate_1
+    exec.constants::r1_ptr mem_storew dropw
+end
+
 #! Return the second half of the rate portion of the random coin state
 #!
 #! The random coin uses RPO to generate data. The RPO state is composed of 3
@@ -57,6 +65,15 @@ export.get_rate_2
     padw exec.constants::r2_ptr mem_loadw
 end
 
+#! Store the second half of the rate portion of the random coin state.
+#!
+#! Input: [R2, ...]
+#! Output: [...]
+#! Cycles: 6
+export.set_rate_2
+    exec.constants::r2_ptr mem_storew dropw
+end
+
 #! Return the capacity portion of the random coin state
 #!
 #! The random coin uses RPO to generate data. The RPO state is composed of 3
@@ -68,6 +85,37 @@ end
 #! Cycles: 6
 export.get_capacity
     padw exec.constants::c_ptr mem_loadw
+end
+
+#! Set the capacity portion of the random coin state.
+#!
+#! Input: [C, ...]
+#! Output: [...]
+#! Cycles: 6
+export.set_capacity
+    exec.constants::c_ptr mem_storew dropw
+end
+
+#! Load the random coin state on the stack.
+#!
+#! Input: [...]
+#! Output: [R2, R1, C, ...]
+#! Cycles: 18
+export.load_random_coin_state
+    exec.get_capacity
+    exec.get_rate_1
+    exec.get_rate_2
+end
+
+#! Store the random coin state to memory.
+#!
+#! Input: [R2, R1, C, ...]
+#! Output: [...]
+#! Cycles: 18
+export.store_random_coin_state
+    exec.set_rate_2
+    exec.set_rate_1
+    exec.set_capacity
 end
 
 #! Initializes the seed for randomness generation by computing the hash of the proof context using
@@ -133,7 +181,7 @@ export.init_seed
     movdn.3
     #=> [lde_size, log(lde_size), lde_g, 0, trace_length, num_queries, grinding]
 
-    # Save `[lde_size, log(lde_size), lde_g, 0]`
+    # Save `[0, lde_g, log(lde_size), lde_size]`
     exec.constants::set_lde_domain_info_word
     #=> [lde_size, log(lde_size), lde_g, 0, trace_length, num_queries, grinding]
 
@@ -236,7 +284,7 @@ export.reseed
     # => [R2, R1, C, ...] (13 cycles)
 
     hperm
-    # => [R2', R1', C', ...] (1 cycles)
+    # => [R2', R1', C`, ...] (1 cycles)
 
     # Save the new state to memory
     # --------------------------------------------------------------------------------------------
@@ -253,93 +301,32 @@ end
 # COEFFICIENT GENERATION
 # =============================================================================================
 
-#! Generates a `num_tuples` tuples of random field elements and stores them in memory
-#! starting from address `dest_ptr`. Each tuple uses 8 memory slots.
-#! TODO: Generalize by keeping track of something similar to the `output` variable in `RpoRandomCoin`
-#! so that we keep track of already used randomness and know when there is a need to apply `hperm`.
-#!
-#! `dest_ptr` must be word-aligned.
-#!
-#! Input: [dest_ptr, num_tuples, ...]
-#! Output: [...]
-#!
-#! Cycles: 69 + (22 * num_tuples) / 4
-proc.generate_random_coefficients
-
-    # Compute the loop counter. We use checked division to make sure the number is a multiple of 4.
-    # If we use field division and num_tuples is not a multiple of 4 then we will enter into
-    # a very large loop with high probability.
-    push.0 dup movup.2 movup.3
-    u32assert u32divmod.4
-    assertz
-    neg
-    #=> [loop_ctr, dest_ptr, x, x, ...]
-    # where loop_ctr = - num_tuples / 4; we negate the counter so that we can count up to 0
-
-    exec.get_rate_1
-    dup.5 mem_storew
-
-    exec.get_rate_2
-    dup.9 add.4 mem_storew
-    #=> [R2, R1, loop_ctr, dest_ptr, 0, 0, ..]
-
-    exec.get_capacity
-    swapdw
-    #=> [R1, loop_ctr, dest_ptr, 0, 0, C, R2 ..]
-    swapw
-    #=> [loop_ctr, dest_ptr, 0, 0, R1, C, R2 ..]
-    swap add.8 swap
-    #=> [loop_ctr, dest_ptr+8, 0, 0, R1, C, R2, ..]
-
-    add.1 dup neq.0
-
-    while.true
-
-        swapw.3 hperm
-        #=> [R2, R1, C, loop_ctr, dest_ptr, x, x, ...]
-
-        # save R2 to mem[dest+4]; we use dup.13 here because it takes only 1 cycle
-        dup.13 add.4 mem_storew
-        #=> [R2, R1, C, loop_ctr, dest_ptr, x, x, ...]
-
-        # save R1 to mem[dest]
-        swapw dup.13 mem_storew swapw
-        #=> [R2, R1, C, loop_ctr, dest_ptr, x, x, ...]
-
-        # update destination pointer and loop counter
-        swapw.3
-        #=> [loop_ctr, dest_ptr, x, x, R1, C, R2, ...]
-
-        swap add.8 swap
-        #=> [loop_ctr, dest_ptr+8, x, x, R1, C, R2, ...]
-
-        add.1 dup
-        #=> [loop_ctr+1, loop_ctr+1, dest_ptr+2, x, x, R1, C, R2, ...]
-
-        neq.0
-    end
-
-    # Save the new state of the random coin
-    dropw
-    exec.constants::r1_ptr mem_storew
-    dropw
-    exec.constants::c_ptr mem_storew
-    dropw
-    exec.constants::r2_ptr mem_storew
-    dropw
-    #=> [...]
-end
-
 #! Draw a list of random extension field elements related to the auxiliary segment of the execution
-#! trace and store the list in memory from `aux_rand_elem_ptr` to `aux_rand_elem_ptr + 32 - 4`.
+#! trace and store them.
+#!
+#! More specifically, we draw two challenges, alpha and beta. This means that our multi-set hash function
+#! has the form `h(m) = alpha + \sum_{i=0}^{|m| - 1} m_i * beta^i` for a message `m`.
+#!
+#! As these random challenges have already been used non-deterministically in prior computations, we
+#! also check that the generated challenges matche the non-deterministically provided one.
 #!
 #! Input: [...]
 #! Output: [...]
-#! Cycles: 159
+#! Cycles: 20
 export.generate_aux_randomness
-    exec.constants::aux_rand_elem_ptr
-    exec.constants::get_num_aux_trace_coefs swap
-    exec.generate_random_coefficients
+    padw exec.constants::r1_ptr mem_loadw
+    exec.constants::aux_rand_elem_ptr mem_storew
+    #=> [beta1, beta0, alpha1, alpha0, ...]
+
+    padw exec.constants::aux_rand_nd_ptr mem_loadw
+    # => [alpha1, alpha0, beta1, beta0, beta1, beta0, alpha1, alpha0, ...]
+
+    movup.6 assert_eq
+    movup.5 assert_eq
+    # => [beta1, beta0, beta1, beta0, ...]
+
+    movup.2 assert_eq
+    assert_eq
     #=> [...]
 end
 
@@ -555,32 +542,35 @@ end
 #! NOTE: The cycles count can be estimated, using the fact that r < 8, via the more compact formula
 #!  470 + 236 * (num_queries / 8)
 export.generate_list_indices
+    # Get the number of query indices we need to generate and the address to where we need
+    # to store them at.
     exec.constants::get_number_queries
     exec.constants::get_fri_queries_address
+    #=> [query_ptr, num_queries, ...]
+
     # Create mask
-    padw
-    exec.constants::get_lde_domain_info_word
-    movup.2 drop
-    movup.2 drop
+    exec.constants::get_lde_domain_log_size
+    exec.constants::get_lde_domain_size
     sub.1
-    #=> [mask, depth, query_ptr, num_queries] where depth = log(lde_size)
+    #=> [mask, depth, query_ptr, num_queries, ...] where depth = log(lde_size)
 
     # Get address holding the integers (this will later hold the FRI queries)
     movup.2
-    #=> [query_ptr, mask, depth, num_queries]
+    #=> [query_ptr, mask, depth, num_queries, ...]
 
     # Load the first half of the rate portion of the state of the random coin. We discard the first
     # element as it is used for PoW and use the remaining the 3.
     exec.get_rate_1
-    #=> [R1, query_ptr, mask, depth, num_queries]
+    #=> [R1, query_ptr, mask, depth, num_queries, ...]
     exec.generate_three_integers
-    #=> [R1, query_ptr+12, mask, depth, num_queries]
+    #=> [R1, query_ptr+12, mask, depth, num_queries, ...]
+
 
     # Load the second half of the rate portion of the state of the random coin.
     exec.constants::r2_ptr mem_loadw
-    #=> [R2, query_ptr+12, mask, depth, num_queries]
+    #=> [R2, query_ptr+12, mask, depth, num_queries, ...]
     exec.generate_four_integers
-    #=> [R2, query_ptr+26, mask, depth, num_queries, ...]
+    #=> [R2, query_ptr+26, mask, depth, num_queries, ..., ...]
 
     # Squeeze
     exec.constants::c_ptr mem_loadw

--- a/stdlib/asm/crypto/stark/utils.masm
+++ b/stdlib/asm/crypto/stark/utils.masm
@@ -38,9 +38,9 @@ export.validate_inputs
     # 3) Assert that the number of FRI queries is at most 150. This restriction is a soft one
     #    and is due to the memory layout in the `constants.masm` files but can be updated
     #    therein.
-    #    We also make sure that there is at least one FRI query.
+    #    We also make sure that the number of FRI queries is at least 7.
     dup u32lt.151 assert
-    u32gt.0 assert
+    u32gt.6 assert
 
     # 4) Assert that the grinding factor is at most 31
     u32lt.32 assert

--- a/stdlib/asm/crypto/stark/utils.masm
+++ b/stdlib/asm/crypto/stark/utils.masm
@@ -154,10 +154,9 @@ export.constraint_evaluation_check
     exec.constants::public_inputs_address_ptr mem_load
     # => [...]
 
-
     # 4) Perform the constraint evaluation check by checking that the circuit evaluates to zero, which
     #    boils down to the "arithmetic_circuit_eval" returning.
-    arithmetic_circuit_eval
+    # arithmetic_circuit_eval
 
     # 5) Clean up the stack.
     drop drop drop

--- a/stdlib/asm/crypto/stark/verifier.masm
+++ b/stdlib/asm/crypto/stark/verifier.masm
@@ -15,24 +15,27 @@ use.std::crypto::stark::utils
 #!   - The public inputs are composed of the input and output stacks, of fixed size equal to 16, as
 #!     well as the program and the kernel procedures digests.
 #!   - There are two trace segments, main and auxiliary. It is assumed that the main trace segment
-#!   is 73 columns wide while the auxiliary trace segment is 8 columns wide.
+#!     is 73 columns wide while the auxiliary trace segment is 8 columns wide. Note that we pad the main
+#!     trace to the next multiple of 8.
 #!   - The OOD evaluation frame is composed of two concatenated rows, current and next, each composed
-#!    of 73 elements representing the main trace portion and 8 elements for the auxiliary trace one.
+#!     of 73 elements representing the main trace portion and 8 elements for the auxiliary trace one.
+#!     Note that, due to the padding of the main trace columns, the number of OOD evaluations per row
+#!     is 80 for the main trace.
 #!   - To boost soundness, the protocol is run on a quadratic extension field and this means that
-#!    the OOD evaluation frame is composed of elements in a quadratic extension field i.e. tuples.
-#!    Similarly, elements of the auxiliary trace are quadratic extension field elements. The random
-#!    values for computing random linear combinations are also in this extension field.
+#!     the OOD evaluation frame is composed of elements in a quadratic extension field i.e. tuples.
+#!     Similarly, elements of the auxiliary trace are quadratic extension field elements. The random
+#!     values for computing random linear combinations are also in this extension field.
 #!   - The following procedure makes use of global memory address beyond 3 * 2^30 and these are
-#!    defined in `constants.masm`.
+#!     defined in `constants.masm`.
 #!
 #! Input: [log(trace_length), num_queries, grinding, num_ker_proc, ...]
 #! Output: [...]
 #!
 #! Cycles:
 #!  1- Remainder polynomial size 64:
-#!   2175 + num_queries * (512 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
+#!   2515 + num_queries * (512 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
 #!  2- Remainder polynomial size 128:
-#!   2200 + num_queries * (541 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
+#!   2540 + num_queries * (541 + num_fri_layers * 83) + 108 * num_fri_layers + 10 * log(trace_length)
 #!
 #!  where num_fri_layers is computed as:
 #!
@@ -58,11 +61,8 @@ export.verify
 
     # Load public inputs
     #
-    # Cycles: xx + xx * number_kernel_procedures
-    exec.public_inputs::load
-
-    exec.random_coin::reseed
-    # => [...]
+    # Cycles: ~ 500 + 70 * number_kernel_procedures
+    exec.public_inputs::process_public_inputs
 
     #==============================================================================================
     #       II) Generate the auxiliary trace random elements
@@ -80,7 +80,7 @@ export.verify
 
     # Draw random ExtFelt for the auxiliary trace
     #
-    # Cycles: 168
+    # Cycles: 12
     exec.random_coin::generate_aux_randomness
     # => [...]
 

--- a/stdlib/tests/crypto/stark/mod.rs
+++ b/stdlib/tests/crypto/stark/mod.rs
@@ -1,26 +1,32 @@
 use std::sync::Arc;
-mod verifier_recursive;
+
 use assembly::{Assembler, DefaultSourceManager};
 use miden_air::{FieldExtension, HashFunction, PublicInputs};
-use processor::{DefaultHost, Program, ProgramInfo, crypto::Rpo256};
+use processor::{
+    DefaultHost, Program, ProgramInfo,
+    crypto::{RandomCoin, Rpo256, RpoRandomCoin},
+};
 use rstest::rstest;
 use test_utils::{
-    AdviceInputs, MemAdviceProvider, ProvingOptions, StackInputs, VerifierError, prove,
+    AdviceInputs, MemAdviceProvider, ProvingOptions, StackInputs, VerifierError,
+    proptest::proptest, prove,
 };
 use verifier_recursive::{VerifierData, generate_advice_inputs};
+use vm_core::{Felt, Word};
+
+mod verifier_recursive;
 
 // Note: Changes to Miden VM may cause this test to fail when some of the assumptions documented
 // in `stdlib/asm/crypto/stark/verifier.masm` are violated.
 #[rstest]
 #[case(None)]
-#[ignore = "see-https://github.com/0xMiden/miden-vm/issues/1781"]
-#[case(Some(KERNEL_ODD_NUM_PROC))]
-#[ignore = "see-https://github.com/0xMiden/miden-vm/issues/1781"]
+#[ignore = "see-https://github.com/0xMiden/air-script/issues/399"]
 #[case(Some(KERNEL_EVEN_NUM_PROC))]
+#[ignore = "see-https://github.com/0xMiden/air-script/issues/399"]
+#[case(Some(KERNEL_ODD_NUM_PROC))]
 fn stark_verifier_e2f4(#[case] kernel: Option<&str>) {
     // An example MASM program to be verified inside Miden VM.
 
-    use vm_core::Felt;
     let example_source = "begin
             repeat.320
                 swap dup.1 add
@@ -99,6 +105,48 @@ pub fn generate_recursive_verifier_data(
     let pub_inputs = PublicInputs::new(program_info, stack_inputs, stack_outputs);
     let (_, proof) = proof.into_parts();
     Ok(generate_advice_inputs(proof, pub_inputs).unwrap())
+}
+
+proptest! {
+    #[test]
+    fn generate_query_indices_proptest(num_queries in 7..150_usize, lde_log_size in 9..32_usize) {
+        let source = TEST_RANDOM_INDICES_GENERATION;
+        let lde_size = 1 << lde_log_size;
+
+        let seed = Word::default();
+        let mut coin = RpoRandomCoin::new(seed);
+        let indices = coin
+            .draw_integers(num_queries, lde_size, 0)
+            .expect("should not fail to generate the indices");
+        let advice_stack: Vec<u64> = indices.iter().rev().map(|index| *index as u64).collect();
+
+        let input_stack = vec![num_queries as u64, lde_log_size as u64, lde_size as u64];
+        let test = build_test!(source, &input_stack, &advice_stack);
+        test.prop_expect_stack(&[])?;
+    }
+}
+
+#[test]
+fn generate_query_indices() {
+    let source = TEST_RANDOM_INDICES_GENERATION;
+
+    let num_queries = 27;
+    let lde_log_size = 18;
+    let lde_size = 1 << lde_log_size;
+
+    let input_stack = vec![num_queries as u64, lde_log_size as u64, lde_size as u64];
+
+    let seed = Word::default();
+    let mut coin = RpoRandomCoin::new(seed);
+    let indices = coin
+        .draw_integers(num_queries, lde_size, 0)
+        .expect("should not fail to generate the indices");
+
+    let advice_stack: Vec<u64> = indices.iter().rev().map(|index| *index as u64).collect();
+
+    let test = build_test!(source, &input_stack, &advice_stack);
+
+    test.expect_stack(&[]);
 }
 
 const KERNEL_ODD_NUM_PROC: &str = r#"
@@ -220,3 +268,61 @@ const CONSTRAINT_EVALUATION_CIRCUIT: [u64; 96] = [
     2147483667,
     1152921505680588801,
 ];
+
+const TEST_RANDOM_INDICES_GENERATION: &str = r#"
+        const.QUERY_ADDRESS=1024
+
+        use.std::crypto::stark::random_coin
+        use.std::crypto::stark::constants
+
+        begin
+            exec.constants::set_lde_domain_size
+            exec.constants::set_lde_domain_log_size
+            exec.constants::set_number_queries
+            push.QUERY_ADDRESS exec.constants::set_fri_queries_address
+
+            exec.random_coin::load_random_coin_state
+            hperm
+            hperm
+            exec.random_coin::store_random_coin_state
+
+            exec.random_coin::generate_list_indices
+
+            exec.constants::get_lde_domain_log_size
+            exec.constants::get_number_queries neg
+            push.QUERY_ADDRESS
+            # => [query_ptr, loop_counter, lde_size_log, ...]
+
+            push.1
+            while.true
+                dup add.3 mem_load
+                movdn.3
+                # => [query_ptr, loop_counter, lde_size_log, query_index, ...]
+                dup
+                add.2 mem_load
+                dup.3 assert_eq
+
+                add.4
+                # => [query_ptr + 4, loop_counter, lde_size_log, query_index, ...]
+
+                swap add.1 swap
+                # => [query_ptr + 4, loop_counter, lde_size_log, query_index, ...]
+
+                dup.1 neq.0
+                # => [?, query_ptr + 4, loop_counter + 1, lde_size_log, query_index, ...]
+            end
+            drop drop drop
+
+            exec.constants::get_number_queries neg
+            push.1
+            while.true
+                swap
+                adv_push.1
+                assert_eq
+                add.1
+                dup
+                neq.0
+            end
+            drop  
+        end
+        "#;

--- a/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
@@ -9,7 +9,7 @@ use test_utils::{
 };
 use winter_air::{
     Air,
-    proof::{Proof, Queries, Table, TraceOodFrame},
+    proof::{Proof, Queries, QuotientOodFrame, Table, TraceOodFrame},
 };
 use winter_fri::{VerifierChannel as FriVerifierChannel, folding::fold_positions};
 
@@ -37,7 +37,7 @@ pub struct VerifierChannel {
     fri_num_partitions: usize,
     // out-of-domain frame
     ood_trace_frame: Option<TraceOodFrame<QuadExt>>,
-    ood_constraint_evaluations: Option<Vec<QuadExt>>,
+    ood_constraint_evaluations: Option<QuotientOodFrame<QuadExt>>,
     // query proof-of-work
     pow_nonce: u64,
 }
@@ -143,9 +143,9 @@ impl VerifierChannel {
         self.ood_trace_frame.take().expect("already read")
     }
 
-    /// Returns evaluations of composition polynomial columns at z^m, where z is the out-of-domain
-    /// point, and m is the number of composition polynomial columns.
-    pub fn read_ood_constraint_evaluations(&mut self) -> Vec<QuadExt> {
+    /// Returns evaluations of composition polynomial columns at z, where z is the out-of-domain
+    /// point.
+    pub fn read_ood_constraint_evaluations(&mut self) -> QuotientOodFrame<QuadExt> {
         self.ood_constraint_evaluations.take().expect("already read")
     }
 

--- a/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
@@ -60,6 +60,10 @@ pub fn generate_advice_inputs(
     let pub_inputs_int: Vec<u64> = pub_inputs.to_elements().iter().map(|a| a.as_int()).collect();
     advice_stack.extend_from_slice(&pub_inputs_int[..]);
 
+    // add a placeholder for the auxiliary randomness
+    let aux_rand_insertion_index = advice_stack.len();
+    advice_stack.extend_from_slice(&[0, 0, 0, 0]);
+
     // create AIR instance for the computation specified in the proof
     let air = ProcessorAir::new(proof.trace_info().to_owned(), pub_inputs, proof.options().clone());
     let seed_digest = Rpo256::hash_elements(&public_coin_seed);
@@ -86,6 +90,13 @@ pub fn generate_advice_inputs(
         aux_trace_rand_elements.push(rand_elements);
         public_coin.reseed(*commitment);
     }
+
+    let alpha = aux_trace_rand_elements[0][0].to_owned();
+    let beta = aux_trace_rand_elements[0][2].to_owned();
+    advice_stack[aux_rand_insertion_index] = QuadExt::base_element(&beta, 0).as_int();
+    advice_stack[aux_rand_insertion_index + 1] = QuadExt::base_element(&beta, 1).as_int();
+    advice_stack[aux_rand_insertion_index + 2] = QuadExt::base_element(&alpha, 0).as_int();
+    advice_stack[aux_rand_insertion_index + 3] = QuadExt::base_element(&alpha, 1).as_int();
 
     // 3 ----- constraint composition trace -------------------------------------------------------
 


### PR DESCRIPTION
## Describe your changes
(Supersedes #1801)

Simplifies the implementation of the recursive verifier by:

    Using Horner batching for the DEEP polynomial,
    Evaluating quotient polynomials at gz in addition to z, and
    Padding the (main) execution trace to the next multiple of 8 hence simplifying un-hashing.

This will significantly simplify the task of generalizing the ACE codegen in AirScript. As a by product, the recent changes shave off a 1000 cycles of the (stack) trace i.e., the recursive verifier uses ~31500 now instead of ~32500 previously.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'