### PR TITLE
chore: Fix a TODO

### DIFF
--- a/processor/src/chiplets/ace/mod.rs
+++ b/processor/src/chiplets/ace/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use alloc::{collections::BTreeMap, vec::Vec};
 
 use miden_air::{

--- a/processor/src/chiplets/ace/tests/encoder.rs
+++ b/processor/src/chiplets/ace/tests/encoder.rs
@@ -1,7 +1,6 @@
 use alloc::vec::Vec;
 
 use miden_core::{Felt, FieldElement, QuadFelt};
-use winter_prover::crypto::ElementHasher;
 
 use super::*;
 use crate::chiplets::ace::instruction::{ID_BITS, MAX_ID};
@@ -36,11 +35,6 @@ impl EncodedCircuit {
 
     pub fn encoded_circuit(&self) -> &[Felt] {
         &self.encoded_circuit
-    }
-
-    /// Computes the hash of all circuit constants and instructions.
-    fn raw_circuit_hash<H: ElementHasher<BaseField = Felt>>(&self) -> H::Digest {
-        H::hash_elements(&self.encoded_circuit)
     }
 
     /// Returns the number of constants in the circuit.

--- a/processor/src/decoder/block_stack.rs
+++ b/processor/src/decoder/block_stack.rs
@@ -39,23 +39,19 @@ impl BlockStack {
         }
 
         // determine additional info about the new block based on its parent
-        let (parent_addr, is_loop_body, is_first_child) = match self.blocks.last() {
+        let (parent_addr, is_loop_body) = match self.blocks.last() {
             Some(parent) => match parent.block_type {
                 // if the parent block is a LOOP block, the new block must be a loop body
                 BlockType::Loop(loop_entered) => {
                     debug_assert!(loop_entered, "parent is un-entered loop");
-                    (parent.addr, true, false)
+                    (parent.addr, true)
                 },
-                // if the parent block is a JOIN block, figure out if the new block is the first
-                // or the second child
-                BlockType::Join(first_child_executed) => {
-                    (parent.addr, false, !first_child_executed)
-                },
-                _ => (parent.addr, false, false),
+                BlockType::Join(_) => (parent.addr, false),
+                _ => (parent.addr, false),
             },
             // if the block stack is empty, a new block is neither a body of a loop nor the first
             // child of a JOIN block; also, we set the parent address to ZERO.
-            None => (ZERO, false, false),
+            None => (ZERO, false),
         };
 
         self.blocks.push(BlockInfo {
@@ -64,7 +60,6 @@ impl BlockStack {
             parent_addr,
             ctx_info,
             is_loop_body,
-            is_first_child,
         });
         parent_addr
     }
@@ -106,8 +101,6 @@ pub struct BlockInfo {
     pub parent_addr: Felt,
     pub ctx_info: Option<ExecutionContextInfo>,
     pub is_loop_body: bool,
-    #[allow(dead_code)] // TODO: remove this filed
-    pub is_first_child: bool,
 }
 
 impl BlockInfo {


### PR DESCRIPTION
## Describe your changes

After https://github.com/0xMiden/miden-vm/pull/1287 the `is_first_child` field became dead code. AFAICT, no functionalities were broken.