### PR TITLE
feat(bench-ci): ci job for bench with required feature flags

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,21 @@
+# Runs bench related jobs.
+
+name: bench
+
+on:
+  push:
+    branches: [main, next]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  bench:
+    name: Bench on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bench for all features
+        run: |
+          rustup update --no-self-update
+          make check-bench
+          make bench

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [BREAKING] Introduce `SourceManagerSync` trait, and remove `Assembler::source_manager()` method [#1966](https://github.com/0xMiden/miden-vm/issues/1966).
 - Fixed `ExecutionOptions::default()` to set `max_cycles` correctly to `1 << 29` ([#1969](https://github.com/0xMiden/miden-vm/pull/1969)).
 - [BREAKING] Revert `get_mapped_value` return signature [(#1981)](https://github.com/0xMiden/miden-vm/issues/1981).
+- Enhancement for all benchmarks (incl. `program_execution_fast`) are built and run in a new CI job with required feature flags [(#https://github.com/0xMiden/miden-vm/issues/1964)](https://github.com/0xMiden/miden-vm/issues/1964)
 
 ## 0.16.2 (2025-07-11)
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ FEATURES_CONCURRENT_EXEC=--features concurrent,executable
 FEATURES_LOG_TREE=--features concurrent,executable,tracing-forest
 FEATURES_METAL_EXEC=--features concurrent,executable,metal,tracing-forest
 ALL_FEATURES_BUT_ASYNC=--features concurrent,executable,metal,testing,with-debug-info,internal
+ALL_FEATURES_FOR_BENCH=--features concurrent,executable,metal,testing,with-debug-info,internal,no_err_ctx
 
 # -- linting --------------------------------------------------------------------------------------
 
@@ -83,7 +84,7 @@ test-package: ## Tests specific package: make test-package package=miden-vm
 
 .PHONY: check
 check: ## Checks all targets and features for errors without code generation
-	cargo check --all-targets ${ALL_FEATURES_BUT_ASYNC}
+	cargo check --all-targets ${ALL_FEATURES_FOR_BENCH}
 
 # --- building ------------------------------------------------------------------------------------
 
@@ -123,6 +124,10 @@ exec-info: ## Builds an executable with log tree enabled
 
 # --- benchmarking --------------------------------------------------------------------------------
 
+.PHONY: check-bench
+check-bench: ## Builds all benchmarks (incl. those needing no_err_ctx)
+	cargo check --benches ${ALL_FEATURES_FOR_BENCH}
+
 .PHONY: bench
 bench: ## Runs benchmarks
-	cargo bench --profile optimized --features internal
+	cargo bench --profile optimized ${ALL_FEATURES_FOR_BENCH}


### PR DESCRIPTION
## Describe your changes
Closes #1964 


This PR updates the `Makefile` and CI workflow to ensure all benchmarks — including `program_execution_fast`, which requires the `no_err_ctx` feature — are built and executed in CI.
Key changes:

* Added `check-bench` Makefile target to build all benchmarks with `internal,no_err_ctx`.
* Updated `bench` target to run with full feature set.
* Created `.github/workflows/bench.yml` to run these targets on push/PR.

This ensures that feature-gated benchmarks are tested consistently and won't silently break.
