### PR TITLE
chore: Add Send + Sync supertraits to SourceManager trait

### DIFF
--- a/assembly/src/assembler/mod.rs
+++ b/assembly/src/assembler/mod.rs
@@ -64,7 +64,7 @@ pub use self::{
 #[derive(Clone)]
 pub struct Assembler {
     /// The source manager to use for compilation and source location information
-    source_manager: Arc<dyn SourceManager + Send + Sync>,
+    source_manager: Arc<dyn SourceManager>,
     /// The global [ModuleGraph] for this assembler.
     module_graph: ModuleGraph,
     /// Whether to treat warning diagnostics as errors
@@ -93,7 +93,7 @@ impl Default for Assembler {
 /// Constructors
 impl Assembler {
     /// Start building an [Assembler]
-    pub fn new(source_manager: Arc<dyn SourceManager + Send + Sync>) -> Self {
+    pub fn new(source_manager: Arc<dyn SourceManager>) -> Self {
         let module_graph = ModuleGraph::new(source_manager.clone());
         Self {
             source_manager,
@@ -105,10 +105,7 @@ impl Assembler {
     }
 
     /// Start building an [`Assembler`] with a kernel defined by the provided [KernelLibrary].
-    pub fn with_kernel(
-        source_manager: Arc<dyn SourceManager + Send + Sync>,
-        kernel_lib: KernelLibrary,
-    ) -> Self {
+    pub fn with_kernel(source_manager: Arc<dyn SourceManager>, kernel_lib: KernelLibrary) -> Self {
         let (kernel, kernel_module, _) = kernel_lib.into_parts();
         let module_graph = ModuleGraph::with_kernel(source_manager.clone(), kernel, kernel_module);
         Self {
@@ -303,7 +300,7 @@ impl Assembler {
     }
 
     /// Returns a link to the source manager used by this assembler.
-    pub fn source_manager(&self) -> Arc<dyn SourceManager + Send + Sync> {
+    pub fn source_manager(&self) -> Arc<dyn SourceManager> {
         self.source_manager.clone()
     }
 

--- a/assembly/src/testing.rs
+++ b/assembly/src/testing.rs
@@ -195,7 +195,7 @@ macro_rules! parse_module {
 ///
 /// Some of the assertion macros defined above require a [TestContext], so be aware of that.
 pub struct TestContext {
-    source_manager: Arc<dyn SourceManager + Send + Sync>,
+    source_manager: Arc<dyn SourceManager>,
     assembler: Assembler,
 }
 
@@ -233,7 +233,7 @@ impl TestContext {
     }
 
     #[inline(always)]
-    pub fn source_manager(&self) -> Arc<dyn SourceManager + Send + Sync> {
+    pub fn source_manager(&self) -> Arc<dyn SourceManager> {
         self.source_manager.clone()
     }
 

--- a/core/src/debuginfo/source_manager.rs
+++ b/core/src/debuginfo/source_manager.rs
@@ -101,7 +101,7 @@ impl SourceManagerError {
     }
 }
 
-pub trait SourceManager: Debug {
+pub trait SourceManager: Debug + Send + Sync {
     /// Returns true if `file` is managed by this source manager
     fn is_manager_of(&self, file: &SourceFile) -> bool {
         match self.get(file.id()) {

--- a/miden/src/cli/data.rs
+++ b/miden/src/cli/data.rs
@@ -109,7 +109,7 @@ impl OutputFile {
 
 pub struct ProgramFile {
     ast: Box<Module>,
-    source_manager: Arc<dyn SourceManager + Send + Sync>,
+    source_manager: Arc<dyn SourceManager>,
 }
 
 /// Helper methods to interact with masm program file.
@@ -125,7 +125,7 @@ impl ProgramFile {
     #[instrument(name = "read_program_file", skip(source_manager), fields(path = %path.as_ref().display()))]
     pub fn read_with(
         path: impl AsRef<Path>,
-        source_manager: Arc<dyn SourceManager + Send + Sync>,
+        source_manager: Arc<dyn SourceManager>,
     ) -> Result<Self, Report> {
         // parse the program into an AST
         let path = path.as_ref();
@@ -160,7 +160,7 @@ impl ProgramFile {
     }
 
     /// Returns the source manager for this program file.
-    pub fn source_manager(&self) -> &Arc<dyn SourceManager + Send + Sync> {
+    pub fn source_manager(&self) -> &Arc<dyn SourceManager> {
         &self.source_manager
     }
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -171,7 +171,7 @@ macro_rules! assert_assembler_diagnostic {
 /// - Execution error test: check that running a program compiled from the given source causes an
 ///   ExecutionError which contains the specified substring.
 pub struct Test {
-    pub source_manager: Arc<dyn SourceManager + Send + Sync>,
+    pub source_manager: Arc<dyn SourceManager>,
     pub source: Arc<SourceFile>,
     pub kernel_source: Option<Arc<SourceFile>>,
     pub stack_inputs: StackInputs,


### PR DESCRIPTION
### Context

We have opted to add `Send + Sync` supertraits to any dyn-compatible traits.

While we did add `Send + Sync` to the trait objects recently, I would like to use the supertraits to ensure we have no issues when moving to make the miden-base and miden-client types `Send + Sync`.

### Changes
- Add `Send + Sync` supertraits to `SourceManager` trait.
- Remove `Send + Sync` from `Arc<dyn SourceManager>`
