### PR TITLE
chore(ci): update upload-pages-artifact to v4

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload book artifact
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/deploy-pages@v4
         with:
           # We specify multiple [output] sections in our book.toml which causes mdbook to create separate folders for each. This moves the generated `html` into its own `html` subdirectory.
           path: ./docs/book/html


### PR DESCRIPTION
## Describe your changes
Hey! pull request updates the GitHub Action `actions/upload-pages-artifact` from version `v3` to `v4`.  
According to GitHub's deprecation notice, v3 will be removed on January 30, 2025.  
Upgrading to v4 ensures compatibility with future GitHub Pages workflows and avoids potential CI failures.

Reference: https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/






