### PR TITLE
Fix release script

### DIFF
--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -11,11 +11,10 @@
 
 cargo publish -p miden-core
 cargo publish -p miden-air
+cargo publish -p miden-assembly
 cargo publish -p miden-processor
 cargo publish -p miden-prover
 cargo publish -p miden-verifier
-cargo publish -p miden-assembly
 cargo publish -p miden-stdlib
-cargo publish -p miden-package
-cargo publish -p miden-test-utils
+cargo publish -p miden-mast-package
 cargo publish -p miden-vm


### PR DESCRIPTION
Fixes release script based on running it for the first time for v0.15.0.

@bobbinth the only thing outstanding is that `miden-test-utils` is still on the initial `v0.1.0` (and has been for 1-2 years). Is there a good reason for not incrementing that version like the others? Basically when we make changes to it, those changes are never released.

Currently the script still fails for that package since v0.1.0 is already on crates.io.