### PR TITLE
Introduce Noop in MAST basic blocks

### DIFF
--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -195,7 +195,7 @@ fn basic_block_and_simple_if_true() -> TestResult {
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop end
         if.true
             basic_block add end
         else
@@ -211,7 +211,7 @@ end";
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop end
         if.true
             basic_block add end
         else
@@ -233,7 +233,7 @@ fn basic_block_and_simple_if_false() -> TestResult {
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop end
         if.true
             basic_block mul end
         else
@@ -249,7 +249,7 @@ end";
     let expected = "\
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop end
         if.true
             basic_block noop end
         else
@@ -773,7 +773,7 @@ fn multiple_constants_push() -> TestResult {
     );
     let expected = "\
 begin
-    basic_block push(21) push(64) push(44) push(72) end
+    basic_block push(21) push(64) push(44) push(72) noop noop noop end
 end";
     let program = context.assemble(source)?;
     assert_str_eq!(format!("{program}"), expected);
@@ -1975,6 +1975,9 @@ begin
         mpverify({code2})
         mpverify({code2})
         mpverify({code1})
+        noop
+        noop
+        noop
     end
 end"
     );
@@ -2038,17 +2041,17 @@ fn nested_control_blocks() -> TestResult {
 begin
     join
         join
-            basic_block push(2) push(3) end
+            basic_block push(2) push(3) noop end
             if.true
                 join
                     basic_block add end
                     while.true
-                        basic_block push(7) push(11) add end
+                        basic_block push(7) push(11) add noop end
                     end
                 end
             else
                 join
-                    basic_block mul push(8) push(8) end
+                    basic_block mul push(8) push(8) noop end
                     if.true
                         basic_block mul end
                     else
@@ -2129,7 +2132,7 @@ fn program_with_one_procedure() -> TestResult {
     let program = context.assemble(source)?;
     let expected = "\
 begin
-    basic_block push(2) push(3) add push(3) push(7) mul end
+    basic_block push(2) push(3) add push(3) push(7) mul noop noop noop end
 end";
     assert_str_eq!(format!("{program}"), expected);
     Ok(())
@@ -2157,12 +2160,14 @@ begin
         mul
         push(11)
         push(5)
+        noop
         push(3)
         push(7)
         mul
         add
         neg
         add
+        noop
     end
 end";
     assert_str_eq!(format!("{program}"), expected);
@@ -2419,7 +2424,7 @@ fn program_with_one_import_and_hex_call() -> TestResult {
 begin
     join
         join
-            basic_block push(4) push(3) end
+            basic_block push(4) push(3) noop end
             external.0xc2545da99d3a1f3f38d957c7893c44d78998d8ea8b11aba7e22c8c2b2a213dae
         end
         call.0x20234ee941e53a15886e733cc8e041198c6e90d2a16ea18ce1030e8c3596dd38
@@ -2556,7 +2561,7 @@ fn program_with_reexported_proc_in_same_library() -> TestResult {
 begin
     join
         join
-            basic_block push(4) push(3) end
+            basic_block push(4) push(3) noop end
             external.0xb9691da1d9b4b364aca0a0990e9f04c446a2faa622c8dd0d8831527dbec61393
         end
         external.0xcb08c107c81c582788cbf63c99f6b455e11b33bb98ca05fe1cfa17c087dfa8f1
@@ -2631,7 +2636,7 @@ fn program_with_reexported_custom_alias_in_same_library() -> TestResult {
 begin
     join
         join
-            basic_block push(4) push(3) end
+            basic_block push(4) push(3) noop end
             external.0xb9691da1d9b4b364aca0a0990e9f04c446a2faa622c8dd0d8831527dbec61393
         end
         external.0xcb08c107c81c582788cbf63c99f6b455e11b33bb98ca05fe1cfa17c087dfa8f1
@@ -2704,7 +2709,7 @@ fn program_with_reexported_proc_in_another_library() -> TestResult {
 begin
     join
         join
-            basic_block push(4) push(3) end
+            basic_block push(4) push(3) noop end
             external.0xb9691da1d9b4b364aca0a0990e9f04c446a2faa622c8dd0d8831527dbec61393
         end
         external.0xcb08c107c81c582788cbf63c99f6b455e11b33bb98ca05fe1cfa17c087dfa8f1
@@ -2960,12 +2965,12 @@ begin
                 join
                     basic_block add end
                     while.true
-                        basic_block push(7) push(11) add end
+                        basic_block push(7) push(11) add noop end
                     end
                 end
             else
                 join
-                    basic_block mul push(8) push(8) end
+                    basic_block mul push(8) push(8) noop end
                     if.true
                         basic_block mul end
                     else
@@ -3021,7 +3026,7 @@ end"
     let program = context.assemble(source)?;
     let expected = "\
 begin
-    basic_block push(2) push(3) push(4) push(5) end
+    basic_block push(2) push(3) push(4) push(5) noop noop noop end
 end";
     assert_str_eq!(format!("{program}"), expected);
     Ok(())
@@ -3041,7 +3046,16 @@ begin push.A adv.push_mapval assert end"
     let expected = format!(
         "\
 begin
-    basic_block push(2) push(2) push(2) push(2) emit({EVENT_MAP_VALUE_TO_STACK}) assert(0) end
+    basic_block
+        push(2)
+        push(2)
+        push(2)
+        push(2)
+        emit({EVENT_MAP_VALUE_TO_STACK})
+        assert(0)
+        noop
+        noop
+    end
 end"
     );
     assert_str_eq!(format!("{program}"), expected);
@@ -3069,6 +3083,8 @@ begin
         push(6740431856120851931)
         emit({EVENT_MAP_VALUE_TO_STACK})
         assert(0)
+        noop
+        noop
     end
 end"
     );

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -40,11 +40,11 @@ pub const BATCH_SIZE: usize = 8;
 /// created according to these rules:
 ///
 /// - A basic block contains one or more batches.
-/// - A batch contains exactly 8 groups.
-/// - A group contains exactly 9 operations or 1 immediate value.
+/// - A batch contains exactly 1, 2, 4 or 8 groups.
+/// - A group contains between 1 and 9 operations or 1 immediate value.
 /// - NOOPs are used to fill a group or batch when necessary.
 /// - An immediate value follows the operation that requires it, using the next available group in
-///   the batch. If there are no batches available in the group, then both the operation and its
+///   the batch. If there are no groups available in the batch, then both the operation and its
 ///   immediate are moved to the next batch.
 ///
 /// Example: 8 pushes result in two operation batches:
@@ -427,6 +427,12 @@ fn batch_ops(ops: Vec<Operation>) -> Vec<OpBatch> {
         batch_acc.add_op(Operation::Noop);
         batches.push(batch_acc.into_batch());
     }
+
+    assert!(
+        batches.iter().all(|b| {
+            b.num_groups() == 1 || b.num_groups() == 2 || b.num_groups() == 4 || b.num_groups() == 8
+        }) && !batches.is_empty()
+    );
 
     batches
 }

--- a/core/src/mast/node/basic_block_node/tests.rs
+++ b/core/src/mast/node/basic_block_node/tests.rs
@@ -52,7 +52,8 @@ fn batch_ops() {
     assert_eq!([2_usize, 0, 0, 0, 0, 0, 0, 0], batch.op_counts);
     assert_eq!(hasher::hash_elements(&batch_groups), hash);
 
-    // --- one group with 7 immediate values --------------------------------------------------
+    // --- one batch of 8 groups, the first with 8 operations and the following 7 with immediate
+    // values ---
     let ops = vec![
         Operation::Push(ONE),
         Operation::Push(Felt::new(2)),
@@ -85,7 +86,9 @@ fn batch_ops() {
     assert_eq!([8_usize, 0, 0, 0, 0, 0, 0, 0], batch.op_counts);
     assert_eq!(hasher::hash_elements(&batch_groups), hash);
 
-    // --- two groups with 7 immediate values; the last push overflows to the second batch ----
+    // --- two batches, the first with 7 groups, one with 9 operations, 6 with immediate values; it
+    // needs to be padded with a 8th group with a Noop so that they are 8 groups in total. The
+    // last push overflows to the second batch ----
     let ops = vec![
         Operation::Add,
         Operation::Mul,
@@ -100,10 +103,10 @@ fn batch_ops() {
     ];
     let (batches, hash) = super::batch_and_hash_ops(ops.clone());
     assert_eq!(2, batches.len());
-
     let batch0 = &batches[0];
-    assert_eq!(ops[..9], batch0.ops);
-    assert_eq!(7, batch0.num_groups());
+    let expected_ops = append_noop(&ops[..9]);
+    assert_eq!(expected_ops, batch0.ops);
+    assert_eq!(8, batch0.num_groups());
 
     let batch0_groups = [
         build_group(&ops[..9]),
@@ -117,7 +120,7 @@ fn batch_ops() {
     ];
 
     assert_eq!(batch0_groups, batch0.groups);
-    assert_eq!([9_usize, 0, 0, 0, 0, 0, 0, 0], batch0.op_counts);
+    assert_eq!([9_usize, 0, 0, 0, 0, 0, 0, 1], batch0.op_counts);
 
     let batch1 = &batches[1];
     assert_eq!(vec![ops[9]], batch1.ops);
@@ -169,7 +172,10 @@ fn batch_ops() {
     assert_eq!(batch_groups, batch.groups);
     assert_eq!(hasher::hash_elements(&batch_groups), hash);
 
-    // --- push at the end of a group is moved into the next group ----------------------------
+    // --- 1 batch, 4 groups. First group has 8 operations, the second one operation (the push), the
+    // third an immediate value, the 4th is padding. Even if the first group has space for one more
+    // operation, given that it is a push at the end of a group, it is moved into the next group.
+    // ----------------------------
     let ops = vec![
         Operation::Add,
         Operation::Mul,
@@ -183,10 +189,10 @@ fn batch_ops() {
     ];
     let (batches, hash) = super::batch_and_hash_ops(ops.clone());
     assert_eq!(1, batches.len());
-
     let batch = &batches[0];
-    assert_eq!(ops, batch.ops);
-    assert_eq!(3, batch.num_groups());
+    let expected_ops = append_noop(&ops[..]);
+    assert_eq!(expected_ops, batch.ops);
+    assert_eq!(4, batch.num_groups());
 
     let batch_groups = [
         build_group(&ops[..8]),
@@ -200,7 +206,7 @@ fn batch_ops() {
     ];
 
     assert_eq!(batch_groups, batch.groups);
-    assert_eq!([8_usize, 1, 0, 0, 0, 0, 0, 0], batch.op_counts);
+    assert_eq!([8_usize, 1, 0, 1, 0, 0, 0, 0], batch.op_counts);
     assert_eq!(hasher::hash_elements(&batch_groups), hash);
 
     // --- push at the end of a group is moved into the next group ----------------------------
@@ -264,8 +270,9 @@ fn batch_ops() {
     assert_eq!(2, batches.len());
 
     let batch0 = &batches[0];
-    assert_eq!(ops[..17], batch0.ops);
-    assert_eq!(7, batch0.num_groups());
+    let expected_ops = append_noop(&ops[0..17]);
+    assert_eq!(expected_ops, batch0.ops);
+    assert_eq!(8, batch0.num_groups());
 
     let batch0_groups = [
         build_group(&ops[..9]),
@@ -279,7 +286,7 @@ fn batch_ops() {
     ];
 
     assert_eq!(batch0_groups, batch0.groups);
-    assert_eq!([9_usize, 0, 0, 0, 0, 0, 8, 0], batch0.op_counts);
+    assert_eq!([9_usize, 0, 0, 0, 0, 0, 8, 1], batch0.op_counts);
 
     let batch1 = &batches[1];
     assert_eq!(ops[17..], batch1.ops);
@@ -340,4 +347,10 @@ fn build_group(ops: &[Operation]) -> Felt {
         group |= (op.op_code() as u64) << (Operation::OP_BITS * i);
     }
     Felt::new(group)
+}
+
+fn append_noop(s: &[Operation]) -> Vec<Operation> {
+    let mut res = s.to_vec();
+    res.push(Operation::Noop);
+    res
 }

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -722,11 +722,6 @@ impl FastProcessor {
         let mut group_idx = 0;
         let mut next_group_idx = 1;
 
-        // round up the number of groups to be processed to the next power of two; we do this
-        // because the processor requires the number of groups to be either 1, 2, 4, or 8; if
-        // the actual number of groups is smaller, we'll pad the batch with NOOPs at the end
-        let num_batch_groups = batch.num_groups().next_power_of_two();
-
         // execute operations in the batch one by one
         for (op_idx_in_batch, op) in batch.ops().iter().enumerate() {
             while let Some(&decorator_id) =
@@ -785,13 +780,6 @@ impl FastProcessor {
                 op_idx_in_group += 1;
             }
         }
-
-        // make sure we execute the required number of operation groups; this would happen when the
-        // actual number of operation groups was not a power of two. In this processor, this
-        // corresponds to incrementing the clock by the number of empty op groups (i.e. 1 NOOP
-        // executed per missing op group).
-
-        self.clk += (num_batch_groups - group_idx) as u32;
 
         Ok(())
     }

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -74,7 +74,7 @@ fn test_stack_underflow_and_overflow_bounds_failure() {
 
         // program 2: just enough dups to get 1 away from the stack buffer overflow error. Since we
         // can't drop the elements, we expect to end the program with a stack output overflow.
-        const NUM_DUPS_NO_OVERFLOW: usize = NUM_DUPS_NO_OVERFLOW_SWAPS_ALLOWED + 1;
+        const NUM_DUPS_NO_OVERFLOW: usize = NUM_DUPS_NO_OVERFLOW_SWAPS_ALLOWED + 1 - 2; // two padding Noop are inserted
 
         let ops = vec![Operation::Dup0; NUM_DUPS_NO_OVERFLOW];
         let program_output_overflow = simple_program_with_ops(ops);
@@ -83,7 +83,7 @@ fn test_stack_underflow_and_overflow_bounds_failure() {
 
         // program 3: just enough dups to get 1 away from the stack buffer overflow error. Since we
         // can't drop the elements, we expect to end the program with a stack output overflow.
-        const NUM_DUPS_WITH_OVERFLOW: usize = NUM_DUPS_NO_OVERFLOW + 1;
+        const NUM_DUPS_WITH_OVERFLOW: usize = NUM_DUPS_NO_OVERFLOW + 2;
 
         let ops = vec![Operation::Dup0; NUM_DUPS_WITH_OVERFLOW];
         let program_with_overflow = simple_program_with_ops(ops);

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -670,20 +670,6 @@ impl Process {
             }
         }
 
-        // make sure we execute the required number of operation groups; this would happen when
-        // the actual number of operation groups was not a power of two
-        for group_idx in group_idx..num_batch_groups {
-            self.decoder.execute_user_op(Operation::Noop, 0);
-            self.execute_op(Operation::Noop, program, host)?;
-
-            // if we are not at the last group yet, set up the decoder for decoding the next
-            // operation groups. the groups were are processing are just NOOPs - so, the op group
-            // value is ZERO
-            if group_idx < num_batch_groups - 1 {
-                self.decoder.start_op_group(ZERO);
-            }
-        }
-
         Ok(())
     }
 


### PR DESCRIPTION
Fixes https://github.com/0xMiden/miden-vm/issues/1815

When a basic block is built, it contains only Noops inserted by the user, however during execution more Noops are inserted by the processor following two specific rules. This complicates the relationship between an operation, a decorator and their clock cycle, making some things more complicated (e.g. https://github.com/0xMiden/miden-vm/pull/1940).

This PR introduces the Noop directly in the basic_blocks of the MastForest, simplifying the work of the processor.

**Only one rule is implemented for now. Making the number of groups 1,2,4 or 8.**