### PR TITLE
fix: race between two cli tests

### DIFF
--- a/miden-vm/tests/integration/cli/cli_test.rs
+++ b/miden-vm/tests/integration/cli/cli_test.rs
@@ -91,7 +91,7 @@ fn cli_bundle_kernel() {
 /// A kernel can bundle with a library w/o exports.
 #[test]
 fn cli_bundle_kernel_noexports() {
-    let output_file = std::env::temp_dir().join("cli_bundle_kernel.masl");
+    let output_file = std::env::temp_dir().join("cli_bundle_kernel_noexports.masl");
 
     let mut cmd = bin_under_test().command();
     cmd.arg("bundle")


### PR DESCRIPTION
Fixes the race between two of the `cli-test` tests.

This is blocking the merge of #1862 