### PR TITLE
Implement `get_size_hint` for most structs.

### DIFF
--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -339,9 +339,23 @@ impl vm_core::ToElements<Felt> for PublicInputs {
 
 impl Serializable for PublicInputs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.program_info.write_into(target);
-        self.stack_inputs.write_into(target);
-        self.stack_outputs.write_into(target);
+        let Self {
+            program_info,
+            stack_inputs,
+            stack_outputs,
+        } = self;
+        program_info.write_into(target);
+        stack_inputs.write_into(target);
+        stack_outputs.write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let Self {
+            program_info,
+            stack_inputs,
+            stack_outputs,
+        } = self;
+        program_info.get_size_hint() + stack_inputs.get_size_hint() + stack_outputs.get_size_hint()
     }
 }
 

--- a/air/src/proof.rs
+++ b/air/src/proof.rs
@@ -142,6 +142,10 @@ impl Serializable for HashFunction {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_u8(*self as u8);
     }
+
+    fn get_size_hint(&self) -> usize {
+        0u8.get_size_hint()
+    }
 }
 
 impl Deserializable for HashFunction {
@@ -152,8 +156,14 @@ impl Deserializable for HashFunction {
 
 impl Serializable for ExecutionProof {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.proof.write_into(target);
-        self.hash_fn.write_into(target);
+        let Self { proof, hash_fn } = self;
+        proof.write_into(target);
+        hash_fn.write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { proof, hash_fn } = self;
+        proof.get_size_hint() + hash_fn.get_size_hint()
     }
 }
 

--- a/assembly-syntax/src/ast/module.rs
+++ b/assembly-syntax/src/ast/module.rs
@@ -87,6 +87,10 @@ impl Serializable for ModuleKind {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         target.write_u8(*self as u8)
     }
+
+    fn get_size_hint(&self) -> usize {
+        0u8.get_size_hint()
+    }
 }
 
 impl Deserializable for ModuleKind {

--- a/assembly-syntax/src/ast/procedure/name.rs
+++ b/assembly-syntax/src/ast/procedure/name.rs
@@ -127,8 +127,15 @@ impl fmt::Display for QualifiedProcedureName {
 
 impl Serializable for QualifiedProcedureName {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.module.write_into(target);
-        self.name.write_into(target);
+        let Self { span: _, module, name } = self;
+
+        module.write_into(target);
+        name.write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { span: _, module, name } = self;
+        module.get_size_hint() + name.get_size_hint()
     }
 }
 
@@ -368,6 +375,10 @@ fn is_valid_unquoted_identifier_char(c: char) -> bool {
 impl Serializable for ProcedureName {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.as_str().write_into(target)
+    }
+
+    fn get_size_hint(&self) -> usize {
+        self.as_str().get_size_hint()
     }
 }
 

--- a/assembly-syntax/src/library/mod.rs
+++ b/assembly-syntax/src/library/mod.rs
@@ -172,13 +172,13 @@ impl Serializable for Library {
         let Self { digest: _, exports, mast_forest } = self;
 
         mast_forest.write_into(target);
+        exports.write_into(target);
+    }
 
-        target.write_usize(exports.len());
-        for (proc_name, proc_node_id) in exports {
-            proc_name.module.write_into(target);
-            proc_name.name.write_into(target);
-            target.write_u32(proc_node_id.as_u32());
-        }
+    fn get_size_hint(&self) -> usize {
+        let Self { digest: _, exports, mast_forest } = self;
+
+        mast_forest.get_size_hint() + exports.get_size_hint()
     }
 }
 
@@ -346,6 +346,12 @@ impl Serializable for KernelLibrary {
         let Self { kernel: _, kernel_info: _, library } = self;
 
         library.write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { kernel: _, kernel_info: _, library } = self;
+
+        library.get_size_hint()
     }
 }
 

--- a/assembly-syntax/src/library/namespace.rs
+++ b/assembly-syntax/src/library/namespace.rs
@@ -221,10 +221,14 @@ impl Serializable for LibraryNamespace {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         // Catch any situations where a namespace was incorrectly constructed
         let bytes = self.as_bytes();
-        assert!(bytes.len() <= u8::MAX as usize, "namespace too long");
+        let len_u8 = bytes.len().try_into().expect("namespace too long");
 
-        target.write_u8(bytes.len() as u8);
+        target.write_u8(len_u8);
         target.write_bytes(bytes);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        0u8.get_size_hint() + self.len()
     }
 }
 

--- a/assembly-syntax/src/library/path.rs
+++ b/assembly-syntax/src/library/path.rs
@@ -491,14 +491,18 @@ impl FromStr for LibraryPath {
 
 impl Serializable for LibraryPath {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let len = self.byte_len();
+        let len_u16: u16 = self.byte_len().try_into().expect("path too long");
 
-        target.write_u16(len as u16);
+        len_u16.write_into(target);
         target.write_bytes(self.inner.ns.as_str().as_bytes());
         for component in self.inner.components.iter() {
             target.write_bytes(b"::");
             target.write_bytes(component.as_str().as_bytes());
         }
+    }
+
+    fn get_size_hint(&self) -> usize {
+        0u16.get_size_hint() + self.byte_len()
     }
 }
 

