### PR TITLE
Al uniformize var len pub inputs treatment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,7 @@ dependencies = [
  "num-bigint",
  "pretty_assertions",
  "rand 0.9.0",
+ "rand_chacha 0.9.0",
  "rstest",
  "serde_json",
  "sha2",

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -10,7 +10,7 @@ extern crate std;
 use alloc::vec::Vec;
 
 use vm_core::{
-    ExtensionOf, ONE, ProgramInfo, StackInputs, StackOutputs, ZERO,
+    ExtensionOf, ONE, ProgramInfo, QuadExtension, StackInputs, StackOutputs, ZERO,
     utils::{ByteReader, ByteWriter, Deserializable, Serializable},
 };
 use winter_air::{
@@ -36,8 +36,12 @@ mod options;
 mod proof;
 
 mod utils;
+
+pub type QuadExt = QuadExtension<Felt>;
+
 // RE-EXPORTS
 // ================================================================================================
+
 pub use errors::ExecutionOptionsError;
 pub use options::{ExecutionOptions, ProvingOptions};
 pub use proof::{ExecutionProof, HashFunction};

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -45,6 +45,7 @@ processor = { package = "miden-processor", path = "../processor", version = "0.1
     "testing",
 ] }
 rand = { version = "0.9", default-features = false }
+rand_chacha = { version = "0.9", default-features = false }
 rstest = { version = "0.24" }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/stdlib/asm/crypto/stark/constants.masm
+++ b/stdlib/asm/crypto/stark/constants.masm
@@ -35,8 +35,17 @@ const.NUM_EVAL_GATES_CIRCUIT=88
 # Op label for kernel procedures table messages
 const.KERNEL_OP_LABEL=0
 
+# Number of fixed length public inputs with padding (in field elements)
+# This is composed of the input/output operand stacks (16 * 2) and the program digest (4) and four
+# zeros for padding to the next multiple of 4. Note that, then, the fixed length public inputs
+# which are stored as extension field elements will be double-word aligned. 
+const.NUM_FIXED_LEN_PUBLIC_INPUTS=40
+
 # MEMORY POINTERS
 # =================================================================================================
+
+# Number of public inputs (in field elements)
+const. NUM_PUBLIC_INPUTS_PTR=4294799997
 
 # Trace domain generator
 const.TRACE_DOMAIN_GENERATOR_PTR=4294799998
@@ -160,6 +169,7 @@ const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 #   +------------------------------------------+-------------------------+
 #   |                  ID                      |        Address          |
 #   +------------------------------------------+-------------------------+
+#   | NUM_PUBLIC_INPUTS_PTR                    |       4294799998        |
 #   | TRACE_DOMAIN_GENERATOR_PTR               |       4294799999        |
 #   | PUBLIC_INPUTS_ADDRESS_PTR                |       4294800000        |
 #   | AUX_RAND_ND_PTR                          |       4294800004        |
@@ -199,6 +209,10 @@ const.OOD_FIXED_TERM_HORNER_EVALS_PTR=4294903448
 
 # ACCESSORS
 # =================================================================================================
+
+export.num_public_inputs_ptr
+    push.NUM_PUBLIC_INPUTS_PTR
+end
 
 export.public_inputs_address_ptr
     push.PUBLIC_INPUTS_ADDRESS_PTR
@@ -485,4 +499,8 @@ end
 
 export.kernel_proc_table_op_label
     push.KERNEL_OP_LABEL
+end
+
+export.get_num_fixed_len_public_inputs
+    push.NUM_FIXED_LEN_PUBLIC_INPUTS
 end

--- a/stdlib/asm/crypto/stark/public_inputs.masm
+++ b/stdlib/asm/crypto/stark/public_inputs.masm
@@ -15,7 +15,7 @@ use.std::crypto::stark::random_coin
 #! auxiliary column. 
 #!
 #! Note that the fixed length public inputs are stored as extension field elements while
-#! variable length one are stored as base field elements.
+#! the variable length ones are stored as base field elements.
 #! Note also that, while loading the above, we compute the hash of the public inputs. The hashing
 #! starts with capacity registers of the hash function set to `C` that is the result of hashing
 #! the proof context.

--- a/stdlib/asm/crypto/stark/public_inputs.masm
+++ b/stdlib/asm/crypto/stark/public_inputs.masm
@@ -14,7 +14,8 @@ use.std::crypto::stark::random_coin
 #! randomness. This reduced value is then used to impose a boundary condition on the relevant
 #! auxiliary column. 
 #!
-#! Note that the public inputs are stored as extension field elements.
+#! Note that the fixed length public inputs are stored as extension field elements while
+#! variable length one are stored as base field elements.
 #! Note also that, while loading the above, we compute the hash of the public inputs. The hashing
 #! starts with capacity registers of the hash function set to `C` that is the result of hashing
 #! the proof context.
@@ -28,7 +29,7 @@ use.std::crypto::stark::random_coin
 #!    The variable-length public inputs are stored temporarily, as this simplifies the task of
 #!    reducing them using the auxiliary randomness. On the other hand, the resulting values from
 #!    the aforementioned reductions are stored right after the fixed-length public inputs. These
-#!    are stored in word-aligned manner and padded with zeros if needed.
+#!    are stored in a word-aligned manner and padded with zeros if needed.
 #! 2. The public inputs address is computed in such a way so as we end up with the following
 #!    memory layout:
 #!
@@ -37,25 +38,29 @@ use.std::crypto::stark::random_coin
 #!    where:
 #!
 #!    1. [a_0...a_{m-1}] are the fixed-length public inputs stored as extension field elements. This
-#!       section is word-aligned.
+#!       section is double-word-aligned.
 #!    2. [b_0...b_{n-1}] are the results of reducing the variable length public inputs using
 #!       auxiliary randomness. This section is word-aligned.
 #!    3. [alpha0, alpha1, beta0, beta1] is the auxiliary randomness.
 #!    4. `OOD-evaluations-start` is the first field element of the section containing the OOD
 #!       evaluations.
+#! 3. Note that for each bus message in a group in the variable length public inputs, each
+#!    message is expected to be padded to the next multiple of 8 and provided in reverse order.
+#!    This has the benefit of making the reduction using the auxiliary randomness more efficient
+#!    using `horner_eval_base`.
 #!
 #!
 #! Input: [C, ...]
 #! Output: [...]
 export.process_public_inputs
-    # 1) Compute the address where the public inputs will be stored and stores it.
+    # 1) Compute the address where the public inputs will be stored and store it.
     #    This also computes the address where the reduced variable-length public inputs will be stored.
     exec.compute_and_store_public_inputs_address
     # => [C, ...]
 
     # 2) Load the public inputs.
     #    This will also hash them so that we can absorb them in the transcript.
-    exec.load
+    exec.load_public_inputs
     # => [D, ...]
 
     # 3) Absorb into the transcript
@@ -66,7 +71,6 @@ export.process_public_inputs
     exec.reduce_variable_length_public_inputs
 end
 
-
 #! Loads from the advice stack the public inputs and stores them in memory starting from address
 #! pointed to by `public_inputs_address_ptr`.
 #! Note that the public inputs are stored as extension field elements.
@@ -76,85 +80,54 @@ end
 #!
 #! Input: [C, ...]
 #! Output: [D, ...]
-export.load
-    # Load the public inputs from the advice provider.
-    # The public inputs are made up of:
-    # 
-    # 1. the input operand stack and the output operand stack both of length 16 field elements,
-    # 2. the digest of the program,
-    # 3. the digests of procedures making up the kernel.
-    #
-    # While loading the public inputs, we also absorb them in the Fiat-Shamir transcript.
-
-    # 1) Load the input and output operand stacks
+export.load_public_inputs
+    # 1) Load and hash the fixed length public inputs
     exec.constants::public_inputs_address_ptr mem_load
     movdn.4
     padw padw
-    repeat.4
+    repeat.5
         exec.load_base_store_extension_double_word
         hperm
     end
-    # => [R2, R1, C, ptr, ...]
-     
-    # 2) Compute the number of digests we have to load. The digests are the program hash
-    #    and kernel procedures digests.
-    exec.constants::get_num_kernel_procedures
-    add.1
+ 
+    # 2) Load and hash the variable length public inputs
 
-    # 3) Load the program hash and kernel procedures digests.
-    #    Note that while we are saving the kernel procedures to memory, this is only done so that
-    #    we can later reduce the kernel procedures digests using randomness.
-    #    The memory region that will (temporarily) hold these digests will be later on over-written.
-    #    We need one call to the RPO permutation per 2 digests, thus we compute the division
-    #    with remainder of the number of digests by 2. If the remainder is 1 then we need
-    #    to pad with the zero word, while we do not need to pad otherwise.
-    u32divmod.2
-    push.0 eq
-    # => [?, num_iter, R2, R1, C, ptr, ...]
-    if.true
-        dup
-        movdn.14
-        push.0
-        neq
-        # => [(num_iter == 0), R2, R1, C, ptr, num_iter, ...]
-        while.true
-            exec.load_base_store_extension_double_word
-            hperm
-            movup.13
-            sub.1
-            movdn.13
-            dup.13
-            push.0
-            neq
-            # => [(num_iter - 1 == 0), R2, R1, C, ptr, num_iter, ...]
-        end
+    ## a) Compute the number of base field elements in total in the variable length public inputs
+    exec.constants::num_public_inputs_ptr mem_load
+    exec.constants::get_num_fixed_len_public_inputs
+    sub
+    # => [num_var_len_pi, R2, R1, C, ptr, ...]
 
-    else
-        dup
-        movdn.14
-        push.0
-        neq
-        # => [(num_iter == 0), R2, R1, C, ptr, num_iter, ...]
-        while.true
-            exec.load_base_store_extension_double_word
-            hperm
-            movup.13
-            sub.1
-            movdn.13
-            dup.13
-            push.0
-            neq
-            # => [(num_iter - 1 == 0), R2, R1, C, ptr, num_iter, ...]
-        end
+    ## b) Compute the number of hash iteration needed to hash the variable length public inputs.
+    ##    We also check the double-word alignment.
+    u32divmod.8
+    # => [rem, num_iter, R2, R1, C, ptr, ...]
+    push.0 assert_eq
+    # => [num_iter, R2, R1, C, ptr, ...]
+    
+    ## c) Prepare the stack for hashing
+    movdn.13
+    # => [R2, R1, C, ptr, num_iter, ...]
+    dup.13 sub.1 swap.14
+    push.0 neq
+    # => [(num_iter == 0), R2, R1, C, ptr, num_iter - 1, ...]
 
-        # Absorb the last digest and pad with zeros
-        exec.load_base_store_extension_word
+    ## d) Hash the variable length public inputs
+    while.true
+        adv_pipe
         hperm
+        # => [R2, R1, C, ptr, num_iter, ...]
+        dup.13 sub.1 swap.14
+        push.0 neq
     end
+    # => [R2, R1, C, ptr, num_iter, ...]
 
+    # 3) Return the final digest
     exec.rpo::squeeze_digest
+    # => [D, ptr, num_iter, ...] where D = R1 the digest
     movup.4 drop
     movup.4 drop
+    # => [D, ...]
 end
 
 #! Reduces the variable-length public inputs using the auxiliary randomness.
@@ -166,6 +139,11 @@ end
 #! contiguously after the fixed-length public inputs.
 #!
 #! Currently, the only variable-length public inputs are the kernel procedure digests.
+#!
+#! Input: 
+#!      - Operand stack: [...]
+#!      - Advice stack: [beta0, beta1, alpha0, alpha1, var_len_pi_1_len, ..., var_len_pi_k_len, ...]
+#! Output: [D, ...]
 proc.reduce_variable_length_public_inputs
     # 1) Load the auxiliary randomness i.e., alpha and beta
     #    We store them as [beta0, beta1, alpha0, alpha1] since `horner_eval_ext` requires memory
@@ -192,6 +170,8 @@ proc.reduce_variable_length_public_inputs
     # 3) Reduce the variable-length public inputs.
     #    These include:
     #    a) Kernel procedure digests.
+    adv_push.1
+    # => [num_ker_procedures, next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...]
     exec.reduce_kernel_digests
     # => [res1, res0, next_var_len_pub_inputs_ptr, var_len_pub_inputs_res_ptr, ...]
 
@@ -211,15 +191,23 @@ end
 
 #! Reduces the kernel procedures digests using auxiliary randomness.
 #!
-#! Input: [digests_ptr, ...]
+#! Input: [num_ker_procedures, digests_ptr, ...]
 #! Output: [res1, res0, next_ptr, ...]
 #!
 #! where:
 #!  1. `digests_ptr` is a pointer to the kernel procedures digests, and
 #!  2. `res = (res0, res1)` is the resulting reduced value.
 proc.reduce_kernel_digests
+    # Assert that the number of kernel procedures is at most 1023
+    dup u32lt.1024 assert
+
+    # Store number of kernel procedures digests
+    push.0.0 dup.2
+    exec.constants::tmp1 mem_storew
+    # => [num_ker_procedures, 0, 0, num_ker_procedures, digests_ptr, ...]
+
     # Load alpha
-    padw exec.constants::aux_rand_nd_ptr mem_loadw
+    exec.constants::aux_rand_nd_ptr mem_loadw
     # => [alpha1, alpha0, beta1, beta0, digests_ptr, ...]
 
     # We will keep [beta0, beta1, alpha0 + op_label, alpha1] on the stack so that we can compute
@@ -248,26 +236,19 @@ proc.reduce_kernel_digests
 
     # Set up the stack for `mem_stream` + `horner_eval_ext`
     swapw
-    padw push.0.0.0
-    # => [0, 0, 0, Y, alpha1, alpha0 + op_label, beta1, beta0,  digests_ptr, beta_ptr, acc1, acc0, ...]
+    padw padw
+    # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0,  digests_ptr, beta_ptr, acc1, acc0, ...]
     # where `Y` is a garbage word.
 
-    # Store the accumulator to compute the grand product 
-    push.1
-    exec.constants::tmp3 mem_store
-    push.0
-    exec.constants::tmp4 mem_store
-
-
-    exec.constants::get_num_kernel_procedures
-    exec.constants::tmp1 mem_storew
-    dup
+    exec.constants::tmp1 mem_loadw dup
     push.0
     neq
 
     while.true
-        mem_stream
-        horner_eval_ext
+        repeat.1
+            mem_stream
+            horner_eval_base
+        end
         # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, acc1, acc0, ...]
 
         swapdw
@@ -284,42 +265,54 @@ proc.reduce_kernel_digests
         dup.3 dup.3
         ext2add
         # => [term1', term0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
-
-        exec.constants::tmp3 mem_load
-        exec.constants::tmp4 mem_load
-        # => [prod_acc1, prod_acc0, term1', term0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
-
-        ext2mul
-        # => [prod_acc1', prod_acc0', alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
-    
-        exec.constants::tmp4 mem_store
-        exec.constants::tmp3 mem_store
-        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, ...]
+  
+        movdn.15
+        movdn.15
+        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, Y, Y, term1', term0', ...]
 
         push.0 movdn.6
         push.0 movdn.6
