### PR TITLE
chore: remove basic block clock cycle optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ to extract more useful information. ([#2028](https://github.com/0xMiden/miden-vm
 - [BREAKING] The serialized representation for `Package` was changed to include
 procedure type information. Older packages will not work with the new serialization code, and vice versa. The version of the binary format was incremented accordingly. ([#2028](https://github.com/0xMiden/miden-vm/pull/2028))
 - [BREAKING] Procedure-related metadata types in the `miden-assembly` crate in some cases now require an optional type signature argument. If that information is not available, you can simply pass `None` to retain current behavior. ([#2028](https://github.com/0xMiden/miden-vm/pull/2028))
+- Remove basic block clock cycle optimization from `FastProcessor` ([#2054](https://github.com/0xMiden/miden-vm/pull/2054))
 
 ## 0.16.4 (2025-07-24)
 

--- a/processor/src/fast/circuit_eval.rs
+++ b/processor/src/fast/circuit_eval.rs
@@ -27,27 +27,14 @@ impl FastProcessor {
     ///
     /// Stack transition:
     /// [ptr, num_read, num_eval, ...] -> [ptr, num_read, num_eval, ...]
-    pub fn op_eval_circuit(
-        &mut self,
-        op_idx: usize,
-        err_ctx: &impl ErrorContext,
-    ) -> Result<(), ExecutionError> {
+    pub fn op_eval_circuit(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
         let num_eval = self.stack_get(2);
         let num_read = self.stack_get(1);
         let ptr = self.stack_get(0);
         let ctx = self.ctx;
-        let clk = self.clk;
-        let circuit_evaluation = eval_circuit_fast_(
-            ctx,
-            ptr,
-            clk,
-            num_read,
-            num_eval,
-            &mut self.memory,
-            op_idx,
-            err_ctx,
-        )?;
-        self.ace.add_circuit_evaluation(clk, circuit_evaluation);
+        let circuit_evaluation =
+            eval_circuit_fast_(ctx, ptr, self.clk, num_read, num_eval, &mut self.memory, err_ctx)?;
+        self.ace.add_circuit_evaluation(self.clk, circuit_evaluation);
 
         Ok(())
     }
@@ -62,7 +49,6 @@ pub fn eval_circuit_fast_(
     num_vars: Felt,
     num_eval: Felt,
     mem: &mut Memory,
-    op_idx: usize,
     err_ctx: &impl ErrorContext,
 ) -> Result<CircuitEvaluation, ExecutionError> {
     let num_vars = num_vars.as_int();
@@ -96,15 +82,12 @@ pub fn eval_circuit_fast_(
     let num_read_rows = num_vars as u32 / 2;
     let num_eval_rows = num_eval as u32;
 
-    let mut evaluation_context =
-        CircuitEvaluation::new(ctx, clk + op_idx, num_read_rows, num_eval_rows);
+    let mut evaluation_context = CircuitEvaluation::new(ctx, clk, num_read_rows, num_eval_rows);
 
     let mut ptr = ptr;
     // perform READ operations
     for _ in 0..num_read_rows {
-        let word = mem
-            .read_word(ctx, ptr, clk + op_idx, err_ctx)
-            .map_err(ExecutionError::MemoryError)?;
+        let word = mem.read_word(ctx, ptr, clk, err_ctx).map_err(ExecutionError::MemoryError)?;
         evaluation_context.do_read(ptr, word)?;
         ptr += PTR_OFFSET_WORD;
     }

--- a/processor/src/fast/field_ops.rs
+++ b/processor/src/fast/field_ops.rs
@@ -25,14 +25,10 @@ impl FastProcessor {
 
     /// Analogous to `Process::op_inv`.
     #[inline(always)]
-    pub fn op_inv(
-        &mut self,
-        op_idx: usize,
-        err_ctx: &impl ErrorContext,
-    ) -> Result<(), ExecutionError> {
+    pub fn op_inv(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
         let top = self.stack_get_mut(0);
         if (*top) == ZERO {
-            return Err(ExecutionError::divide_by_zero(self.clk + op_idx, err_ctx));
+            return Err(ExecutionError::divide_by_zero(self.clk, err_ctx));
         }
         *top = top.inv();
         Ok(())

--- a/processor/src/fast/horner_ops.rs
+++ b/processor/src/fast/horner_ops.rs
@@ -17,14 +17,13 @@ impl FastProcessor {
     #[inline(always)]
     pub fn op_horner_eval_base(
         &mut self,
-        op_idx: usize,
         err_ctx: &impl ErrorContext,
     ) -> Result<(), ExecutionError> {
         // read the values of the coefficients, over the base field, from the stack
         let coeffs = self.get_coeffs_as_base_elements();
 
         // read the evaluation point alpha from memory
-        let alpha = self.get_evaluation_point(op_idx, err_ctx)?;
+        let alpha = self.get_evaluation_point(err_ctx)?;
 
         // compute the updated accumulator value
         let (acc_new1, acc_new0) = {
@@ -50,14 +49,13 @@ impl FastProcessor {
     #[inline(always)]
     pub fn op_horner_eval_ext(
         &mut self,
-        op_idx: usize,
         err_ctx: &impl ErrorContext,
     ) -> Result<(), ExecutionError> {
         // read the values of the coefficients, over the base field, from the stack
         let coef = self.get_coeffs_as_quad_ext_elements();
 
         // read the evaluation point alpha from memory
-        let alpha = self.get_evaluation_point(op_idx, err_ctx)?;
+        let alpha = self.get_evaluation_point(err_ctx)?;
 
         // compute the updated accumulator value
         let (acc_new1, acc_new0) = {
@@ -103,14 +101,13 @@ impl FastProcessor {
     /// Returns the evaluation point.
     fn get_evaluation_point(
         &mut self,
-        op_idx: usize,
         err_ctx: &impl ErrorContext,
     ) -> Result<QuadFelt, ExecutionError> {
         let (alpha_0, alpha_1) = {
             let addr = self.stack_get(ALPHA_ADDR_INDEX);
             let word = self
                 .memory
-                .read_word(self.ctx, addr, self.clk + op_idx, err_ctx)
+                .read_word(self.ctx, addr, self.clk, err_ctx)
                 .map_err(ExecutionError::MemoryError)?;
 
             (word[0], word[1])

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -94,12 +94,6 @@ const DOUBLE_WORD_SIZE: Felt = Felt::new(8);
 ///   by 1 for every row that `Process` adds to the main trace.
 ///     - It is important to do so because the clock cycle is used to determine the context ID for
 ///       new execution contexts when using `call` or `dyncall`.
-/// - When executing a basic block, the clock cycle is not incremented for every individual
-///   operation for performance reasons.
-///     - Rather, we use `clk + operation_index` to determine the clock cycle when needed.
-///     - However this performance improvement is slightly offset by the need to parse operation
-///       batches exactly the same as `Process`. We will be able to recover the performance loss by
-///       redesigning the `BasicBlockNode`.
 #[derive(Debug)]
 pub struct FastProcessor {
     /// The stack is stored in reverse order, so that the last element is at the top of the stack.
@@ -113,10 +107,6 @@ pub struct FastProcessor {
     bounds_check_counter: usize,
 
     /// The current clock cycle.
-    ///
-    /// However, when we are in a basic block, this corresponds to the clock cycle at which the
-    /// basic block was entered. Hence, given an operation, we need to add its index in the
-    /// block to this value to get the clock cycle.
     pub(super) clk: RowIndex,
 
     /// The current context ID.
@@ -855,9 +845,6 @@ impl FastProcessor {
             batch_offset_in_block += op_batch.ops().len();
         }
 
-        // update clock with all the operations that executed
-        self.clk += batch_offset_in_block as u32;
-
         // Corresponds to the row inserted for the END operation added to the trace.
         self.clk += 1_u32;
 
@@ -869,7 +856,7 @@ impl FastProcessor {
             let decorator = program
                 .get_decorator_by_id(decorator_id)
                 .ok_or(ExecutionError::DecoratorNotFoundInForest { decorator_id })?;
-            self.execute_decorator(decorator, 0, host)?;
+            self.execute_decorator(decorator, host)?;
         }
 
         self.execute_after_exit_decorators(node_id, program, host)
@@ -903,7 +890,7 @@ impl FastProcessor {
                 let decorator = program
                     .get_decorator_by_id(decorator_id)
                     .ok_or(ExecutionError::DecoratorNotFoundInForest { decorator_id })?;
-                self.execute_decorator(decorator, op_idx_in_batch, host)?;
+                self.execute_decorator(decorator, host)?;
             }
 
             // decode and execute the operation
@@ -917,9 +904,7 @@ impl FastProcessor {
             // whereas all the other operations are synchronous (resulting in a significant
             // performance improvement).
             match op {
-                Operation::Emit(event_id) => {
-                    self.op_emit(*event_id, op_idx_in_block, host, &err_ctx).await?
-                },
+                Operation::Emit(event_id) => self.op_emit(*event_id, host, &err_ctx).await?,
                 _ => {
                     // if the operation is not an Emit, we execute it normally
                     self.execute_op(op, op_idx_in_block, program, host, &err_ctx)?;
@@ -952,6 +937,8 @@ impl FastProcessor {
             } else {
                 op_idx_in_group += 1;
             }
+
+            self.clk += 1_u32;
         }
 
         // make sure we execute the required number of operation groups; this would happen when the
@@ -976,7 +963,7 @@ impl FastProcessor {
             .expect("internal error: node id {node_id} not found in current forest");
 
         for &decorator_id in node.before_enter() {
-            self.execute_decorator(&current_forest[decorator_id], 0, host)?;
+            self.execute_decorator(&current_forest[decorator_id], host)?;
         }
 
         Ok(())
@@ -994,7 +981,7 @@ impl FastProcessor {
             .expect("internal error: node id {node_id} not found in current forest");
 
         for &decorator_id in node.after_exit() {
-            self.execute_decorator(&current_forest[decorator_id], 0, host)?;
+            self.execute_decorator(&current_forest[decorator_id], host)?;
         }
 
         Ok(())
@@ -1004,13 +991,12 @@ impl FastProcessor {
     fn execute_decorator(
         &mut self,
         decorator: &Decorator,
-        op_idx_in_batch: usize,
         host: &mut impl AsyncHost,
     ) -> Result<(), ExecutionError> {
         match decorator {
             Decorator::Debug(options) => {
                 if self.in_debug_mode {
-                    let process = &mut self.state(op_idx_in_batch);
+                    let process = &mut self.state();
                     host.on_debug(process, options)?;
                 }
             },
@@ -1018,7 +1004,7 @@ impl FastProcessor {
                 // do nothing
             },
             Decorator::Trace(id) => {
-                let process = &mut self.state(op_idx_in_batch);
+                let process = &mut self.state();
                 host.on_trace(process, *id)?;
             },
         };
@@ -1053,14 +1039,12 @@ impl FastProcessor {
             Operation::Noop => {
                 // do nothing
             },
-            Operation::Assert(err_code) => {
-                self.op_assert(*err_code, op_idx, host, program, err_ctx)?
-            },
+            Operation::Assert(err_code) => self.op_assert(*err_code, host, program, err_ctx)?,
             Operation::FmpAdd => self.op_fmpadd(),
             Operation::FmpUpdate => self.op_fmpupdate()?,
             Operation::SDepth => self.op_sdepth(),
             Operation::Caller => self.op_caller()?,
-            Operation::Clk => self.op_clk(op_idx)?,
+            Operation::Clk => self.op_clk()?,
             Operation::Emit(_event_id) => {
                 panic!("emit instruction requires async, so is not supported by execute_op()")
             },
@@ -1084,7 +1068,7 @@ impl FastProcessor {
             Operation::Add => self.op_add()?,
             Operation::Neg => self.op_neg()?,
             Operation::Mul => self.op_mul()?,
-            Operation::Inv => self.op_inv(op_idx, err_ctx)?,
+            Operation::Inv => self.op_inv(err_ctx)?,
             Operation::Incr => self.op_incr()?,
             Operation::And => self.op_and(err_ctx)?,
             Operation::Or => self.op_or(err_ctx)?,
@@ -1101,7 +1085,7 @@ impl FastProcessor {
             Operation::U32sub => self.op_u32sub(op_idx, err_ctx)?,
             Operation::U32mul => self.op_u32mul(err_ctx)?,
             Operation::U32madd => self.op_u32madd(err_ctx)?,
-            Operation::U32div => self.op_u32div(op_idx, err_ctx)?,
+            Operation::U32div => self.op_u32div(err_ctx)?,
             Operation::U32and => self.op_u32and(err_ctx)?,
             Operation::U32xor => self.op_u32xor(err_ctx)?,
             Operation::U32assert2(err_code) => self.op_u32assert2(*err_code, err_ctx)?,
@@ -1145,23 +1129,23 @@ impl FastProcessor {
 
             // ----- input / output ---------------------------------------------------------------
             Operation::Push(element) => self.op_push(*element),
-            Operation::AdvPop => self.op_advpop(op_idx, err_ctx)?,
-            Operation::AdvPopW => self.op_advpopw(op_idx, err_ctx)?,
-            Operation::MLoadW => self.op_mloadw(op_idx, err_ctx)?,
-            Operation::MStoreW => self.op_mstorew(op_idx, err_ctx)?,
+            Operation::AdvPop => self.op_advpop(err_ctx)?,
+            Operation::AdvPopW => self.op_advpopw(err_ctx)?,
+            Operation::MLoadW => self.op_mloadw(err_ctx)?,
+            Operation::MStoreW => self.op_mstorew(err_ctx)?,
             Operation::MLoad => self.op_mload(err_ctx)?,
             Operation::MStore => self.op_mstore(err_ctx)?,
-            Operation::MStream => self.op_mstream(op_idx, err_ctx)?,
-            Operation::Pipe => self.op_pipe(op_idx, err_ctx)?,
+            Operation::MStream => self.op_mstream(err_ctx)?,
+            Operation::Pipe => self.op_pipe(err_ctx)?,
 
             // ----- cryptographic operations -----------------------------------------------------
             Operation::HPerm => self.op_hperm(),
             Operation::MpVerify(err_code) => self.op_mpverify(*err_code, program, err_ctx)?,
             Operation::MrUpdate => self.op_mrupdate(err_ctx)?,
             Operation::FriE2F4 => self.op_fri_ext2fold4()?,
-            Operation::HornerBase => self.op_horner_eval_base(op_idx, err_ctx)?,
-            Operation::HornerExt => self.op_horner_eval_ext(op_idx, err_ctx)?,
-            Operation::EvalCircuit => self.op_eval_circuit(op_idx, err_ctx)?,
+            Operation::HornerBase => self.op_horner_eval_base(err_ctx)?,
+            Operation::HornerExt => self.op_horner_eval_ext(err_ctx)?,
+            Operation::EvalCircuit => self.op_eval_circuit(err_ctx)?,
         }
 
         Ok(())
@@ -1384,14 +1368,12 @@ impl FastProcessor {
 #[derive(Debug)]
 pub struct FastProcessState<'a> {
     pub(super) processor: &'a mut FastProcessor,
-    /// the index of the operation in its basic block
-    pub(super) op_idx: usize,
 }
 
 impl FastProcessor {
     #[inline(always)]
-    pub fn state(&mut self, op_idx: usize) -> ProcessState<'_> {
-        ProcessState::Fast(FastProcessState { processor: self, op_idx })
+    pub fn state(&mut self) -> ProcessState<'_> {
+        ProcessState::Fast(FastProcessState { processor: self })
     }
 }
 

--- a/processor/src/fast/sys_ops.rs
+++ b/processor/src/fast/sys_ops.rs
@@ -12,13 +12,12 @@ impl FastProcessor {
     pub fn op_assert(
         &mut self,
         err_code: Felt,
-        op_idx: usize,
         host: &mut impl BaseHost,
         program: &MastForest,
         err_ctx: &impl ErrorContext,
     ) -> Result<(), ExecutionError> {
         if self.stack_get(0) != ONE {
-            let process = &mut self.state(op_idx);
+            let process = &mut self.state();
             host.on_assert_failed(process, err_code);
             let err_msg = program.resolve_error_message(err_code);
             return Err(ExecutionError::failed_assertion(
@@ -75,9 +74,9 @@ impl FastProcessor {
     }
 
     /// Analogous to `Process::op_clk`.
-    pub fn op_clk(&mut self, op_idx: usize) -> Result<(), ExecutionError> {
+    pub fn op_clk(&mut self) -> Result<(), ExecutionError> {
         self.increment_stack_size();
-        self.stack_write(0, (self.clk + op_idx).into());
+        self.stack_write(0, self.clk.into());
         Ok(())
     }
 
@@ -86,11 +85,10 @@ impl FastProcessor {
     pub async fn op_emit(
         &mut self,
         event_id: u32,
-        op_idx: usize,
         host: &mut impl AsyncHost,
         err_ctx: &impl ErrorContext,
     ) -> Result<(), ExecutionError> {
-        let process = &mut self.state(op_idx);
+        let process = &mut self.state();
         // If it's a system event, handle it directly. Otherwise, forward it to the host.
         if let Some(system_event) = SystemEvent::from_event_id(event_id) {
             handle_system_event(process, system_event, err_ctx)

--- a/processor/src/fast/u32_ops.rs
+++ b/processor/src/fast/u32_ops.rs
@@ -115,12 +115,8 @@ impl FastProcessor {
 
     /// Analogous to `Process::op_u32div`.
     #[inline(always)]
-    pub fn op_u32div(
-        &mut self,
-        op_idx: usize,
-        err_ctx: &impl ErrorContext,
-    ) -> Result<(), ExecutionError> {
-        let clk = self.clk + op_idx;
+    pub fn op_u32div(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
+        let clk = self.clk;
         self.u32_pop2_applyfn_push_results(
             ZERO,
             |first, second| {

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -833,7 +833,7 @@ impl<'a> ProcessState<'a> {
     pub fn clk(&self) -> RowIndex {
         match self {
             ProcessState::Slow(state) => state.system.clk(),
-            ProcessState::Fast(state) => state.processor.clk + state.op_idx,
+            ProcessState::Fast(state) => state.processor.clk,
         }
     }
 


### PR DESCRIPTION
Removes the basic block clock cycle optimization from `FastProcessor`.

This was from a premature optimization from before - I confirmed that this change didn't change the performance of the `blake3_1to1` benchmark (might have also improved performance by ~2%). This makes the code much simpler to read.