--- a/assembly-syntax/src/library/version.rs
+++ b/assembly-syntax/src/library/version.rs
@@ -77,9 +77,13 @@ impl fmt::Display for Version {
 }
 impl Serializable for Version {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write_u16(self.major);
-        target.write_u16(self.minor);
-        target.write_u16(self.patch);
+        let Self { major, minor, patch } = *self;
+        [major, minor, patch].write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { major, minor, patch } = self;
+        [major, minor, patch].map(Serializable::get_size_hint).into_iter().sum()
     }
 }
 impl Deserializable for Version {

--- a/core/src/advice/map.rs
+++ b/core/src/advice/map.rs
@@ -131,10 +131,11 @@ impl Extend<(Word, Vec<Felt>)> for AdviceMap {
 
 impl Serializable for AdviceMap {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write_usize(self.0.len());
-        for (key, values) in self.0.iter() {
-            target.write((key, values));
-        }
+        self.0.write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        self.0.get_size_hint()
     }
 }
 

--- a/core/src/debuginfo/source_manager.rs
+++ b/core/src/debuginfo/source_manager.rs
@@ -2,6 +2,7 @@ use alloc::{boxed::Box, collections::BTreeMap, string::String, sync::Arc, vec::V
 use core::{error::Error, fmt::Debug};
 
 use super::*;
+use crate::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 // SOURCE ID
 // ================================================================================================
@@ -57,6 +58,22 @@ impl TryFrom<usize> for SourceId {
             Ok(n) if n < u32::MAX => Ok(Self(n)),
             _ => Err(()),
         }
+    }
+}
+
+impl Serializable for SourceId {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target)
+    }
+
+    fn get_size_hint(&self) -> usize {
+        self.0.get_size_hint()
+    }
+}
+
+impl Deserializable for SourceId {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        source.read_u32().map(Self)
     }
 }
 

--- a/core/src/debuginfo/span.rs
+++ b/core/src/debuginfo/span.rs
@@ -256,8 +256,16 @@ impl<T: Serializable> Span<T> {
 
 impl<T: Serializable> Serializable for Span<T> {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.span.write_into(target);
-        self.spanned.write_into(target);
+        let Self { span, spanned } = self;
+
+        span.write_into(target);
+        spanned.write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { span, spanned } = self;
+
+        span.get_size_hint() + spanned.get_size_hint()
     }
 }
 
@@ -408,9 +416,17 @@ impl From<SourceSpan> for miette::SourceSpan {
 
 impl Serializable for SourceSpan {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        target.write_u32(self.source_id.to_u32());
-        target.write_u32(self.start.into());
-        target.write_u32(self.end.into())
+        let Self { source_id, start, end } = self;
+
+        source_id.write_into(target);
+        start.write_into(target);
+        end.write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { source_id, start, end } = self;
+
+        source_id.get_size_hint() + start.get_size_hint() + end.get_size_hint()
     }
 }
 

--- a/core/src/kernel.rs
+++ b/core/src/kernel.rs
@@ -64,6 +64,14 @@ impl Serializable for Kernel {
         target.write_u8(self.0.len().try_into().expect("too many kernel procedures"));
         target.write_many(&self.0)
     }
+
+    fn get_size_hint(&self) -> usize {
+        let mut size = 0u8.get_size_hint();
+        for element in &self.0 {
+            size += element.get_size_hint();
+        }
+        size
+    }
 }
 
 impl Deserializable for Kernel {

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -18,7 +18,7 @@ pub use node::{
 
 use crate::{
     AdviceMap, Decorator, DecoratorList, Felt, Operation, Word,
-    utils::{ByteWriter, DeserializationError, Serializable},
+    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 
 mod serialization;
@@ -646,6 +646,22 @@ impl fmt::Display for MastNodeId {
     }
 }
 
+impl Deserializable for MastNodeId {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        source.read_u32().map(Self)
+    }
+}
+
+impl Serializable for MastNodeId {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into(target)
+    }
+
+    fn get_size_hint(&self) -> usize {
+        self.0.get_size_hint()
+    }
+}
+
 // ITERATOR
 
 /// Iterates over all the nodes a root depends on, in pre-order. The iteration can include other
@@ -747,6 +763,10 @@ impl fmt::Display for DecoratorId {
 impl Serializable for DecoratorId {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.0.write_into(target)
+    }
+
+    fn get_size_hint(&self) -> usize {
+        self.0.get_size_hint()
     }
 }
 

--- a/core/src/mast/serialization/decorator.rs
+++ b/core/src/mast/serialization/decorator.rs
@@ -127,6 +127,12 @@ impl Serializable for DecoratorInfo {
         variant.write_into(target);
         decorator_data_offset.write_into(target);
     }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { variant, decorator_data_offset } = self;
