### PR TITLE
fix: internal assembler error on local word overflow

### DIFF
--- a/assembly/src/assembler/instruction/mem_ops.rs
+++ b/assembly/src/assembler/instruction/mem_ops.rs
@@ -138,7 +138,10 @@ pub fn local_to_absolute_addr(
     let max = if is_single {
         num_proc_locals - 1
     } else {
-        num_proc_locals - 4
+        // If a word local value is used, then the procedure needs at least 4 local values.
+        u16::checked_sub(num_proc_locals, 4).ok_or_else(|| AssemblyError::Other(Report::msg(
+            "number of procedure locals was set to less 4, but word-sized local values were used".to_string()
+        ).into()))?
     };
 
     // Local values are placed under the frame pointer, so we need to calculate the offset of the


### PR DESCRIPTION
Attempting to assemble the following Miden procedure would previously result in a panic in Miden's assembler:
```asm
proc.foo.2
  loc_storew.0
end
```

This PR fixes the internal panic and instead emits a compiler error.

I wasn't sure if this kind of thing should get a changelog entry or not — let me know if it should.

Fixes #1843

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'