### PR TITLE
Exploration of using the sans-IO pattern in the `FastProcessor`

### DIFF
--- a/miden-vm/benches/program_execution_fast.rs
+++ b/miden-vm/benches/program_execution_fast.rs
@@ -2,7 +2,6 @@ use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use miden_processor::{AdviceInputs, fast::FastProcessor};
 use miden_stdlib::StdLibrary;
 use miden_vm::{Assembler, DefaultHost, StackInputs, internal::InputFile};
-use tokio::runtime::Runtime;
 use walkdir::WalkDir;
 
 /// Benchmark the execution of all the masm examples in the `masm-examples` directory.
@@ -49,7 +48,7 @@ fn program_execution_fast(c: &mut Criterion) {
                         .assemble_program(&source)
                         .expect("Failed to compile test source.");
                     let stack_inputs: Vec<_> = stack_inputs.iter().rev().copied().collect();
-                    bench.to_async(Runtime::new().unwrap()).iter_batched(
+                    bench.iter_batched(
                         || {
                             let host = DefaultHost::default()
                                 .with_library(&StdLibrary::default())
@@ -62,8 +61,8 @@ fn program_execution_fast(c: &mut Criterion) {
 
                             (host, program.clone(), processor)
                         },
-                        |(mut host, program, processor)| async move {
-                            processor.execute(&program, &mut host).await.unwrap();
+                        |(mut host, program, processor)| {
+                            processor.execute(&program, &mut host).unwrap();
                         },
                         BatchSize::SmallInput,
                     );

--- a/processor/src/continuation_stack.rs
+++ b/processor/src/continuation_stack.rs
@@ -1,8 +1,7 @@
 use alloc::{sync::Arc, vec::Vec};
 
 use miden_core::{
-    Program,
-    mast::{MastForest, MastNodeId},
+    mast::{MastForest, MastNodeId}, Program
 };
 
 /// A hint for the initial size of the continuation stack.
@@ -26,6 +25,8 @@ pub enum Continuation {
     FinishCall(MastNodeId),
     /// Process the finish phase of a Dyn node.
     FinishDyn(MastNodeId),
+    /// Process the finish phase of an External node.
+    FinishExternal(MastNodeId),
     /// Enter a new MAST forest, where all subsequent `MastNodeId`s will be relative to this forest.
     ///
     /// When we encounter an `ExternalNode`, we enter the corresponding MAST forest directly, and
@@ -86,6 +87,10 @@ impl ContinuationStack {
     /// Pushes a dyn finish continuation onto the stack.
     pub fn push_finish_dyn(&mut self, node_id: MastNodeId) {
         self.stack.push(Continuation::FinishDyn(node_id));
+    }
+
+    pub fn push_finish_external(&mut self, node_id: MastNodeId) {
+        self.stack.push(Continuation::FinishExternal(node_id));
     }
 
     /// Pushes a continuation to start processing the given node.

--- a/processor/src/fast/sys_ops.rs
+++ b/processor/src/fast/sys_ops.rs
@@ -2,7 +2,7 @@ use miden_core::{Felt, mast::MastForest, sys_events::SystemEvent};
 
 use super::{ExecutionError, FastProcessor, ONE};
 use crate::{
-    AsyncHost, BaseHost, ErrorContext, FMP_MIN,
+    BaseHost, ErrorContext, FMP_MIN, SyncHost,
     operations::sys_ops::sys_event_handlers::handle_system_event, system::FMP_MAX,
 };
 
@@ -83,11 +83,11 @@ impl FastProcessor {
 
     /// Analogous to `Process::op_emit`.
     #[inline(always)]
-    pub async fn op_emit(
+    pub fn op_emit(
         &mut self,
         event_id: u32,
         op_idx: usize,
-        host: &mut impl AsyncHost,
+        host: &mut impl SyncHost,
         err_ctx: &impl ErrorContext,
     ) -> Result<(), ExecutionError> {
         let process = &mut self.state(op_idx);
@@ -96,7 +96,6 @@ impl FastProcessor {
             handle_system_event(process, system_event, err_ctx)
         } else {
             host.on_event(process, event_id)
-                .await
                 .map_err(|err| ExecutionError::event_error(err, event_id, err_ctx))
         }
     }


### PR DESCRIPTION
**Disclaimer:** this PR is not meant to be merged. It is meant to get a feel for what the entire `FastProcessor` would look like if calls to the `AsyncHost` were replaced by the sans-IO pattern (first discussed [here](https://github.com/0xMiden/miden-base/issues/401#issuecomment-2658767755)).

I only implemented swapping the `AsyncHost::get_mast_forest()` call with the sans-IO alternative when processing an `ExternalNode`. The API is very rough, and very much not cleaned up.

The interesting public methods are `FastProcessor::{execute_sans_io, execute_sans_io_finish_external, execute_sync_host, execute_async_host}`. Internally, an external node is processed in `{start, finish}_external_node()` (and the new `MastForest` is fetched by the caller).

Observations:
- We are able to offer sync and `async` APIs effortlessly (👍👍👍)
- The performance is likely to be much better than what we have with the current async-only API, since the core of the functionality is synchronous
  - I am not able to actually benchmark it because this PR doesn't actually run due to the bunch of `unimplemented!()` I inserted 🙂
- We would expose the sans-io API on top of the sync/async (making @Mirko-von-Leipzig happy)