-        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, Y, Y, ...]
-
+        # => [alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, Y, Y, term1', term0', ...]
+ 
         swapdw
-        # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, ...]
+        # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, term1', term0', ...]
 
         exec.constants::tmp1 mem_loadw sub.1
         exec.constants::tmp1 mem_storew
-
+ 
         dup
         push.0
         neq
     end
-    # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, ...]
+    # => [Y, Y, alpha1, alpha0 + op_label, beta1, beta0, digests_ptr, beta_ptr, 0, 0, term1', term0', ...]
     dropw dropw dropw
-    # => [digests_ptr, beta_ptr, 0, 0, ...]
-    movdn.3
-    drop drop drop
-    # => [digests_ptr, ...]
+    # => [digests_ptr, beta_ptr, 0, 0, term1', term0', ...]
+    dup exec.constants::tmp2 mem_store
+    exec.constants::tmp1 mem_loadw drop drop drop
 
-    exec.constants::tmp3 mem_load
-    exec.constants::tmp4 mem_load
+    push.1.0
+    movup.2
+    dup
+    push.0
+    neq
+    # => [loop, n, acc1, acc0, term1_1, term1_0, ..., termn_1, termn_0, ...]
+
+    while.true
+        sub.1 movdn.4
+        # => [acc1, acc0, term1_1, term1_0, n - 1, ..., termn_1, termn_0, ...]
+        ext2mul
+        # => [acc1', acc0', n - 1, ..., termn_1, termn_0, ...]
+        movup.2
+        dup
+        push.0
+        neq
+        # => [loop, n - 1, acc1', acc0', term1_1, term1_0, ..., termn_1, termn_0, ...]
+    end
+
+    drop
+    exec.constants::tmp2 mem_load movdn.2
     # => [prod_acc1, prod_acc0, digests_ptr, ...]
