### PR TITLE
WIP: stdlib smt: support leaves with multiple key-value pairs

### DIFF
--- a/stdlib/asm/collections/smt.masm
+++ b/stdlib/asm/collections/smt.masm
@@ -358,13 +358,14 @@ end
 #!   Operand stack: [pair_count, K, R]
 #!   Advice stack:  [V1, K2, V2, K2, ...]
 proc.get_multi_leaf_value
-    dup
-    # => [pair_count, pair_count, K, R]
-    movdn.9
+    dup movdn.9
     # => [pair_count, K, R, pair_count]
 
     gt.0
     # => [has_more, K, R, pair_count]
+    # The loop should always run at least once, or this procedure's invariants are invalid.
+    assert.err="unreachable: get_multi_leaf_value called with 0 pairs"
+    push.1
     while.true
         # => [K, R, pair_count]
 
@@ -374,19 +375,13 @@ proc.get_multi_leaf_value
 
         # Get the pair's key so we can compare it against the caller-provided key.
 
-        movupw.2
-        # => [K, V', K', R, pair_count]
-
-        movupw.2
+        movupw.2 movupw.2
         # => [K', K, V', R, pair_count]
 
         eqw
         # => [key_eq, K', K, V', R, pair_count]
 
-        movdn.4
-        # => [K', key_eq, K, V', R, pair_count]
-
-        dropw
+        movdn.4 dropw
         # => [key_eq, K, V', R, pair_count]
 
         if.true
@@ -399,7 +394,6 @@ proc.get_multi_leaf_value
 
             push.0
             # => [has_more_pairs = 0, V', R, pair_count]
-            #movup.9 add.1 movdn.9
         else
             # => [V', K, R, pair_count]
 
@@ -412,12 +406,12 @@ proc.get_multi_leaf_value
             movup.8 sub.1 movdn.8
             # => [K, R, pair_count]
 
-            # Prepare stack for the next while loop condition.
+            # Prepare stack for the next loop condition.
             dup.8 gt.0
 
             # => [has_more_pairs, K, R, pair_count]
         end
-    end # End while
+    end
 
     # While loop over.
     # => [?, R, pair_count]
@@ -515,13 +509,11 @@ export.get
         else
             # => [leaf_size, NV, K, R]
 
-            movdn.12
-            # => [NV, K, R, leaf_size]
-
-            dropw # We don't care about the node value anymore.
+            # We don't care about the node's hash anymore.
+            movdn.12 dropw
             # => [K, R, leaf_size]
 
-            # Get pair count from leaf size.
+            # Each pair is 8 fields.
             movup.8 div.8
             # => [pair_count, K, R]
 

--- a/stdlib/asm/collections/smt.masm
+++ b/stdlib/asm/collections/smt.masm
@@ -353,6 +353,88 @@ end
 # GET
 # =================================================================================================
 
+
+#! Inputs:
+#!   Operand stack: [pair_count, K, R]
+#!   Advice stack:  [V1, K2, V2, K2, ...]
+proc.get_multi_leaf_value
+    dup
+    # => [pair_count, pair_count, K, R]
+    movdn.9
+    # => [pair_count, K, R, pair_count]
+
+    gt.0
+    # => [has_more, K, R, pair_count]
+    while.true
+        # => [K, R, pair_count]
+
+        # Get the next pair from the advice stack.
+        adv_push.8
+        # => [V', K', K, R, pair_count]
+
+        # Get the pair's key so we can compare it against the caller-provided key.
+
+        movupw.2
+        # => [K, V', K', R, pair_count]
+
+        movupw.2
+        # => [K', K, V', R, pair_count]
+
+        eqw
+        # => [key_eq, K', K, V', R, pair_count]
+
+        movdn.4
+        # => [K', key_eq, K, V', R, pair_count]
+
+        dropw
+        # => [key_eq, K, V', R, pair_count]
+
+        if.true
+            # => [K, V', R, pair_count]
+
+            # We've found the right pair. Cleanup our stack, and prepare stack outputs.
+
+            # We no longer need the original key.
+            dropw # => [V', R, pair_count]
+
+            push.0
+            # => [has_more_pairs = 0, V', R, pair_count]
+            #movup.9 add.1 movdn.9
+        else
+            # => [V', K, R, pair_count]
+
+            # Discard the pair-value from the advice provider, and prepare the stack
+            # for the next loop condition.
+            swapw dropw
+            # => [K, R, pair_count]
+
+            # Decrement pair_count.
+            movup.8 sub.1 movdn.8
+            # => [K, R, pair_count]
+
+            # Prepare stack for the next while loop condition.
+            dup.8 gt.0
+
+            # => [has_more_pairs, K, R, pair_count]
+        end
+    end # End while
+
+    # While loop over.
+    # => [?, R, pair_count]
+
+    # Check pair_count. It will tell us the meaining of the first stack word.
+    movup.8 eq.0
+    if.true
+        # => [K, R]
+
+        # Value not found for this key.
+        padw swapw dropw
+    else
+        # => [V, R]
+        nop
+    end
+end
+
 #! Returns the value located under the specified key in the Sparse Merkle Tree defined by the
 #! specified root.
 #!
