### PR TITLE
docs: add emit instruction to instruction reference

### DIFF
--- a/docs/src/user_docs/assembly/instruction_reference.md
+++ b/docs/src/user_docs/assembly/instruction_reference.md
@@ -321,4 +321,17 @@ Instructions for inspecting VM state during execution. These do not affect VM st
 - **Cycles:** 0 (does not consume VM cycles).
 - **Notes:**
     - Prints the specified part of the VM state.
-    - Ignored if assembler is not in debug mode. 
+    - Ignored if assembler is not in debug mode.
+
+### `emit`
+
+- **Syntax:** `emit.<event_id>`
+- **Stack Input:** `[...]`
+- **Stack Output:** `[...]`
+- **Cycles:** 5
+- **Notes:**
+    - Emits an event with the specified `event_id` to the host.
+    - Does not change the state of the operand stack.
+    - The `event_id` can be any 32-bit value specified either directly or via a [named constant](./code_organization.md#constants).
+    - Events allow programs to communicate contextual information to the host for triggering appropriate actions.
+    - Example: `emit.123` or `emit.EVENT_ID_1` 


### PR DESCRIPTION
Add documentation for the emit instruction to the Miden VM instruction reference.

The emit instruction was already documented in the events.md file but was missing
from the comprehensive instruction reference. This commit adds complete
documentation including:

- Syntax: emit.<event_id>
- Stack behavior: no change to operand stack
- Cycle count: 5 cycles
- Detailed notes explaining purpose and usage
- Examples of usage with direct values and named constants

This resolves GitHub issue #2046 which requested documentation for the emit
instruction in the instruction reference.

The documentation is based entirely on existing code analysis and follows the
same format as other instructions in the reference.