### PR TITLE
draft: handle `Sync` requirements around `dyn SourceManager` for multithreaded executors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Move `fn with_source_manager` from `Process` to the `host` [#2019](https://github.com/0xMiden/miden-vm/pull/2019).
 - Move the `SourceManager` from the processor to the host [#2019](https://github.com/0xMiden/miden-vm/pull/2019).
 - Add `AdviceProvider::into_parts()` method ([#2024](https://github.com/0xMiden/miden-vm/pull/2024)).
+- [BREAKING] `{AsyncHost,SyncHost}::on_event` now returns a list of `AdviceProvider` mutations ([#2003](https://github.com/0xMiden/miden-vm/pull/2003)).
 
 #### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Move the `SourceManager` from the processor to the host [#2019](https://github.com/0xMiden/miden-vm/pull/2019).
 - Add `AdviceProvider::into_parts()` method ([#2024](https://github.com/0xMiden/miden-vm/pull/2024)).
 - [BREAKING] `{AsyncHost,SyncHost}::on_event` now returns a list of `AdviceProvider` mutations ([#2003](https://github.com/0xMiden/miden-vm/pull/2003)).
+- Add constraints evaluation check to recursive verifier ([#1997](https://github.com/0xMiden/miden-vm/pull/1997)).
+- Add `AdviceProvider::into_parts()` method ([#2024](https://github.com/0xMiden/miden-vm/pull/2024)).
 
 #### Changes
 

--- a/crates/debug/types/Cargo.toml
+++ b/crates/debug/types/Cargo.toml
@@ -25,7 +25,6 @@ std = [
     "thiserror/std",
 ]
 serde = ["dep:serde", "dep:serde_spanned", "serde_spanned?/serde"]
-syncbound = []
 
 [dependencies]
 memchr = { version = "2.7", default-features = false }

--- a/crates/debug/types/Cargo.toml
+++ b/crates/debug/types/Cargo.toml
@@ -25,6 +25,7 @@ std = [
     "thiserror/std",
 ]
 serde = ["dep:serde", "dep:serde_spanned", "serde_spanned?/serde"]
+syncbound = []
 
 [dependencies]
 memchr = { version = "2.7", default-features = false }

--- a/crates/debug/types/src/lib.rs
+++ b/crates/debug/types/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
 
 #[cfg(any(feature = "std", test))]

--- a/crates/debug/types/src/source_manager.rs
+++ b/crates/debug/types/src/source_manager.rs
@@ -242,7 +242,7 @@ pub trait SourceManagerExt: SourceManager {
             .map(|s| SourceContent::new(lang, uri.clone(), s))
             .map_err(|source| {
                 SourceManagerError::custom_with_source(
-                    format!("failed to load filed at `{}`", path.display()),
+                    alloc::format!("failed to load filed at `{}`", path.display()),
                     source,
                 )
             })?;

--- a/crates/debug/types/src/source_manager.rs
+++ b/crates/debug/types/src/source_manager.rs
@@ -242,7 +242,7 @@ pub trait SourceManagerExt: SourceManager {
             .map(|s| SourceContent::new(lang, uri.clone(), s))
             .map_err(|source| {
                 SourceManagerError::custom_with_source(
-                    format!("failed to load filed at `{}`", path.display()),
+                    std::format!("failed to load filed at `{}`", path.display()),
                     source,
                 )
             })?;

--- a/crates/debug/types/src/source_manager.rs
+++ b/crates/debug/types/src/source_manager.rs
@@ -262,18 +262,9 @@ impl<T: ?Sized + SourceManager> SourceManagerExt for T {}
 /// [SourceManager] is a supertrait of [SourceManagerSync], so you may use instances of the
 /// [SourceManagerSync] where the [SourceManager] is required, either implicitly or via explicit
 /// downcasting, e.g. `Arc<dyn SourceManagerSync> as Arc<dyn SourceManager>`.
-
-#[cfg(target_arch = "wasm32")]
 pub trait SourceManagerSync: SourceManager + Send + Sync {}
 
-#[cfg(target_arch = "wasm32")]
 impl<T: ?Sized + SourceManager + Send + Sync> SourceManagerSync for T {}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub trait SourceManagerSync: SourceManager + Send {}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl<T: ?Sized + SourceManager + Send> SourceManagerSync for T {}
 
 // DEFAULT SOURCE MANAGER
 // ================================================================================================

--- a/crates/debug/types/src/source_manager.rs
+++ b/crates/debug/types/src/source_manager.rs
@@ -242,7 +242,7 @@ pub trait SourceManagerExt: SourceManager {
             .map(|s| SourceContent::new(lang, uri.clone(), s))
             .map_err(|source| {
                 SourceManagerError::custom_with_source(
-                    std::format!("failed to load filed at `{}`", path.display()),
+                    format!("failed to load filed at `{}`", path.display()),
                     source,
                 )
             })?;
@@ -254,8 +254,6 @@ pub trait SourceManagerExt: SourceManager {
 #[cfg(feature = "std")]
 impl<T: ?Sized + SourceManager> SourceManagerExt for T {}
 
-// TODO rename to reflect the fact it's a "glue" trait that adapts per target, but only after
-// the `-base` has been validated to work with this approach.
 /// [SourceManagerSync] is a marker trait for [SourceManager] implementations that are also Send +
 /// Sync, and is automatically implemented for any [SourceManager] that meets those requirements.
 ///

--- a/crates/debug/types/src/source_manager.rs
+++ b/crates/debug/types/src/source_manager.rs
@@ -260,9 +260,18 @@ impl<T: ?Sized + SourceManager> SourceManagerExt for T {}
 /// [SourceManager] is a supertrait of [SourceManagerSync], so you may use instances of the
 /// [SourceManagerSync] where the [SourceManager] is required, either implicitly or via explicit
 /// downcasting, e.g. `Arc<dyn SourceManagerSync> as Arc<dyn SourceManager>`.
+
+#[cfg(feature = "syncbound")]
 pub trait SourceManagerSync: SourceManager + Send + Sync {}
 
+#[cfg(feature = "syncbound")]
 impl<T: ?Sized + SourceManager + Send + Sync> SourceManagerSync for T {}
+
+#[cfg(not(feature = "syncbound"))]
+pub trait SourceManagerSync: SourceManager + Send {}
+
+#[cfg(not(feature = "syncbound"))]
+impl<T: ?Sized + SourceManager + Send> SourceManagerSync for T {}
 
 // DEFAULT SOURCE MANAGER
 // ================================================================================================

--- a/crates/debug/types/src/source_manager.rs
+++ b/crates/debug/types/src/source_manager.rs
@@ -254,6 +254,8 @@ pub trait SourceManagerExt: SourceManager {
 #[cfg(feature = "std")]
 impl<T: ?Sized + SourceManager> SourceManagerExt for T {}
 
+// TODO rename to reflect the fact it's a "glue" trait that adapts per target, but only after
+// the `-base` has been validated to work with this approach.
 /// [SourceManagerSync] is a marker trait for [SourceManager] implementations that are also Send +
 /// Sync, and is automatically implemented for any [SourceManager] that meets those requirements.
 ///

--- a/crates/debug/types/src/source_manager.rs
+++ b/crates/debug/types/src/source_manager.rs
@@ -261,16 +261,16 @@ impl<T: ?Sized + SourceManager> SourceManagerExt for T {}
 /// [SourceManagerSync] where the [SourceManager] is required, either implicitly or via explicit
 /// downcasting, e.g. `Arc<dyn SourceManagerSync> as Arc<dyn SourceManager>`.
 
-#[cfg(feature = "syncbound")]
+#[cfg(target_arch = "wasm32")]
 pub trait SourceManagerSync: SourceManager + Send + Sync {}
 
-#[cfg(feature = "syncbound")]
+#[cfg(target_arch = "wasm32")]
 impl<T: ?Sized + SourceManager + Send + Sync> SourceManagerSync for T {}
 
-#[cfg(not(feature = "syncbound"))]
+#[cfg(not(target_arch = "wasm32"))]
 pub trait SourceManagerSync: SourceManager + Send {}
 
-#[cfg(not(feature = "syncbound"))]
+#[cfg(not(target_arch = "wasm32"))]
 impl<T: ?Sized + SourceManager + Send> SourceManagerSync for T {}
 
 // DEFAULT SOURCE MANAGER

--- a/miden-vm/tests/integration/operations/decorators/mod.rs
+++ b/miden-vm/tests/integration/operations/decorators/mod.rs
@@ -68,7 +68,7 @@ impl SyncHost for TestHost {
 }
 
 impl AsyncHost for TestHost {
-    async fn get_mast_forest(&self, _node_digest: &Word) -> Option<Arc<MastForest>> {
+    fn get_mast_forest(&self, _node_digest: &Word) -> Option<Arc<MastForest>> {
         // Empty MAST forest store
         None
     }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -33,6 +33,7 @@ testing = ["miden-air/testing", "tokio"]
 no_err_ctx = []
 # Like `testing`, but slows down the processor speed to make it easier to debug.
 bus-debugger = ["testing", "miden-air/testing"]
+syncbound = ["miden-debug-types/syncbound"]
 
 [dependencies]
 miden-air.workspace = true

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -33,7 +33,6 @@ testing = ["miden-air/testing", "tokio"]
 no_err_ctx = []
 # Like `testing`, but slows down the processor speed to make it easier to debug.
 bus-debugger = ["testing", "miden-air/testing"]
-syncbound = ["miden-debug-types/syncbound"]
 
 [dependencies]
 miden-air.workspace = true
@@ -43,7 +42,9 @@ miden-utils-diagnostics.workspace = true
 tracing.workspace = true
 thiserror.workspace = true
 # For `testing`
-tokio = { version = "1.46", default-features = false, features = ["rt"], optional = true }
+tokio = { version = "1.46", default-features = false, features = [
+    "rt",
+], optional = true }
 winter-prover.workspace = true
 
 [dev-dependencies]

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -1169,7 +1169,6 @@ impl FastProcessor {
     {
         let mast_forest = host
             .get_mast_forest(&node_digest)
-            .await
             .ok_or_else(|| get_mast_forest_failed(node_digest, err_ctx))?;
 
         // We limit the parts of the program that can be called externally to procedure

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -8,7 +8,7 @@ use pretty_assertions::assert_eq;
 use super::*;
 use crate::{
     AdviceMutation, AsyncHost, BaseHost, EventError, MastForestStore, MemMastForestStore,
-    MemoryAddress, ProcessState, SyncHost, host::SFuture,
+    MemoryAddress, ProcessState, SyncHost, host::FutureAliasWrapper,
 };
 
 #[test]
@@ -292,7 +292,10 @@ impl<S> AsyncHost for ConsistencyHost<S>
 where
     S: SourceManagerSync,
 {
-    fn get_mast_forest(&self, node_digest: &Word) -> impl SFuture<Option<Arc<MastForest>>> {
+    fn get_mast_forest(
+        &self,
+        node_digest: &Word,
+    ) -> impl FutureAliasWrapper<Option<Arc<MastForest>>> {
         let val = self.store.get(node_digest);
         async move { val }
     }

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -293,8 +293,7 @@ where
     S: SourceManagerSync,
 {
     fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
-        let val = self.store.get(node_digest);
-        val
+        self.store.get(node_digest)
     }
 
     // Note: clippy complains about this not using the `async` keyword, but if we use `async`, it

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -8,7 +8,7 @@ use pretty_assertions::assert_eq;
 use super::*;
 use crate::{
     AdviceMutation, AsyncHost, BaseHost, EventError, MastForestStore, MemMastForestStore,
-    MemoryAddress, ProcessState, SyncHost, host::AsyncHostFuture,
+    MemoryAddress, ProcessState, SyncHost,
 };
 
 #[test]
@@ -292,9 +292,9 @@ impl<S> AsyncHost for ConsistencyHost<S>
 where
     S: SourceManagerSync,
 {
-    fn get_mast_forest(&self, node_digest: &Word) -> impl AsyncHostFuture<Option<Arc<MastForest>>> {
+    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
         let val = self.store.get(node_digest);
-        async move { val }
+        val
     }
 
     // Note: clippy complains about this not using the `async` keyword, but if we use `async`, it

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -8,7 +8,7 @@ use pretty_assertions::assert_eq;
 use super::*;
 use crate::{
     AdviceMutation, AsyncHost, BaseHost, EventError, MastForestStore, MemMastForestStore,
-    MemoryAddress, ProcessState, SyncHost,
+    MemoryAddress, ProcessState, SyncHost, host::SFuture,
 };
 
 #[test]
@@ -292,8 +292,9 @@ impl<S> AsyncHost for ConsistencyHost<S>
 where
     S: SourceManagerSync,
 {
-    async fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
-        self.store.get(node_digest)
+    fn get_mast_forest(&self, node_digest: &Word) -> impl SFuture<Option<Arc<MastForest>>> {
+        let val = self.store.get(node_digest);
+        async move { val }
     }
 
     // Note: clippy complains about this not using the `async` keyword, but if we use `async`, it

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -8,7 +8,7 @@ use pretty_assertions::assert_eq;
 use super::*;
 use crate::{
     AdviceMutation, AsyncHost, BaseHost, EventError, MastForestStore, MemMastForestStore,
-    MemoryAddress, ProcessState, SyncHost, host::FutureAliasWrapper,
+    MemoryAddress, ProcessState, SyncHost, host::AsyncHostFuture,
 };
 
 #[test]
@@ -292,10 +292,7 @@ impl<S> AsyncHost for ConsistencyHost<S>
 where
     S: SourceManagerSync,
 {
-    fn get_mast_forest(
-        &self,
-        node_digest: &Word,
-    ) -> impl FutureAliasWrapper<Option<Arc<MastForest>>> {
+    fn get_mast_forest(&self, node_digest: &Word) -> impl AsyncHostFuture<Option<Arc<MastForest>>> {
         let val = self.store.get(node_digest);
         async move { val }
     }

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -41,9 +41,9 @@ type SimpleMerkleMap = BTreeMap<Word, StoreNode>;
 /// Advice data is store in-memory using [BTreeMap]s as its backing storage.
 #[derive(Debug, Clone, Default)]
 pub struct AdviceProvider {
-    pub stack: Vec<Felt>,
-    pub map: AdviceMap,
-    pub store: MerkleStore<SimpleMerkleMap>,
+    stack: Vec<Felt>,
+    map: AdviceMap,
+    store: MerkleStore<SimpleMerkleMap>,
 }
 
 impl AdviceProvider {

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -41,9 +41,9 @@ type SimpleMerkleMap = BTreeMap<Word, StoreNode>;
 /// Advice data is store in-memory using [BTreeMap]s as its backing storage.
 #[derive(Debug, Clone, Default)]
 pub struct AdviceProvider {
-    stack: Vec<Felt>,
-    map: AdviceMap,
-    store: MerkleStore<SimpleMerkleMap>,
+    pub stack: Vec<Felt>,
+    pub map: AdviceMap,
+    pub store: MerkleStore<SimpleMerkleMap>,
 }
 
 impl AdviceProvider {
@@ -57,14 +57,14 @@ impl AdviceProvider {
 
     fn apply_mutation(&mut self, mutation: AdviceMutation) -> Result<(), AdviceError> {
         match mutation {
-            AdviceMutation::ExtendStack { iter } => {
-                self.extend_stack(iter);
+            AdviceMutation::ExtendStack { values } => {
+                self.extend_stack(values);
             },
             AdviceMutation::ExtendMap { other } => {
                 self.extend_map(&other)?;
             },
-            AdviceMutation::ExtendMerkleStore { iter } => {
-                self.extend_merkle_store(iter);
+            AdviceMutation::ExtendMerkleStore { infos } => {
+                self.extend_merkle_store(infos);
             },
         }
         Ok(())

--- a/processor/src/host/default.rs
+++ b/processor/src/host/default.rs
@@ -179,8 +179,7 @@ where
     S: SourceManagerSync,
 {
     fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
-        let val = self.store.get(node_digest);
-        val
+        self.store.get(node_digest)
     }
 
     fn on_event(

--- a/processor/src/host/default.rs
+++ b/processor/src/host/default.rs
@@ -8,7 +8,7 @@ use miden_debug_types::{
 use crate::{
     AdviceMutation, AsyncHost, BaseHost, DebugHandler, EventHandler, EventHandlerRegistry,
     ExecutionError, MastForestStore, MemMastForestStore, ProcessState, SyncHost,
-    host::{EventError, SFuture},
+    host::{EventError, FutureAliasWrapper},
 };
 
 // DEFAULT HOST IMPLEMENTATION
@@ -178,7 +178,10 @@ where
     D: DebugHandler,
     S: SourceManagerSync,
 {
-    fn get_mast_forest(&self, node_digest: &Word) -> impl SFuture<Option<Arc<MastForest>>> {
+    fn get_mast_forest(
+        &self,
+        node_digest: &Word,
+    ) -> impl FutureAliasWrapper<Option<Arc<MastForest>>> {
         let val = self.store.get(node_digest);
         async move { val }
     }
@@ -187,7 +190,7 @@ where
         &mut self,
         process: &ProcessState<'_>,
         event_id: u32,
-    ) -> impl SFuture<Result<Vec<AdviceMutation>, EventError>> {
+    ) -> impl FutureAliasWrapper<Result<Vec<AdviceMutation>, EventError>> {
         let result = <Self as SyncHost>::on_event(self, process, event_id);
         async move { result }
     }

--- a/processor/src/host/default.rs
+++ b/processor/src/host/default.rs
@@ -187,7 +187,7 @@ where
         &mut self,
         process: &ProcessState<'_>,
         event_id: u32,
-    ) -> impl SFuture<Result<Vec<AdviceMutation>, EventError>> + Send {
+    ) -> impl SFuture<Result<Vec<AdviceMutation>, EventError>> {
         let result = <Self as SyncHost>::on_event(self, process, event_id);
         async move { result }
     }

--- a/processor/src/host/default.rs
+++ b/processor/src/host/default.rs
@@ -8,7 +8,7 @@ use miden_debug_types::{
 use crate::{
     AdviceMutation, AsyncHost, BaseHost, DebugHandler, EventHandler, EventHandlerRegistry,
     ExecutionError, MastForestStore, MemMastForestStore, ProcessState, SyncHost,
-    host::{EventError, FutureAliasWrapper},
+    host::{AsyncHostFuture, EventError},
 };
 
 // DEFAULT HOST IMPLEMENTATION
@@ -178,10 +178,7 @@ where
     D: DebugHandler,
     S: SourceManagerSync,
 {
-    fn get_mast_forest(
-        &self,
-        node_digest: &Word,
-    ) -> impl FutureAliasWrapper<Option<Arc<MastForest>>> {
+    fn get_mast_forest(&self, node_digest: &Word) -> impl AsyncHostFuture<Option<Arc<MastForest>>> {
         let val = self.store.get(node_digest);
         async move { val }
     }
@@ -190,7 +187,7 @@ where
         &mut self,
         process: &ProcessState<'_>,
         event_id: u32,
-    ) -> impl FutureAliasWrapper<Result<Vec<AdviceMutation>, EventError>> {
+    ) -> impl AsyncHostFuture<Result<Vec<AdviceMutation>, EventError>> {
         let result = <Self as SyncHost>::on_event(self, process, event_id);
         async move { result }
     }

--- a/processor/src/host/default.rs
+++ b/processor/src/host/default.rs
@@ -178,9 +178,9 @@ where
     D: DebugHandler,
     S: SourceManagerSync,
 {
-    fn get_mast_forest(&self, node_digest: &Word) -> impl AsyncHostFuture<Option<Arc<MastForest>>> {
+    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
         let val = self.store.get(node_digest);
-        async move { val }
+        val
     }
 
     fn on_event(

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -111,10 +111,7 @@ pub trait AsyncHost: BaseHost {
 
     /// Returns MAST forest corresponding to the specified digest, or None if the MAST forest for
     /// this digest could not be found in this [AsyncHost].
-    fn get_mast_forest(
-        &self,
-        node_digest: &Word,
-    ) -> impl Future<Output = Option<Arc<MastForest>>> + Send;
+    fn get_mast_forest(&self, node_digest: &Word) -> impl SFuture<Option<Arc<MastForest>>>;
 
     /// Handles the event emitted from the VM and provides advice mutations to be applied to
     /// the advice provider.
@@ -122,5 +119,9 @@ pub trait AsyncHost: BaseHost {
         &mut self,
         process: &ProcessState<'_>,
         event_id: u32,
-    ) -> impl Future<Output = Result<Vec<AdviceMutation>, EventError>> + Send;
+    ) -> impl SFuture<Result<Vec<AdviceMutation>, EventError>>;
 }
+
+pub trait SFuture<O>: Future<Output = O> + Send {}
+
+impl<T, O> SFuture<O> for T where T: Future<Output = O> + Send {}

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -124,7 +124,7 @@ pub trait AsyncHost: BaseHost {
 
     /// Returns MAST forest corresponding to the specified digest, or None if the MAST forest for
     /// this digest could not be found in this [AsyncHost].
-    fn get_mast_forest(&self, node_digest: &Word) -> impl AsyncHostFuture<Option<Arc<MastForest>>>;
+    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>>;
 
     /// Handles the event emitted from the VM and provides advice mutations to be applied to
     /// the advice provider.
@@ -140,14 +140,14 @@ pub trait AsyncHost: BaseHost {
 /// Depending on the the target being `wasm32-unknown-unknown` the
 /// trait bounds are _without_ `+ Send`, otherwise with `+ Send` to
 /// ensure functionality for mutli threaded executor.
-#[cfg(target_arch = "wasm32")]
-pub trait FutureAliasWrapper<O>: Future<Output = O> {}
+#[cfg(not(feature = "std"))]
+pub trait AsyncHostFuture<O>: Future<Output = O> {}
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(not(feature = "std"))]
 impl<T, O> AsyncHostFuture<O> for T where T: Future<Output = O> {}
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "std")]
 pub trait AsyncHostFuture<O>: Future<Output = O> + Send {}
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "std")]
 impl<T, O> AsyncHostFuture<O> for T where T: Future<Output = O> + Send {}

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -124,10 +124,7 @@ pub trait AsyncHost: BaseHost {
 
     /// Returns MAST forest corresponding to the specified digest, or None if the MAST forest for
     /// this digest could not be found in this [AsyncHost].
-    fn get_mast_forest(
-        &self,
-        node_digest: &Word,
-    ) -> impl FutureAliasWrapper<Option<Arc<MastForest>>>;
+    fn get_mast_forest(&self, node_digest: &Word) -> impl AsyncHostFuture<Option<Arc<MastForest>>>;
 
     /// Handles the event emitted from the VM and provides advice mutations to be applied to
     /// the advice provider.
@@ -135,7 +132,7 @@ pub trait AsyncHost: BaseHost {
         &mut self,
         process: &ProcessState<'_>,
         event_id: u32,
-    ) -> impl FutureAliasWrapper<Result<Vec<AdviceMutation>, EventError>>;
+    ) -> impl AsyncHostFuture<Result<Vec<AdviceMutation>, EventError>>;
 }
 
 /// Alias for a `Future`
@@ -147,10 +144,10 @@ pub trait AsyncHost: BaseHost {
 pub trait FutureAliasWrapper<O>: Future<Output = O> {}
 
 #[cfg(target_arch = "wasm32")]
-impl<T, O> FutureAliasWrapper<O> for T where T: Future<Output = O> {}
+impl<T, O> AsyncHostFuture<O> for T where T: Future<Output = O> {}
 
 #[cfg(not(target_arch = "wasm32"))]
-pub trait FutureAliasWrapper<O>: Future<Output = O> + Send {}
+pub trait AsyncHostFuture<O>: Future<Output = O> + Send {}
 
 #[cfg(not(target_arch = "wasm32"))]
-impl<T, O> FutureAliasWrapper<O> for T where T: Future<Output = O> + Send {}
+impl<T, O> AsyncHostFuture<O> for T where T: Future<Output = O> + Send {}

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -137,9 +137,9 @@ pub trait AsyncHost: BaseHost {
 
 /// Alias for a `Future`
 ///
-/// Depending on the the target being `wasm32-unknown-unknown` the
-/// trait bounds are _without_ `+ Send`, otherwise with `+ Send` to
-/// ensure functionality for mutli threaded executor.
+/// If feature `std` is enabled, we add `Send` to the required bounds,
+/// otherwise we do not. This impacts usability with a multithreaded
+/// executor.
 #[cfg(not(feature = "std"))]
 pub trait AsyncHostFuture<O>: Future<Output = O> {}
 

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -28,11 +28,24 @@ pub use mast_forest_store::{MastForestStore, MemMastForestStore};
 /// Any possible way an event can modify the advice map
 #[derive(Debug, PartialEq, Eq)]
 pub enum AdviceMutation {
-    ExtendStack { iter: Vec<Felt> },
+    ExtendStack { values: Vec<Felt> },
     ExtendMap { other: AdviceMap },
-    ExtendMerkleStore { iter: Vec<InnerNodeInfo> },
+    ExtendMerkleStore { infos: Vec<InnerNodeInfo> },
 }
 
+impl AdviceMutation {
+    pub fn extend_stack(iter: impl IntoIterator<Item = Felt>) -> Self {
+        Self::ExtendStack { values: Vec::from_iter(iter) }
+    }
+
+    pub fn extend_map(other: AdviceMap) -> Self {
+        Self::ExtendMap { other }
+    }
+
+    pub fn extend_merkle_store(infos: impl IntoIterator<Item = InnerNodeInfo>) -> Self {
+        Self::ExtendMerkleStore { infos: Vec::from_iter(infos) }
+    }
+}
 // HOST TRAIT
 // ================================================================================================
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -232,7 +232,6 @@ pub struct Process {
     chiplets: Chiplets,
     max_cycles: u32,
     enable_tracing: bool,
-    source_manager: Arc<dyn SourceManager>,
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -245,7 +244,6 @@ pub struct Process {
     pub chiplets: Chiplets,
     pub max_cycles: u32,
     pub enable_tracing: bool,
-    pub source_manager: Arc<dyn SourceManager>,
 }
 
 impl Process {
@@ -275,11 +273,6 @@ impl Process {
         )
     }
 
-    pub fn with_source_manager(mut self, source_manager: Arc<dyn SourceManager>) -> Self {
-        self.source_manager = source_manager;
-        self
-    }
-
     fn initialize(
         kernel: Kernel,
         stack: StackInputs,
@@ -296,7 +289,6 @@ impl Process {
             chiplets: Chiplets::new(kernel),
             max_cycles: execution_options.max_cycles(),
             enable_tracing: execution_options.enable_tracing(),
-            source_manager: Arc::new(DefaultSourceManager::default()),
         }
     }
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -30,7 +30,7 @@ use miden_core::{
         OpBatch, SplitNode,
     },
 };
-use miden_debug_types::{DefaultSourceManager, SourceManager, SourceSpan};
+use miden_debug_types::SourceSpan;
 pub use winter_prover::matrix::ColMatrix;
 
 pub(crate) mod continuation_stack;

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -55,7 +55,7 @@ use range::RangeChecker;
 
 mod host;
 pub use host::{
-    AdviceMutation, AsyncHost, BaseHost, FutureAliasWrapper, MastForestStore, MemMastForestStore,
+    AdviceMutation, AsyncHost, AsyncHostFuture, BaseHost, MastForestStore, MemMastForestStore,
     SyncHost,
     advice::{AdviceError, AdviceInputs, AdviceProvider},
     default::{DefaultDebugHandler, DefaultHost, HostLibrary},

--- a/stdlib/tests/crypto/falcon.rs
+++ b/stdlib/tests/crypto/falcon.rs
@@ -72,7 +72,7 @@ pub fn push_falcon_signature(process: &ProcessState) -> Result<Vec<AdviceMutatio
     let signature_result = falcon_sign(pk_sk, msg)
         .ok_or(FalconError::MalformedSignatureKey { key_type: "RPO Falcon512" })?;
 
-    Ok(vec![AdviceMutation::ExtendStack { iter: signature_result }])
+    Ok(vec![AdviceMutation::extend_stack(signature_result)])
 }
 
 // EVENT ERROR


### PR DESCRIPTION
## Describe your changes

The current approach is making the `Sync` bound conditional on the `target_arch`, but it has implications in `miden-base`, i.e. `impl DataStore` is captured in closure scope and hence also needs to have `Sync`.

The next steps: Attempt to use a generic and see if this fares any better. 

Note: Previously https://github.com/0xMiden/miden-vm/pull/2027 which I can't seem to re-open.

Most relevant discussion items:

* https://github.com/0xMiden/miden-vm/pull/2027#discussion_r2228480630
* https://github.com/0xMiden/miden-vm/pull/2027#discussion_r2234137549