### PR TITLE
chore: update exported doc files in EXPORTED.md

### DIFF
--- a/docs/src/EXPORTED.md
+++ b/docs/src/EXPORTED.md
@@ -46,6 +46,7 @@
       - [Hash Chiplet](./design/chiplets/hasher.md)
       - [Bitwise Chiplet](./design/chiplets/bitwise.md)
       - [Memory Chiplet](./design/chiplets/memory.md)
+      - [ACE Chiplet](./design/chiplets/ace.md)
       - [Kernel ROM Chiplet](./design/chiplets/kernel_rom.md)
     - [Lookup arguments](./design/lookups/main.md)
       - [Multiset checks](./design/lookups/multiset.md)


### PR DESCRIPTION
## Description

This PR updates the `docs/EXPORTED.md` file to match the `docs/SUMMARY.md` file. This change exports the recently created ACE chiplet markdown file to the `docs/EXPORTED.md` file. This minor change fixes errors when building the mdbook generated in the miden-docs repo.
