### PR TITLE
fix: remove unnecessary clone in SubtreeIterator usage

### DIFF
--- a/assembly/src/mast_forest_builder.rs
+++ b/assembly/src/mast_forest_builder.rs
@@ -502,7 +502,7 @@ impl MastForestBuilder {
     /// * If dynamically-linked, then an external node is inserted, and its MastNodeId is returned
     pub fn ensure_external_link(&mut self, mast_root: Word) -> Result<MastNodeId, Report> {
         if let Some(root_id) = self.statically_linked_mast.find_procedure_root(mast_root) {
-            for old_id in SubtreeIterator::new(&root_id, &self.statically_linked_mast.clone()) {
+            for old_id in SubtreeIterator::new(&root_id, &self.statically_linked_mast) {
                 let node = self.statically_linked_mast[old_id]
                     .remap_children(&self.statically_linked_mast_remapping);
                 let new_id = self.ensure_node(node)?;


### PR DESCRIPTION
## Describe your changes
Removed redundant .clone() call when passing self.statically_linked_mast to SubtreeIterator::new. The iterator accepts a reference (&MastForest) and doesn't require ownership, while self.statically_linked_mast is already an Arc<MastForest>. This improves performance by eliminating an unnecessary cloning operation.