+
 end
 
 #! Computes the address where the public inputs are to be stored and returns it.
@@ -333,75 +326,41 @@ end
 #! the public inputs right before the auxiliary random values and OOD evaluations.
 #! Hence the address where public inputs are stored is computed using a negative offset
 #! from the address where the OOD are stored.
+#! We compute two pointers, one to the public inputs and the other is for the portion
+#! within the public inputs region storing the variable length public inputs. This will be
+#! the region storing, temporarily, the variable length public inputs that are to be reduced
+#! by the auxiliary randomness and, permanently, the results of the aforementioned reductions.
 #!
 #! Input: [...]
 #! Output: [...]
 proc.compute_and_store_public_inputs_address
-
     # 1) Get a pointer to where OOD evaluations are stored
     exec.constants::ood_trace_current_ptr
+    # => [ood_evals_ptr, ...]
 
-    # 2) Compute the offset
+    # 2) Compute the pointer to the reductions of the variable length public inputs
     #
-    # The public inputs are made up of:
-    # 
-    # 1. the input operand stack and the output operand stack both of length 16 field elements,
-    # 2. the digest of the program,
-    # 3. the digests of procedures making up the kernel.
-    #
-    # In total, we need to allocate 16 * 2 * 2 + 4 * 2
-    # We also need to allocate space for the auxiliary randomness, i.e., 2 * 2
-    # We also need to allocate space for the result of reducing the kernel procedures using
-    # the auxiliary randomness, i.e., 2.
-    # We round up to the next multiple of 4 in order to guarantee memory word-alignment.
-    sub.80
+    # We need to account for the number of variable-length
+    # public inputs groups. For each group we allocate 2 slots and we pad with zeros so that
+    # things are word aligned. As of now, we only have one group.
+    # We also need to account for the auxiliary randomness i.e., 4 base field elements.
+    sub.4       # 2 auxiliary random values
+    sub.4       # 1 variable length public input reduced value, with padding for word-alignment
+    # => [res_var_len_pi_reductions_ptr, ...]
 
