### PR TITLE
fix `debug.local` panic and incorrect value printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - `miden debug` rewind command no longer panics at clock 0 (#1751)
 - Prevent overflow in ACE circuit evaluation (#1820)
+- `debug.local` decorators no longer panic or print incorrect values (#1859)
 
 ## 0.14.0 (2025-05-07)
 

--- a/assembly/src/assembler/instruction/mod.rs
+++ b/assembly/src/assembler/instruction/mod.rs
@@ -529,7 +529,7 @@ impl Assembler {
 
             Instruction::Debug(options) => {
                 if self.in_debug_mode() {
-                    block_builder.push_decorator(Decorator::Debug(options.compile()?))?;
+                    block_builder.push_decorator(Decorator::Debug(options.compile(proc_ctx)?))?;
                 }
             },
 

--- a/assembly/src/assembler/instruction/mod.rs
+++ b/assembly/src/assembler/instruction/mod.rs
@@ -529,9 +529,7 @@ impl Assembler {
 
             Instruction::Debug(options) => {
                 if self.in_debug_mode() {
-                    block_builder.push_decorator(Decorator::Debug(
-                        options.clone().try_into().expect("unresolved constant"),
-                    ))?;
+                    block_builder.push_decorator(Decorator::Debug(options.compile()?))?;
                 }
             },
 

--- a/assembly/src/ast/instruction/debug.rs
+++ b/assembly/src/ast/instruction/debug.rs
@@ -1,6 +1,9 @@
 use core::fmt;
 
-use crate::ast::{ImmU8, ImmU16, ImmU32};
+use crate::{
+    AssemblyError,
+    ast::{ImmU8, ImmU16, ImmU32},
+};
 
 // DEBUG OPTIONS
 // ================================================================================================
@@ -18,31 +21,42 @@ pub enum DebugOptions {
     AdvStackTop(ImmU16),
 }
 
-impl crate::prettier::PrettyPrint for DebugOptions {
-    fn render(&self) -> crate::prettier::Document {
-        crate::prettier::display(self)
+impl DebugOptions {
+    /// Compiles the AST representation of a `debug` instruction into its VM representation.
+    ///
+    /// This function does not currently return any errors, but may in the future.
+    ///
+    /// See [crate::Assembler] for an overview of AST compilation.
+    pub fn compile(&self) -> Result<vm_core::DebugOptions, AssemblyError> {
+        type Ast = DebugOptions;
+        type Vm = vm_core::DebugOptions;
+
+        // NOTE: these `ast::Immediate::expect_value()` calls *should* be safe, because by the time
+        // we're compiling debug options all immediate-constant arguments should be resolved.
+        let compiled = match self {
+            Ast::StackAll => Vm::StackAll,
+            Ast::StackTop(n) => Vm::StackTop(n.expect_value()),
+            Ast::MemAll => Vm::MemAll,
+            Ast::MemInterval(start, end) => {
+                Vm::MemInterval(start.expect_value(), end.expect_value())
+            },
+            Ast::LocalInterval(start, end) => {
+                let (start, end) = (start.expect_value(), end.expect_value());
+                Vm::LocalInterval(start, end, end - start)
+            },
+            Ast::AdvStackTop(n) => Vm::AdvStackTop(n.expect_value()),
+            other @ (Ast::LocalRangeFrom(_) | Ast::LocalAll) => {
+                unimplemented!("compilation of debug instruction {other:?}");
+            },
+        };
+
+        Ok(compiled)
     }
 }
 
-impl TryFrom<DebugOptions> for vm_core::DebugOptions {
-    type Error = ();
-
-    fn try_from(options: DebugOptions) -> Result<Self, Self::Error> {
-        match options {
-            DebugOptions::StackAll => Ok(Self::StackAll),
-            DebugOptions::StackTop(ImmU8::Value(n)) => Ok(Self::StackTop(n.into_inner())),
-            DebugOptions::MemAll => Ok(Self::MemAll),
-            DebugOptions::MemInterval(ImmU32::Value(start), ImmU32::Value(end)) => {
-                Ok(Self::MemInterval(start.into_inner(), end.into_inner()))
-            },
-            DebugOptions::LocalInterval(ImmU16::Value(start), ImmU16::Value(end)) => {
-                let start = start.into_inner();
-                let end = end.into_inner();
-                Ok(Self::LocalInterval(start, end, end - start))
-            },
-            DebugOptions::AdvStackTop(ImmU16::Value(n)) => Ok(Self::AdvStackTop(n.into_inner())),
-            _ => Err(()),
-        }
+impl crate::prettier::PrettyPrint for DebugOptions {
+    fn render(&self) -> crate::prettier::Document {
+        crate::prettier::display(self)
     }
 }
 

--- a/assembly/src/ast/instruction/debug.rs
+++ b/assembly/src/ast/instruction/debug.rs
@@ -57,9 +57,6 @@ impl DebugOptions {
                 Vm::LocalInterval(0, end_exclusive - 1, proc_ctx.num_locals())
             },
             Ast::AdvStackTop(n) => Vm::AdvStackTop(n.expect_value()),
-            other @ Ast::LocalRangeFrom(_) => {
-                unimplemented!("compilation of debug instruction {other:?}");
-            },
         };
 
         Ok(compiled)

--- a/assembly/src/ast/instruction/debug.rs
+++ b/assembly/src/ast/instruction/debug.rs
@@ -48,8 +48,16 @@ impl DebugOptions {
                 let (start, end) = (start.expect_value(), end.expect_value());
                 Vm::LocalInterval(start, end, proc_ctx.num_locals())
             },
+            Ast::LocalRangeFrom(index) => {
+                let index = index.expect_value();
+                Vm::LocalInterval(index, index, proc_ctx.num_locals())
+            },
+            Ast::LocalAll => {
+                let end_exclusive = Ord::min(1, proc_ctx.num_locals());
+                Vm::LocalInterval(0, end_exclusive - 1, proc_ctx.num_locals())
+            },
             Ast::AdvStackTop(n) => Vm::AdvStackTop(n.expect_value()),
-            other @ (Ast::LocalRangeFrom(_) | Ast::LocalAll) => {
+            other @ Ast::LocalRangeFrom(_) => {
                 unimplemented!("compilation of debug instruction {other:?}");
             },
         };

--- a/assembly/src/ast/instruction/debug.rs
+++ b/assembly/src/ast/instruction/debug.rs
@@ -2,6 +2,7 @@ use core::fmt;
 
 use crate::{
     AssemblyError,
+    assembler::ProcedureContext,
     ast::{ImmU8, ImmU16, ImmU32},
 };
 
@@ -27,7 +28,10 @@ impl DebugOptions {
     /// This function does not currently return any errors, but may in the future.
     ///
     /// See [crate::Assembler] for an overview of AST compilation.
-    pub fn compile(&self) -> Result<vm_core::DebugOptions, AssemblyError> {
+    pub fn compile(
+        &self,
+        proc_ctx: &ProcedureContext,
+    ) -> Result<vm_core::DebugOptions, AssemblyError> {
         type Ast = DebugOptions;
         type Vm = vm_core::DebugOptions;
 
@@ -42,7 +46,7 @@ impl DebugOptions {
             },
             Ast::LocalInterval(start, end) => {
                 let (start, end) = (start.expect_value(), end.expect_value());
-                Vm::LocalInterval(start, end, end - start)
+                Vm::LocalInterval(start, end, proc_ctx.num_locals())
             },
             Ast::AdvStackTop(n) => Vm::AdvStackTop(n.expect_value()),
             other @ (Ast::LocalRangeFrom(_) | Ast::LocalAll) => {

--- a/assembly/src/parser/grammar.lalrpop
+++ b/assembly/src/parser/grammar.lalrpop
@@ -742,7 +742,7 @@ Debug: Instruction = {
     "debug" "." "local" <n:Imm<U16>> <m:Imm<U16>> => Instruction::Debug(DebugOptions::LocalInterval(n, m)),
     "debug" "." "local" <n:MaybeImm<U16>> => {
         match n {
-            Some(n) => Instruction::Debug(DebugOptions::LocalInterval(n.clone(), n)),
+            Some(n) => Instruction::Debug(DebugOptions::LocalRangeFrom(n)),
             None => Instruction::Debug(DebugOptions::LocalAll),
         }
     },


### PR DESCRIPTION
## Describe your changes

The compilation of `ast::DebugOptions` was slightly refactored to accommodate these fixes, but bare `debug.local` no longer panics and instead prints all local values, and the other two variants now print from the correct part of memory.

I considered adding tests for this, but currently most of the heavy lifting is also done in the functions that do the actual printing.

Fixes #1853.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'