### PR TITLE
Revert "chore(ci): update upload-pages-artifact to v4 (#1841)"

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload book artifact
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
-        uses: actions/deploy-pages@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           # We specify multiple [output] sections in our book.toml which causes mdbook to create separate folders for each. This moves the generated `html` into its own `html` subdirectory.
           path: ./docs/book/html


### PR DESCRIPTION
This reverts #1841, which broke the book deployment build. Re-reading the [article](https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/#what-you-need-to-do), `actions/upload-pages-artifact@v3` is one of the recommended actions to use, which we were already using.