### PR TITLE
chore: add ExecutionProof::new_dummy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.16.3 (TBD)
+
+#### Changes
+
+- Add `new_dummy` method on `ExecutionProof` ([#2007](https://github.com/0xMiden/miden-vm/pull/2007)).
+
 ## 0.16.2 (2025-07-11)
 
 - Fix `debug::print_vm_stack` which was returning the advice stack instead of the system stack [(#1984)](https://github.com/0xMiden/miden-vm/issues/1984).

--- a/air/src/proof.rs
+++ b/air/src/proof.rs
@@ -165,3 +165,19 @@ impl Deserializable for ExecutionProof {
         Ok(ExecutionProof { proof, hash_fn })
     }
 }
+
+// TESTING UTILS
+// ================================================================================================
+
+#[cfg(any(test, feature = "testing"))]
+impl ExecutionProof {
+    /// Creates a dummy `ExecutionProof` for testing purposes only.
+    ///
+    /// Uses a dummy `Proof` and the default `HashFunction`.
+    pub fn new_dummy() -> Self {
+        ExecutionProof {
+            proof: Proof::new_dummy(),
+            hash_fn: HashFunction::default(),
+        }
+    }
+}


### PR DESCRIPTION
## Describe your changes

Adds a `new_dummy` method to `ExecutionProof`. The reason behind is to ease the testing of `ProvenTransaction`'s validations without needing to execute a transaction.

Related to: https://github.com/0xMiden/miden-node/pull/1093

## Checklist before requesting a review
- [X] Repo forked and branch created from `next` according to naming convention.
- [X] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [X] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [X] Relevant issues are linked in the PR description.
- [ ] Tests added for new functionality.
- [X] Documentation/comments updated according to changes.
- [X] Updated `CHANGELOG.md'