### PR TITLE
Add compile_library to Library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `AssemblyError` was removed, and all uses replaced with `Report` (#1881).
 - Licensed the project under the Apache 2.0 license (in addition to the MIT) (#1840).
 - Uniform chiplet bus message flag encoding (#1887).
+- Add `compile_library` to `Library` implementation (#1899).
 
 #### Enhancements
 

--- a/assembly/src/library/mod.rs
+++ b/assembly/src/library/mod.rs
@@ -112,17 +112,18 @@ impl Library {
         let source_manager = assembler.source_manager();
 
         let library_path = LibraryPath::new(library_path)
-            .map_err(|err| Report::msg(format!("Invalid library path: {}", err)))?;
+            .map_err(|err| Report::msg(format!("Invalid library path: {err}")))?;
 
         let mut parser = ModuleParser::new(crate::ast::ModuleKind::Library);
         let module = parser
             .parse_str(library_path, library_code, &*source_manager)
-            .map_err(|err| Report::msg(format!("Failed to parse module: {}", err)))?;
+            .map_err(|err| Report::msg(format!("Failed to parse module: {err}")))?;
 
         let library = assembler
             .clone()
             .assemble_library([module])
-            .map_err(|err| Report::msg(format!("Failed to assemble library: {}", err)))?;
+            .map_err(|err| Report::msg(format!("Failed to assemble library: {err}")))?;
+
         Ok(library)
     }
 }


### PR DESCRIPTION
**Summary:**

This PR introduces the `compile_library` function to the `Library` implementation.

**Motivation:**

While working on tutorial code and other projects, I frequently encountered the need to manually create libraries for note and transaction scripts. Recognizing the utility of a helper function, I realized it would be best to add the `compile_library` function somewhere in our repositories as opposed to creating a separate crate for utility functions.

**Functionality:**

The `compile_library` function facilitates the creation of a Miden assembly library using provided account code and library path.

**Context:**

This PR addresses feedback from [https://github.com/0xMiden/miden-client/pull/944](https://github.com/0xMiden/miden-client/pull/944). I realized that integrating `compile_library` into the miden-vm repository aligns more effectively with its purpose than placing it in miden-client or miden-base.