+
+        variant.get_size_hint() + decorator_data_offset.get_size_hint()
+    }
 }
 
 impl Deserializable for DecoratorInfo {
@@ -193,6 +199,10 @@ impl From<&Decorator> for EncodedDecoratorVariant {
 impl Serializable for EncodedDecoratorVariant {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.discriminant().write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        self.discriminant().get_size_hint()
     }
 }
 

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -90,6 +90,12 @@ impl Serializable for MastNodeInfo {
         ty.write_into(target);
         digest.write_into(target);
     }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { ty, digest } = self;
+
+        ty.get_size_hint() + digest.get_size_hint()
+    }
 }
 
 impl Deserializable for MastNodeInfo {
@@ -210,6 +216,10 @@ impl Serializable for MastNodeType {
 
         let value = (discriminant << 60) | payload;
         target.write_u64(value);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        0u64.get_size_hint()
     }
 }
 

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -187,6 +187,11 @@ impl Serializable for MastForest {
         before_enter_decorators.write_into(target);
         after_exit_decorators.write_into(target);
     }
+
+    // TODO: Not clear how to implement simply
+    // fn get_size_hint(&self) -> usize {
+    //     todo!()
+    // }
 }
 
 impl Deserializable for MastForest {

--- a/core/src/mast/serialization/string_table.rs
+++ b/core/src/mast/serialization/string_table.rs
@@ -63,6 +63,12 @@ impl Serializable for StringTable {
         table.write_into(target);
         data.write_into(target);
     }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { table, data, refc_strings: _ } = self;
+
+        table.get_size_hint() + data.get_size_hint()
+    }
 }
 
 impl Deserializable for StringTable {

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -153,9 +153,17 @@ impl Program {
 
 impl Serializable for Program {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.mast_forest.write_into(target);
-        self.kernel.write_into(target);
-        target.write_u32(self.entrypoint.as_u32());
+        let Self { mast_forest, entrypoint, kernel } = self;
+
+        mast_forest.write_into(target);
+        kernel.write_into(target);
+        entrypoint.as_u32().write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { mast_forest, entrypoint, kernel } = self;
+
+        mast_forest.get_size_hint() + kernel.get_size_hint() + entrypoint.get_size_hint()
     }
 }
 
@@ -247,8 +255,16 @@ impl From<Program> for ProgramInfo {
 
 impl Serializable for ProgramInfo {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.program_hash.write_into(target);
-        self.kernel.write_into(target);
+        let Self { program_hash, kernel } = self;
+
+        program_hash.write_into(target);
+        kernel.write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { program_hash, kernel } = self;
+
+        program_hash.get_size_hint() + kernel.get_size_hint()
     }
 }
 

--- a/core/src/stack/inputs.rs
+++ b/core/src/stack/inputs.rs
@@ -96,6 +96,15 @@ impl Serializable for StackInputs {
         target.write_u8(num_stack_values);
         target.write_many(&self.elements[..num_stack_values as usize]);
     }
+
+    fn get_size_hint(&self) -> usize {
+        let num_stack_values = get_num_stack_values(self);
+        let mut size = num_stack_values.get_size_hint();
+        for element in &self.elements[..num_stack_values as usize] {
+            size += element.get_size_hint();
+        }
+        size
+    }
 }
 
 impl Deserializable for StackInputs {

--- a/core/src/stack/outputs.rs
+++ b/core/src/stack/outputs.rs
@@ -130,6 +130,16 @@ impl Serializable for StackOutputs {
         target.write_u8(num_stack_values);
         target.write_many(&self.elements[..num_stack_values as usize]);
     }
+
+    fn get_size_hint(&self) -> usize {
+        let num_stack_values = get_num_stack_values(self);
+
+        let mut size = num_stack_values.get_size_hint();
+        for element in &self.elements[..num_stack_values as usize] {
+            size += element.get_size_hint();
+        }
+        size
+    }
 }
 
 impl Deserializable for StackOutputs {

--- a/package/src/dependency/mod.rs
+++ b/package/src/dependency/mod.rs
@@ -17,6 +17,10 @@ impl Serializable for DependencyName {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.0.write_into(target);
     }
+
+    fn get_size_hint(&self) -> usize {
+        self.0.get_size_hint()
+    }
 }
 
 impl Deserializable for DependencyName {
@@ -41,8 +45,16 @@ pub struct Dependency {
 
 impl Serializable for Dependency {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.name.0.write_into(target);
-        self.digest.write_into(target);
+        let Self { name, digest } = self;
+
+        name.write_into(target);
+        digest.write_into(target);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { name, digest } = self;
+
+        name.get_size_hint() + digest.get_size_hint()
     }
 }
 

--- a/processor/src/host/advice/inputs.rs
+++ b/processor/src/host/advice/inputs.rs
@@ -142,6 +142,12 @@ impl Serializable for AdviceInputs {
         map.write_into(target);
         store.write_into(target);
     }
+
+    fn get_size_hint(&self) -> usize {
+        let Self { stack, map, store } = self;
+
+        stack.get_size_hint() + map.get_size_hint() + store.get_size_hint()
+    }
 }
 
 impl Deserializable for AdviceInputs {


### PR DESCRIPTION
## Describe your changes

This was an old branch that implemented `get_size_hint` for some of our types. Leaving as draft for now until I make sure it makes sense. I saw a discussion around moving to serde, so these changes may not even be necessary.



## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'