### PR TITLE
fix(processor): fix `debug.stack` being `debug.adv_stack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - [BREAKING] Implement preliminary changes for lazy loading of external `MastForest` `AdviceMap`s ([#1949](https://github.com/0xMiden/miden-vm/issues/1949)).
 - [BREAKING] Introduce `SourceManagerSync` trait, and remove `Assembler::source_manager()` method [#1966](https://github.com/0xMiden/miden-vm/issues/1966).
 
+#### Fixes
+
+- Fix `debug.stack`, which was incorrectly printing the advice stack instead of the operand stack ([#1984](https://github.com/0xMiden/miden-vm/issues/1984)).
+
 ## 0.16.1 (2025-07-10)
 
 - Make `Process::state()` public and re-introduce `From<&Process> for ProcessState`.

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -38,7 +38,7 @@ pub fn print_debug_info(process: &ProcessState, options: &DebugOptions) {
 /// Prints the number of stack items specified by `n` if it is provided, otherwise prints
 /// the whole stack.
 fn print_vm_stack(process: &ProcessState, n: Option<u8>) {
-    let stack = process.advice_provider().stack();
+    let stack = process.get_stack_state();
 
     // if n is empty, print the entire stack
     let num_items = if let Some(n) = n {


### PR DESCRIPTION
## Describe your changes

Commit d4e82bcaf11e3e27d7caffa8e870530b3d3ccc06, part of PR #1957, incorrectly contained the following patch:

```diff
-fn print_vm_stack(process: &ProcessState, n: Option<usize>) {
-    let stack = process.get_stack_state();
+fn print_vm_stack(process: &ProcessState, n: Option<u8>) {
+    let stack = process.advice_provider().stack();
```

This made `debug.stack` equivalent to `debug.adv_stack`.

This commit fixes this bug.

Fixes #1984.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'