-    # 3) Store the address of public inputs
+    # 3) Compute the pointer to the public inputs
+    #
+    # We need to account for the fact that fixed-length public inputs are stored as extension field
+    # elements. 
     dup
+    exec.constants::get_num_fixed_len_public_inputs
+    mul.2
+    sub
+    # => [public_inputs_ptr, res_var_len_pi_reductions_ptr, ...]
+
+    # 4) Store both pointers
     exec.constants::public_inputs_address_ptr mem_store
-
-    # 4) Store the address of the variable length public inputs
-    add.72
     exec.constants::variable_length_public_inputs_address_ptr mem_store
-end
-
-#! Loads 4 base field elements from the advice stack and saves them as extension field elements.
-#!
-#!
-#! Input: [Y, Y, C, ptr, ...]
-#! Output: [0, 0, 0, 0, A, C, ptr, ..]
-proc.load_base_store_extension_word
-    # 1) Load the 4 base elements making up the word from the advice stack and save them temporarily 
-    adv_loadw
-    exec.constants::tmp1 mem_storew
-
-    # 2) Represent the 4 base field elements as elements in the quadratic extension field
-    swapw
-    exec.constants::zeroize_stack_word
-    # => [0, 0, 0, 0, a3, a2, a1, a0, C, ptr, ...]
-    movdn.6
-    # => [0, 0, 0, a3, a2, a1, 0, a0, C, ptr, ...]
-    movdn.4
-    # => [0, 0, a3, a2, 0, a1, 0, a0, C, ptr, ...]
-    movdn.2
-    # => [0, a3, 0, a2, 0, a1, 0, a0, C, ptr, ...]
-
-
-    # 3) Save the first 2 extension field elements
-    swapw
-    dup.12
-    mem_storew
-
-    # 4) Load the temporarily saved 4 base elements as a word for use in `hperm`
-    exec.constants::tmp1 mem_loadw
-    swapw
-
-    # 5) Save the second 2 extension field elements
-    dup.12 add.4
-    mem_storew
-
-    # 6) Load the ZERO word for padding
-    exec.constants::zeroize_stack_word
 end
 
 #! Loads 8 base field elements from the advice stack and saves them as extension field elements.

--- a/stdlib/asm/crypto/stark/random_coin.masm
+++ b/stdlib/asm/crypto/stark/random_coin.masm
@@ -119,13 +119,12 @@ export.store_random_coin_state
 end
 
 #! Initializes the seed for randomness generation by computing the hash of the proof context using
-#! the trace length, number of queries, the number of bits of grinding and the number of kernel
-#! procedures defining the kernel against which the program being verified was compiled.
+#! the trace length, number of queries, the number of bits of grinding.
 #! Currently, this part, as well as the rest of the STARK verifier assumes a blowup factor
 #! equal to 8.
 #! The ouput of this procedure is the capacity portion of the state after applying `hperm`.
 #!
