### PR TITLE
Distinguish Noop required for padding when serializing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Changes
 - [BREAKING] Introduce `SourceManagerSync` trait, and remove `Assembler::source_manager()` method [#1966](https://github.com/0xMiden/miden-vm/issues/1966)
 - [BREAKING] Implement preliminary changes for lazy loading of external `MastForest` `AdviceMap`s ([#1949](https://github.com/0xMiden/miden-vm/issues/1949)).
+- [BREAKING] Change serialization of MastForest to account for padding `Noop` operations [#1974](https://github.com/0xMiden/miden-vm/pull/1974)
 
 ## 0.16.0 (2025-07-08)
 

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -422,6 +422,13 @@ fn batch_ops(ops: Vec<Operation>) -> Vec<OpBatch> {
         batches.push(batch);
     }
 
+    // If the block is empty, we insert a single batch with a Noop
+    if batches.is_empty() {
+        batch_acc = OpBatchAccumulator::new();
+        batch_acc.add_op(Operation::Noop);
+        batches.push(batch_acc.into_batch());
+    }
+
     batches
 }
 

--- a/core/src/mast/node/basic_block_node/op_batch.rs
+++ b/core/src/mast/node/basic_block_node/op_batch.rs
@@ -27,6 +27,20 @@ impl OpBatch {
         &self.ops
     }
 
+    pub fn ops_by_group(&self) -> [Vec<&Operation>; BATCH_SIZE] {
+        let mut res = Vec::new();
+        let mut pos = 0;
+        for group_size in self.op_counts {
+            let mut group_ops = Vec::new();
+            for _ in 0..group_size {
+                group_ops.push(&self.ops[pos]);
+                pos += 1;
+            }
+            res.push(group_ops)
+        }
+        res.try_into().unwrap()
+    }
+
     /// Returns a list of operation groups contained in this batch.
     ///
     /// Each group is represented by a single field element.

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -4,7 +4,7 @@ use core::fmt;
 
 pub use basic_block_node::{
     BATCH_SIZE as OP_BATCH_SIZE, BasicBlockNode, GROUP_SIZE as OP_GROUP_SIZE, OpBatch,
-    OperationOrDecorator,
+    OperationOrDecorator, read_batches_from, write_batches_into,
 };
 
 mod call_node;


### PR DESCRIPTION
In principle a basic block can be serialized as a sequence of operations. However, when we meet a Noop during deserialization, it is unclear if it was inserted by the user or by the padding rules in [batch_ops]. 
If it was introduced by the user it should be preserved and treated like any other operation, for example it should be grouped together with other operations in a group. 
If it was introduced by padding then it should create its own group or be the trailing operation of a group.

In order to distinguish these two cases, during serialization each Noop is followed by an extra boolean flag. During deserialization, if a Noop is coming from padding, it is not inserted in the sequence of operations and it will be automatically inserted again by the padding rules. If the Noop is not padding, it is included in the sequence like any other operation.

Fixes https://github.com/0xMiden/miden-vm/issues/1965