### PR TITLE
Use crate dependency in core for serialization types

### DIFF
--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -15,9 +15,11 @@ pub use node::{
     BasicBlockNode, CallNode, DynNode, ExternalNode, JoinNode, LoopNode, MastNode, MastNodeExt,
     OP_BATCH_SIZE, OP_GROUP_SIZE, OpBatch, OperationOrDecorator, SplitNode,
 };
-use winter_utils::{ByteWriter, DeserializationError, Serializable};
 
-use crate::{AdviceMap, Decorator, DecoratorList, Felt, Operation, Word};
+use crate::{
+    AdviceMap, Decorator, DecoratorList, Felt, Operation, Word,
+    utils::{ByteWriter, DeserializationError, Serializable},
+};
 
 mod serialization;
 

--- a/core/src/mast/serialization/basic_blocks.rs
+++ b/core/src/mast/serialization/basic_blocks.rs
@@ -1,9 +1,11 @@
 use alloc::vec::Vec;
 
-use winter_utils::{ByteReader, DeserializationError, Serializable, SliceReader};
-
 use super::NodeDataOffset;
-use crate::{Operation, mast::BasicBlockNode};
+use crate::{
+    Operation,
+    mast::BasicBlockNode,
+    utils::{ByteReader, DeserializationError, Serializable, SliceReader},
+};
 
 // BASIC BLOCK DATA BUILDER
 // ================================================================================================

--- a/core/src/mast/serialization/decorator.rs
+++ b/core/src/mast/serialization/decorator.rs
@@ -2,15 +2,18 @@ use alloc::vec::Vec;
 
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
-use winter_utils::{
-    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
-};
 
 use super::{
     DecoratorDataOffset,
     string_table::{StringTable, StringTableBuilder},
 };
-use crate::{AssemblyOp, DebugOptions, Decorator, debuginfo::Uri};
+use crate::{
+    AssemblyOp, DebugOptions, Decorator,
+    debuginfo::Uri,
+    utils::{
+        ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
+    },
+};
 
 /// Represents a serialized [`Decorator`].
 ///

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -1,10 +1,9 @@
 use alloc::vec::Vec;
 
-use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
-
 use super::{NodeDataOffset, basic_blocks::BasicBlockDataDecoder};
-use crate::mast::{
-    BasicBlockNode, CallNode, JoinNode, LoopNode, MastNode, MastNodeId, SplitNode, Word,
+use crate::{
+    mast::{BasicBlockNode, CallNode, JoinNode, LoopNode, MastNode, MastNodeId, SplitNode, Word},
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 
 // MAST NODE INFO

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -47,10 +47,12 @@ use alloc::{
 
 use decorator::{DecoratorDataBuilder, DecoratorInfo};
 use string_table::StringTable;
-use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 use super::{DecoratorId, MastForest, MastNode, MastNodeId};
-use crate::AdviceMap;
+use crate::{
+    AdviceMap,
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+};
 
 mod decorator;
 

--- a/core/src/mast/serialization/string_table.rs
+++ b/core/src/mast/serialization/string_table.rs
@@ -2,11 +2,11 @@ use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 use core::cell::RefCell;
 
 use miden_crypto::hash::blake::{Blake3_256, Blake3Digest};
-use winter_utils::{
-    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
-};
 
 use super::{StringDataOffset, StringIndex};
+use crate::utils::{
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
+};
 
 pub struct StringTable {
     data: Vec<u8>,

--- a/core/src/mast/tests.rs
+++ b/core/src/mast/tests.rs
@@ -4,9 +4,13 @@ use math::FieldElement;
 use miden_crypto::WORD_SIZE;
 use proptest::prelude::*;
 use rand_utils::prng_array;
-use winter_utils::{Deserializable, Serializable};
 
-use crate::{Felt, Kernel, ProgramInfo, Word, chiplets::hasher, mast::DynNode};
+use crate::{
+    Felt, Kernel, ProgramInfo, Word,
+    chiplets::hasher,
+    mast::DynNode,
+    utils::{Deserializable, Serializable},
+};
 
 #[test]
 fn dyn_hash_is_correct() {

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -1,12 +1,16 @@
 use core::fmt;
 
-use super::Felt;
 mod decorators;
 pub use decorators::{AssemblyOp, DebugOptions, Decorator, DecoratorIterator, DecoratorList};
+use opcode_constants::*;
+
+use crate::{
+    Felt,
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+};
+
 // OPERATIONS OP CODES
 // ================================================================================================
-use opcode_constants::*;
-use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 /// Opcode patterns have the following meanings:
 /// - 00xxxxx operations do not shift the stack; constraint degree can be up to 2.

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -3,13 +3,14 @@ use core::fmt;
 
 use math::FieldElement;
 use miden_crypto::{Felt, WORD_SIZE, Word};
-use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 use super::Kernel;
 use crate::{
     AdviceMap,
     mast::{MastForest, MastNode, MastNodeId},
-    utils::ToElements,
+    utils::{
+        ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, ToElements,
+    },
 };
 
 // PROGRAM


### PR DESCRIPTION
This small PR switches to using `crate::utils` as the source of serialization types in the `miden-core` create (instead of importing them from `winter-utils`).