-#! Input: [log(trace_length), num_queries, grinding, num_ker_proc, ...]
+#! Input: [log(trace_length), num_queries, grinding, ...]
 #! Output: [C, ...]
 #! Cycles: 210
 export.init_seed
@@ -134,7 +133,6 @@ export.init_seed
     dup exec.constants::set_trace_length_log
     dup.1 exec.constants::set_number_queries
     dup.2 exec.constants::set_grinding_factor
-    dup.3 exec.constants::set_num_kernel_procedures
 
     # Pre-load constants used by hperm into memory and initialize the state of the random coin to zeros.
     # Since memory beyond 3 * 2^30 does not have any special meaning, we can use the memory region
@@ -146,7 +144,7 @@ export.init_seed
     exec.constants::r1_ptr mem_storew
     exec.constants::r2_ptr mem_storew
     dropw
-    #=> [log(trace_length), num_queries, grinding, num_ker_proc, ...]
+    #=> [log(trace_length), num_queries, grinding, ...]
 
     # Create the initial seed for randomness generation from proof context
 
@@ -154,22 +152,22 @@ export.init_seed
     dup
     pow2
     u32split assertz
-    #=> [trace_length, log(trace_length), num_queries, grinding, num_ker_proc, ...]
+    #=> [trace_length, log(trace_length), num_queries, grinding, ...]
 
     ## Save the trace length and its log to memory
     dup.0 exec.constants::set_trace_length
-    #=> [trace_length, log(trace_length), num_queries, grinding, num_ker_proc, ...]
+    #=> [trace_length, log(trace_length), num_queries, grinding, ...]
 
     ## Compute log size of LDE domain
     swap
     exec.constants::get_blowup_factor_log
     add
-    #=> [log(lde_size), trace_length, num_queries, grinding, num_ker_proc, ...]
+    #=> [log(lde_size), trace_length, num_queries, grinding, ...]
 
     ## Compute size of LDE domain
     dup
     pow2
-    #=> [lde_size, log(lde_size), trace_length, num_queries, grinding, num_ker_proc, ...]
+    #=> [lde_size, log(lde_size), trace_length, num_queries, grinding, ...]
 
     # Compute lde_domain generator
     dup.1
@@ -222,38 +220,27 @@ export.init_seed
     ## field extension and FRI parameters
     ## field extension degree || FRI folding factor || FRI remainder polynomial max degree || blowup factor
     push.0x02047f08
-    # => [proof_options, modulus1, modulus0, trace_length, trace_info, num_queries, grinding, num_ker_proc, ...]
+    # => [proof_options, modulus1, modulus0, trace_length, trace_info, num_queries, grinding, ...]
 
     movup.6
     movup.6
-    # => [num_queries, grinding, proof_options, modulus1, modulus0, trace_length, trace_info, num_ker_proc, ...]
+    # => [num_queries, grinding, proof_options, modulus1, modulus0, trace_length, trace_info, ...]
 
     exec.constants::get_num_constraints
     movdn.3
-    # => [num_queries, grinding, proof_options, num_constraints, modulus1, modulus0, trace_length, trace_info, num_ker_proc, ...]
+    # => [num_queries, grinding, proof_options, num_constraints, modulus1, modulus0, trace_length, trace_info, ...]
 
-    # We will need to absorb:
-    #
-    # 1. The proof context (8 field elements)
-    # 2. The input stack (16 field elements)
-    # 3. The output stack (16 field elements)
-    # 4. The program hash (4 field elements)
-    # 5. The kernel procedures digests (4 times the number of procedures in the kernel)
-    #
-    # This means that the division with remainder of the number of field elements that will be absorbed by
-    # 8 is either equal to 4 if the number of kernel procedures is even or to 0 otherwise.
-    
-    movup.8
-    is_odd
-    # => [(num_ker_proc % 2 == 1), num_queries, grinding, proof_options, num_constraints, modulus1, modulus0, trace_length, trace_info, ...]
-
-    push.4
-    push.0
-    movup.2
-    cdrop
+    # We get the number of the variable length public inputs section non-deterministically so that
+    # we can initialize the capacity portion of the sponge state. The total number of public inputs
+    # is easily derived using an addition.
+    adv_push.1
+    exec.constants::get_num_fixed_len_public_inputs add
+    dup exec.constants::num_public_inputs_ptr mem_store
+    u32divmod.8
+    # => [rem, quo, num_queries, grinding, proof_options, num_constraints, modulus1, modulus0, trace_length, trace_info, ...]
 
     # Hash proof context
-
+    swap drop
     push.0.0.0
     movdnw.2
     # => [B, A, 0, 0, 0, c, ...]

--- a/stdlib/asm/crypto/stark/utils.masm
+++ b/stdlib/asm/crypto/stark/utils.masm
@@ -19,19 +19,21 @@ end
 
 #! Validates the inputs to the recursive verifier.
 #!
-#! Input: [log(trace_length), num_queries, grinding, num_ker_proc, ...]
-#! Output: [log(trace_length), num_queries, grinding, num_ker_proc, ...]
+#! Input: [log(trace_length), num_queries, grinding, ...]
+#! Output: [log(trace_length), num_queries, grinding, ...]
 #!
 #! Cycles: 45
 export.validate_inputs
     # 1) Assert that all inputs are u32 so that we can use u32 operations in what follows
+    push.0
     dupw
     u32assertw
