### PR TITLE
hotfix: make `Process::state()` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.15.1 (2025-07-10)
+
+- Make `Process::state()` public and re-introduce `From<&Process> for ProcessState`.
+
 ## 0.16.0 (2025-07-08)
 
 #### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.15.1 (2025-07-10)
+## 0.16.1 (2025-07-10)
 
 - Make `Process::state()` public and re-introduce `From<&Process> for ProcessState`.
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -748,7 +748,7 @@ pub enum ProcessState<'a> {
 
 impl Process {
     #[inline(always)]
-    fn state(&mut self) -> ProcessState<'_> {
+    pub fn state(&mut self) -> ProcessState<'_> {
         ProcessState::Slow(SlowProcessState {
             advice: &mut self.advice,
             system: &self.system,

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -881,6 +881,12 @@ impl<'a> ProcessState<'a> {
     }
 }
 
+impl<'a> From<&'a mut Process> for ProcessState<'a> {
+    fn from(process: &'a mut Process) -> Self {
+        process.state()
+    }
+}
+
 // HELPERS
 // ================================================================================================
 


### PR DESCRIPTION
## Describe your changes

Makes `Process::state()` public after removing `From<&Process> for ProcessState`

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'