### PR TITLE
Assembler: add clear_debug_info to reduce size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 #### Enhancements
 
 - The documentation for the `Assembler` and its APIs was improved, to better explain how each affects the final assembled artifact (#1881).
+- Add `clear_debug_info` to `Program` and `Library` to reduce their size (#1889).
 
 #### Fixes
 

--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -102,6 +102,16 @@ impl Library {
             ..self
         }
     }
+
+    /// Clears all debug information in order to reduce the library size.
+    pub fn clear_debug_info(self) -> Self {
+        let mut mast_forest = (*self.mast_forest).clone();
+        mast_forest.clear_debug_info();
+        Self {
+            mast_forest: Arc::new(mast_forest),
+            ..self
+        }
+    }
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -3302,3 +3302,43 @@ fn vendoring() -> TestResult {
 fn test_assert_diagnostic_lines() {
     assert_diagnostic_lines!(report!("the error string"), "the error string", "other", "lines");
 }
+
+#[test]
+fn test_clear_debug_info() {
+    let source = "
+    const.ERR1=\"oh no\"
+
+    const.DEFAULT_CONST=100
+
+    proc.foo
+        push.1.2 add
+        debug.stack.8
+    end
+
+    begin
+        emit.DEFAULT_CONST
+
+        exec.foo
+
+        debug.stack.4
+
+        drop
+
+        trace.DEFAULT_CONST
+
+        assert.err=ERR1
+    end
+    ";
+
+    let assembler = Assembler::default().with_debug_mode(true);
+    let program = assembler.assemble_program(source).unwrap();
+
+    let mut target_with_debug_info = Vec::new();
+    program.write_into(&mut target_with_debug_info);
+
+    let mut target_without_debug_info = Vec::new();
+    program.clear_debug_info().write_into(&mut target_without_debug_info);
+
+    assert!(target_with_debug_info.len() == 588);
+    assert!(target_without_debug_info.len() == 158);
+}

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -282,6 +282,23 @@ impl MastForest {
         let block = MastNode::new_basic_block_with_raw_decorators(operations, decorators, self)?;
         self.add_node(block)
     }
+
+    /// Clears all debug information: decorators and error_codes.
+    pub fn clear_debug_info(&mut self) {
+        self.decorators.clear();
+        self.error_codes.clear();
+        for node in self.nodes.iter_mut() {
+            match node {
+                MastNode::Block(n) => n.clear_decorators(),
+                MastNode::Join(n) => n.clear_decorators(),
+                MastNode::Split(n) => n.clear_decorators(),
+                MastNode::Loop(n) => n.clear_decorators(),
+                MastNode::Call(n) => n.clear_decorators(),
+                MastNode::Dyn(n) => n.clear_decorators(),
+                MastNode::External(n) => n.clear_decorators(),
+            }
+        }
+    }
 }
 
 /// Helpers

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -231,6 +231,11 @@ impl BasicBlockNode {
     pub fn set_decorators(&mut self, decorator_list: DecoratorList) {
         self.decorators = decorator_list;
     }
+
+    /// Clears the decorators.
+    pub fn clear_decorators(&mut self) {
+        self.decorators.clear();
+    }
 }
 
 impl MastNodeExt for BasicBlockNode {

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -166,6 +166,12 @@ impl CallNode {
     pub fn after_exit(&self) -> &[DecoratorId] {
         &self.after_exit
     }
+
+    /// Clears the decorators.
+    pub fn clear_decorators(&mut self) {
+        self.before_enter.clear();
+        self.after_exit.clear();
+    }
 }
 
 /// Mutators

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -102,6 +102,12 @@ impl DynNode {
     pub fn after_exit(&self) -> &[DecoratorId] {
         &self.after_exit
     }
+
+    /// Clears the decorators.
+    pub fn clear_decorators(&mut self) {
+        self.before_enter.clear();
+        self.after_exit.clear();
+    }
 }
 
 /// Mutators

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -54,6 +54,12 @@ impl ExternalNode {
     pub fn after_exit(&self) -> &[DecoratorId] {
         &self.after_exit
     }
+
+    /// Clears the decorators.
+    pub fn clear_decorators(&mut self) {
+        self.before_enter.clear();
+        self.after_exit.clear();
+    }
 }
 
 /// Mutators

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -107,6 +107,12 @@ impl JoinNode {
     pub fn after_exit(&self) -> &[DecoratorId] {
         &self.after_exit
     }
+
+    /// Clears the decorators.
+    pub fn clear_decorators(&mut self) {
+        self.before_enter.clear();
+        self.after_exit.clear();
+    }
 }
 
 /// Mutators

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -96,6 +96,12 @@ impl LoopNode {
     pub fn after_exit(&self) -> &[DecoratorId] {
         &self.after_exit
     }
+
+    /// Clears the decorators.
+    pub fn clear_decorators(&mut self) {
+        self.before_enter.clear();
+        self.after_exit.clear();
+    }
 }
 
 /// Mutators

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -109,6 +109,12 @@ impl SplitNode {
     pub fn after_exit(&self) -> &[DecoratorId] {
         &self.after_exit
     }
+
+    /// Clears the decorators.
+    pub fn clear_decorators(&mut self) {
+        self.before_enter.clear();
+        self.after_exit.clear();
+    }
 }
 
 /// Mutators

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -65,6 +65,16 @@ impl Program {
             ..self
         }
     }
+
+    /// Clears all debug information in order to reduce the program size.
+    pub fn clear_debug_info(self) -> Self {
+        let mut mast_forest = (*self.mast_forest).clone();
+        mast_forest.clear_debug_info();
+        Self {
+            mast_forest: Arc::new(mast_forest),
+            ..self
+        }
+    }
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Temporary mitigation to https://github.com/0xMiden/miden-vm/issues/1873 and https://github.com/0xMiden/miden-base/issues/1441 and waiting for the better solution described in https://github.com/0xMiden/miden-vm/issues/1776.

This PR introduces the function `clear_debug_info` that allows to strip a compiled program or library from all decorators and all error_codes so to reduce its size. This information is permanently lost and there is no easy way to "re-attach" the debug info afterwards like it would be possible in https://github.com/0xMiden/miden-vm/issues/1776.

A simple test shows a significant reduction from 588 to 158 bytes.