-    # => [log(trace_length), num_queries, grinding, log(trace_length), num_queries, grinding, ...]
+    # => [0, log(trace_length), num_queries, grinding, 0, log(trace_length), num_queries, grinding, ...]
 
     # 2) Assert that the trace length is at most 29. The 2-adicity of our field is 32 and since
     #    the blowup factor is 8, we need to make sure that the LDE size is at most 2^32.
     #    We also check that the trace length is greater than the minimal length supported i.e., 2^6.
+    drop
     dup u32lt.30 assert
     u32gt.5 assert
 
@@ -45,8 +47,8 @@ export.validate_inputs
     # 4) Assert that the grinding factor is at most 31
     u32lt.32 assert
 
-    # 5) Assert that the number of kernel procedures is at most 127
-    u32lt.128 assert
+    # 5) Clean up the stack
+    drop
 end
 
 #! Sets up auxiliary inputs to the arithmetic circuit for the constraint evaluation check.

--- a/stdlib/asm/crypto/stark/verifier.masm
+++ b/stdlib/asm/crypto/stark/verifier.masm
@@ -28,7 +28,7 @@ use.std::crypto::stark::utils
 #!   - The following procedure makes use of global memory address beyond 3 * 2^30 and these are
 #!     defined in `constants.masm`.
 #!
-#! Input: [log(trace_length), num_queries, grinding, num_ker_proc, ...]
+#! Input: [log(trace_length), num_queries, grinding,  ...]
 #! Output: [...]
 #!
 #! Cycles:
@@ -51,7 +51,7 @@ export.verify
     #
     # Cycles: 45
     exec.utils::validate_inputs
-    # => [log(trace_length), num_queries, grinding, num_ker_proc, ...]
+    # => [log(trace_length), num_queries, grinding, ...]
 
     # Initialize the seed using proof context
     #

--- a/stdlib/tests/crypto/stark/mod.rs
+++ b/stdlib/tests/crypto/stark/mod.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{array, sync::Arc};
 
 use assembly::{Assembler, DefaultSourceManager};
 use miden_air::{FieldExtension, HashFunction, PublicInputs};
@@ -6,13 +6,15 @@ use processor::{
     DefaultHost, Program, ProgramInfo,
     crypto::{RandomCoin, Rpo256, RpoRandomCoin},
 };
+use rand::{Rng, RngCore, SeedableRng};
+use rand_chacha::ChaCha20Rng;
 use rstest::rstest;
 use test_utils::{
     AdviceInputs, MemAdviceProvider, ProvingOptions, StackInputs, VerifierError,
     proptest::proptest, prove,
 };
-use verifier_recursive::{VerifierData, generate_advice_inputs};
-use vm_core::{Felt, Word};
+use verifier_recursive::{QuadExt, VerifierData, generate_advice_inputs};
+use vm_core::{Felt, FieldElement, WORD_SIZE, Word, ZERO};
 
 mod verifier_recursive;
 
