### PR TITLE
chore: add AdviceInputs::map() accessor

### DIFF
--- a/processor/src/host/advice/inputs.rs
+++ b/processor/src/host/advice/inputs.rs
@@ -1,4 +1,4 @@
-use alloc::{sync::Arc, vec::Vec};
+use alloc::vec::Vec;
 
 use miden_core::{
     AdviceMap, Felt, Word,
@@ -21,12 +21,11 @@ use miden_core::{
 /// 2. Key-mapped element lists which can be pushed onto the advice stack.
 /// 3. Merkle store, which is used to provide nondeterministic inputs for instructions that operates
 ///    with Merkle trees.
-#[cfg(not(feature = "testing"))]
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AdviceInputs {
-    pub(super) stack: Vec<Felt>,
-    pub(super) map: AdviceMap,
-    pub(super) store: MerkleStore,
+    stack: Vec<Felt>,
+    map: AdviceMap,
+    store: MerkleStore,
 }
 
 impl AdviceInputs {
@@ -109,20 +108,29 @@ impl AdviceInputs {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns a reference to the advice stack.
+    /// Returns a reference to the advice stack of this advice inputs.
     pub fn stack(&self) -> &[Felt] {
         &self.stack
     }
 
-    /// Fetch a values set mapped by the given key.
-    pub fn mapped_values(&self, key: &Word) -> Option<&Arc<[Felt]>> {
-        self.map.get(key)
+    /// Returns a reference to the [AdviceMap] of this advice inputs.
+    pub fn map(&self) -> &AdviceMap {
+        &self.map
     }
 
-    /// Returns the underlying [MerkleStore].
+    /// Returns the underlying [MerkleStore] of this advice inputs.
     pub const fn merkle_store(&self) -> &MerkleStore {
         &self.store
     }
+
+    // DESTRUCTORS
+    // --------------------------------------------------------------------------------------------
+
+    /// Returns the underlying components of these advice inputs (stack, map, store).
+    pub fn into_parts(self) -> (Vec<Felt>, AdviceMap, MerkleStore) {
+        (self.stack, self.map, self.store)
+    }
+
 }
 
 impl Serializable for AdviceInputs {
@@ -141,17 +149,6 @@ impl Deserializable for AdviceInputs {
         let store = MerkleStore::read_from(source)?;
         Ok(Self { stack, map, store })
     }
-}
-
-// TESTING
-// ================================================================================================
-
-#[cfg(feature = "testing")]
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct AdviceInputs {
-    pub stack: Vec<Felt>,
-    pub map: AdviceMap,
-    pub store: MerkleStore,
 }
 
 // TESTS

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -304,15 +304,15 @@ impl AdviceProvider {
 
     /// Extends the contents of this instance with the contents of an `AdviceInputs`.
     pub fn extend_from_inputs(&mut self, inputs: &AdviceInputs) -> Result<(), AdviceError> {
-        self.extend_stack(inputs.stack.iter().cloned().rev());
-        self.extend_merkle_store(inputs.store.inner_nodes());
-        self.extend_map(&inputs.map)
+        self.extend_stack(inputs.stack().iter().cloned().rev());
+        self.extend_merkle_store(inputs.merkle_store().inner_nodes());
+        self.extend_map(&inputs.map())
     }
 }
 
 impl From<AdviceInputs> for AdviceProvider {
     fn from(inputs: AdviceInputs) -> Self {
-        let AdviceInputs { mut stack, map, store } = inputs;
+        let ( mut stack, map, store ) = inputs.into_parts();
         stack.reverse();
         Self { stack, map, store }
     }


### PR DESCRIPTION
This is a simpler version of https://github.com/0xMiden/miden-vm/pull/1999 to address https://github.com/0xMiden/miden-vm/issues/1995. The changes include:

- Added `AdviceInputs::map()` accessor.
- Made all fields in `AdviceInputs` private (under all features).
- Added `AdviceInputs::into_parts()` destructor.