### PR TITLE
Add range checks for Falcon mod reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 #### Fixes
 - `miden debug` rewind command no longer panics at clock 0 (#1751)
 
+#### Enhancements
+- Add range checks to the `push_falcon_mod_result` advice injector to make sure that the inputs are `u32` (#1819).
 
 ## 0.14.0 (2025-05-07)
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -71,6 +71,16 @@ pub enum ExecutionError {
         source_file: Option<Arc<SourceFile>>,
         clk: RowIndex,
     },
+    #[error("Operand stack input is {input} but it is not a u32 at clock cycle {clk}")]
+    #[diagnostic()]
+    InputNotU32 {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        clk: RowIndex,
+        input: u64,
+    },
     #[error("failed to execute the dynamic code block provided by the stack with root 0x{hex}; the block could not be found",
       hex = to_hex(.digest.as_bytes())
     )]
@@ -349,6 +359,15 @@ impl ExecutionError {
     pub fn divide_by_zero(clk: RowIndex, err_ctx: &ErrorContext<'_, impl MastNodeExt>) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
         Self::DivideByZero { clk, label, source_file }
+    }
+
+    pub fn input_not_u32(
+        clk: RowIndex,
+        input: u64,
+        err_ctx: &ErrorContext<'_, impl MastNodeExt>,
+    ) -> Self {
+        let (label, source_file) = err_ctx.label_and_source_file();
+        Self::InputNotU32 { clk, input, label, source_file }
     }
 
     pub fn dynamic_node_not_found(

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -71,16 +71,6 @@ pub enum ExecutionError {
         source_file: Option<Arc<SourceFile>>,
         clk: RowIndex,
     },
-    #[error("Operand stack input is {input} but it is not a u32 at clock cycle {clk}")]
-    #[diagnostic()]
-    InputNotU32 {
-        #[label]
-        label: SourceSpan,
-        #[source_code]
-        source_file: Option<Arc<SourceFile>>,
-        clk: RowIndex,
-        input: u64,
-    },
     #[error("failed to execute the dynamic code block provided by the stack with root 0x{hex}; the block could not be found",
       hex = to_hex(.digest.as_bytes())
     )]
@@ -287,6 +277,18 @@ pub enum ExecutionError {
         value: Felt,
         err_code: Felt,
     },
+    #[error(
+        "Operand stack input is {input} but it is expected to fit in a u32 at clock cycle {clk}"
+    )]
+    #[diagnostic()]
+    NotU32StackValue {
+        #[label]
+        label: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        clk: RowIndex,
+        input: u64,
+    },
     #[error("stack should have at most {MIN_STACK_DEPTH} elements at the end of program execution, but had {} elements", MIN_STACK_DEPTH + .0)]
     OutputStackOverflow(usize),
     #[error("a program has already been executed in this process")]
@@ -367,7 +369,7 @@ impl ExecutionError {
         err_ctx: &ErrorContext<'_, impl MastNodeExt>,
     ) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
-        Self::InputNotU32 { clk, input, label, source_file }
+        Self::NotU32StackValue { clk, input, label, source_file }
     }
 
     pub fn dynamic_node_not_found(

--- a/processor/src/operations/sys_ops/sys_event_handlers.rs
+++ b/processor/src/operations/sys_ops/sys_event_handlers.rs
@@ -387,12 +387,13 @@ pub fn push_u64_div_result(
 ///   Operand stack: [a1, a0, ...]
 ///   Advice stack: [q1, q0, r, ...]
 ///
-/// Where (a0, a1) are the 32-bit limbs of the dividend (with a0 representing the 32 least
+/// where (a0, a1) are the 32-bit limbs of the dividend (with a0 representing the 32 least
 /// significant bits and a1 representing the 32 most significant bits).
 /// Similarly, (q0, q1) represent the quotient and r the remainder.
 ///
 /// # Errors
-/// Returns an error if the divisor is ZERO.
+/// - Returns an error if the divisor is ZERO.
+/// - Returns an error if either a0 or a1 is not a u32.
 pub fn push_falcon_mod_result(
     advice_provider: &mut impl AdviceProvider,
     process: ProcessState,
@@ -400,6 +401,12 @@ pub fn push_falcon_mod_result(
 ) -> Result<(), ExecutionError> {
     let dividend_hi = process.get_stack_item(0).as_int();
     let dividend_lo = process.get_stack_item(1).as_int();
+    if dividend_lo > u32::MAX as u64 {
+        return Err(ExecutionError::input_not_u32(process.clk(), dividend_lo, err_ctx));
+    }
+    if dividend_hi > u32::MAX as u64 {
+        return Err(ExecutionError::input_not_u32(process.clk(), dividend_hi, err_ctx));
+    }
     let dividend = (dividend_hi << 32) + dividend_lo;
 
     let (quotient, remainder) = (dividend / M, dividend % M);

--- a/stdlib/asm/crypto/dsa/rpo_falcon512.masm
+++ b/stdlib/asm/crypto/dsa/rpo_falcon512.masm
@@ -26,6 +26,9 @@ const.MEMORY_POINTER_OFFSET_OF_HASH_TO_POINT_POLY_FROM_PRODUCT_POLY=1024
 #!
 #! [c, ...] | c = a % M
 #!
+#! Note that it is the responsibility of the calling procedure to insure that `a_hi` and `a_lo` are
+#! within the appropriate range i.e., they are u32-s.
+#!
 #! Cycles: 27
 export.mod_12289
     adv.push_falcon_div
@@ -402,6 +405,8 @@ export.diff_mod_M
     #=> [res_hi, res_lo, ..]
 
     # 5) Reduce modulo M
+    #    Note that by virtue of the above, we are guaranteed that `res_hi` and `res_lo` are u32-s,
+    #    and hence calling `mod_12289` is safe.
     exec.mod_12289
     #=> [e, ...]
 end

--- a/stdlib/asm/crypto/dsa/rpo_falcon512.masm
+++ b/stdlib/asm/crypto/dsa/rpo_falcon512.masm
@@ -26,7 +26,7 @@ const.MEMORY_POINTER_OFFSET_OF_HASH_TO_POINT_POLY_FROM_PRODUCT_POLY=1024
 #!
 #! [c, ...] | c = a % M
 #!
-#! Note that it is the responsibility of the calling procedure to insure that `a_hi` and `a_lo` are
+#! Note that it is the responsibility of the calling procedure to ensure that `a_hi` and `a_lo` are
 #! within the appropriate range i.e., they are u32-s.
 #!
 #! Cycles: 27


### PR DESCRIPTION
## Describe your changes
Addresses #1819
Adds some range checks to make sure that the Falcon modular reduction advice injector receives inputs that are `u32`.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'