### PR TITLE
refactor(dependency): Reuse existing serialization for DependencyName

### DIFF
--- a/package/src/dependency/mod.rs
+++ b/package/src/dependency/mod.rs
@@ -54,14 +54,14 @@ pub struct Dependency {
 
 impl Serializable for Dependency {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.name.0.write_into(target);
+        self.name.write_into(target);
         self.digest.write_into(target);
     }
 }
 
 impl Deserializable for Dependency {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let name = DependencyName(String::read_from(source)?);
+        let name = DependencyName::read_from(source)?;
         let digest = Word::read_from(source)?;
         Ok(Self { name, digest })
     }


### PR DESCRIPTION
This PR refactors the serialization and deserialization logic for the Dependency struct to improve code reuse and encapsulation.
Previously, the `Serializable `and `Deserializable `implementations for `Dependency `accessed the inner field of `DependencyName` directly (i.e., `self.name.0`).
This approach had a couple of drawbacks:
- It breaks encapsulation by reaching into the internal representation of `DependencyName`.
- It ignores the existing `Serializable `/ `Deserializable `implementations that `DependencyName `already provides, leading to less maintainable code.
This change simplifies the code by delegating the serialization task to `DependencyName ` itself, which already knows how to handle it.
