### PR TITLE
feat(syntax): add support for breakpoint instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `debug.stack_adv` and `debug.stack_adv.<n>` to help debug the advice stack (#1828).
 - Add a complete description of the constraints for `horner_eval_base` and `horner_eval_ext` (#1817).
 - Add documentation for ACE chiplet (#1766)
+- Add support for setting debugger breakpoints via `breakpoint` instruction
 
 #### Changes
 

--- a/assembly/src/parser/grammar.lalrpop
+++ b/assembly/src/parser/grammar.lalrpop
@@ -73,6 +73,7 @@ extern {
         "cswap" => Token::Cswap,
         "cswapw" => Token::Cswapw,
         "debug" => Token::Debug,
+        "breakpoint" => Token::Breakpoint,
         "div" => Token::Div,
         "drop" => Token::Drop,
         "dropw" => Token::Dropw,
@@ -724,6 +725,7 @@ Call: Instruction = {
 
 #[inline]
 Debug: Instruction = {
+    "breakpoint" => Instruction::Breakpoint,
     "debug" "." "stack" <n:MaybeImm<U8>> => {
         match n {
             Some(n) => Instruction::Debug(DebugOptions::StackTop(n.map(|spanned| spanned.into_inner()))),

--- a/assembly/src/parser/token.rs
+++ b/assembly/src/parser/token.rs
@@ -161,6 +161,7 @@ pub enum Token<'input> {
     AssertEqw,
     ArithmeticCircuitEval,
     Begin,
+    Breakpoint,
     Caller,
     Call,
     Cdrop,
@@ -349,6 +350,7 @@ impl fmt::Display for Token<'_> {
             Token::AssertEqw => write!(f, "assert_eqw"),
             Token::ArithmeticCircuitEval => write!(f, "arithmetic_circuit_eval"),
             Token::Begin => write!(f, "begin"),
+            Token::Breakpoint => write!(f, "breakpoint"),
             Token::Caller => write!(f, "caller"),
             Token::Call => write!(f, "call"),
             Token::Cdrop => write!(f, "cdrop"),
@@ -544,6 +546,7 @@ impl<'input> Token<'input> {
                 | Token::AssertEq
                 | Token::AssertEqw
                 | Token::ArithmeticCircuitEval
+                | Token::Breakpoint
                 | Token::Caller
                 | Token::Call
                 | Token::Cdrop
@@ -693,6 +696,7 @@ impl<'input> Token<'input> {
         ("assert_eq", Token::AssertEq),
         ("assert_eqw", Token::AssertEqw),
         ("begin", Token::Begin),
+        ("breakpoint", Token::Breakpoint),
         ("caller", Token::Caller),
         ("call", Token::Call),
         ("cdrop", Token::Cdrop),


### PR DESCRIPTION
This PR adds support for setting debugger breakpoints in MASM syntax via the `breakpoint` keyword. The instruction actually already existed, it just wasn't surfaced in the syntax for some reason. This makes it possible to explicitly set a breakpoint to be triggered when the debugger reaches that instruction.

NOTE: I'm not sure how the current debugger handles this, but I made use of it in `midenc-debug` recently, which is when I found out it wasn't supported in MASM syntax. I've been sitting on this PR for awhile, and just got around to submitting it.