@@ -28,7 +30,7 @@ fn stark_verifier_e2f4(#[case] kernel: Option<&str>) {
     // An example MASM program to be verified inside Miden VM.
 
     let example_source = "begin
-            repeat.320
+            repeat.32
                 swap dup.1 add
             end
         end";
@@ -107,23 +109,113 @@ pub fn generate_recursive_verifier_data(
     Ok(generate_advice_inputs(proof, pub_inputs).unwrap())
 }
 
-proptest! {
-    #[test]
-    fn generate_query_indices_proptest(num_queries in 7..150_usize, lde_log_size in 9..32_usize) {
-        let source = TEST_RANDOM_INDICES_GENERATION;
-        let lde_size = 1 << lde_log_size;
+#[rstest]
+#[case(0)]
+#[case(1)]
+#[case(2)]
+#[case(3)]
+#[case(8)]
+#[case(1000)]
+fn variable_length_public_inputs(#[case] num_kernel_proc_digests: usize) {
+    // STARK parameters
+    let num_queries = 27;
+    let log_trace_len = 10;
+    let grinding_bits = 16;
+    let initial_stack = vec![num_queries, log_trace_len, grinding_bits];
 
-        let seed = Word::default();
-        let mut coin = RpoRandomCoin::new(seed);
-        let indices = coin
-            .draw_integers(num_queries, lde_size, 0)
-            .expect("should not fail to generate the indices");
-        let advice_stack: Vec<u64> = indices.iter().rev().map(|index| *index as u64).collect();
+    // Seeded random number generator for reproducibility
+    let seed = [0_u8; 32];
+    let mut rng = ChaCha20Rng::from_seed(seed);
 
-        let input_stack = vec![num_queries as u64, lde_log_size as u64, lde_size as u64];
-        let test = build_test!(source, &input_stack, &advice_stack);
-        test.prop_expect_stack(&[])?;
-    }
+    // 1) Generate fixed length public inputs
+
+    let input_operand_stack: [u64; 16] = array::from_fn(|_| rng.next_u64());
+    let output_operand_stack: [u64; 16] = array::from_fn(|_| rng.next_u64());
+    let program_digest: [u64; 4] = array::from_fn(|_| rng.next_u64());
+
+    let mut fixed_length_public_inputs = input_operand_stack.to_vec();
+    fixed_length_public_inputs.extend_from_slice(&output_operand_stack);
+    fixed_length_public_inputs.extend_from_slice(&program_digest);
+    let fix_len_pi_with_padding = fixed_length_public_inputs.len().next_multiple_of(8);
+    fixed_length_public_inputs.resize(fix_len_pi_with_padding, 0);
+
+    // 2) Generate the variable length public inputs, i.e., the kernel procedures digests
+
+    let num_elements_kernel_proc_digests =
+        num_kernel_proc_digests * (WORD_SIZE.next_multiple_of(8));
+    let kernel_procedures_digests =
+        generate_kernel_procedures_digests(&mut rng, num_kernel_proc_digests);
+
+    // 3) Generate the auxiliary randomness
+
+    let auxiliary_rand_values: [u64; 4] = array::from_fn(|_| rng.next_u64());
+
+    // 4) Build the advice stack
+
+    let mut advice_stack = vec![num_elements_kernel_proc_digests as u64];
+    advice_stack.extend_from_slice(&fixed_length_public_inputs);
+    advice_stack.extend_from_slice(&kernel_procedures_digests);
+    advice_stack.extend_from_slice(&auxiliary_rand_values);
+    advice_stack.push(num_kernel_proc_digests as u64);
+
+    // 5) Compute the expected randomness-reduced value of all the kernel procedures digests
+
+    let beta =
+        QuadExt::new(Felt::new(auxiliary_rand_values[0]), Felt::new(auxiliary_rand_values[1]));
+    let alpha =
+        QuadExt::new(Felt::new(auxiliary_rand_values[2]), Felt::new(auxiliary_rand_values[3]));
+    let reduced_value = reduce_kernel_procedures_digests(&kernel_procedures_digests, alpha, beta);
+    let [reduced_value_0, reduced_value_1] = reduced_value.to_base_elements();
+
+    // 6) Run the test
+
+    let source = format!(
+        "
+        use.std::crypto::stark::random_coin
+        use.std::crypto::stark::constants
+        use.std::crypto::stark::public_inputs
+        begin
+            # 1) Initialize the FS transcript
+            exec.random_coin::init_seed
+            # => [C, ...]
+
+            # 2) Process the public inputs
+            exec.public_inputs::process_public_inputs
+            # => [...]
+
+            # 3) Load the reduced value of all kernel procedures digests
+            #    Note that the memory layout is as follows:
+            #    [..., a_0, ..., a_[m-1], b_0, b_1, 0, 0, alpha0, alpha1, beta0, beta1, OOD-evaluations-start, ...]
+            #
+            #    where:
+            #
+            #    i) [a_0, ..., a[m-1]] are the fixed length public inputs,
+            #    ii) [b_0, b_1] is the reduced value of all kernel procedures digests,
+            #    iii) [alpha0, alpha1, beta0, beta1] is the auxiliary randomness,
+            #    iv) [OOD-evaluations-start, ...] the start of the section that will hold the OOD evaluations,
+            #
+            #    Note that [b_0, b_1, 0, 0, alpha0, alpha1, beta0, beta1, OOD-evaluations-start, ...] will hold temporarily
+            #    the kernel procedures digests, but there will be later on overwritten by the reduced value, the auxiliary
+            #    randomness, and the OOD evaluations.
+            padw
+            exec.constants::ood_trace_current_ptr
+            sub.8
+            mem_loadw
+
+            # 4) Compare with the expected result, including the padding
+            push.{reduced_value_0}
+            push.{reduced_value_1}
+            push.0.0
+            eqw assert
+
+            # 5) Clean up the stack
+            dropw dropw
+        end
+        "
+    );
+
+    let test = build_test!(source, &initial_stack, &advice_stack);
+    test.expect_stack(&[]);
 }
 
 #[test]
@@ -149,6 +241,73 @@ fn generate_query_indices() {
     test.expect_stack(&[]);
 }
 
+proptest! {
+    #[test]
+    fn generate_query_indices_proptest(num_queries in 7..150_usize, lde_log_size in 9..32_usize) {
+        let source = TEST_RANDOM_INDICES_GENERATION;
+        let lde_size = 1 << lde_log_size;
+
+        let seed = Word::default();
+        let mut coin = RpoRandomCoin::new(seed);
+        let indices = coin
+            .draw_integers(num_queries, lde_size, 0)
+            .expect("should not fail to generate the indices");
+        let advice_stack: Vec<u64> = indices.iter().rev().map(|index| *index as u64).collect();
+
+        let input_stack = vec![num_queries as u64, lde_log_size as u64, lde_size as u64];
+        let test = build_test!(source, &input_stack, &advice_stack);
+        test.prop_expect_stack(&[])?;
+    }
+}
+
+// HELPERS
+// ===============================================================================================
+
+/// Generates a vector with a specific number of kernel procedures digests given a `Rng`.
+///
+/// The digests are padded to the next multiple of 8 and are reversed. This is done in order to
+/// make reducing these, in the recursive verifier, faster using Horner evaluation.
+fn generate_kernel_procedures_digests<R: Rng>(
+    rng: &mut R,
+    num_kernel_proc_digests: usize,
+) -> Vec<u64> {
+    let num_elements_kernel_proc_digests = num_kernel_proc_digests * 2 * WORD_SIZE;
+
+    let mut kernel_proc_digests: Vec<u64> = Vec::with_capacity(num_elements_kernel_proc_digests);
+
+    (0..num_kernel_proc_digests).for_each(|_| {
+        let digest: [u64; WORD_SIZE] = array::from_fn(|_| rng.next_u64());
+        let mut digest = digest.to_vec();
+        digest.resize(WORD_SIZE * 2, 0);
+        digest.reverse();
+        kernel_proc_digests.extend_from_slice(&digest);
+    });
+
+    kernel_proc_digests
+}
+
+fn reduce_kernel_procedures_digests(
+    kernel_procedures_digests: &[u64],
+    alpha: QuadExt,
+    beta: QuadExt,
+) -> QuadExt {
+    kernel_procedures_digests
+        .chunks(2 * WORD_SIZE)
+        .map(|digest| reduce_digest(digest, alpha, beta))
+        .fold(QuadExt::ONE, |acc, term| acc * term)
+}
+
+fn reduce_digest(digest: &[u64], alpha: QuadExt, beta: QuadExt) -> QuadExt {
+    alpha
+        + beta
+            * digest
+                .iter()
+                .fold(QuadExt::ZERO, |acc, coef| acc * beta + QuadExt::new(Felt::new(*coef), ZERO))
+}
+
+// CONSTANTS
+// ===============================================================================================
+
 const KERNEL_ODD_NUM_PROC: &str = r#"
         export.foo
             add
@@ -167,6 +326,64 @@ const KERNEL_EVEN_NUM_PROC: &str = r#"
         export.bar
             div
         end"#;
+
+const TEST_RANDOM_INDICES_GENERATION: &str = r#"
+        const.QUERY_ADDRESS=1024
+
+        use.std::crypto::stark::random_coin
+        use.std::crypto::stark::constants
+
+        begin
+            exec.constants::set_lde_domain_size
+            exec.constants::set_lde_domain_log_size
+            exec.constants::set_number_queries
+            push.QUERY_ADDRESS exec.constants::set_fri_queries_address
+
+            exec.random_coin::load_random_coin_state
+            hperm
+            hperm
+            exec.random_coin::store_random_coin_state
+
+            exec.random_coin::generate_list_indices
+
+            exec.constants::get_lde_domain_log_size
+            exec.constants::get_number_queries neg
+            push.QUERY_ADDRESS
+            # => [query_ptr, loop_counter, lde_size_log, ...]
+
+            push.1
+            while.true
+                dup add.3 mem_load
+                movdn.3
+                # => [query_ptr, loop_counter, lde_size_log, query_index, ...]
+                dup
+                add.2 mem_load
+                dup.3 assert_eq
+
+                add.4
+                # => [query_ptr + 4, loop_counter, lde_size_log, query_index, ...]
+
+                swap add.1 swap
+                # => [query_ptr + 4, loop_counter, lde_size_log, query_index, ...]
+
+                dup.1 neq.0
+                # => [?, query_ptr + 4, loop_counter + 1, lde_size_log, query_index, ...]
+            end
+            drop drop drop
+
+            exec.constants::get_number_queries neg
+            push.1
+            while.true
+                swap
+                adv_push.1
+                assert_eq
+                add.1
+                dup
+                neq.0
+            end
+            drop  
+        end
+        "#;
 
 /// This is an output of the ACE codegen in AirScript and encodes the circuit for executing
 /// the constraint evaluation check i.e., DEEP-ALI.
@@ -268,61 +485,3 @@ const CONSTRAINT_EVALUATION_CIRCUIT: [u64; 96] = [
     2147483667,
     1152921505680588801,
 ];
-
-const TEST_RANDOM_INDICES_GENERATION: &str = r#"
-        const.QUERY_ADDRESS=1024
-
-        use.std::crypto::stark::random_coin
-        use.std::crypto::stark::constants
-
-        begin
-            exec.constants::set_lde_domain_size
-            exec.constants::set_lde_domain_log_size
-            exec.constants::set_number_queries
-            push.QUERY_ADDRESS exec.constants::set_fri_queries_address
-
-            exec.random_coin::load_random_coin_state
-            hperm
-            hperm
-            exec.random_coin::store_random_coin_state
-
-            exec.random_coin::generate_list_indices
-
-            exec.constants::get_lde_domain_log_size
-            exec.constants::get_number_queries neg
-            push.QUERY_ADDRESS
-            # => [query_ptr, loop_counter, lde_size_log, ...]
-
-            push.1
-            while.true
-                dup add.3 mem_load
-                movdn.3
-                # => [query_ptr, loop_counter, lde_size_log, query_index, ...]
-                dup
-                add.2 mem_load
-                dup.3 assert_eq
-
-                add.4
-                # => [query_ptr + 4, loop_counter, lde_size_log, query_index, ...]
-
-                swap add.1 swap
-                # => [query_ptr + 4, loop_counter, lde_size_log, query_index, ...]
-
-                dup.1 neq.0
-                # => [?, query_ptr + 4, loop_counter + 1, lde_size_log, query_index, ...]
-            end
-            drop drop drop
-
-            exec.constants::get_number_queries neg
-            push.1
-            while.true
-                swap
-                adv_push.1
-                assert_eq
-                add.1
-                dup
-                neq.0
-            end
-            drop  
-        end
-        "#;


### PR DESCRIPTION
## Describe your changes

Improves on the previous solution in #1813 in the following ways:

1. We now pad the fixed length public inputs (PI) to the next multiple of 8 so that the un-hashing of the fixed length PI and variable length PI is easier to untangle. This makes the implementation more robust to changes in the sizes of the fixed length PI.
2. The variable length public inputs, in the case of the Miden VM the kernel procedure digests, are padded to the next multiple of 8 in addition to them being processed in reverse order. This has the advantage of making the step of reducing the variable PIs using the auxiliary randomness much more performant than before.
3. The variable public inputs reduction procedure has being simplified and optimized so as to avoid the need for a couple of memory loads and stores per digest of the kernel. This has also a non-negligible performance benefit (especially for very large kernels). The current implementation is also more modular i.e., changing to LogUp should be as easy as changing a couple of MASM lines.
4. Added a unit test to check that the reduced values are computed and stored correctly.

I am putting in draft while waiting for the previous PRs in this series to be merged.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'