### PR TITLE
Prepare release 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Changelog
 
-## 0.15.0 (TBD)
+## 0.15.0 (2025-06-06)
 
 #### Enhancements
 
 - Add `debug.stack_adv` and `debug.stack_adv.<n>` to help debug the advice stack (#1828).
 - Add a complete description of the constraints for `horner_eval_base` and `horner_eval_ext` (#1817).
 - Add documentation for ACE chiplet (#1766)
-- Add support for setting debugger breakpoints via `breakpoint` instruction
+- Add support for setting debugger breakpoints via `breakpoint` instruction (#1860)
 - Improve error messages for some procedure locals-related errors (#1863)
+- Add range checks to the `push_falcon_mod_result` advice injector to make sure that the inputs are `u32` (#1819).
 
 #### Changes
 
@@ -24,10 +25,6 @@
 
 - `miden debug` rewind command no longer panics at clock 0 (#1751)
 - Prevent overflow in ACE circuit evaluation (#1820)
-
-#### Enhancements
-
-- Add range checks to the `push_falcon_mod_result` advice injector to make sure that the inputs are `u32` (#1819).
 
 ## 0.14.0 (2025-05-07)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,25 +400,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -816,12 +813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,17 +832,6 @@ checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -880,6 +860,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,9 +948,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
@@ -1335,12 +1341,13 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -1965,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "13.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a2d683a4ac90aeef5b1013933f6d977bd37d51ff3f4dad829d4931a7e6be86"
+checksum = "62fd9ca5ebc709e8535e8ef7c658eb51457987e48c98ead2be482172accc408d"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -1977,9 +1984,9 @@ dependencies = [
  "memchr",
  "nix",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
  "utf8parse",
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,12 +363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,14 +474,21 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "convert_case",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version 0.4.1",
  "syn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,9 +1874,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
 dependencies = [
  "futures-timer",
  "futures-util",
@@ -1886,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
 dependencies = [
  "cfg-if",
  "glob",

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -37,6 +37,6 @@ winter-air = { package = "winter-air", version = "0.12", default-features = fals
 winter-prover = { package = "winter-prover", version = "0.12", default-features = false }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion = "0.6"
 proptest = "1.6"
 rand-utils = { package = "winter-rand-utils", version = "0.12" }

--- a/assembly/src/assembler/module_graph/mod.rs
+++ b/assembly/src/assembler/module_graph/mod.rs
@@ -519,7 +519,7 @@ impl ModuleGraph {
     ///
     /// # Panics
     /// - Panics if index is invalid.
-    pub fn get_procedure_unsafe(&self, id: GlobalProcedureIndex) -> ProcedureWrapper {
+    pub fn get_procedure_unsafe(&self, id: GlobalProcedureIndex) -> ProcedureWrapper<'_> {
         match &self.modules[id.module.as_usize()] {
             WrappedModule::Ast(m) => ProcedureWrapper::Ast(&m[id.index]),
             WrappedModule::Info(m) => {

--- a/assembly/src/library/path.rs
+++ b/assembly/src/library/path.rs
@@ -234,7 +234,7 @@ impl LibraryPath {
     }
 
     /// Returns an iterator over all components of the path.
-    pub fn components(&self) -> impl Iterator<Item = LibraryPathComponent> + '_ {
+    pub fn components(&self) -> impl Iterator<Item = LibraryPathComponent<'_>> + '_ {
         core::iter::once(LibraryPathComponent::Namespace(&self.inner.ns))
             .chain(self.inner.components.iter().map(LibraryPathComponent::Normal))
     }

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -181,7 +181,7 @@ impl BasicBlockNode {
 
     /// Returns a [`DecoratorIterator`] which allows us to iterate through the decorator list of
     /// this basic block node while executing operation batches of this basic block node.
-    pub fn decorator_iter(&self) -> DecoratorIterator {
+    pub fn decorator_iter(&self) -> DecoratorIterator<'_> {
         DecoratorIterator::new(&self.decorators)
     }
 
@@ -202,7 +202,7 @@ impl BasicBlockNode {
 
     /// Returns an iterator over all operations and decorator, in the order in which they appear in
     /// the program.
-    pub fn iter(&self) -> impl Iterator<Item = OperationOrDecorator> {
+    pub fn iter(&self) -> impl Iterator<Item = OperationOrDecorator<'_>> {
         OperationOrDecoratorIterator::new(self)
     }
 }

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -86,7 +86,7 @@ vm-core = { package = "miden-core", path = "../core", version = "0.15", default-
 
 [dev-dependencies]
 assert_cmd = "2.0"
-criterion = "0.5"
+criterion = "0.6"
 escargot = "0.5"
 num-bigint = "0.4"
 predicates = "3.1"

--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -73,7 +73,7 @@ hex = { version = "0.4", optional = true }
 processor = { package = "miden-processor", path = "../processor", version = "0.15", default-features = false }
 prover = { package = "miden-prover", path = "../prover", version = "0.15", default-features = false }
 package = { package = "miden-mast-package", path = "../package", version = "0.15", default-features = false }
-rustyline = { version = "13.0", default-features = false, optional = true }
+rustyline = { version = "16.0", default-features = false, optional = true }
 serde = { version = "1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 
 [dependencies]
 assembly = { package = "miden-assembly", path = "../assembly", version = "0.15", default-features = false }
-derive_more = "0.99"
+derive_more = { version = "2.0.1", features = ["from"] }
 vm-core = { package = "miden-core", path = "../core", version = "0.15", default-features = false }
 
 [dev-dependencies]

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = { workspace = true }
 assembly = { package = "miden-assembly", path = "../assembly", version = "0.15", default-features = false }
 logtest = { version = "2.0", default-features = false }
 pretty_assertions = "1.4"
-rstest = { version = "0.24" }
+rstest = { version = "0.25" }
 test-utils = { package = "miden-test-utils", path = "../test-utils" }
 winter-fri = { package = "winter-fri", version = "0.12" }
 winter-utils = { package = "winter-utils", version = "0.12" }

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -2,11 +2,12 @@
 
 # Expects 
 # 1. to be run from the root of the repository
-# 2. for ~/.cargo/credentials.toml to contain your crates.io token
-#   (see https://doc.rust-lang.org/cargo/reference/publishing.html)
-
-git checkout main
-git pull origin main
+# 2. for ~/.cargo/credentials.toml to contain your crates.io token (see
+#   https://doc.rust-lang.org/cargo/reference/publishing.html)
+#
+# It is recommended to run this script while still on the `next` branch right before merging it into
+# `main`, so that if any error occurs, we can fix it and re-run the script directly without having
+# to merge the fix into `next`, and then merge `next` into `main` again.
 
 cargo publish -p miden-core
 cargo publish -p miden-air

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -45,7 +45,7 @@ processor = { package = "miden-processor", path = "../processor", version = "0.1
     "testing",
 ] }
 rand = { version = "0.9", default-features = false }
-rstest = { version = "0.24" }
+rstest = { version = "0.25" }
 serde_json = "1.0"
 sha2 = "0.10"
 sha3 = "0.10"

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -36,7 +36,7 @@ vm-core = { package = "miden-core", path = "../core", version = "0.15", default-
 
 [dev-dependencies]
 blake3 = "1.5"
-criterion = "0.5"
+criterion = "0.6"
 miden-air = { package = "miden-air", path = "../air", version = "0.15", default-features = false }
 num = "0.4"
 num-bigint = "0.4"


### PR DESCRIPTION
This is the last PR that will make it into v0.15. It

- fixes clippy
- updates the changelog
- updates a bunch of dependencies to their latest version
- improve the release script
