### PR TITLE
Change signature of `Host::get_mast_forest` from `&self` to `&mut self`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [BREAKING] Updated dependencies Winterfell to v0.13 and Crypto to v0.15 (#1896).
 - Fixed instructions with errors print without quotes (#1882).
 - [BREAKING] Convert `AdviceProvider` into a struct ([#1904](https://github.com/0xMiden/miden-vm/issues/1904), [#1905](https://github.com/0xMiden/miden-vm/issues/1905))
+- [BREAKING] `Host::get_mast_forest` takes `&mut self` ([#1902](https://github.com/0xMiden/miden-vm/issues/1902)
 
 #### Enhancements
 

--- a/miden-vm/tests/integration/operations/decorators/mod.rs
+++ b/miden-vm/tests/integration/operations/decorators/mod.rs
@@ -27,7 +27,7 @@ impl Host for TestHost {
         &mut self.adv_provider
     }
 
-    fn get_mast_forest(&self, _node_digest: &Word) -> Option<Arc<MastForest>> {
+    fn get_mast_forest(&mut self, _node_digest: &Word) -> Option<Arc<MastForest>> {
         // Empty MAST forest store
         None
     }

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -249,7 +249,7 @@ impl Host for ConsistencyHost {
         &mut self.advice_provider
     }
 
-    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
+    fn get_mast_forest(&mut self, node_digest: &Word) -> Option<Arc<MastForest>> {
         self.store.get(node_digest)
     }
 

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -38,7 +38,7 @@ pub trait Host {
 
     /// Returns MAST forest corresponding to the specified digest, or None if the MAST forest for
     /// this digest could not be found in this [Host].
-    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>>;
+    fn get_mast_forest(&mut self, node_digest: &Word) -> Option<Arc<MastForest>>;
 
     // PROVIDED METHODS
     // --------------------------------------------------------------------------------------------
@@ -102,7 +102,7 @@ where
         H::advice_provider_mut(self)
     }
 
-    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
+    fn get_mast_forest(&mut self, node_digest: &Word) -> Option<Arc<MastForest>> {
         H::get_mast_forest(self, node_digest)
     }
 
@@ -191,7 +191,7 @@ impl Host for DefaultHost {
         &mut self.adv_provider
     }
 
-    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
+    fn get_mast_forest(&mut self, node_digest: &Word) -> Option<Arc<MastForest>> {
         self.store.get(node_digest)
     }
 

--- a/test-utils/src/host.rs
+++ b/test-utils/src/host.rs
@@ -36,7 +36,7 @@ impl Host for TestHost {
         self.0.advice_provider_mut()
     }
 
-    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<processor::MastForest>> {
+    fn get_mast_forest(&mut self, node_digest: &Word) -> Option<Arc<MastForest>> {
         self.0.get_mast_forest(node_digest)
     }
 


### PR DESCRIPTION
Fixes #1902

## Describe your changes

Make Host::get_mast_forest take a mutable reference to `self`.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'