### PR TITLE
refactor: `on_event` should not require `&mut ProcessState` and error context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Implement `copy_digest` and `hash_memory_double_words` procedures in the `std::crypto::hashes::rpo` module ([#1971](https://github.com/0xMiden/miden-vm/pull/1971)).
 - Add `extend_` methods on AdviceProvider [#1982](https://github.com/0xMiden/miden-vm/pull/1982).
+- [BREAKING] Change API on `on_event` and introduce the `AdviceMutation` ([#2003](https://github.com/0xMiden/miden-vm/pull/2003)).
 
 #### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Implement `copy_digest` and `hash_memory_double_words` procedures in the `std::crypto::hashes::rpo` module ([#1971](https://github.com/0xMiden/miden-vm/pull/1971)).
 - Add `extend_` methods on AdviceProvider [#1982](https://github.com/0xMiden/miden-vm/pull/1982).
-- [BREAKING] Change API on `on_event` and introduce the `AdviceMutation` ([#2003](https://github.com/0xMiden/miden-vm/pull/2003)).
+- [BREAKING] `{AsyncHost,SyncHost}::on_event` now returns a list of `AdviceProvider` mutations ([#2003](https://github.com/0xMiden/miden-vm/pull/2003)).
 
 #### Changes
 

--- a/crates/utils/testing/src/lib.rs
+++ b/crates/utils/testing/src/lib.rs
@@ -31,7 +31,7 @@ pub use miden_processor::{
     AdviceInputs, AdviceProvider, ContextId, ExecutionError, ExecutionOptions, ExecutionTrace,
     Process, ProcessState, VmStateIterator,
 };
-use miden_processor::{DefaultHost, EventError, Program, fast::FastProcessor};
+use miden_processor::{AdviceMutation, DefaultHost, EventError, Program, fast::FastProcessor};
 use miden_prover::utils::range;
 pub use miden_prover::{MerkleTreeVC, ProvingOptions, prove};
 pub use miden_verifier::{AcceptableOptions, VerifierError, verify};
@@ -156,7 +156,7 @@ macro_rules! assert_assembler_diagnostic {
 }
 
 /// Alias for a free function or closure handling an `Event`.
-type HandlerFunc = fn(&mut ProcessState) -> Result<(), EventError>;
+type HandlerFunc = fn(&ProcessState) -> Result<Vec<AdviceMutation>, EventError>;
 
 /// This is a container for the data required to run tests, which allows for running several
 /// different types of tests.
@@ -466,10 +466,10 @@ impl Test {
         let (program, kernel) = self.compile().expect("Failed to compile test source.");
         let mut host = TestHost::default();
         if let Some(kernel) = kernel {
-            host.load_library(kernel.mast_forest()).unwrap();
+            host.load_library(kernel.mast_forest().clone()).unwrap();
         }
         for library in &self.libraries {
-            host.load_library(library.mast_forest()).unwrap();
+            host.load_library(library.mast_forest().clone()).unwrap();
         }
         for (id, handler_func) in &self.handlers {
             host.load_handler(*id, *handler_func).unwrap();

--- a/miden-vm/tests/integration/operations/decorators/mod.rs
+++ b/miden-vm/tests/integration/operations/decorators/mod.rs
@@ -23,14 +23,18 @@ pub struct TestHost {
 impl BaseHost for TestHost {
     fn on_debug(
         &mut self,
-        _process: &ProcessState,
+        _process: &mut ProcessState,
         options: &DebugOptions,
     ) -> Result<(), ExecutionError> {
         self.debug_handler.push(options.to_string());
         Ok(())
     }
 
-    fn on_trace(&mut self, _process: &ProcessState, trace_id: u32) -> Result<(), ExecutionError> {
+    fn on_trace(
+        &mut self,
+        _process: &mut ProcessState,
+        trace_id: u32,
+    ) -> Result<(), ExecutionError> {
         self.trace_handler.push(trace_id);
         Ok(())
     }

--- a/miden-vm/tests/integration/operations/decorators/mod.rs
+++ b/miden-vm/tests/integration/operations/decorators/mod.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use miden_core::DebugOptions;
 use miden_processor::{
-    AsyncHost, BaseHost, EventError, ExecutionError, MastForest, ProcessState, SyncHost,
+    AdviceMutation, AsyncHost, BaseHost, EventError, ExecutionError, MastForest, ProcessState,
+    SyncHost,
 };
 use miden_prover::Word;
 
@@ -22,18 +23,14 @@ pub struct TestHost {
 impl BaseHost for TestHost {
     fn on_debug(
         &mut self,
-        _process: &mut ProcessState,
+        _process: &ProcessState,
         options: &DebugOptions,
     ) -> Result<(), ExecutionError> {
         self.debug_handler.push(options.to_string());
         Ok(())
     }
 
-    fn on_trace(
-        &mut self,
-        _process: &mut ProcessState,
-        trace_id: u32,
-    ) -> Result<(), ExecutionError> {
+    fn on_trace(&mut self, _process: &ProcessState, trace_id: u32) -> Result<(), ExecutionError> {
         self.trace_handler.push(trace_id);
         Ok(())
     }
@@ -45,9 +42,13 @@ impl SyncHost for TestHost {
         None
     }
 
-    fn on_event(&mut self, _process: &mut ProcessState, event_id: u32) -> Result<(), EventError> {
+    fn on_event(
+        &mut self,
+        _process: &ProcessState,
+        event_id: u32,
+    ) -> Result<Vec<AdviceMutation>, EventError> {
         self.event_handler.push(event_id);
-        Ok(())
+        Ok(Vec::new())
     }
 }
 
@@ -59,10 +60,10 @@ impl AsyncHost for TestHost {
 
     fn on_event(
         &mut self,
-        _process: &mut ProcessState<'_>,
+        _process: &ProcessState<'_>,
         event_id: u32,
-    ) -> impl Future<Output = Result<(), EventError>> + Send {
+    ) -> impl Future<Output = Result<Vec<AdviceMutation>, EventError>> + Send {
         self.event_handler.push(event_id);
-        async move { Ok(()) }
+        async move { Ok(Vec::new()) }
     }
 }

--- a/miden-vm/tests/integration/operations/sys_ops.rs
+++ b/miden-vm/tests/integration/operations/sys_ops.rs
@@ -83,6 +83,6 @@ fn assert_eq_fail() {
 #[test]
 fn emit() {
     let mut test = build_op_test!("emit.42", &[0, 0, 0, 0]);
-    test.add_event_handler(42, |_| Ok(()));
+    test.add_event_handler(42, |_| Ok(Vec::new()));
     test.prove_and_verify(vec![], false);
 }

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -1510,7 +1510,7 @@ fn set_user_op_helpers_many() {
 fn build_trace(stack_inputs: &[u64], program: &Program) -> (DecoderTrace, usize) {
     let stack_inputs = StackInputs::try_from_ints(stack_inputs.iter().copied()).unwrap();
     let mut host = DefaultHost::default();
-    host.load_handler(EMIT_EVENT_ID, |_: &mut ProcessState| Ok(())).unwrap();
+    host.load_handler(EMIT_EVENT_ID, |_: &ProcessState| Ok(Vec::new())).unwrap();
     let mut process = Process::new(
         Kernel::default(),
         stack_inputs,

--- a/processor/src/fast/sys_ops.rs
+++ b/processor/src/fast/sys_ops.rs
@@ -90,14 +90,14 @@ impl FastProcessor {
         host: &mut impl AsyncHost,
         err_ctx: &impl ErrorContext,
     ) -> Result<(), ExecutionError> {
-        let process = &mut self.state(op_idx);
+        let mut process = self.state(op_idx);
         // If it's a system event, handle it directly. Otherwise, forward it to the host.
         if let Some(system_event) = SystemEvent::from_event_id(event_id) {
-            handle_system_event(process, system_event, err_ctx)
+            handle_system_event(&mut process, system_event, err_ctx)
         } else {
             let clk = process.clk();
             let mutations = host
-                .on_event(&*process, event_id)
+                .on_event(&process, event_id)
                 .await
                 .map_err(|err| ExecutionError::event_error(err, event_id, err_ctx))?;
             for mutation in mutations {

--- a/processor/src/fast/sys_ops.rs
+++ b/processor/src/fast/sys_ops.rs
@@ -100,11 +100,9 @@ impl FastProcessor {
                 .on_event(&process, event_id)
                 .await
                 .map_err(|err| ExecutionError::event_error(err, event_id, err_ctx))?;
-            for mutation in mutations {
-                self.advice
-                    .apply_mutation(mutation)
-                    .map_err(|err| ExecutionError::advice_error(err, clk, err_ctx))?;
-            }
+            self.advice
+                .apply_mutations(mutations)
+                .map_err(|err| ExecutionError::advice_error(err, clk, err_ctx))?;
             Ok(())
         }
     }

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -240,8 +240,12 @@ impl ConsistencyHost {
 }
 
 impl BaseHost for ConsistencyHost {
-    fn on_trace(&mut self, process: &ProcessState, trace_id: u32) -> Result<(), ExecutionError> {
-        let snapshot = ProcessStateSnapshot::from(process);
+    fn on_trace(
+        &mut self,
+        process: &mut ProcessState,
+        trace_id: u32,
+    ) -> Result<(), ExecutionError> {
+        let snapshot = ProcessStateSnapshot::from(&*process);
         self.snapshots.entry(trace_id).or_default().push(snapshot);
 
         Ok(())

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -5,8 +5,8 @@ use pretty_assertions::assert_eq;
 
 use super::*;
 use crate::{
-    AsyncHost, BaseHost, EventError, MastForestStore, MemMastForestStore, MemoryAddress,
-    ProcessState, SyncHost,
+    AdviceMutation, AsyncHost, BaseHost, EventError, MastForestStore, MemMastForestStore,
+    MemoryAddress, ProcessState, SyncHost,
 };
 
 #[test]
@@ -204,8 +204,8 @@ struct ProcessStateSnapshot {
     mem_state: Vec<(MemoryAddress, Felt)>,
 }
 
-impl From<&mut ProcessState<'_>> for ProcessStateSnapshot {
-    fn from(state: &mut ProcessState) -> Self {
+impl From<&ProcessState<'_>> for ProcessStateSnapshot {
+    fn from(state: &ProcessState) -> Self {
         ProcessStateSnapshot {
             clk: state.clk(),
             ctx: state.ctx(),
@@ -240,11 +240,7 @@ impl ConsistencyHost {
 }
 
 impl BaseHost for ConsistencyHost {
-    fn on_trace(
-        &mut self,
-        process: &mut ProcessState,
-        trace_id: u32,
-    ) -> Result<(), ExecutionError> {
+    fn on_trace(&mut self, process: &ProcessState, trace_id: u32) -> Result<(), ExecutionError> {
         let snapshot = ProcessStateSnapshot::from(process);
         self.snapshots.entry(trace_id).or_default().push(snapshot);
 
@@ -259,10 +255,10 @@ impl SyncHost for ConsistencyHost {
 
     fn on_event(
         &mut self,
-        _process: &mut ProcessState<'_>,
+        _process: &ProcessState<'_>,
         _event_id: u32,
-    ) -> Result<(), EventError> {
-        Ok(())
+    ) -> Result<Vec<AdviceMutation>, EventError> {
+        Ok(Vec::new())
     }
 }
 
@@ -276,10 +272,10 @@ impl AsyncHost for ConsistencyHost {
     #[allow(clippy::manual_async_fn)]
     fn on_event(
         &mut self,
-        _process: &mut ProcessState<'_>,
+        _process: &ProcessState<'_>,
         _event_id: u32,
-    ) -> impl Future<Output = Result<(), EventError>> + Send {
+    ) -> impl Future<Output = Result<Vec<AdviceMutation>, EventError>> + Send {
         let _ = (_process, _event_id);
-        async move { Ok(()) }
+        async move { Ok(Vec::new()) }
     }
 }

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -14,6 +14,8 @@ pub use inputs::AdviceInputs;
 mod errors;
 pub use errors::AdviceError;
 
+use crate::host::AdviceMutation;
+
 // TYPE ALIASES
 // ================================================================================================
 
@@ -45,6 +47,51 @@ pub struct AdviceProvider {
 }
 
 impl AdviceProvider {
+    pub fn apply_mutation(&mut self, mutation: AdviceMutation) -> Result<(), AdviceError> {
+        match mutation {
+            AdviceMutation::PopStack => {
+                self.pop_stack()?;
+            },
+            AdviceMutation::PopStackWord => {
+                self.pop_stack_word()?;
+            },
+            AdviceMutation::PopStackDword => {
+                self.pop_stack_dword()?;
+            },
+            AdviceMutation::PushStack { value } => {
+                self.push_stack(value);
+            },
+            AdviceMutation::PushStackWord { word } => {
+                self.push_stack_word(&word);
+            },
+            AdviceMutation::PushFromMap { key, include_len } => {
+                self.push_from_map(key, include_len)?;
+            },
+            AdviceMutation::ExtendStack { iter } => {
+                self.extend_stack(iter);
+            },
+            AdviceMutation::InsertIntoMap { key, values } => {
+                self.insert_into_map(key, values)?;
+            },
+            AdviceMutation::ExtendMap { other } => {
+                self.extend_map(&other)?;
+            },
+            AdviceMutation::UpdateMerkleNode { root, depth, index, value } => {
+                self.update_merkle_node(root, &depth, &index, value)?;
+            },
+            AdviceMutation::MergeRoots { lhs, rhs } => {
+                self.merge_roots(lhs, rhs)?;
+            },
+            AdviceMutation::ExtendMerkleStore { iter } => {
+                self.extend_merkle_store(iter);
+            },
+            AdviceMutation::ExtendFromInputs { inputs } => {
+                self.extend_from_inputs(&inputs)?;
+            },
+        }
+        Ok(())
+    }
+
     // ADVICE STACK
     // --------------------------------------------------------------------------------------------
 

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -47,46 +47,24 @@ pub struct AdviceProvider {
 }
 
 impl AdviceProvider {
-    pub fn apply_mutation(&mut self, mutation: AdviceMutation) -> Result<(), AdviceError> {
+    /// Apply the mutations given in order to the `AdviceProvider`.
+    pub fn apply_mutations(
+        &mut self,
+        mutations: impl IntoIterator<Item = AdviceMutation>,
+    ) -> Result<(), AdviceError> {
+        mutations.into_iter().try_for_each(|mutation| self.apply_mutation(mutation))
+    }
+
+    fn apply_mutation(&mut self, mutation: AdviceMutation) -> Result<(), AdviceError> {
         match mutation {
-            AdviceMutation::PopStack => {
-                self.pop_stack()?;
-            },
-            AdviceMutation::PopStackWord => {
-                self.pop_stack_word()?;
-            },
-            AdviceMutation::PopStackDword => {
-                self.pop_stack_dword()?;
-            },
-            AdviceMutation::PushStack { value } => {
-                self.push_stack(value);
-            },
-            AdviceMutation::PushStackWord { word } => {
-                self.push_stack_word(&word);
-            },
-            AdviceMutation::PushFromMap { key, include_len } => {
-                self.push_from_map(key, include_len)?;
-            },
             AdviceMutation::ExtendStack { iter } => {
                 self.extend_stack(iter);
-            },
-            AdviceMutation::InsertIntoMap { key, values } => {
-                self.insert_into_map(key, values)?;
             },
             AdviceMutation::ExtendMap { other } => {
                 self.extend_map(&other)?;
             },
-            AdviceMutation::UpdateMerkleNode { root, depth, index, value } => {
-                self.update_merkle_node(root, &depth, &index, value)?;
-            },
-            AdviceMutation::MergeRoots { lhs, rhs } => {
-                self.merge_roots(lhs, rhs)?;
-            },
             AdviceMutation::ExtendMerkleStore { iter } => {
                 self.extend_merkle_store(iter);
-            },
-            AdviceMutation::ExtendFromInputs { inputs } => {
-                self.extend_from_inputs(&inputs)?;
             },
         }
         Ok(())

--- a/processor/src/host/default.rs
+++ b/processor/src/host/default.rs
@@ -86,13 +86,17 @@ impl<D: DebugHandler> DefaultHost<D> {
 impl BaseHost for DefaultHost {
     fn on_debug(
         &mut self,
-        process: &ProcessState,
+        process: &mut ProcessState,
         options: &DebugOptions,
     ) -> Result<(), ExecutionError> {
         self.debug_handler.on_debug(process, options)
     }
 
-    fn on_trace(&mut self, process: &ProcessState, trace_id: u32) -> Result<(), ExecutionError> {
+    fn on_trace(
+        &mut self,
+        process: &mut ProcessState,
+        trace_id: u32,
+    ) -> Result<(), ExecutionError> {
         self.debug_handler.on_trace(process, trace_id)
     }
 

--- a/processor/src/host/default.rs
+++ b/processor/src/host/default.rs
@@ -3,8 +3,8 @@ use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use miden_core::{DebugOptions, Felt, Word, mast::MastForest};
 
 use crate::{
-    AsyncHost, BaseHost, DebugHandler, EventHandler, EventHandlerRegistry, ExecutionError,
-    MastForestStore, MemMastForestStore, ProcessState, SyncHost, host::EventError,
+    AdviceMutation, AsyncHost, BaseHost, DebugHandler, EventHandler, EventHandlerRegistry,
+    ExecutionError, MastForestStore, MemMastForestStore, ProcessState, SyncHost, host::EventError,
 };
 
 // DEFAULT HOST IMPLEMENTATION
@@ -86,22 +86,18 @@ impl<D: DebugHandler> DefaultHost<D> {
 impl BaseHost for DefaultHost {
     fn on_debug(
         &mut self,
-        process: &mut ProcessState,
+        process: &ProcessState,
         options: &DebugOptions,
     ) -> Result<(), ExecutionError> {
         self.debug_handler.on_debug(process, options)
     }
 
-    fn on_trace(
-        &mut self,
-        process: &mut ProcessState,
-        trace_id: u32,
-    ) -> Result<(), ExecutionError> {
+    fn on_trace(&mut self, process: &ProcessState, trace_id: u32) -> Result<(), ExecutionError> {
         self.debug_handler.on_trace(process, trace_id)
     }
 
     /// Handles the failure of the assertion instruction.
-    fn on_assert_failed(&mut self, _process: &mut ProcessState, _err_code: Felt) {}
+    fn on_assert_failed(&mut self, _process: &ProcessState, _err_code: Felt) {}
 }
 
 impl SyncHost for DefaultHost {
@@ -109,10 +105,14 @@ impl SyncHost for DefaultHost {
         self.store.get(node_digest)
     }
 
-    fn on_event(&mut self, process: &mut ProcessState, event_id: u32) -> Result<(), EventError> {
-        if self.event_handlers.handle_event(event_id, process)? {
+    fn on_event(
+        &mut self,
+        process: &ProcessState,
+        event_id: u32,
+    ) -> Result<Vec<AdviceMutation>, EventError> {
+        if let Some(mutations) = self.event_handlers.handle_event(event_id, process)? {
             // the event was handled by the registered event handlers; just return
-            return Ok(());
+            return Ok(mutations);
         }
 
         // EventError is a `Box` so we can define the error anonymously.
@@ -131,9 +131,9 @@ impl AsyncHost for DefaultHost {
 
     fn on_event(
         &mut self,
-        process: &mut ProcessState<'_>,
+        process: &ProcessState<'_>,
         event_id: u32,
-    ) -> impl Future<Output = Result<(), EventError>> + Send {
+    ) -> impl Future<Output = Result<Vec<AdviceMutation>, EventError>> + Send {
         let result = <Self as SyncHost>::on_event(self, process, event_id);
         async move { result }
     }

--- a/processor/src/host/handlers.rs
+++ b/processor/src/host/handlers.rs
@@ -120,8 +120,10 @@ impl EventHandlerRegistry {
 
     /// Handles the event if the registry contains a handler with the same identifier.
     ///
-    /// Returns a bool indicating whether the event was handled. If the event was handled but
-    /// returned an error, it is propagated to the caller.
+    /// Returns an `Option<_>` indicating whether the event was handled, wrapping resulting
+    /// mutations if any. Returns `None` if the event was not handled, if the event was handled
+    /// successfully `Some(mutations)` is returned, and if the handler returns an error, it is
+    /// propagated to the caller.
     pub fn handle_event(
         &self,
         id: u32,

--- a/processor/src/host/handlers.rs
+++ b/processor/src/host/handlers.rs
@@ -128,8 +128,7 @@ impl EventHandlerRegistry {
         process: &ProcessState,
     ) -> Result<Option<Vec<AdviceMutation>>, EventError> {
         if let Some(handler) = self.handlers.get(&id) {
-            let mutations = handler.on_event(process)?;
-            return Ok(Some(mutations));
+            return handler.on_event(process).map(Some);
         }
 
         Ok(None)

--- a/processor/src/host/handlers.rs
+++ b/processor/src/host/handlers.rs
@@ -7,7 +7,7 @@ use core::{error::Error, fmt, fmt::Debug};
 
 use miden_core::DebugOptions;
 
-use crate::{ExecutionError, ProcessState};
+use crate::{AdviceMutation, ExecutionError, ProcessState};
 
 // EVENT HANDLER TRAIT
 // ================================================================================================
@@ -19,16 +19,19 @@ use crate::{ExecutionError, ProcessState};
 /// be stored in the process's advice provider.
 pub trait EventHandler: Send + Sync + 'static {
     /// Handles the event when triggered.
-    fn on_event(&self, process: &mut ProcessState) -> Result<(), EventError>;
+    fn on_event(&self, process: &ProcessState) -> Result<Vec<AdviceMutation>, EventError>;
 }
 
 /// Default implementation for both free functions and closures with signature
-/// `fn(&mut ProcessState) -> Result<(), HandlerError>`
+/// `fn(&ProcessState) -> Result<(), HandlerError>`
 impl<F> EventHandler for F
 where
-    F: for<'a> Fn(&'a mut ProcessState) -> Result<(), EventError> + Send + Sync + 'static,
+    F: for<'a> Fn(&'a ProcessState) -> Result<Vec<AdviceMutation>, EventError>
+        + Send
+        + Sync
+        + 'static,
 {
-    fn on_event(&self, process: &mut ProcessState) -> Result<(), EventError> {
+    fn on_event(&self, process: &ProcessState) -> Result<Vec<AdviceMutation>, EventError> {
         self(process)
     }
 }
@@ -39,7 +42,7 @@ where
 /// A generic [`Error`] wrapper allowing handlers to return errors to the Host caller.
 ///
 /// Error handlers can define their own [`Error`] type which can be seamlessly converted
-/// into this type since it is a [`Box`].  
+/// into this type since it is a [`Box`].
 ///
 /// # Example
 ///
@@ -79,9 +82,9 @@ pub type EventError = Box<dyn Error + Send + Sync + 'static>;
 ///             // the event was handled by the registered event handlers; just return
 ///             return Ok(());
 ///         }
-///         
+///
 ///         // implement custom event handling
-///         
+///
 ///         Err(EventError::UnhandledEvent { id: event_id })
 ///     }
 /// }
@@ -119,13 +122,17 @@ impl EventHandlerRegistry {
     ///
     /// Returns a bool indicating whether the event was handled. If the event was handled but
     /// returned an error, it is propagated to the caller.
-    pub fn handle_event(&self, id: u32, process: &mut ProcessState) -> Result<bool, EventError> {
+    pub fn handle_event(
+        &self,
+        id: u32,
+        process: &ProcessState,
+    ) -> Result<Option<Vec<AdviceMutation>>, EventError> {
         if let Some(handler) = self.handlers.get(&id) {
-            handler.on_event(process)?;
-            return Ok(true);
+            let mutations = handler.on_event(process)?;
+            return Ok(Some(mutations));
         }
 
-        Ok(false)
+        Ok(None)
     }
 }
 
@@ -144,7 +151,7 @@ pub trait DebugHandler: Sync {
     /// This function is invoked when the `Debug` decorator is executed.
     fn on_debug(
         &mut self,
-        process: &mut ProcessState,
+        process: &ProcessState,
         options: &DebugOptions,
     ) -> Result<(), ExecutionError> {
         let _ = (&process, options);
@@ -154,11 +161,7 @@ pub trait DebugHandler: Sync {
     }
 
     /// This function is invoked when the `Trace` decorator is executed.
-    fn on_trace(
-        &mut self,
-        process: &mut ProcessState,
-        trace_id: u32,
-    ) -> Result<(), ExecutionError> {
+    fn on_trace(&mut self, process: &ProcessState, trace_id: u32) -> Result<(), ExecutionError> {
         let _ = (&process, trace_id);
         #[cfg(feature = "std")]
         std::println!(

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -1,8 +1,11 @@
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
+use core::future::Future;
 
-use miden_core::{DebugOptions, Felt, Word, mast::MastForest};
+use miden_core::{
+    AdviceMap, DebugOptions, Felt, Word, crypto::merkle::InnerNodeInfo, mast::MastForest,
+};
 
-use crate::{EventError, ExecutionError, ProcessState};
+use crate::{AdviceInputs, EventError, ExecutionError, ProcessState};
 
 pub(super) mod advice;
 
@@ -17,6 +20,53 @@ use handlers::DebugHandler;
 
 mod mast_forest_store;
 pub use mast_forest_store::{MastForestStore, MemMastForestStore};
+
+// ADVICE MAP MUTATIONS
+// ================================================================================================
+
+/// Any possible way an event can modify the advice map
+#[derive(Debug, PartialEq, Eq)]
+pub enum AdviceMutation {
+    PopStack,
+    PopStackWord,
+    PopStackDword,
+    PushStack {
+        value: Felt,
+    },
+    PushStackWord {
+        word: Word,
+    },
+    PushFromMap {
+        key: Word,
+        include_len: bool,
+    },
+    ExtendStack {
+        iter: Vec<Felt>,
+    },
+    InsertIntoMap {
+        key: Word,
+        values: Vec<Felt>,
+    },
+    ExtendMap {
+        other: AdviceMap,
+    },
+    UpdateMerkleNode {
+        root: Word,
+        depth: Felt,
+        index: Felt,
+        value: Word,
+    },
+    MergeRoots {
+        lhs: Word,
+        rhs: Word,
+    },
+    ExtendMerkleStore {
+        iter: Vec<InnerNodeInfo>,
+    },
+    ExtendFromInputs {
+        inputs: AdviceInputs,
+    },
+}
 
 // HOST TRAIT
 // ================================================================================================
@@ -35,23 +85,19 @@ pub trait BaseHost {
     /// Handles the debug request from the VM.
     fn on_debug(
         &mut self,
-        process: &mut ProcessState,
+        process: &ProcessState,
         options: &DebugOptions,
     ) -> Result<(), ExecutionError> {
         DefaultDebugHandler.on_debug(process, options)
     }
 
     /// Handles the trace emitted from the VM.
-    fn on_trace(
-        &mut self,
-        process: &mut ProcessState,
-        trace_id: u32,
-    ) -> Result<(), ExecutionError> {
+    fn on_trace(&mut self, process: &ProcessState, trace_id: u32) -> Result<(), ExecutionError> {
         DefaultDebugHandler.on_trace(process, trace_id)
     }
 
     /// Handles the failure of the assertion instruction.
-    fn on_assert_failed(&mut self, _process: &mut ProcessState, _err_code: Felt) {}
+    fn on_assert_failed(&mut self, _process: &ProcessState, _err_code: Felt) {}
 }
 
 /// Defines an interface by which the VM can interact with the host.
@@ -70,17 +116,11 @@ pub trait SyncHost: BaseHost {
     fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>>;
 
     /// Handles the event emitted from the VM.
-    fn on_event(&mut self, process: &mut ProcessState, event_id: u32) -> Result<(), EventError> {
-        let _ = (&process, event_id);
-        #[cfg(feature = "std")]
-        std::println!(
-            "Event with id {} emitted at step {} in context {}",
-            event_id,
-            process.clk(),
-            process.ctx()
-        );
-        Ok(())
-    }
+    fn on_event(
+        &mut self,
+        process: &ProcessState,
+        event_id: u32,
+    ) -> Result<Vec<AdviceMutation>, EventError>;
 }
 
 // ASYNC HOST trait
@@ -101,10 +141,11 @@ pub trait AsyncHost: BaseHost {
         node_digest: &Word,
     ) -> impl Future<Output = Option<Arc<MastForest>>> + Send;
 
-    /// Handles the event emitted from the VM.
+    /// Handles the event emitted from the VM and provides advice mutations to be applied to
+    /// the advice provider.
     fn on_event(
         &mut self,
-        process: &mut ProcessState<'_>,
+        process: &ProcessState<'_>,
         event_id: u32,
-    ) -> impl Future<Output = Result<(), EventError>> + Send;
+    ) -> impl Future<Output = Result<Vec<AdviceMutation>, EventError>> + Send;
 }

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -5,7 +5,7 @@ use miden_core::{
     AdviceMap, DebugOptions, Felt, Word, crypto::merkle::InnerNodeInfo, mast::MastForest,
 };
 
-use crate::{AdviceInputs, EventError, ExecutionError, ProcessState};
+use crate::{EventError, ExecutionError, ProcessState};
 
 pub(super) mod advice;
 
@@ -27,45 +27,9 @@ pub use mast_forest_store::{MastForestStore, MemMastForestStore};
 /// Any possible way an event can modify the advice map
 #[derive(Debug, PartialEq, Eq)]
 pub enum AdviceMutation {
-    PopStack,
-    PopStackWord,
-    PopStackDword,
-    PushStack {
-        value: Felt,
-    },
-    PushStackWord {
-        word: Word,
-    },
-    PushFromMap {
-        key: Word,
-        include_len: bool,
-    },
-    ExtendStack {
-        iter: Vec<Felt>,
-    },
-    InsertIntoMap {
-        key: Word,
-        values: Vec<Felt>,
-    },
-    ExtendMap {
-        other: AdviceMap,
-    },
-    UpdateMerkleNode {
-        root: Word,
-        depth: Felt,
-        index: Felt,
-        value: Word,
-    },
-    MergeRoots {
-        lhs: Word,
-        rhs: Word,
-    },
-    ExtendMerkleStore {
-        iter: Vec<InnerNodeInfo>,
-    },
-    ExtendFromInputs {
-        inputs: AdviceInputs,
-    },
+    ExtendStack { iter: Vec<Felt> },
+    ExtendMap { other: AdviceMap },
+    ExtendMerkleStore { iter: Vec<InnerNodeInfo> },
 }
 
 // HOST TRAIT
@@ -85,14 +49,18 @@ pub trait BaseHost {
     /// Handles the debug request from the VM.
     fn on_debug(
         &mut self,
-        process: &ProcessState,
+        process: &mut ProcessState,
         options: &DebugOptions,
     ) -> Result<(), ExecutionError> {
         DefaultDebugHandler.on_debug(process, options)
     }
 
     /// Handles the trace emitted from the VM.
-    fn on_trace(&mut self, process: &ProcessState, trace_id: u32) -> Result<(), ExecutionError> {
+    fn on_trace(
+        &mut self,
+        process: &mut ProcessState,
+        trace_id: u32,
+    ) -> Result<(), ExecutionError> {
         DefaultDebugHandler.on_trace(process, trace_id)
     }
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -53,7 +53,7 @@ use range::RangeChecker;
 
 mod host;
 pub use host::{
-    AsyncHost, BaseHost, MastForestStore, MemMastForestStore, SyncHost,
+    AdviceMutation, AsyncHost, BaseHost, MastForestStore, MemMastForestStore, SyncHost,
     advice::{AdviceError, AdviceInputs, AdviceProvider},
     default::{DefaultDebugHandler, DefaultHost, HostLibrary},
     handlers::{DebugHandler, EventError, EventHandler, EventHandlerRegistry},

--- a/processor/src/operations/horner_ops.rs
+++ b/processor/src/operations/horner_ops.rs
@@ -262,7 +262,7 @@ impl Process {
 
 #[cfg(test)]
 mod tests {
-    use std::vec::Vec;
+    use alloc::vec::Vec;
 
     use miden_core::{Felt, Operation, QuadFelt, StackInputs, ZERO, mast::MastForest};
     use miden_utils_testing::{build_test, rand::rand_array};

--- a/processor/src/operations/sys_ops/mod.rs
+++ b/processor/src/operations/sys_ops/mod.rs
@@ -146,14 +146,14 @@ impl Process {
         self.stack.copy_state(0);
         self.decoder.set_user_op_helpers(Operation::Emit(event_id), &[event_id.into()]);
 
-        let process = &mut self.state();
+        let process = self.state();
         // If it's a system event, handle it directly. Otherwise, forward it to the host.
         if let Some(system_event) = SystemEvent::from_event_id(event_id) {
-            handle_system_event(process, system_event, err_ctx)
+            handle_system_event(&mut process, system_event, err_ctx)
         } else {
             let clk = process.clk();
             let mutations = host
-                .on_event(&*process, event_id)
+                .on_event(&process, event_id)
                 .map_err(|err| ExecutionError::event_error(err, event_id, err_ctx))?;
             for mutation in mutations {
                 self.advice

--- a/processor/src/operations/sys_ops/mod.rs
+++ b/processor/src/operations/sys_ops/mod.rs
@@ -146,7 +146,7 @@ impl Process {
         self.stack.copy_state(0);
         self.decoder.set_user_op_helpers(Operation::Emit(event_id), &[event_id.into()]);
 
-        let process = self.state();
+        let mut process = self.state();
         // If it's a system event, handle it directly. Otherwise, forward it to the host.
         if let Some(system_event) = SystemEvent::from_event_id(event_id) {
             handle_system_event(&mut process, system_event, err_ctx)

--- a/processor/src/operations/sys_ops/mod.rs
+++ b/processor/src/operations/sys_ops/mod.rs
@@ -155,11 +155,9 @@ impl Process {
             let mutations = host
                 .on_event(&process, event_id)
                 .map_err(|err| ExecutionError::event_error(err, event_id, err_ctx))?;
-            for mutation in mutations {
-                self.advice
-                    .apply_mutation(mutation)
-                    .map_err(|err| ExecutionError::advice_error(err, clk, err_ctx))?;
-            }
+            self.advice
+                .apply_mutations(mutations)
+                .map_err(|err| ExecutionError::advice_error(err, clk, err_ctx))?;
             Ok(())
         }
     }

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -4,8 +4,8 @@ use miden_air::{Felt, ProvingOptions, RowIndex};
 use miden_assembly::{Assembler, DefaultSourceManager, utils::Serializable};
 use miden_core::{StarkField, ZERO};
 use miden_processor::{
-    AdviceInputs, EventError, ExecutionError, ProcessState, Program, ProgramInfo, StackInputs,
-    crypto::RpoRandomCoin,
+    AdviceInputs, AdviceMutation, EventError, ExecutionError, ProcessState, Program, ProgramInfo,
+    StackInputs, crypto::RpoRandomCoin,
 };
 use miden_stdlib::{StdLibrary, falcon_sign};
 use miden_utils_testing::{
@@ -60,7 +60,7 @@ const EVENT_FALCON_SIG_TO_STACK: u32 = 3419226139;
 /// - SIGNATURE is the signature being verified.
 ///
 /// The advice provider is expected to contain the private key associated to the public key PK.
-pub fn push_falcon_signature(process: &mut ProcessState) -> Result<(), EventError> {
+pub fn push_falcon_signature(process: &ProcessState) -> Result<Vec<AdviceMutation>, EventError> {
     let pub_key = process.get_stack_word(0);
     let msg = process.get_stack_word(1);
 
@@ -72,10 +72,9 @@ pub fn push_falcon_signature(process: &mut ProcessState) -> Result<(), EventErro
     let result = falcon_sign(pk_sk, msg)
         .ok_or(FalconError::MalformedSignatureKey { key_type: "RPO Falcon512" })?;
 
-    for r in result {
-        process.advice_provider_mut().push_stack(r);
-    }
-    Ok(())
+    Ok(Vec::from_iter(
+        result.into_iter().map(|value| AdviceMutation::PushStack { value }),
+    ))
 }
 
 // EVENT ERROR

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -69,12 +69,10 @@ pub fn push_falcon_signature(process: &ProcessState) -> Result<Vec<AdviceMutatio
         .get_mapped_values(&pub_key)
         .ok_or(FalconError::NoSecretKey { key: pub_key })?;
 
-    let result = falcon_sign(pk_sk, msg)
+    let signature_result = falcon_sign(pk_sk, msg)
         .ok_or(FalconError::MalformedSignatureKey { key_type: "RPO Falcon512" })?;
 
-    Ok(Vec::from_iter(
-        result.into_iter().map(|value| AdviceMutation::PushStack { value }),
-    ))
+    Ok(vec![AdviceMutation::ExtendStack { iter: signature_result }])
 }
 
 // EVENT ERROR


### PR DESCRIPTION
## Describe your changes

Removes the dependency of a `&mut ProcessState` by a layer of indirection, being `AdviceMutation` The mutations are applied after the respective call to the `(Sync|Async)Host`-trait implementors. The `handler` has been changed in the same fashion, returning a set of `AdivceMutation`s.  

Also remove the `impl err_ctx` to avoid another data dependency.