### PR TITLE
Unify `QuadFelt`

### DIFF
--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -10,7 +10,7 @@ extern crate std;
 use alloc::vec::Vec;
 
 use vm_core::{
-    ExtensionOf, ONE, ProgramInfo, QuadExtension, StackInputs, StackOutputs, ZERO,
+    ExtensionOf, ONE, ProgramInfo, StackInputs, StackOutputs, ZERO,
     utils::{ByteReader, ByteWriter, Deserializable, Serializable},
 };
 use winter_air::{
@@ -36,8 +36,6 @@ mod options;
 mod proof;
 
 mod utils;
-
-pub type QuadExt = QuadExtension<Felt>;
 
 // RE-EXPORTS
 // ================================================================================================

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -95,6 +95,7 @@ pub use math::{
     fields::{QuadExtension, f64::BaseElement as Felt},
     polynom,
 };
+pub type QuadFelt = QuadExtension<Felt>;
 
 pub mod prettier {
     pub use miden_formatting::{prettier::*, pretty_via_display, pretty_via_to_string};

--- a/miden-vm/tests/integration/operations/ext2_ops.rs
+++ b/miden-vm/tests/integration/operations/ext2_ops.rs
@@ -1,4 +1,5 @@
-use test_utils::{FieldElement, QuadFelt, build_op_test, rand::rand_value};
+use test_utils::{build_op_test, rand::rand_value};
+use vm_core::{FieldElement, QuadFelt};
 
 // EXT2 OPS ASSERTIONS - MANUAL TESTS
 // ================================================================================================

--- a/processor/src/chiplets/ace/mod.rs
+++ b/processor/src/chiplets/ace/mod.rs
@@ -6,10 +6,10 @@ use miden_air::{
     RowIndex,
     trace::{chiplets::ace::ACE_CHIPLET_NUM_COLS, main_trace::MainTrace},
 };
-use vm_core::{FieldElement, ZERO};
+use vm_core::{Felt, FieldElement, QuadFelt, ZERO};
 
 use crate::{
-    ContextId, ExecutionError, Felt, QuadFelt,
+    ContextId, ExecutionError,
     chiplets::memory::Memory,
     errors::{AceError, ErrorContext},
     trace::TraceFragment,

--- a/processor/src/chiplets/ace/tests/circuit.rs
+++ b/processor/src/chiplets/ace/tests/circuit.rs
@@ -1,6 +1,8 @@
-use std::prelude::rust_2015::Vec;
+use alloc::vec::Vec;
 
-use crate::{Felt, QuadFelt, chiplets::ace::instruction::Op};
+use vm_core::{Felt, QuadFelt};
+
+use super::*;
 
 /// A `Circuit` is a DAG representing a multivariate polynomial over its inputs.
 /// The nodes are laid out linearly, starting with the leaves and ending with the evaluation.

--- a/processor/src/chiplets/ace/tests/encoder.rs
+++ b/processor/src/chiplets/ace/tests/encoder.rs
@@ -1,15 +1,10 @@
-use std::prelude::rust_2024::Vec;
+use alloc::vec::Vec;
 
+use vm_core::{Felt, FieldElement, QuadFelt};
 use winter_prover::crypto::ElementHasher;
 
-use crate::{
-    Felt, QuadFelt,
-    chiplets::ace::{
-        instruction::{ID_BITS, MAX_ID, Op},
-        tests::circuit::{Circuit, CircuitLayout, Instruction, NodeID},
-    },
-    math::FieldElement,
-};
+use super::*;
+use crate::chiplets::ace::instruction::{ID_BITS, MAX_ID};
 
 #[derive(Debug)]
 pub enum EncodingError {

--- a/processor/src/chiplets/ace/tests/mod.rs
+++ b/processor/src/chiplets/ace/tests/mod.rs
@@ -10,10 +10,10 @@ use miden_air::{
         V_2_0_IDX, V_2_1_IDX,
     },
 };
-use vm_core::{WORD_SIZE, ZERO};
+use vm_core::{Felt, QuadFelt, WORD_SIZE, Word, ZERO};
 
 use crate::{
-    ContextId, Felt, QuadFelt, Word,
+    ContextId,
     chiplets::{
         ace::{
             eval_circuit,

--- a/processor/src/chiplets/ace/trace.rs
+++ b/processor/src/chiplets/ace/trace.rs
@@ -9,10 +9,10 @@ use miden_air::{
         V_1_1_IDX, V_2_0_IDX, V_2_1_IDX,
     },
 };
-use vm_core::FieldElement;
+use vm_core::{Felt, FieldElement, QuadFelt, Word};
 
 use crate::{
-    ContextId, ExecutionError, Felt, QuadFelt, Word,
+    ContextId, ExecutionError,
     chiplets::ace::{
         MAX_NUM_ACE_WIRES,
         instruction::{Op, decode_instruction},

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -4,6 +4,7 @@ use core::error::Error;
 use miden_air::RowIndex;
 use miette::Diagnostic;
 use vm_core::{
+    Felt, QuadFelt, Word,
     debuginfo::{SourceFile, SourceManager, SourceSpan},
     mast::{DecoratorId, MastForest, MastNodeExt, MastNodeId},
     stack::MIN_STACK_DEPTH,
@@ -11,10 +12,7 @@ use vm_core::{
 };
 use winter_prover::ProverError;
 
-use super::{
-    Felt, QuadFelt, Word,
-    system::{FMP_MAX, FMP_MIN},
-};
+use super::system::{FMP_MAX, FMP_MIN};
 use crate::{MemoryError, host::advice::AdviceError};
 
 // EXECUTION ERROR

--- a/processor/src/fast/circuit_eval.rs
+++ b/processor/src/fast/circuit_eval.rs
@@ -1,9 +1,9 @@
 use miden_air::RowIndex;
-use vm_core::{Felt, FieldElement};
+use vm_core::{Felt, FieldElement, QuadFelt};
 
 use super::{FastProcessor, memory::Memory};
 use crate::{
-    ContextId, ExecutionError, QuadFelt,
+    ContextId, ExecutionError,
     chiplets::{CircuitEvaluation, MAX_NUM_ACE_WIRES, PTR_OFFSET_ELEM, PTR_OFFSET_WORD},
     errors::{AceError, ErrorContext},
 };

--- a/processor/src/fast/fri_ops.rs
+++ b/processor/src/fast/fri_ops.rs
@@ -1,10 +1,10 @@
 // CONSTANTS
 // ================================================================================================
 
-use vm_core::{ExtensionOf, Felt, FieldElement, ONE, StarkField, ZERO};
+use vm_core::{ExtensionOf, Felt, FieldElement, ONE, QuadFelt, StarkField, ZERO};
 
 use super::FastProcessor;
-use crate::{ExecutionError, QuadFelt};
+use crate::ExecutionError;
 
 const EIGHT: Felt = Felt::new(8);
 const TWO_INV: Felt = Felt::new(9223372034707292161);

--- a/processor/src/fast/horner_ops.rs
+++ b/processor/src/fast/horner_ops.rs
@@ -1,9 +1,9 @@
 use core::array;
 
-use vm_core::Felt;
+use vm_core::{Felt, QuadFelt};
 
 use super::FastProcessor;
-use crate::{ErrorContext, ExecutionError, QuadFelt};
+use crate::{ErrorContext, ExecutionError};
 
 // CONSTANTS
 // ================================================================================================

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -98,8 +98,6 @@ pub mod crypto {
 // TYPE ALIASES
 // ================================================================================================
 
-type QuadFelt = QuadExtension<Felt>;
-
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct MemoryAddress(u32);
 

--- a/processor/src/operations/ext2_ops.rs
+++ b/processor/src/operations/ext2_ops.rs
@@ -29,15 +29,11 @@ impl Process {
 
 #[cfg(test)]
 mod tests {
-    type QuadFelt = QuadExtension<Felt>;
     use test_utils::rand::rand_value;
-    use vm_core::{QuadExtension, mast::MastForest};
+    use vm_core::{Operation, QuadFelt, ZERO, mast::MastForest};
 
-    use super::{
-        super::{Felt, MIN_STACK_DEPTH, Operation},
-        Process,
-    };
-    use crate::{DefaultHost, StackInputs, ZERO};
+    use super::*;
+    use crate::{DefaultHost, StackInputs, operations::MIN_STACK_DEPTH};
 
     // ARITHMETIC OPERATIONS
     // --------------------------------------------------------------------------------------------

--- a/processor/src/operations/fri_ops.rs
+++ b/processor/src/operations/fri_ops.rs
@@ -1,6 +1,6 @@
-use vm_core::{ExtensionOf, FieldElement, ONE, StarkField, ZERO};
+use vm_core::{ExtensionOf, FieldElement, ONE, QuadFelt, StarkField, ZERO};
 
-use super::{super::QuadFelt, ExecutionError, Felt, Operation, Process};
+use super::{ExecutionError, Felt, Operation, Process};
 
 // CONSTANTS
 // ================================================================================================

--- a/processor/src/operations/horner_ops.rs
+++ b/processor/src/operations/horner_ops.rs
@@ -1,6 +1,6 @@
-use vm_core::{Felt, FieldElement, Operation};
+use vm_core::{Felt, FieldElement, Operation, QuadFelt};
 
-use crate::{ExecutionError, Process, QuadFelt, errors::ErrorContext};
+use crate::{ExecutionError, Process, errors::ErrorContext};
 
 // CONSTANTS
 // ================================================================================================
@@ -265,10 +265,10 @@ mod tests {
     use std::vec::Vec;
 
     use test_utils::{build_test, rand::rand_array};
-    use vm_core::{Felt, Operation, StackInputs, ZERO, mast::MastForest};
+    use vm_core::{Felt, Operation, QuadFelt, StackInputs, ZERO, mast::MastForest};
 
     use super::{ACC_HIGH_INDEX, ACC_LOW_INDEX, ALPHA_ADDR_INDEX, *};
-    use crate::{ContextId, DefaultHost, Process, QuadFelt};
+    use crate::{ContextId, DefaultHost, Process};
 
     #[test]
     fn horner_eval_base() {

--- a/processor/src/operations/sys_ops/sys_event_handlers.rs
+++ b/processor/src/operations/sys_ops/sys_event_handlers.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use vm_core::{
-    Felt, FieldElement, WORD_SIZE, Word, ZERO,
+    Felt, FieldElement, QuadFelt, WORD_SIZE, Word, ZERO,
     crypto::{
         hash::Rpo256,
         merkle::{EmptySubtreeRoots, SMT_DEPTH, Smt},
@@ -9,7 +9,7 @@ use vm_core::{
     sys_events::SystemEvent,
 };
 
-use crate::{ExecutionError, MemoryError, ProcessState, QuadFelt, errors::ErrorContext};
+use crate::{ExecutionError, MemoryError, ProcessState, errors::ErrorContext};
 
 /// The offset of the domain value on the stack in the `hdword_to_map_with_domain` system event.
 pub const HDWORD_TO_MAP_WITH_DOMAIN_DOMAIN_OFFSET: usize = 8;

--- a/stdlib/tests/crypto/arithmetic_circuit_eval.rs
+++ b/stdlib/tests/crypto/arithmetic_circuit_eval.rs
@@ -1,5 +1,5 @@
-use test_utils::{QuadFelt, rand::rand_value};
-use vm_core::{Felt, FieldElement, ONE, ZERO};
+use test_utils::rand::rand_value;
+use vm_core::{Felt, FieldElement, ONE, QuadFelt, ZERO};
 
 #[test]
 fn arithmetic_circuit_eval_and_execute() {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -63,11 +63,6 @@ mod test_builders;
 #[cfg(not(target_family = "wasm"))]
 pub use proptest;
 
-// TYPE ALIASES
-// ================================================================================================
-
-pub type QuadFelt = vm_core::QuadExtension<Felt>;
-
 // CONSTANTS
 // ================================================================================================
 


### PR DESCRIPTION
## Describe your changes

Add `QuadFelt` definition to `core` and removes duplicate definitions. Unify name to `QuadFelt` rather than `QuadExt`.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'