### PR TITLE
Introduce `SourceManagerSync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - [BREAKING] Incremented MSRV to 1.88.
 
+#### Changes
+- [BREAKING] Introduce `SourceManagerSync` trait, and remove `Assembler::source_manager()` method [#1966](https://github.com/0xMiden/miden-vm/issues/1966)
+
 ## 0.16.0 (2025-07-08)
 
 #### Enhancements
@@ -60,7 +63,7 @@
 - Moved implementation of `miden_assembly_syntax::diagnostics` into a new `miden-utils-diagnostics` crate ([#1945](https://github.com/0xMiden/miden-vm/pull/1945)).
 - Moved implementation of `miden_core::debuginfo` into a new `miden-debug-types` crate ([#1945](https://github.com/0xMiden/miden-vm/pull/1945)).
 - Moved implementation of `miden_core::sync` into a new `miden-utils-sync` crate ([#1945](https://github.com/0xMiden/miden-vm/pull/1945)).
-+- [BREAKING] Replaced `miden_assembly_syntax::Version` with `semver::Version` ([#1946](https://github.com/0xMiden/pull/1946))
+- [BREAKING] Replaced `miden_assembly_syntax::Version` with `semver::Version` ([#1946](https://github.com/0xMiden/pull/1946))
 
 #### Fixes
 

--- a/assembly-syntax/src/testing/context.rs
+++ b/assembly-syntax/src/testing/context.rs
@@ -22,7 +22,7 @@ use crate::{
 /// Some of the assertion macros defined in this crate require a [SyntaxTestContext], so be aware of
 /// that.
 pub struct SyntaxTestContext {
-    source_manager: Arc<dyn SourceManager + Send + Sync>,
+    source_manager: Arc<dyn SourceManager>,
     warnings_as_errors: bool,
 }
 
@@ -66,7 +66,7 @@ impl SyntaxTestContext {
     }
 
     #[inline(always)]
-    pub fn source_manager(&self) -> Arc<dyn SourceManager + Send + Sync> {
+    pub fn source_manager(&self) -> Arc<dyn SourceManager> {
         self.source_manager.clone()
     }
 

--- a/assembly/src/assembler.rs
+++ b/assembly/src/assembler.rs
@@ -73,7 +73,7 @@ use crate::{
 #[derive(Clone)]
 pub struct Assembler {
     /// The source manager to use for compilation and source location information
-    source_manager: Arc<dyn SourceManager + Send + Sync>,
+    source_manager: Arc<dyn SourceManager>,
     /// The linker instance used internally to link assembler inputs
     linker: Linker,
     /// Whether to treat warning diagnostics as errors
@@ -99,7 +99,7 @@ impl Default for Assembler {
 /// Constructors
 impl Assembler {
     /// Start building an [Assembler]
-    pub fn new(source_manager: Arc<dyn SourceManager + Send + Sync>) -> Self {
+    pub fn new(source_manager: Arc<dyn SourceManager>) -> Self {
         let linker = Linker::new(source_manager.clone());
         Self {
             source_manager,
@@ -110,10 +110,7 @@ impl Assembler {
     }
 
     /// Start building an [`Assembler`] with a kernel defined by the provided [KernelLibrary].
-    pub fn with_kernel(
-        source_manager: Arc<dyn SourceManager + Send + Sync>,
-        kernel_lib: KernelLibrary,
-    ) -> Self {
+    pub fn with_kernel(source_manager: Arc<dyn SourceManager>, kernel_lib: KernelLibrary) -> Self {
         let (kernel, kernel_module, _) = kernel_lib.into_parts();
         let linker = Linker::with_kernel(source_manager.clone(), kernel, kernel_module);
         Self {
@@ -317,11 +314,6 @@ impl Assembler {
     /// If the assembler was instantiated without a kernel, the internal kernel will be empty.
     pub fn kernel(&self) -> &Kernel {
         self.linker.kernel()
-    }
-
-    /// Returns a link to the source manager used by this assembler.
-    pub fn source_manager(&self) -> Arc<dyn SourceManager + Send + Sync> {
-        self.source_manager.clone()
     }
 
     #[cfg(any(test, feature = "testing"))]

--- a/assembly/src/testing.rs
+++ b/assembly/src/testing.rs
@@ -27,7 +27,7 @@ use crate::diagnostics::reporting::set_panic_hook;
 ///
 /// Some of the assertion macros defined above require a [TestContext], so be aware of that.
 pub struct TestContext {
-    source_manager: Arc<dyn SourceManager + Send + Sync>,
+    source_manager: Arc<dyn SourceManager>,
     assembler: Assembler,
 }
 
@@ -71,7 +71,7 @@ impl TestContext {
     }
 
     #[inline(always)]
-    pub fn source_manager(&self) -> Arc<dyn SourceManager + Send + Sync> {
+    pub fn source_manager(&self) -> Arc<dyn SourceManager> {
         self.source_manager.clone()
     }
 

--- a/crates/debug/types/src/lib.rs
+++ b/crates/debug/types/src/lib.rs
@@ -28,7 +28,7 @@ pub use self::{
         ByteIndex, ByteOffset, ColumnIndex, ColumnNumber, LineIndex, LineNumber, SourceContent,
         SourceContentUpdateError, SourceFile, SourceFileRef, SourceLanguage,
     },
-    source_manager::{DefaultSourceManager, SourceId, SourceManager},
+    source_manager::{DefaultSourceManager, SourceId, SourceManager, SourceManagerSync},
     span::{SourceSpan, Span, Spanned},
 };
 

--- a/crates/debug/types/src/source_manager.rs
+++ b/crates/debug/types/src/source_manager.rs
@@ -254,6 +254,16 @@ pub trait SourceManagerExt: SourceManager {
 #[cfg(feature = "std")]
 impl<T: ?Sized + SourceManager> SourceManagerExt for T {}
 
+/// [SourceManagerSync] is a marker trait for [SourceManager] implementations that are also Send +
+/// Sync, and is automatically implemented for any [SourceManager] that meets those requirements.
+///
+/// [SourceManager] is a supertrait of [SourceManagerSync], so you may use instances of the
+/// [SourceManagerSync] where the [SourceManager] is required, either implicitly or via explicit
+/// downcasting, e.g. `Arc<dyn SourceManagerSync> as Arc<dyn SourceManager>`.
+pub trait SourceManagerSync: SourceManager + Send + Sync {}
+
+impl<T: ?Sized + SourceManager + Send + Sync> SourceManagerSync for T {}
+
 // DEFAULT SOURCE MANAGER
 // ================================================================================================
 

--- a/crates/utils/testing/src/lib.rs
+++ b/crates/utils/testing/src/lib.rs
@@ -312,7 +312,7 @@ impl Test {
             .fold(assembler, |mut assembler, (path, source)| {
                 let module = source
                     .parse_with_options(
-                        &assembler.source_manager(),
+                        &self.source_manager,
                         ParseOptions::new(ModuleKind::Library, path.clone()).unwrap(),
                     )
                     .expect("invalid masm source code");

--- a/crates/utils/testing/src/lib.rs
+++ b/crates/utils/testing/src/lib.rs
@@ -169,7 +169,7 @@ macro_rules! assert_assembler_diagnostic {
 /// - Execution error test: check that running a program compiled from the given source causes an
 ///   ExecutionError which contains the specified substring.
 pub struct Test {
-    pub source_manager: Arc<dyn SourceManager + Send + Sync>,
+    pub source_manager: Arc<dyn SourceManager>,
     pub source: Arc<SourceFile>,
     pub kernel_source: Option<Arc<SourceFile>>,
     pub stack_inputs: StackInputs,

--- a/miden-vm/benches/program_execution.rs
+++ b/miden-vm/benches/program_execution.rs
@@ -1,4 +1,7 @@
+use std::sync::Arc;
+
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use miden_assembly::DefaultSourceManager;
 use miden_processor::{AdviceInputs, ExecutionOptions, execute};
 use miden_stdlib::StdLibrary;
 use miden_vm::{Assembler, DefaultHost, StackInputs, internal::InputFile};
@@ -47,7 +50,7 @@ fn program_execution(c: &mut Criterion) {
                     assembler
                         .link_dynamic_library(StdLibrary::default())
                         .expect("failed to load stdlib");
-                    let source_manager = assembler.source_manager();
+                    let source_manager = Arc::new(DefaultSourceManager::default());
 
                     let program = assembler
                         .assemble_program(&source)

--- a/miden-vm/src/cli/data.rs
+++ b/miden-vm/src/cli/data.rs
@@ -6,12 +6,13 @@ use std::{
 };
 
 use miden_assembly::{
-    Assembler, Library, LibraryNamespace, SourceManager,
+    Assembler, Library, LibraryNamespace,
     ast::{Module, ModuleKind},
     diagnostics::{Report, WrapErr},
     report,
     utils::Deserializable,
 };
+use miden_debug_types::SourceManagerSync;
 use miden_stdlib::StdLibrary;
 use miden_vm::{ExecutionProof, Program, StackOutputs, Word, utils::SliceReader};
 use serde::{Deserialize, Serialize};
@@ -109,7 +110,7 @@ impl OutputFile {
 
 pub struct ProgramFile {
     ast: Box<Module>,
-    source_manager: Arc<dyn SourceManager + Send + Sync>,
+    source_manager: Arc<dyn SourceManagerSync>,
 }
 
 /// Helper methods to interact with masm program file.
@@ -125,7 +126,7 @@ impl ProgramFile {
     #[instrument(name = "read_program_file", skip(source_manager), fields(path = %path.as_ref().display()))]
     pub fn read_with(
         path: impl AsRef<Path>,
-        source_manager: Arc<dyn SourceManager + Send + Sync>,
+        source_manager: Arc<dyn SourceManagerSync>,
     ) -> Result<Self, Report> {
         // parse the program into an AST
         let path = path.as_ref();
@@ -162,7 +163,7 @@ impl ProgramFile {
     }
 
     /// Returns the source manager for this program file.
-    pub fn source_manager(&self) -> &Arc<dyn SourceManager + Send + Sync> {
+    pub fn source_manager(&self) -> &Arc<dyn SourceManagerSync> {
         &self.source_manager
     }
 }

--- a/miden-vm/src/repl/mod.rs
+++ b/miden-vm/src/repl/mod.rs
@@ -1,6 +1,6 @@
-use std::{collections::BTreeSet, path::PathBuf};
+use std::{collections::BTreeSet, path::PathBuf, sync::Arc};
 
-use miden_assembly::{Assembler, Library};
+use miden_assembly::{Assembler, DefaultSourceManager, Library};
 use miden_processor::{AdviceInputs, ContextId, MemoryAddress};
 use miden_stdlib::StdLibrary;
 use miden_vm::{DefaultHost, StackInputs, math::Felt};
@@ -311,7 +311,7 @@ fn execute(
         assembler.link_dynamic_library(library).map_err(|err| format!("{err}"))?;
     }
 
-    let source_manager = assembler.source_manager();
+    let source_manager = Arc::new(DefaultSourceManager::default());
     let program = assembler.assemble_program(program).map_err(|err| format!("{err}"))?;
 
     let stack_inputs = StackInputs::default();


### PR DESCRIPTION
Closes #1966 

This is a stacked PR on top of #1945 to avoid breaking changes when we merge that one.

Note that contrary to what was discussed in https://github.com/0xMiden/miden-vm/pull/1884#discussion_r2188948366, `ErrorContextImpl` uses `Arc<dyn SourceManager>` (instead of `SourceManagerSync`), and hence is not `Send` or `Sync` (and hence cannot be sent across threads, or be included in the returned `Future` of our `AsyncHost` methods). This is because it is actually not *needed* at this moment, so I prefer to only include the bounds if we find that we do indeed need to send error contexts across threads (which we currently don't).