### PR TITLE
Convert `FastProcessor` to iterative execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed `ExecutionOptions::default()` to set `max_cycles` correctly to `1 << 29` ([#1969](https://github.com/0xMiden/miden-vm/pull/1969)).
 - [BREAKING] Revert `get_mapped_value` return signature [(#1981)](https://github.com/0xMiden/miden-vm/issues/1981).
 - [BREAKING] Implement custom Event handlers ([#1584](https://github.com/0xMiden/miden-vm/pull/1584)).
+- Convert `FastProcessor::execute()` from recursive to iterative execution ([#1989](https://github.com/0xMiden/miden-vm/issues/1989))
 
 ## 0.16.2 (2025-07-11)
 

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -143,6 +143,85 @@ impl MastNode {
         }
     }
 
+    /// Unwraps the inner basic block node if the [`MastNode`] wraps a [`BasicBlockNode`]; panics
+    /// otherwise.
+    ///
+    /// # Panics
+    /// Panics if the [`MastNode`] does not wrap a [`BasicBlockNode`].
+    pub fn unwrap_basic_block(&self) -> &BasicBlockNode {
+        match self {
+            Self::Block(basic_block_node) => basic_block_node,
+            other => unwrap_failed(other, "basic block"),
+        }
+    }
+
+    /// Unwraps the inner join node if the [`MastNode`] wraps a [`JoinNode`]; panics otherwise.
+    ///
+    /// # Panics
+    /// - if the [`MastNode`] does not wrap a [`JoinNode`].
+    pub fn unwrap_join(&self) -> &JoinNode {
+        match self {
+            Self::Join(join_node) => join_node,
+            other => unwrap_failed(other, "join"),
+        }
+    }
+
+    /// Unwraps the inner split node if the [`MastNode`] wraps a [`SplitNode`]; panics otherwise.
+    ///
+    /// # Panics
+    /// - if the [`MastNode`] does not wrap a [`SplitNode`].
+    pub fn unwrap_split(&self) -> &SplitNode {
+        match self {
+            Self::Split(split_node) => split_node,
+            other => unwrap_failed(other, "split"),
+        }
+    }
+
+    /// Unwraps the inner loop node if the [`MastNode`] wraps a [`LoopNode`]; panics otherwise.
+    ///
+    /// # Panics
+    /// - if the [`MastNode`] does not wrap a [`LoopNode`].
+    pub fn unwrap_loop(&self) -> &LoopNode {
+        match self {
+            Self::Loop(loop_node) => loop_node,
+            other => unwrap_failed(other, "loop"),
+        }
+    }
+
+    /// Unwraps the inner call node if the [`MastNode`] wraps a [`CallNode`]; panics otherwise.
+    ///
+    /// # Panics
+    /// - if the [`MastNode`] does not wrap a [`CallNode`].
+    pub fn unwrap_call(&self) -> &CallNode {
+        match self {
+            Self::Call(call_node) => call_node,
+            other => unwrap_failed(other, "call"),
+        }
+    }
+
+    /// Unwraps the inner dynamic node if the [`MastNode`] wraps a [`DynNode`]; panics otherwise.
+    ///
+    /// # Panics
+    /// - if the [`MastNode`] does not wrap a [`DynNode`].
+    pub fn unwrap_dyn(&self) -> &DynNode {
+        match self {
+            Self::Dyn(dyn_node) => dyn_node,
+            other => unwrap_failed(other, "dyn"),
+        }
+    }
+
+    /// Unwraps the inner external node if the [`MastNode`] wraps a [`ExternalNode`]; panics
+    /// otherwise.
+    ///
+    /// # Panics
+    /// - if the [`MastNode`] does not wrap a [`ExternalNode`].
+    pub fn unwrap_external(&self) -> &ExternalNode {
+        match self {
+            Self::External(external_node) => external_node,
+            other => unwrap_failed(other, "external"),
+        }
+    }
+
     /// Remap the node children to their new positions indicated by the given [`Remapping`].
     pub fn remap_children(&self, remapping: &Remapping) -> Self {
         use MastNode::*;
@@ -397,4 +476,25 @@ pub trait MastNodeExt: Send + Sync {
 
         None
     }
+}
+
+// HELPERS
+// ===============================================================================================
+
+/// This function is analogous to the `unwrap_failed()` function used in the implementation of
+/// `core::result::Result` `unwrap_*()` methods.
+#[cold]
+#[inline(never)]
+#[track_caller]
+fn unwrap_failed(node: &MastNode, expected: &str) -> ! {
+    let actual = match node {
+        MastNode::Block(_) => "basic block",
+        MastNode::Join(_) => "join",
+        MastNode::Split(_) => "split",
+        MastNode::Loop(_) => "loop",
+        MastNode::Call(_) => "call",
+        MastNode::Dyn(_) => "dynamic",
+        MastNode::External(_) => "external",
+    };
+    panic!("tried to unwrap {expected} node, but got {actual}");
 }

--- a/processor/src/continuation_stack.rs
+++ b/processor/src/continuation_stack.rs
@@ -1,0 +1,104 @@
+use alloc::{sync::Arc, vec::Vec};
+
+use miden_core::{
+    Program,
+    mast::{MastForest, MastNodeId},
+};
+
+/// A hint for the initial size of the continuation stack.
+const CONTINUATION_STACK_SIZE_HINT: usize = 64;
+
+/// Represents a unit of work in the continuation stack.
+///
+/// This enum defines the different types of continuations that can be performed on MAST nodes
+/// during program execution.
+#[derive(Debug)]
+pub enum Continuation {
+    /// Start processing a node in the MAST forest.
+    StartNode(MastNodeId),
+    /// Process the finish phase of a Join node.
+    FinishJoin(MastNodeId),
+    /// Process the finish phase of a Split node.
+    FinishSplit(MastNodeId),
+    /// Process the finish phase of a Loop node.
+    FinishLoop(MastNodeId),
+    /// Process the finish phase of a Call node.
+    FinishCall(MastNodeId),
+    /// Process the finish phase of a Dyn node.
+    FinishDyn(MastNodeId),
+    /// Enter a new MAST forest, where all subsequent `MastNodeId`s will be relative to this forest.
+    ///
+    /// When we encounter an `ExternalNode`, we enter the corresponding MAST forest directly, and
+    /// push an `EnterForest` continuation to restore the previous forest when done.
+    EnterForest(Arc<MastForest>),
+}
+
+/// [ContinuationStack] reifies the call stack used by the processor when executing a program made
+/// up of possibly multiple MAST forests.
+///
+/// This allows the processor to execute a program iteratively in a loop rather than recursively
+/// traversing the nodes. It also allows the processor to pass the state of execution to another
+/// processor for further processing, which is useful for parallel execution of MAST forests.
+pub struct ContinuationStack {
+    stack: Vec<Continuation>,
+}
+
+impl ContinuationStack {
+    /// Creates a new continuation stack for a program.
+    ///
+    /// # Arguments
+    /// * `program` - The program whose execution will be managed by this continuation stack
+    pub fn new(program: &Program) -> Self {
+        let mut stack = Vec::with_capacity(CONTINUATION_STACK_SIZE_HINT);
+        stack.push(Continuation::StartNode(program.entrypoint()));
+
+        Self { stack }
+    }
+
+    /// Pushes a continuation to enter the given MAST forest on the continuation stack.
+    ///
+    /// # Arguments
+    /// * `forest` - The MAST forest to enter
+    pub fn push_enter_forest(&mut self, forest: Arc<MastForest>) {
+        self.stack.push(Continuation::EnterForest(forest));
+    }
+
+    /// Pushes a join finish continuation onto the stack.
+    pub fn push_finish_join(&mut self, node_id: MastNodeId) {
+        self.stack.push(Continuation::FinishJoin(node_id));
+    }
+
+    /// Pushes a split finish continuation onto the stack.
+    pub fn push_finish_split(&mut self, node_id: MastNodeId) {
+        self.stack.push(Continuation::FinishSplit(node_id));
+    }
+
+    /// Pushes a loop finish continuation onto the stack.
+    pub fn push_finish_loop(&mut self, node_id: MastNodeId) {
+        self.stack.push(Continuation::FinishLoop(node_id));
+    }
+
+    /// Pushes a call finish continuation onto the stack.
+    pub fn push_finish_call(&mut self, node_id: MastNodeId) {
+        self.stack.push(Continuation::FinishCall(node_id));
+    }
+
+    /// Pushes a dyn finish continuation onto the stack.
+    pub fn push_finish_dyn(&mut self, node_id: MastNodeId) {
+        self.stack.push(Continuation::FinishDyn(node_id));
+    }
+
+    /// Pushes a continuation to start processing the given node.
+    ///
+    /// # Arguments
+    /// * `node_id` - The ID of the node to process
+    pub fn push_start_node(&mut self, node_id: MastNodeId) {
+        self.stack.push(Continuation::StartNode(node_id));
+    }
+
+    /// Pops the next continuation from the continuation stack, and returns it along with its
+    /// associated MAST forest.
+    pub fn pop_continuation(&mut self) -> Option<Continuation> {
+        self.stack.pop()
+    }
+}

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -33,6 +33,8 @@ use miden_core::{
 use miden_debug_types::{DefaultSourceManager, SourceManager, SourceSpan};
 pub use winter_prover::matrix::ColMatrix;
 
+pub(crate) mod continuation_stack;
+
 pub mod fast;
 use fast::FastProcessState;
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -529,6 +529,15 @@ impl Process {
                     .find_procedure_root(callee_hash)
                     .ok_or(ExecutionError::malfored_mast_forest_in_host(callee_hash, &()))?;
 
+                // Merge the advice map of this forest into the advice provider.
+                // Note that the map may be merged multiple times if a different procedure from the
+                // same forest is called.
+                // For now, only compiled libraries contain non-empty advice maps, so for most
+                // cases, this call will be cheap.
+                self.advice
+                    .extend_map(mast_forest.advice_map())
+                    .map_err(|err| ExecutionError::advice_error(err, self.system.clk(), &()))?;
+
                 self.execute_mast_node(root_id, &mast_forest, host)?
             },
         }


### PR DESCRIPTION
Closes #1989

Note: `ContinuationStack` is meant to replace/be merged with the `ExecutionTraversal` in #1839.

Unfortunately, we get the same performance on the `blake3_1to1` benchmark with this change (where we were hoping for an improvement). I didn't try to optimize too much yet, as I'd focus on fully merging #1839 first.