### PR TITLE
chore: update EXPORTED.md

### DIFF
--- a/docs/src/EXPORTED.md
+++ b/docs/src/EXPORTED.md
@@ -21,6 +21,7 @@
       - [Cryptographic Operations](./user_docs/assembly/cryptographic_operations.md)
       - [Events](./user_docs/assembly/events.md)
       - [Debugging](./user_docs/assembly/debugging.md)
+      - [Instruction Reference](./user_docs/assembly/instruction_reference.md)
     - [Miden Standard Library](./user_docs/stdlib/main.md)
       - [std::collections](./user_docs/stdlib/collections.md)
       - [std::crypto::dsa](./user_docs/stdlib/crypto/dsa.md)


### PR DESCRIPTION
This small PR updates the `EXPORTED.md` file which ensures that the documentation is visible in the miden-book.

The `EXPORTED.md` file represents which md files are displayed in the miden-book.

Fixes this: https://midengroup.slack.com/archives/C08UNH9UEM8/p1753859432326219