@@ -431,9 +513,21 @@ export.get
             hmerge assert_eqw
             # => [V, R]
         else
-            # Multiple kv-pair case
-            # TODO (fail for now)
-            push.1 assertz
+            # => [leaf_size, NV, K, R]
+
+            movdn.12
+            # => [NV, K, R, leaf_size]
+
+            dropw # We don't care about the node value anymore.
+            # => [K, R, leaf_size]
+
+            # Get pair count from leaf size.
+            movup.8 div.8
+            # => [pair_count, K, R]
+
+            exec.get_multi_leaf_value
+
+            # => [V, R]
         end
     end
 end

--- a/stdlib/tests/collections/smt.rs
+++ b/stdlib/tests/collections/smt.rs
@@ -3,19 +3,20 @@ use super::*;
 // TEST DATA
 // ================================================================================================
 
+const fn word(e0: u64, e1: u64, e2: u64, e3: u64) -> Word {
+    Word::new([Felt::new(e0), Felt::new(e1), Felt::new(e2), Felt::new(e3)])
+}
+
 /// Note: We never insert at the same key twice. This is so that the `smt::get` test can loop over
 /// leaves, get the associated value, and compare. We test inserting at the same key twice in tests
 /// that use different data.
 const LEAVES: [(Word, Word); 2] = [
     (
-        Word::new([Felt::new(101), Felt::new(102), Felt::new(103), Felt::new(104)]),
-        Word::new([Felt::new(1_u64), Felt::new(2_u64), Felt::new(3_u64), Felt::new(4_u64)]),
+        word(101, 102, 103, 104),
+        // Most significant Felt differs from previous
+        word(1_u64, 2_u64, 3_u64, 4_u64),
     ),
-    // Most significant Felt differs from previous
-    (
-        Word::new([Felt::new(105), Felt::new(106), Felt::new(107), Felt::new(108)]),
-        Word::new([Felt::new(5_u64), Felt::new(6_u64), Felt::new(7_u64), Felt::new(8_u64)]),
-    ),
+    (word(105, 106, 107, 108), word(5_u64, 6_u64, 7_u64, 8_u64)),
 ];
 
 /// Tests `get` on every key present in the SMT, as well as an empty leaf

--- a/stdlib/tests/collections/smt.rs
+++ b/stdlib/tests/collections/smt.rs
@@ -19,6 +19,14 @@ const LEAVES: [(Word, Word); 2] = [
     (word(105, 106, 107, 108), word(5_u64, 6_u64, 7_u64, 8_u64)),
 ];
 
+/// Unlike the above `LEAVES`, these leaves use the same value for their most-significant felts, to
+/// test leaves with multiple pairs.
+const LEAVES_MULTI: [(Word, Word); 2] = [
+    (word(101, 102, 103, 69420), word(0x1, 0x2, 0x3, 0x4)),
+    // Most significant felt does NOT differ from previous.
+    (word(201, 202, 203, 69420), word(0xb, 0xc, 0xd, 0xe)),
+];
+
 /// Tests `get` on every key present in the SMT, as well as an empty leaf
 #[test]
 fn test_smt_get() {
@@ -52,6 +60,34 @@ fn test_smt_get() {
         EMPTY_WORD,
         &smt,
     );
+}
+
+#[test]
+fn test_smt_get_multi() {
+    let expect_value_from_get = |key: Word, value: Word, smt: &Smt| {
+        let source = "
+            use.std::collections::smt
+
+            begin
+                exec.smt::get
+            end
+        ";
+
+        let mut initial_stack: Vec<u64> = Default::default();
+        append_word_to_vec(&mut initial_stack, smt.root().into());
+        append_word_to_vec(&mut initial_stack, key.into());
+        let expected_output = build_expected_stack(value, smt.root().into());
+
+        let (store, advice_map) = build_advice_inputs(smt);
+        build_test!(source, &initial_stack, &[], store, advice_map).expect_stack(&expected_output);
+    };
+
+    let smt = Smt::with_entries(LEAVES_MULTI).unwrap();
+    let (k0, v0) = LEAVES_MULTI[0];
+    let (k1, v1) = LEAVES_MULTI[1];
+
+    expect_value_from_get(k0, v0, &smt);
+    expect_value_from_get(k1, v1, &smt);
 }
 
 /// Tests inserting and removing key-value pairs to an SMT. We do the insert/removal twice to ensure


### PR DESCRIPTION
## Describe your changes

This is a draft implementation for `smt::get` supporting leaves with multiple kv-pairs in `miden-stdlib`. `smt::set` has not been implemented yet.

Fixes #1218.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'