### PR TITLE
enforce `SourceManager` to be `Send + Sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Implement `copy_digest` and `hash_memory_double_words` procedures in the `std::crypto::hashes::rpo` module ([#1971](https://github.com/0xMiden/miden-vm/pull/1971)).
 - Add `extend_` methods on AdviceProvider [#1982](https://github.com/0xMiden/miden-vm/pull/1982).
+- Extend trait bound requirements to `Send + Sync` for `SourceManager`
 
 #### Changes
 

--- a/crates/utils/testing/src/lib.rs
+++ b/crates/utils/testing/src/lib.rs
@@ -490,7 +490,7 @@ impl Test {
         let stack_inputs: Vec<Felt> = self.stack_inputs.clone().into_iter().rev().collect();
         let advice_inputs: AdviceInputs = self.advice_inputs.clone();
         let fast_process = FastProcessor::new_with_advice_inputs(&stack_inputs, advice_inputs)
-            .with_source_manager(self.source_manager.clone());
+            .with_source_manager(Arc::clone(&self.source_manager));
         let fast_result = fast_process.execute_sync(&program, &mut host);
 
         match slow_result {

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -220,7 +220,7 @@ impl FastProcessor {
     }
 
     /// Set the internal source manager to an externally initialized one.
-    pub fn with_source_manager(mut self, source_manager: Arc<dyn SourceManager>) -> Self {
+    pub fn with_source_manager(mut self, source_manager: Arc<dyn SourceManager + 'static>) -> Self {
         self.source_manager = source_manager;
         self
     }


### PR DESCRIPTION
## Describe your changes

Extend the required trait bounds of `SourceManager` to `SourceManager + Send + Sync`.

Required for https://github.com/0xMiden/miden-base/pull/1580

I am not sure how _sane_ the changeset is, re other consumers of `miden-vm`-crates.


## Checklist before requesting a review

- Updated `CHANGELOG.md'