### PR TITLE
fix: correct URI authority documentation and optimize From<&str> conversion

### DIFF
--- a/crates/debug/types/src/lib.rs
+++ b/crates/debug/types/src/lib.rs
@@ -68,7 +68,7 @@ impl Uri {
         }
     }
 
-    /// Returns the scheme portion of this URI, if present.
+    /// Returns the authority portion of this URI, if present.
     pub fn authority(&self) -> Option<&str> {
         let uri = self.0.as_ref();
         let (_, rest) = uri.split_once("//")?;
@@ -120,9 +120,7 @@ impl AsRef<str> for Uri {
 impl From<&str> for Uri {
     #[inline]
     fn from(value: &str) -> Self {
-        use alloc::string::ToString;
-
-        value.to_string().into()
+        Self(value.into())
     }
 }
 


### PR DESCRIPTION
Fix documentation error and performance issue in Uri implementation

**Problems identified:**
1. Incorrect documentation comment for `authority()` method - it was duplicating 
   the comment from `scheme()` method instead of describing authority extraction
2. Inefficient `From<&str>` implementation creating unnecessary intermediate String

**Solutions:**
1. Fixed documentation comment for `authority()` method to correctly describe 
   that it returns the authority portion of the URI, not the scheme portion
2. Optimized `From<&str>` implementation by directly converting &str to Arc<str> 
   instead of going through String conversion, eliminating unnecessary allocation

**Why these changes:**
- Documentation accuracy is crucial for API usability and maintainability
- The authority() method correctly implements RFC 3986 URI parsing, but the 
  wrong comment could mislead developers about its purpose
- Performance optimization removes redundant String allocation in the common 
  case of creating Uri from string literals or references, improving efficiency 
  without changing behavior
