### PR TITLE
feat: add `AdviceProvider::into_parts()` method

### DIFF
--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -302,11 +302,22 @@ impl AdviceProvider {
         self.store.extend(iter);
     }
 
+    // MUTATORS
+    // --------------------------------------------------------------------------------------------
+
     /// Extends the contents of this instance with the contents of an `AdviceInputs`.
     pub fn extend_from_inputs(&mut self, inputs: &AdviceInputs) -> Result<(), AdviceError> {
         self.extend_stack(inputs.stack.iter().cloned().rev());
         self.extend_merkle_store(inputs.store.inner_nodes());
         self.extend_map(&inputs.map)
+    }
+
+    /// Consumes `self` and return its parts (stack, map, store).
+    ///
+    /// Note that the order of the stack is such that the element at the top of the stack is at the
+    /// end of the returned vector.
+    pub fn into_parts(self) -> (Vec<Felt>, AdviceMap, MerkleStore) {
+        (self.stack, self.map, self.store)
     }
 }
 


### PR DESCRIPTION
This small PR addresses https://github.com/0xMiden/miden-vm/issues/2018 by implementing `AdviceProvider::into_parts()` method. I went with this option as implementing `From<AdviceProvider> for AdviceInputs` is a bit more tricky as we'd need to reverse the advice stack, which I don't think we really care for.

Another option is to just discard the stack and return only `(AdviceMap, MerkleStore)` from this method, but I decided to be a bit more comprehensive in case the stack is also needed for some reason.