### PR TITLE
feat: implement custom sections in package format, prototype new serialization format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "miden-bite"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "bumpalo",
  "env_logger",
@@ -1188,9 +1198,13 @@ version = "0.17.0"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
+ "miden-bite",
  "miden-core",
  "proptest",
  "proptest-derive",
+ "serde",
+ "serde-untagged",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2075,6 +2089,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2553,6 +2578,12 @@ dependencies = [
  "termcolor",
  "toml",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,8 @@ dependencies = [
  "regex",
  "rustc_version 0.4.1",
  "semver 1.0.26",
+ "serde",
+ "serde-untagged",
  "smallvec",
  "thiserror 2.0.12",
 ]
@@ -1130,6 +1132,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "proptest",
+ "serde",
  "thiserror 2.0.12",
  "winter-math",
  "winter-rand-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-bite"
+version = "0.16.0"
+dependencies = [
+ "bumpalo",
+ "env_logger",
+ "indexmap",
+ "log",
+ "proptest",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "miden-core"
 version = "0.17.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ overflow-checks = true
 [workspace.dependencies]
 # Workspace crates
 miden-air = { path = "./air", version = "0.17", default-features = false }
+miden-bite = { path = "./crates/utils/bite", version = "0.17", default-features = false }
 miden-assembly = { path = "./assembly", version = "0.17", default-features = false }
 miden-assembly-syntax = { path = "./assembly-syntax", version = "0.17", default-features = false }
 miden-core = { path = "./core", version = "0.17", default-features = false }
@@ -72,6 +73,7 @@ serde = { version = "1.0", default-features = false, features = [
     "rc",
 ] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+serde-untagged = "0.1"
 smallvec = { version = "1.13", default-features = false, features = [
     "union",
     "const_generics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ miden-formatting = { version = "0.1", default-features = false }
 midenc-hir-type = { version = "0.1", default-features = false }
 
 # Third-party crates
+env_logger = "0.11"
 log = "0.4"
 proptest = { version = "1.7", default-features = false, features = [
     "no_std",

--- a/assembly-syntax/Cargo.toml
+++ b/assembly-syntax/Cargo.toml
@@ -30,7 +30,7 @@ logging = ["dep:env_logger"]
 
 [dependencies]
 aho-corasick = { version = "1.1", default-features = false }
-env_logger = { version = "0.11", optional = true }
+env_logger = { workspace = true, optional = true }
 lalrpop-util = { version = "0.22", default-features = false }
 log.workspace = true
 miden-core.workspace = true

--- a/assembly-syntax/Cargo.toml
+++ b/assembly-syntax/Cargo.toml
@@ -23,7 +23,14 @@ std = [
     "miden-utils-diagnostics/std",
     "thiserror/std",
 ]
-serde = ["miden-debug-types/serde", "midenc-hir-type/serde", "semver/serde"]
+serde = [
+    "dep:serde",
+    "dep:serde-untagged",
+    "miden-debug-types/serde",
+    "midenc-hir-type/serde",
+    "semver/serde",
+    "smallvec/serde",
+]
 arbitrary = ["dep:proptest", "dep:proptest-derive"]
 testing = ["arbitrary", "logging"]
 logging = ["dep:env_logger"]
@@ -44,6 +51,8 @@ regex = { version = "1.10", default-features = false, features = [
     "perf",
 ] }
 semver = { version = "1.0", default-features = false }
+serde = { workspace = true, optional = true }
+serde-untagged = { workspace = true, optional = true }
 smallvec.workspace = true
 thiserror.workspace = true
 

--- a/assembly-syntax/src/ast/ident.rs
+++ b/assembly-syntax/src/ast/ident.rs
@@ -199,6 +199,27 @@ impl FromStr for Ident {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for Ident {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Ident {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let name = <&'de str as serde::Deserialize>::deserialize(deserializer)?;
+        Self::new(name).map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(feature = "arbitrary")]
 pub(crate) mod testing {
     use alloc::string::String;

--- a/assembly-syntax/src/ast/procedure/name.rs
+++ b/assembly-syntax/src/ast/procedure/name.rs
@@ -14,6 +14,9 @@ use miden_core::utils::{
 use miden_debug_types::{SourceSpan, Span, Spanned};
 use miden_utils_diagnostics::{IntoDiagnostic, Report, miette};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{
     LibraryNamespace, LibraryPath,
     ast::{CaseKindError, Ident, IdentError},
@@ -157,6 +160,103 @@ impl Deserializable for QualifiedProcedureName {
     }
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for QualifiedProcedureName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            let name = format!("{}", self);
+            serializer.serialize_str(&name)
+        } else {
+            use serde::ser::SerializeStruct;
+
+            let mut builder = serializer.serialize_struct("QualifiedProcedureName", 2)?;
+            builder.serialize_field("module", &self.module)?;
+            builder.serialize_field("name", &self.name)?;
+            builder.end()
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for QualifiedProcedureName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Visitor;
+
+        if deserializer.is_human_readable() {
+            let name = <&'de str as serde::Deserialize>::deserialize(deserializer)?;
+            return Self::from_str(name).map_err(serde::de::Error::custom);
+        }
+
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Module,
+            Name,
+        }
+
+        struct QualifiedProcedureNameVisitor;
+        impl<'de> Visitor<'de> for QualifiedProcedureNameVisitor {
+            type Value = QualifiedProcedureName;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter.write_str("struct QualifiedProcedureName")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let module = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let name = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                Ok(QualifiedProcedureName::new(module, name))
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut module = None;
+                let mut name = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Module => {
+                            if module.is_some() {
+                                return Err(serde::de::Error::duplicate_field("module"));
+                            }
+                            module = Some(map.next_value()?);
+                        },
+                        Field::Name => {
+                            if name.is_some() {
+                                return Err(serde::de::Error::duplicate_field("name"));
+                            }
+                            name = Some(map.next_value()?);
+                        },
+                    }
+                }
+                let module = module.ok_or_else(|| serde::de::Error::missing_field("module"))?;
+                let name = name.ok_or_else(|| serde::de::Error::missing_field("name"))?;
+                Ok(QualifiedProcedureName::new(module, name))
+            }
+        }
+
+        deserializer.deserialize_struct(
+            "QualifiedProcedureName",
+            &["module", "name"],
+            QualifiedProcedureNameVisitor,
+        )
+    }
+}
+
 // PROCEDURE NAME
 // ================================================================================================
 
@@ -196,6 +296,8 @@ impl Deserializable for QualifiedProcedureName {
 /// end
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct ProcedureName(Ident);
 
 impl ProcedureName {

--- a/assembly-syntax/src/library/mod.rs
+++ b/assembly-syntax/src/library/mod.rs
@@ -8,6 +8,9 @@ use miden_core::{
 use midenc_hir_type::{FunctionType, Type};
 use smallvec::SmallVec;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::ast::QualifiedProcedureName;
 
 mod error;
@@ -29,12 +32,14 @@ pub use self::{
 
 /// Metadata about a procedure exported by the interface of a [Library]
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LibraryExport {
     /// The id of the MAST root node of the exported procedure
     pub node: MastNodeId,
     /// The fully-qualified name of the exported procedure
     pub name: QualifiedProcedureName,
     /// The type signature of the exported procedure, if known
+    #[cfg_attr(feature = "serde", serde(default))]
     pub signature: Option<FunctionType>,
 }
 
@@ -280,8 +285,12 @@ impl Library {
 /// - There must be at least one exported procedure.
 /// - The number of exported procedures cannot exceed [Kernel::MAX_NUM_PROCEDURES] (i.e., 256).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "Library"))]
 pub struct KernelLibrary {
+    #[cfg_attr(feature = "serde", serde(skip))]
     kernel: Kernel,
+    #[cfg_attr(feature = "serde", serde(skip))]
     kernel_info: ModuleInfo,
     library: Library,
 }
@@ -407,6 +416,116 @@ impl Deserializable for Library {
         let digest = mast_forest.compute_nodes_commitment(exports.values().map(|e| &e.node));
 
         Ok(Self { digest, exports, mast_forest })
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Library {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        struct LibraryExports<'a>(&'a BTreeMap<QualifiedProcedureName, LibraryExport>);
+        impl serde::Serialize for LibraryExports<'_> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                use serde::ser::SerializeSeq;
+                let mut serializer = serializer.serialize_seq(Some(self.0.len()))?;
+                for elem in self.0.values() {
+                    serializer.serialize_element(elem)?;
+                }
+                serializer.end()
+            }
+        }
+
+        let Self { digest: _, exports, mast_forest } = self;
+
+        let mut serializer = serializer.serialize_struct("Library", 2)?;
+        serializer.serialize_field("mast_forest", mast_forest)?;
+        serializer.serialize_field("exports", &LibraryExports(exports))?;
+        serializer.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Library {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Visitor;
+
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "snake_case")]
+        enum Field {
+            MastForest,
+            Exports,
+        }
+
+        struct LibraryVisitor;
+
+        impl<'de> Visitor<'de> for LibraryVisitor {
+            type Value = Library;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter.write_str("struct Library")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mast_forest = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let exports: Vec<LibraryExport> = seq
+                    .next_element()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                let exports =
+                    exports.into_iter().map(|export| (export.name.clone(), export)).collect();
+                Library::new(mast_forest, exports).map_err(serde::de::Error::custom)
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut mast_forest = None;
+                let mut exports = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::MastForest => {
+                            if mast_forest.is_some() {
+                                return Err(serde::de::Error::duplicate_field("mast_forest"));
+                            }
+                            mast_forest = Some(map.next_value()?);
+                        },
+                        Field::Exports => {
+                            if exports.is_some() {
+                                return Err(serde::de::Error::duplicate_field("exports"));
+                            }
+                            let items: Vec<LibraryExport> = map.next_value()?;
+                            exports = Some(
+                                items
+                                    .into_iter()
+                                    .map(|export| (export.name.clone(), export))
+                                    .collect(),
+                            );
+                        },
+                    }
+                }
+                let mast_forest =
+                    mast_forest.ok_or_else(|| serde::de::Error::missing_field("mast_forest"))?;
+                let exports = exports.ok_or_else(|| serde::de::Error::missing_field("exports"))?;
+                Library::new(mast_forest, exports).map_err(serde::de::Error::custom)
+            }
+        }
+
+        deserializer.deserialize_struct("Library", &["mast_forest", "exports"], LibraryVisitor)
     }
 }
 

--- a/assembly-syntax/src/library/namespace.rs
+++ b/assembly-syntax/src/library/namespace.rs
@@ -166,6 +166,17 @@ impl LibraryNamespace {
     pub fn to_ident(&self) -> Ident {
         Ident::from_raw_parts(Span::unknown(self.as_refcounted_str()))
     }
+
+    #[cfg(feature = "serde")]
+    const fn tag(&self) -> u8 {
+        // SAFETY: This is safe because we have given this enum a
+        // primitive representation with #[repr(u8)], with the first
+        // field of the underlying union-of-structs the discriminant
+        //
+        // See the section on "accessing the numeric value of the discriminant"
+        // here: https://doc.rust-lang.org/std/mem/fn.discriminant.html
+        unsafe { *(self as *const Self).cast::<u8>() }
+    }
 }
 
 impl core::ops::Deref for LibraryNamespace {
@@ -237,5 +248,103 @@ impl Deserializable for LibraryNamespace {
         let name =
             str::from_utf8(name).map_err(|e| DeserializationError::InvalidValue(e.to_string()))?;
         Self::new(name).map_err(|e| DeserializationError::InvalidValue(e.to_string()))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for LibraryNamespace {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            match self {
+                Self::Kernel => serializer.serialize_str(Self::KERNEL_PATH),
+                Self::Exec => serializer.serialize_str(Self::EXEC_PATH),
+                Self::Anon => serializer.serialize_str(Self::ANON_PATH),
+                Self::User(ns) => serializer.serialize_str(ns),
+            }
+        } else {
+            use serde::ser::SerializeTupleVariant;
+            let tag = self.tag() as u32;
+            match self {
+                Self::Kernel => {
+                    serializer.serialize_unit_variant("LibraryNamespace", tag, "Kernel")
+                },
+                Self::Exec => serializer.serialize_unit_variant("LibraryNamespace", tag, "Exec"),
+                Self::Anon => serializer.serialize_unit_variant("LibraryNamespace", tag, "Anon"),
+                Self::User(custom) => {
+                    let mut tuple =
+                        serializer.serialize_tuple_variant("LibraryNamespace", tag, "User", 1)?;
+                    tuple.serialize_field(&custom.as_ref())?;
+                    tuple.end()
+                },
+            }
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LibraryNamespace {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::{SeqAccess, Unexpected};
+
+        if deserializer.is_human_readable() {
+            let name = <&'de str as serde::Deserialize>::deserialize(deserializer)?;
+            match name {
+                Self::KERNEL_PATH => Ok(Self::Kernel),
+                Self::EXEC_PATH => Ok(Self::Exec),
+                Self::ANON_PATH => Ok(Self::Anon),
+                other => Self::new(other).map_err(serde::de::Error::custom),
+            }
+        } else {
+            const KERNEL: u8 = LibraryNamespace::Kernel.tag();
+            const EXEC: u8 = LibraryNamespace::Exec.tag();
+            const ANON: u8 = LibraryNamespace::Anon.tag();
+            const USER: u8 = ANON + 1;
+
+            serde_untagged::UntaggedEnumVisitor::new()
+                .expecting("a valid section id")
+                .string(|s| Self::from_str(s).map_err(serde::de::Error::custom))
+                .u8(|tag| match tag {
+                    KERNEL => Ok(Self::Kernel),
+                    EXEC => Ok(Self::Exec),
+                    ANON => Ok(Self::Anon),
+                    USER => {
+                        Err(serde::de::Error::custom("expected a user-defined library namespace"))
+                    },
+                    other => Err(serde::de::Error::invalid_value(
+                        Unexpected::Unsigned(other as u64),
+                        &"a valid library namespace variant",
+                    )),
+                })
+                .seq(|mut seq| {
+                    let tag = seq.next_element::<u8>()?.ok_or_else(|| {
+                        serde::de::Error::invalid_length(0, &"a valid library namespace variant")
+                    })?;
+                    match tag {
+                        KERNEL => Ok(Self::Kernel),
+                        EXEC => Ok(Self::Exec),
+                        ANON => Ok(Self::Anon),
+                        USER => seq
+                            .next_element::<&str>()?
+                            .ok_or_else(|| {
+                                serde::de::Error::invalid_length(
+                                    1,
+                                    &"a user-defined library namespace",
+                                )
+                            })
+                            .and_then(|s| Self::new(s).map_err(serde::de::Error::custom)),
+                        other => Err(serde::de::Error::invalid_value(
+                            Unexpected::Unsigned(other as u64),
+                            &"a valid library namespace variant",
+                        )),
+                    }
+                })
+                .deserialize(deserializer)
+        }
     }
 }

--- a/assembly-syntax/src/library/path.rs
+++ b/assembly-syntax/src/library/path.rs
@@ -15,6 +15,9 @@ use miden_core::utils::{
 use miden_debug_types::Span;
 use smallvec::smallvec;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{
     LibraryNamespace,
     ast::{Ident, IdentError},
@@ -123,6 +126,7 @@ pub struct LibraryPath {
 /// The data of a [LibraryPath] is allocated on the heap to make a [LibraryPath] the size of a
 /// pointer, rather than the size of 4 pointers. This makes them cheap to clone and move around.
 #[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct LibraryPathInner {
     /// The namespace of this library path
     ns: LibraryNamespace,
@@ -510,6 +514,37 @@ impl Deserializable for LibraryPath {
         let path =
             str::from_utf8(path).map_err(|e| DeserializationError::InvalidValue(e.to_string()))?;
         Self::new(path).map_err(|e| DeserializationError::InvalidValue(e.to_string()))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for LibraryPath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if serializer.is_human_readable() {
+            let name = format!("{}", self);
+            serializer.serialize_str(&name)
+        } else {
+            self.inner.serialize(serializer)
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for LibraryPath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let name = <&'de str as serde::Deserialize>::deserialize(deserializer)?;
+            Self::new(name).map_err(serde::de::Error::custom)
+        } else {
+            let inner = <Arc<LibraryPathInner> as serde::Deserialize>::deserialize(deserializer)?;
+            Ok(Self { inner })
+        }
     }
 }
 

--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -24,7 +24,7 @@ testing = ["logging", "miden-assembly-syntax/testing"]
 logging = ["dep:env_logger"]
 
 [dependencies]
-env_logger = { version = "0.11", optional = true }
+env_logger = { workspace = true, optional = true }
 log.workspace = true
 miden-assembly-syntax.workspace = true
 miden-core.workspace = true

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -3677,7 +3677,7 @@ prop_compose! {
 
         let manifest = PackageManifest::new(exports).with_dependencies(manifest.dependencies().cloned());
 
-        Package { name, mast, manifest, account_component_metadata_bytes: None }
+        Package { name, mast, manifest, sections: Default::default() }
     }
 }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -27,7 +27,12 @@ std = [
     "winter-math/std",
     "winter-utils/std",
 ]
-serde = ["miden-crypto/serde", "miden-debug-types/serde", "winter-math/serde"]
+serde = [
+    "dep:serde",
+    "miden-crypto/serde",
+    "miden-debug-types/serde",
+    "winter-math/serde",
+]
 
 [dependencies]
 miden-crypto.workspace = true
@@ -35,6 +40,7 @@ miden-debug-types.workspace = true
 miden-formatting.workspace = true
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
+serde = { workspace = true, optional = true }
 thiserror.workspace = true
 winter-math.workspace = true
 winter-utils.workspace = true

--- a/core/src/advice/map.rs
+++ b/core/src/advice/map.rs
@@ -7,6 +7,9 @@ use alloc::{
     vec::Vec,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{
     Felt, Word,
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
@@ -21,6 +24,8 @@ use crate::{
 /// associated with a given key onto the advice stack using `adv.push_mapval` instruction. The VM
 /// can also insert new values into the advice map during execution.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct AdviceMap(BTreeMap<Word, Arc<[Felt]>>);
 
 /// Pair representing a key-value entry in an [`AdviceMap`]

--- a/core/src/kernel.rs
+++ b/core/src/kernel.rs
@@ -2,6 +2,9 @@ use alloc::vec::Vec;
 
 use miden_crypto::Word;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{
     errors::KernelError,
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
@@ -15,6 +18,8 @@ use crate::{
 /// The internally-stored list always has a consistent order, regardless of the order of procedure
 /// list used to instantiate a kernel.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct Kernel(Vec<Word>);
 
 impl Kernel {

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -7,6 +7,10 @@ use core::{
     fmt, mem,
     ops::{Index, IndexMut},
 };
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 mod node;
 pub use node::{
     BasicBlockNode, CallNode, DynNode, ExternalNode, JoinNode, LoopNode, MastNode, MastNodeExt,
@@ -42,6 +46,7 @@ mod tests;
 /// A [`MastForest`] does not have an entrypoint, and hence is not executable. A [`crate::Program`]
 /// can be built from a [`MastForest`] to specify an entrypoint.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MastForest {
     /// All of the nodes local to the trees comprising the MAST forest.
     nodes: Vec<MastNode>,
@@ -556,6 +561,8 @@ impl IndexMut<DecoratorId> for MastForest {
 /// [`MastNodeId`] handles. Hence, [`MastNodeId`] equality must not be used to test for equality of
 /// the underlying [`MastNode`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct MastNodeId(u32);
 
 /// Operations that mutate a MAST often produce this mapping between old and new NodeIds.
@@ -695,6 +702,8 @@ impl Iterator for SubtreeIterator<'_> {
 /// An opaque handle to a [`Decorator`] in some [`MastForest`]. It is the responsibility of the user
 /// to use a given [`DecoratorId`] with the corresponding [`MastForest`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct DecoratorId(u32);
 
 impl DecoratorId {

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -4,6 +4,9 @@ use core::{fmt, mem};
 use miden_crypto::{Felt, Word, ZERO};
 use miden_formatting::prettier::PrettyPrint;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::{
     DecoratorIterator, DecoratorList, Operation,
     chiplets::hasher,
@@ -61,6 +64,7 @@ pub const BATCH_SIZE: usize = 8;
 /// Where `batches` is the concatenation of each `batch` in the basic block, and each batch is 8
 /// field elements (512 bits).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct BasicBlockNode {
     /// The primitive operations contained in this basic block.
     ///
@@ -69,6 +73,7 @@ pub struct BasicBlockNode {
     /// Multiple batches are used for blocks consisting of more than 72 operations.
     op_batches: Vec<OpBatch>,
     digest: Word,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     decorators: DecoratorList,
 }
 

--- a/core/src/mast/node/basic_block_node/op_batch.rs
+++ b/core/src/mast/node/basic_block_node/op_batch.rs
@@ -1,5 +1,8 @@
 use alloc::vec::Vec;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::{BATCH_SIZE, Felt, GROUP_SIZE, Operation, ZERO};
 
 // OPERATION BATCH
@@ -10,6 +13,7 @@ use super::{BATCH_SIZE, Felt, GROUP_SIZE, Operation, ZERO};
 /// An operation batch consists of up to 8 operation groups, with each group containing up to 9
 /// operations or a single immediate value.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct OpBatch {
     pub(super) ops: Vec<Operation>,
     pub(super) groups: [Felt; BATCH_SIZE],

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -7,6 +7,9 @@ use miden_formatting::{
     prettier::{Document, PrettyPrint, const_text, nl, text},
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::MastNodeExt;
 use crate::{
     OPCODE_CALL, OPCODE_SYSCALL,
@@ -24,11 +27,14 @@ use crate::{
 /// - A simple call: the callee is executed in the new user context.
 /// - A syscall: the callee is executed in the root context.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CallNode {
     callee: MastNodeId,
     is_syscall: bool,
     digest: Word,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     before_enter: Vec<DecoratorId>,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     after_exit: Vec<DecoratorId>,
 }
 

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -4,6 +4,9 @@ use core::fmt;
 use miden_crypto::{Felt, Word};
 use miden_formatting::prettier::{Document, PrettyPrint, const_text, nl};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::MastNodeExt;
 use crate::{
     OPCODE_DYN, OPCODE_DYNCALL,
@@ -15,9 +18,12 @@ use crate::{
 
 /// A Dyn node specifies that the node to be executed next is defined dynamically via the stack.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DynNode {
     is_dyncall: bool,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     before_enter: Vec<DecoratorId>,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     after_exit: Vec<DecoratorId>,
 }
 

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -7,6 +7,9 @@ use miden_formatting::{
     prettier::{Document, PrettyPrint, const_text, nl, text},
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::MastNodeExt;
 use crate::mast::{DecoratorId, MastForest};
 
@@ -22,9 +25,12 @@ use crate::mast::{DecoratorId, MastForest};
 /// The hash of an external node is the hash of the procedure it represents, such that an external
 /// node can be swapped with the actual subtree that it represents without changing the MAST root.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ExternalNode {
     digest: Word,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     before_enter: Vec<DecoratorId>,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     after_exit: Vec<DecoratorId>,
 }
 

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -3,6 +3,9 @@ use core::fmt;
 
 use miden_crypto::{Felt, Word};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::MastNodeExt;
 use crate::{
     OPCODE_JOIN,
@@ -17,10 +20,13 @@ use crate::{
 /// A Join node describe sequential execution. When the VM encounters a Join node, it executes the
 /// first child first and the second child second.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct JoinNode {
     children: [MastNodeId; 2],
     digest: Word,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     before_enter: Vec<DecoratorId>,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     after_exit: Vec<DecoratorId>,
 }
 

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -4,6 +4,9 @@ use core::fmt;
 use miden_crypto::{Felt, Word};
 use miden_formatting::prettier::PrettyPrint;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::MastNodeExt;
 use crate::{
     OPCODE_LOOP,
@@ -21,10 +24,13 @@ use crate::{
 /// If the top of the stack is neither `0` nor `1` when the condition is checked, the execution
 /// fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LoopNode {
     body: MastNodeId,
     digest: Word,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     before_enter: Vec<DecoratorId>,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     after_exit: Vec<DecoratorId>,
 }
 

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -2,6 +2,9 @@ mod basic_block_node;
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 pub use basic_block_node::{
     BATCH_SIZE as OP_BATCH_SIZE, BasicBlockNode, GROUP_SIZE as OP_GROUP_SIZE, OpBatch,
     OperationOrDecorator,
@@ -37,6 +40,7 @@ use crate::{
 // ================================================================================================
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MastNode {
     Block(BasicBlockNode),
     Join(JoinNode),

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -4,6 +4,9 @@ use core::fmt;
 use miden_crypto::{Felt, Word};
 use miden_formatting::prettier::PrettyPrint;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::MastNodeExt;
 use crate::{
     OPCODE_SPLIT,
@@ -21,10 +24,13 @@ use crate::{
 /// the `on_true` child is executed. If the value is `0`, then the `on_false` child is executed. If
 /// the value is neither `0` nor `1`, the execution fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SplitNode {
     branches: [MastNodeId; 2],
     digest: Word,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     before_enter: Vec<DecoratorId>,
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Vec::is_empty"))]
     after_exit: Vec<DecoratorId>,
 }
 

--- a/core/src/operations/decorators/assembly_op.rs
+++ b/core/src/operations/decorators/assembly_op.rs
@@ -3,12 +3,17 @@ use core::fmt;
 
 use miden_debug_types::Location;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 // ASSEMBLY OP
 // ================================================================================================
 
 /// Contains information corresponding to an assembly instruction (only applicable in debug mode).
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct AssemblyOp {
+    #[cfg_attr(feature = "serde", serde(default))]
     location: Option<Location>,
     context_name: String,
     op: String,

--- a/core/src/operations/decorators/debug.rs
+++ b/core/src/operations/decorators/debug.rs
@@ -1,5 +1,8 @@
 use core::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 // DEBUG OPTIONS
 // ================================================================================================
 
@@ -8,6 +11,7 @@ use core::fmt;
 /// These options define the debug info which gets printed out when the Debug decorator is
 /// executed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum DebugOptions {
     /// Print out the entire contents of the stack for the current execution context.
     StackAll,

--- a/core/src/operations/decorators/mod.rs
+++ b/core/src/operations/decorators/mod.rs
@@ -4,6 +4,9 @@ use core::fmt;
 use miden_crypto::hash::blake::Blake3_256;
 use num_traits::ToBytes;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 mod assembly_op;
 pub use assembly_op::AssemblyOp;
 
@@ -23,6 +26,7 @@ use crate::mast::{DecoratorFingerprint, DecoratorId};
 /// Executing decorators does not advance the VM clock. As such, many decorators can be executed in
 /// a single VM cycle.
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Decorator {
     /// Adds information about the assembly instruction at a particular index (only applicable in
     /// debug mode).

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -1,5 +1,8 @@
 use core::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 mod decorators;
 pub use decorators::{AssemblyOp, DebugOptions, Decorator, DecoratorIterator, DecoratorList};
 use opcode_constants::*;
@@ -130,6 +133,7 @@ pub(super) mod opcode_constants {
 
 /// A set of native VM operations which take exactly one cycle to execute.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(u8)]
 pub enum Operation {
     // ----- system operations -------------------------------------------------------------------

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -5,6 +5,9 @@ use miden_crypto::{Felt, WORD_SIZE, Word};
 use winter_math::FieldElement;
 use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::Kernel;
 use crate::{
     AdviceMap,
@@ -21,6 +24,7 @@ use crate::{
 /// execution begins, and a definition of the kernel against which the program must be executed
 /// (the kernel can be an empty kernel).
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Program {
     mast_forest: Arc<MastForest>,
     /// The "entrypoint" is the node where execution of the program begins.

--- a/crates/utils/bite/Cargo.toml
+++ b/crates/utils/bite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-bite"
-version = "0.16.0"
+version = "0.17.0"
 description = "BITE is Binary Interchange, Tiny Encoding - a compact binary file format"
 documentation = "https://docs.rs/miden-bite/0.16.0"
 readme = "README.md"

--- a/crates/utils/bite/Cargo.toml
+++ b/crates/utils/bite/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "miden-bite"
+version = "0.16.0"
+description = "BITE is Binary Interchange, Tiny Encoding - a compact binary file format"
+documentation = "https://docs.rs/miden-bite/0.16.0"
+readme = "README.md"
+categories = ["no-std"]
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+
+[features]
+default = ["std"]
+std = ["indexmap/std", "serde/std", "thiserror/std"]
+
+[dependencies]
+bumpalo = { version = "3.19", default-features = false }
+log.workspace = true
+indexmap = { version = "2.10", default-features = false }
+serde.workspace = true
+smallvec.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+env_logger.workspace = true
+proptest.workspace = true

--- a/crates/utils/bite/README.md
+++ b/crates/utils/bite/README.md
@@ -1,0 +1,1 @@
+# miden-cram

--- a/crates/utils/bite/src/de/mod.rs
+++ b/crates/utils/bite/src/de/mod.rs
@@ -1,0 +1,806 @@
+use alloc::{format, vec::Vec};
+
+use serde::de;
+use smallvec::ToSmallVec;
+
+use crate::Type;
+
+use super::{Error, Limits, MAGIC, Result, VERSION, varint};
+
+/// Deserialize a value of type `T` from the given BITE-encoded byte slice.
+pub fn from_bytes<'de, T>(bytes: &'de [u8]) -> Result<T>
+where
+    T: de::Deserialize<'de>,
+{
+    from_bytes_with_limits(bytes, Limits::default())
+}
+
+/// Deserialize a value of type `T` from the given BITE-encoded byte slice, while applying the
+/// provided limits during deserialization.
+pub fn from_bytes_with_limits<'de, T>(bytes: &'de [u8], limits: Limits) -> Result<T>
+where
+    T: de::Deserialize<'de>,
+{
+    let mut deserializer = BiteDeserializer::new(bytes, limits)?;
+    T::deserialize(&mut deserializer)
+}
+
+struct BiteDeserializer<'de> {
+    data: &'de [u8],
+    position: usize,
+    depth: usize,
+    limits: Limits,
+    strings: Vec<&'de str>,
+}
+
+struct Snapshot {
+    position: usize,
+    depth: usize,
+}
+
+impl<'de> BiteDeserializer<'de> {
+    pub fn new(data: &'de [u8], limits: Limits) -> Result<Self> {
+        let mut deserializer = Self {
+            data,
+            position: 0,
+            strings: Vec::new(),
+            limits,
+            depth: 0,
+        };
+
+        deserializer.read_header()?;
+        deserializer.read_string_table()?;
+
+        Ok(deserializer)
+    }
+
+    fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            position: self.position,
+            depth: self.depth,
+        }
+    }
+
+    fn restore(&mut self, snapshot: Snapshot) {
+        self.position = snapshot.position;
+        self.depth = snapshot.depth;
+    }
+
+    fn read_header(&mut self) -> Result<()> {
+        if self.data.len() < 8 {
+            return Err(Error::UnexpectedEof);
+        }
+
+        if &self.data[..MAGIC.len()] != MAGIC {
+            return Err(Error::InvalidMagic);
+        }
+        self.position = MAGIC.len();
+
+        let version = self.data[self.position];
+        if version != VERSION {
+            return Err(Error::InvalidVersion(version));
+        }
+        self.position += 1;
+
+        Ok(())
+    }
+
+    fn read_string_table(&mut self) -> Result<()> {
+        log::trace!(target: "de", "reading string table");
+        // Read number of entries in string table
+        let num_strings = self.read_varint()?;
+        let num_strings = u32::try_from(num_strings).map_err(|_| Error::LimitExceeded {
+            limit_type: "string table length",
+            value: num_strings,
+            max: u32::MAX as usize,
+        })? as usize;
+
+        log::trace!(target: "de", "found string table with {num_strings} entries");
+
+        // Read string table entries
+        self.strings.reserve(num_strings);
+        for id in 0..num_strings {
+            let len = self.read_varint()?;
+            let len = u32::try_from(len).map_err(|_| Error::LimitExceeded {
+                limit_type: "string length",
+                value: len,
+                max: u32::MAX as usize,
+            })? as usize;
+            log::trace!(target: "de", "reading string id {id} (length is {len})");
+            let bytes = self.read_bytes(len)?;
+            let s = core::str::from_utf8(bytes).map_err(Error::InvalidUtf8)?;
+            log::trace!(target: "de", "string id {id} read as '{s}'");
+            self.strings.push(s);
+        }
+
+        log::trace!(target: "de", "successfully read all string table entries");
+
+        Ok(())
+    }
+
+    #[inline]
+    fn read_byte(&mut self) -> Result<u8> {
+        let byte = self.data.get(self.position).copied().ok_or(Error::UnexpectedEof)?;
+
+        self.position += 1;
+
+        Ok(byte)
+    }
+
+    #[inline]
+    fn read_bytes(&mut self, count: usize) -> Result<&'de [u8]> {
+        let bytes = self
+            .data
+            .get(self.position..self.position + count)
+            .ok_or(Error::UnexpectedEof)?;
+        self.position += count;
+        Ok(bytes)
+    }
+
+    #[inline]
+    fn read_exact<const N: usize>(&mut self) -> Result<&'de [u8; N]> {
+        let bytes = self.data.get(self.position..self.position + N).ok_or(Error::UnexpectedEof)?;
+        self.position += N;
+        Ok(unsafe { <&'de [u8; N]>::try_from(bytes).unwrap_unchecked() })
+    }
+
+    #[inline]
+    fn read_varint(&mut self) -> Result<u64> {
+        varint::decode(self.data, &mut self.position)
+    }
+
+    #[inline]
+    fn read_type_tag(&mut self) -> Result<Type> {
+        self.read_byte().and_then(Type::try_from)
+    }
+
+    #[inline]
+    fn peek_type_tag(&mut self) -> Result<Type> {
+        let byte = self.data.get(self.position).copied().ok_or(Error::UnexpectedEof)?;
+
+        Type::try_from(byte)
+    }
+
+    #[inline]
+    fn expect_type_tag(&mut self, expected: Type) -> Result<()> {
+        self.read_type_tag().and_then(|ty| {
+            if ty != expected {
+                Err(Error::UnexpectedType {
+                    actual: ty,
+                    expected: [expected].to_smallvec(),
+                })
+            } else {
+                Ok(())
+            }
+        })
+    }
+
+    #[inline]
+    fn expect_type_tags(&mut self, expected: &[Type]) -> Result<Type> {
+        self.read_type_tag().and_then(|ty| {
+            if expected.contains(&ty) {
+                Ok(ty)
+            } else {
+                Err(Error::UnexpectedType {
+                    actual: ty,
+                    expected: expected.to_smallvec(),
+                })
+            }
+        })
+    }
+
+    fn check_depth(&mut self) -> Result<()> {
+        self.depth += 1;
+        if self.depth > self.limits.max_depth {
+            return Err(Error::LimitExceeded {
+                limit_type: "depth",
+                value: self.depth as u64,
+                max: self.limits.max_depth,
+            });
+        }
+        Ok(())
+    }
+
+    fn exit_depth(&mut self) {
+        self.depth -= 1;
+    }
+}
+
+impl<'de> de::Deserializer<'de> for &mut BiteDeserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        let ty = self.read_type_tag()?;
+        log::trace!(target: "de", "deserialize_any: {ty}");
+        match ty {
+            Type::False => visitor.visit_bool(false),
+            Type::True => visitor.visit_bool(true),
+            Type::None => visitor.visit_none(),
+            Type::Some => visitor.visit_some(self),
+            Type::Int => {
+                let value = self.read_varint()?;
+                visitor.visit_u64(value)
+            },
+            Type::SInt => {
+                let value = self.read_varint()?;
+                let leading_zeroes = value.leading_zeros();
+                log::trace!(target: "de", "parsed signed integer with {leading_zeroes} leading zeros");
+                match leading_zeroes {
+                    0..32 => visitor.visit_i64(value as i64),
+                    32..48 => visitor.visit_i32(value as u32 as i32),
+                    48..56 => visitor.visit_i16(value as u16 as i16),
+                    _ => visitor.visit_i8(value as u8 as i8),
+                }
+            },
+            Type::I8 => {
+                let byte = self.read_byte()?;
+                visitor.visit_i8(byte as i8)
+            },
+            Type::U8 => {
+                let byte = self.read_byte()?;
+                visitor.visit_u8(byte)
+            },
+            Type::F32 => {
+                self.position -= 1;
+                self.deserialize_f32(visitor)
+            },
+            Type::F64 => {
+                self.position -= 1;
+                self.deserialize_f64(visitor)
+            },
+            Type::Char => {
+                self.position -= 1;
+                self.deserialize_char(visitor)
+            },
+            Type::Bytes => {
+                self.position -= 1;
+                self.deserialize_bytes(visitor)
+            },
+            Type::Str => {
+                self.position -= 1;
+                self.deserialize_str(visitor)
+            },
+            Type::Seq => {
+                self.position -= 1;
+                self.deserialize_seq(visitor)
+            },
+            Type::Map => {
+                self.position -= 1;
+                self.deserialize_map(visitor)
+            },
+            Type::UnitVariant | Type::NewtypeVariant | Type::StructVariant | Type::TupleVariant => {
+                self.position -= 1;
+                self.check_depth()?;
+                let result = visitor.visit_enum(EnumAccess::new(self));
+                self.exit_depth();
+                result
+            },
+        }
+    }
+
+    fn deserialize_bool<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize bool");
+        let ty = self.expect_type_tags(&[Type::True, Type::False])?;
+        visitor.visit_bool(ty == Type::True)
+    }
+
+    fn deserialize_i8<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize i8");
+        self.expect_type_tag(Type::I8)?;
+        let byte = self.read_byte()?;
+        visitor.visit_i8(byte as i8)
+    }
+
+    fn deserialize_i16<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize i16");
+        self.expect_type_tag(Type::SInt)?;
+        let value = self.read_varint()?;
+        if value > u16::MAX as u64 {
+            return Err(Error::Custom(format!(
+                "expected valid i16 value, got {value} which is out of range for that type"
+            )));
+        }
+        visitor.visit_i16(value as u16 as i16)
+    }
+
+    fn deserialize_i32<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize i32");
+        self.expect_type_tag(Type::SInt)?;
+        let value = self.read_varint()?;
+        if value > u32::MAX as u64 {
+            return Err(Error::Custom(format!(
+                "expected valid i32 value, got {value} which is out of range for that type"
+            )));
+        }
+        visitor.visit_i32(value as u32 as i32)
+    }
+
+    fn deserialize_i64<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize i64");
+        self.expect_type_tag(Type::SInt)?;
+        let value = self.read_varint()?;
+        visitor.visit_i64(value as i64)
+    }
+
+    fn deserialize_u8<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize u8");
+        self.expect_type_tag(Type::U8)?;
+        visitor.visit_u8(self.read_byte()?)
+    }
+
+    fn deserialize_u16<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize u16");
+        self.expect_type_tag(Type::Int)?;
+        let value = self.read_varint()?;
+        if value > u16::MAX as u64 {
+            return Err(Error::Custom(format!(
+                "expected valid u16 value, got {value} which is out of range for that type"
+            )));
+        }
+        visitor.visit_u16(value as u16)
+    }
+
+    fn deserialize_u32<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize u32");
+        self.expect_type_tag(Type::Int)?;
+        let value = self.read_varint()?;
+        if value > u32::MAX as u64 {
+            return Err(Error::Custom(format!(
+                "expected valid u32 value, got {value} which is out of range for that type"
+            )));
+        }
+        visitor.visit_u32(value as u32)
+    }
+
+    fn deserialize_u64<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize u64");
+        self.expect_type_tag(Type::Int)?;
+        let value = self.read_varint()?;
+        visitor.visit_u64(value)
+    }
+
+    fn deserialize_f32<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize f32");
+        self.expect_type_tag(Type::F32)?;
+        let bytes = self.read_exact::<4>()?;
+        let value = f32::from_le_bytes(*bytes);
+        visitor.visit_f32(value)
+    }
+
+    fn deserialize_f64<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize f64");
+        self.expect_type_tag(Type::F64)?;
+        let bytes = self.read_exact::<8>()?;
+        let value = f64::from_le_bytes(*bytes);
+        visitor.visit_f64(value)
+    }
+
+    fn deserialize_char<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize char");
+        self.expect_type_tag(Type::Char)?;
+        let code = self.read_varint()?;
+        let code = u32::try_from(code).map_err(|_| Error::InvalidUtf8Char)?;
+        let c = char::from_u32(code).ok_or(Error::InvalidUtf8Char)?;
+        visitor.visit_char(c)
+    }
+
+    fn deserialize_str<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize str");
+        self.expect_type_tag(Type::Str)?;
+        let index = self.read_varint()?;
+        log::trace!(target: "de", "parsed string index {index}");
+        if index > u32::MAX as u64 {
+            return Err(Error::Custom(format!(
+                "expected valid string table index, got {index} which is out of bounds"
+            )));
+        }
+        let index = index as usize;
+        if index >= self.strings.len() {
+            return Err(Error::InvalidStringId(index));
+        }
+        visitor.visit_borrowed_str(self.strings[index])
+    }
+
+    fn deserialize_string<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_bytes<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize bytes");
+        self.expect_type_tag(Type::Bytes)?;
+        let len = self.read_varint()?;
+        log::trace!(target: "de", "parsed length of {len}");
+        if len > usize::MAX as u64 {
+            return Err(Error::Custom(format!(
+                "expected valid length, got {len} which is out of bounds"
+            )));
+        }
+        let bytes = self.read_bytes(len as usize)?;
+        visitor.visit_borrowed_bytes(bytes)
+    }
+
+    fn deserialize_byte_buf<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        self.deserialize_bytes(visitor)
+    }
+
+    fn deserialize_option<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize option");
+        match self.read_type_tag()? {
+            Type::None => visitor.visit_none(),
+            Type::Some => visitor.visit_some(self),
+            _ => {
+                // The field must've been skipped
+                self.position -= 1;
+                visitor.visit_none()
+            },
+        }
+    }
+
+    fn deserialize_unit<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize unit");
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize unit struct '{_name}'");
+        visitor.visit_unit()
+    }
+
+    fn deserialize_newtype_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize newtype struct '{_name}'");
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize sequence");
+
+        // If we don't see the seq tag, the sequence may have been skipped, so read an empty one
+        if self.peek_type_tag()? != Type::Seq {
+            return visitor.visit_seq(SeqAccess::new(self, 0));
+        }
+
+        self.expect_type_tag(Type::Seq)?;
+        let len = self.read_varint()?;
+        log::trace!(target: "de", "parsed length of {len}");
+        if len > usize::MAX as u64 {
+            return Err(Error::Custom(format!(
+                "expected valid sequence length, got {len} which is out of bounds"
+            )));
+        }
+        let len = len as usize;
+        if len > self.limits.max_sequence_length {
+            return Err(Error::LimitExceeded {
+                limit_type: "sequence_length",
+                value: len as u64,
+                max: self.limits.max_sequence_length,
+            });
+        }
+        self.check_depth()?;
+        let result = visitor.visit_seq(SeqAccess::new(self, len));
+        self.exit_depth();
+        result
+    }
+
+    fn deserialize_tuple<V: de::Visitor<'de>>(self, len: usize, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize tuple (expected arity {len})");
+
+        self.check_depth()?;
+        let result = visitor.visit_seq(SeqAccess::new(self, len));
+        self.exit_depth();
+        result
+    }
+
+    fn deserialize_tuple_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize tuple struct '{_name}' (expected arity {len})");
+        self.deserialize_tuple(len, visitor)
+    }
+
+    fn deserialize_map<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize map");
+
+        // If we don't see the map tag, the map may have been skipped, so read an empty map
+        if self.peek_type_tag()? != Type::Map {
+            return visitor.visit_map(MapAccess::new(self, 0)?);
+        }
+
+        self.expect_type_tag(Type::Map)?;
+        let len = self.read_varint()?;
+        log::trace!(target: "de", "parsed length of {len}");
+        if len > usize::MAX as u64 {
+            return Err(Error::Custom(format!(
+                "expected valid map size, got {len} which is out of bounds"
+            )));
+        }
+        let len = len as usize;
+        if len > self.limits.max_map_entries {
+            return Err(Error::LimitExceeded {
+                limit_type: "map_entries",
+                value: len as u64,
+                max: self.limits.max_map_entries,
+            });
+        }
+        self.check_depth()?;
+        let result = visitor.visit_map(MapAccess::new(self, len)?);
+        self.exit_depth();
+        result
+    }
+
+    fn deserialize_struct<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize struct '{_name}' with {} fields", fields.len());
+
+        self.check_depth()?;
+        let result = visitor.visit_seq(SeqAccess::new(self, fields.len()));
+        self.exit_depth();
+        result
+    }
+
+    fn deserialize_enum<V: de::Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize enum '{_name}' with {} variants", _variants.len());
+        self.check_depth()?;
+        let result = visitor.visit_enum(EnumAccess::new(self));
+        self.exit_depth();
+        result
+    }
+
+    fn deserialize_identifier<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize identifier");
+        self.deserialize_str(visitor)
+    }
+
+    fn deserialize_ignored_any<V: de::Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize ignored");
+        self.deserialize_any(visitor)
+    }
+}
+
+// Helper structs for complex types
+struct SeqAccess<'a, 'de> {
+    de: &'a mut BiteDeserializer<'de>,
+    remaining: usize,
+}
+
+impl<'a, 'de> SeqAccess<'a, 'de> {
+    fn new(de: &'a mut BiteDeserializer<'de>, count: usize) -> Self {
+        Self { de, remaining: count }
+    }
+}
+
+impl<'de> de::SeqAccess<'de> for SeqAccess<'_, 'de> {
+    type Error = Error;
+
+    fn next_element_seed<T: de::DeserializeSeed<'de>>(
+        &mut self,
+        seed: T,
+    ) -> Result<Option<T::Value>> {
+        if self.remaining == 0 {
+            log::trace!(target: "de", "finished deserializing sequence");
+            return Ok(None);
+        }
+        log::trace!(target: "de", "deserialize next element");
+        self.remaining -= 1;
+        seed.deserialize(&mut *self.de).map(Some)
+    }
+}
+
+struct MapAccess<'a, 'de> {
+    de: &'a mut BiteDeserializer<'de>,
+    remaining: usize,
+    current_key: usize,
+    next_value: usize,
+    keys_end: usize,
+    values_end: usize,
+}
+
+impl<'a, 'de> MapAccess<'a, 'de> {
+    fn new(de: &'a mut BiteDeserializer<'de>, count: usize) -> Result<Self> {
+        // If the map is empty, there is nothing to do
+        if count == 0 {
+            let pos = de.position;
+            return Ok(Self {
+                de,
+                remaining: 0,
+                current_key: pos,
+                next_value: pos,
+                keys_end: pos,
+                values_end: pos,
+            });
+        }
+
+        // We begin at the start of the key segment
+        //
+        // The length of the segment comes first
+        let keys_len = de.read_varint()?;
+
+        // The offset of the first key immediately follows the length
+        let current_key = de.position;
+
+        // The offset of the value segment occurs immediately after the keys
+        let value_segment_offset = usize::try_from(keys_len).map_err(|_| Error::LimitExceeded {
+            limit_type: "map keys",
+            value: keys_len,
+            max: u32::MAX as usize,
+        })?;
+
+        // Validate the value segment offset
+        let value_segment_start =
+            current_key.checked_add(value_segment_offset).ok_or(Error::UnexpectedEof)?;
+
+        // Save the current deserializer state while we look forward at the value segment
+        let snapshot = de.snapshot();
+        de.position = value_segment_start;
+
+        // The size of the value segment precedes the values themselves, parse that now
+        let values_len = de.read_varint()?;
+        let value_segment_len = usize::try_from(values_len).map_err(|_| Error::LimitExceeded {
+            limit_type: "map values",
+            value: values_len,
+            max: u32::MAX as usize,
+        })?;
+
+        // The offset of the first value immediately follows the length
+        let next_value = de.position;
+
+        // Validate the value segment length
+        let values_end = next_value.checked_add(value_segment_len).ok_or(Error::UnexpectedEof)?;
+
+        // Restore the deserializer state to the start of the key segment, if the map is non-empty
+        de.restore(snapshot);
+
+        Ok(Self {
+            de,
+            remaining: count,
+            current_key,
+            next_value,
+            keys_end: value_segment_start,
+            values_end,
+        })
+    }
+}
+
+impl<'de> de::MapAccess<'de> for MapAccess<'_, 'de> {
+    type Error = Error;
+
+    fn next_key_seed<K: de::DeserializeSeed<'de>>(&mut self, seed: K) -> Result<Option<K::Value>> {
+        if self.remaining == 0 {
+            log::trace!(target: "de", "finished deserializing map");
+            return Ok(None);
+        }
+        self.remaining -= 1;
+
+        log::trace!(target: "de", "deserialize next map key");
+
+        // If we expect more keys, but we're already past the end of the keys segment, the file
+        // is corrupted
+        if self.de.position >= self.keys_end {
+            return Err(Error::MapCorrupted);
+        }
+
+        let key = seed.deserialize(&mut *self.de).map(Some)?;
+        self.current_key = self.de.position;
+
+        // Similarly, if we finish deserializing a key and we've moved past the end of the keys
+        // segment, the file is corrupted
+        if self.de.position > self.keys_end {
+            return Err(Error::MapCorrupted);
+        }
+
+        Ok(key)
+    }
+
+    fn next_value_seed<V: de::DeserializeSeed<'de>>(&mut self, seed: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize next map value");
+
+        // We need to snapshot the current deserializer and advance into the values segment
+        let snapshot = self.de.snapshot();
+        self.de.position = self.next_value;
+
+        // If we expect more values, but we're already past the end of the values segment, the file
+        // is corrupted
+        if self.de.position >= self.values_end {
+            return Err(Error::MapCorrupted);
+        }
+
+        let value = seed.deserialize(&mut *self.de)?;
+        self.next_value = self.de.position;
+
+        // Similarly, if we finish deserializing a value and we've moved past the end of the values
+        // segment, the file is corrupted
+        if self.de.position > self.values_end {
+            return Err(Error::MapCorrupted);
+        }
+
+        // Restore the deserializer state to the next key, if present
+        if self.remaining > 0 {
+            self.de.restore(snapshot);
+        }
+
+        Ok(value)
+    }
+}
+
+struct EnumAccess<'a, 'de> {
+    de: &'a mut BiteDeserializer<'de>,
+}
+
+impl<'a, 'de> EnumAccess<'a, 'de> {
+    fn new(de: &'a mut BiteDeserializer<'de>) -> Self {
+        Self { de }
+    }
+}
+
+impl<'de> de::EnumAccess<'de> for EnumAccess<'_, 'de> {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V: de::DeserializeSeed<'de>>(
+        self,
+        seed: V,
+    ) -> Result<(V::Value, Self::Variant)> {
+        log::trace!(target: "de", "deserialize enum variant");
+        self.de.expect_type_tags(&[
+            Type::UnitVariant,
+            Type::NewtypeVariant,
+            Type::StructVariant,
+            Type::TupleVariant,
+        ])?;
+        let val = seed.deserialize(&mut *self.de)?;
+        Ok((val, self))
+    }
+}
+
+impl<'de> de::VariantAccess<'de> for EnumAccess<'_, 'de> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<()> {
+        log::trace!(target: "de", "deserialize unit variant");
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T: de::DeserializeSeed<'de>>(self, seed: T) -> Result<T::Value> {
+        log::trace!(target: "de", "deserialize newtype variant");
+        seed.deserialize(&mut *self.de)
+    }
+
+    fn tuple_variant<V: de::Visitor<'de>>(self, len: usize, visitor: V) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize tuple variant of len {len}");
+        self.de.check_depth()?;
+        let result = visitor.visit_seq(SeqAccess::new(&mut *self.de, len));
+        self.de.exit_depth();
+        result
+    }
+
+    fn struct_variant<V: de::Visitor<'de>>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value> {
+        log::trace!(target: "de", "deserialize struct variant with {} fields", fields.len());
+        self.de.check_depth()?;
+        let result = visitor.visit_seq(SeqAccess::new(&mut *self.de, fields.len()));
+        self.de.exit_depth();
+        result
+    }
+}

--- a/crates/utils/bite/src/lib.rs
+++ b/crates/utils/bite/src/lib.rs
@@ -1,0 +1,189 @@
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(any(test, feature = "std"))]
+extern crate std;
+
+mod de;
+mod ser;
+#[cfg(test)]
+mod tests;
+mod varint;
+
+pub use self::de::{from_bytes, from_bytes_with_limits};
+pub use self::ser::to_bytes;
+
+use alloc::string::{String, ToString};
+use core::fmt;
+use smallvec::SmallVec;
+
+/// The magic byte sequence used to identify BITE-encoded byte streams
+const MAGIC: &[u8] = b"BITE\0";
+
+/// The current BITE version identifier
+const VERSION: u8 = 1;
+
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Errors which can occur during serialization/deserialization
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("invalid magic number")]
+    InvalidMagic,
+    #[error("invalid version number: expected {VERSION}, got {0}")]
+    InvalidVersion(u8),
+    #[error("unexpected end of file")]
+    UnexpectedEof,
+    #[error("corrupted string table")]
+    StringTableCorrupted,
+    #[error("corrupted map")]
+    MapCorrupted,
+    #[error("limit exceeded: {limit_type} limit of {value} exceeds {max}")]
+    LimitExceeded {
+        limit_type: &'static str,
+        value: u64,
+        max: usize,
+    },
+    #[error("invalid type tag: {0} is not a recognized type tag")]
+    InvalidTypeTag(u8),
+    #[error("unexpected type: expected {}, got {actual}", format_csv(expected))]
+    UnexpectedType {
+        actual: Type,
+        expected: SmallVec<[Type; 1]>,
+    },
+    #[error("invalid index into string table: {0} is out of bounds")]
+    InvalidStringId(usize),
+    #[error("invalid variable-length encoded integer: must be 64-bits or less")]
+    InvalidVarint,
+    #[error("invalid utf-8 string: {0}")]
+    InvalidUtf8(#[from] core::str::Utf8Error),
+    #[error("invalid utf-8 grapheme/codepoint")]
+    InvalidUtf8Char,
+    #[error("unrecognized enum variant: {0}")]
+    InvalidEnumVariant(u32),
+    #[error("{0}")]
+    Custom(String),
+}
+
+fn format_csv<T: fmt::Display>(values: &[T]) -> String {
+    use core::fmt::Write;
+
+    let mut csv = String::new();
+    for (i, value) in values.iter().enumerate() {
+        if i > 0 {
+            csv.push_str(", ");
+        }
+        write!(&mut csv, "{value}").unwrap();
+    }
+    csv
+}
+
+impl serde::ser::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Error::Custom(msg.to_string())
+    }
+}
+
+impl serde::de::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        Error::Custom(msg.to_string())
+    }
+}
+
+/// Configurable limits to impose during serialization/deserialization
+#[derive(Debug, Clone)]
+pub struct Limits {
+    /// The maximum number of bytes in a string
+    pub max_string_length: usize,
+    /// The maximum number of elements in a sequence
+    pub max_sequence_length: usize,
+    /// The maximum number of entries in a map
+    pub max_map_entries: usize,
+    /// The maximum depth of the object tree
+    pub max_depth: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        const DEFAULT_LIMIT: usize = u32::MAX as usize;
+        Self {
+            max_string_length: DEFAULT_LIMIT,
+            max_sequence_length: DEFAULT_LIMIT,
+            max_map_entries: DEFAULT_LIMIT,
+            max_depth: 64,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Type {
+    False = 0,
+    True = 1,
+    None = 2,
+    Some = 3,
+    Int = 4,
+    SInt = 5,
+    I8 = 6,
+    U8 = 7,
+    F32 = 8,
+    F64 = 9,
+    Char = 10,
+    Bytes = 11,
+    Str = 12,
+    Seq = 13,
+    Map = 14,
+    UnitVariant = 15,
+    NewtypeVariant = 16,
+    StructVariant = 17,
+    TupleVariant = 18,
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::False | Self::True => f.write_str("bool"),
+            Self::None | Self::Some => f.write_str("option"),
+            Self::Int => f.write_str("unsigned variable-length integer"),
+            Self::SInt => f.write_str("signed variable-length integer"),
+            Self::I8 => f.write_str("i8"),
+            Self::U8 => f.write_str("u8"),
+            Self::F32 => f.write_str("f32"),
+            Self::F64 => f.write_str("f64"),
+            Self::Char => f.write_str("char"),
+            Self::Bytes => f.write_str("bytes"),
+            Self::Str => f.write_str("string"),
+            Self::Seq => f.write_str("sequence"),
+            Self::Map => f.write_str("map"),
+            Self::UnitVariant => f.write_str("unit variant"),
+            Self::NewtypeVariant => f.write_str("newtype variant"),
+            Self::StructVariant => f.write_str("struct variant"),
+            Self::TupleVariant => f.write_str("tuple variant"),
+        }
+    }
+}
+
+impl TryFrom<u8> for Type {
+    type Error = Error;
+
+    fn try_from(value: u8) -> core::result::Result<Self, Self::Error> {
+        if value > Self::TupleVariant.tag() {
+            return Err(Error::InvalidTypeTag(value));
+        }
+
+        Ok(unsafe { core::mem::transmute::<u8, Type>(value) })
+    }
+}
+
+impl Type {
+    pub const fn tag(&self) -> u8 {
+        // SAFETY: This is safe because we have given this enum a
+        // primitive representation with #[repr(u8)], with the first
+        // field of the underlying union-of-structs the discriminant
+        //
+        // See the section on "accessing the numeric value of the discriminant"
+        // here: https://doc.rust-lang.org/std/mem/fn.discriminant.html
+        unsafe { *(self as *const Self).cast::<u8>() }
+    }
+}

--- a/crates/utils/bite/src/ser/mod.rs
+++ b/crates/utils/bite/src/ser/mod.rs
@@ -1,0 +1,551 @@
+use alloc::vec::Vec;
+
+use serde::ser;
+
+use crate::Type;
+
+use super::{Error, MAGIC, Result, VERSION, varint};
+
+/// Serialize `value` into a vector of BITE-encoded bytes
+pub fn to_bytes<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: ser::Serialize,
+{
+    let allocator = bumpalo::Bump::new();
+    let mut serializer = BiteSerializer::new(&allocator);
+
+    // Serialize data to temporary buffer
+    value.serialize(&mut serializer)?;
+
+    // Create output buffer with header, string table, and serialized data
+    let capacity =
+        serializer.output.len() + MAGIC.len() + 1 + 4 + serializer.strings.size_in_bytes();
+    let mut output = Vec::with_capacity(capacity);
+
+    // Magic
+    output.extend_from_slice(MAGIC);
+
+    // Version
+    output.push(VERSION);
+
+    // String table length
+    log::trace!(target: "ser", "serializing string table with {} entries", serializer.strings.len());
+    varint::encode(serializer.strings.len() as u64, &mut output);
+
+    // String table
+    if !serializer.strings.is_empty() {
+        for (i, s) in serializer.strings.iter().enumerate() {
+            log::trace!(target: "ser", "serializing string id {i}: '{s}'");
+            varint::encode(s.len() as u64, &mut output);
+            output.extend_from_slice(s.as_bytes());
+        }
+    }
+
+    // Data
+    output.append(&mut serializer.output);
+
+    Ok(output)
+}
+
+/// Implements serialization of the Serde data model into BITE binary format
+pub struct BiteSerializer<'a> {
+    strings: StringTable<'a>,
+    output: Vec<u8>,
+}
+
+impl<'a> BiteSerializer<'a> {
+    pub fn new(allocator: &'a bumpalo::Bump) -> Self {
+        Self {
+            strings: StringTable::new(allocator),
+            output: Vec::with_capacity(1024),
+        }
+    }
+
+    #[inline]
+    fn write_byte(&mut self, byte: u8) {
+        self.output.push(byte);
+    }
+
+    #[inline]
+    fn write_bytes(&mut self, bytes: &[u8]) {
+        self.output.extend_from_slice(bytes);
+    }
+
+    #[inline]
+    fn write_varint(&mut self, value: u64) {
+        varint::encode(value, &mut self.output);
+    }
+}
+
+// Implement serde::Serializer for CbfSerializer
+impl<'a, 'alloc> ser::Serializer for &'a mut BiteSerializer<'alloc> {
+    type Ok = ();
+    type Error = Error;
+    type SerializeSeq = SeqSerializer<'a, 'alloc>;
+    type SerializeTuple = Self;
+    type SerializeTupleStruct = Self;
+    type SerializeTupleVariant = Self;
+    type SerializeMap = MapSerializer<'a, 'alloc>;
+    type SerializeStruct = Self;
+    type SerializeStructVariant = Self;
+
+    fn serialize_bool(self, v: bool) -> Result<()> {
+        log::trace!(target: "ser", "serializing bool: {v}");
+        self.write_byte(if v { Type::True.tag() } else { Type::False.tag() });
+        Ok(())
+    }
+
+    fn serialize_i8(self, v: i8) -> Result<()> {
+        log::trace!(target: "ser", "serializing i8: {v}");
+        self.write_bytes(&[Type::I8.tag(), v as u8]);
+        Ok(())
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<()> {
+        log::trace!(target: "ser", "serializing i16: {v}");
+        self.write_byte(Type::SInt.tag());
+        self.write_varint(v as u16 as u64);
+        Ok(())
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<()> {
+        log::trace!(target: "ser", "serializing i32: {v}");
+        self.write_byte(Type::SInt.tag());
+        self.write_varint(v as u32 as u64);
+        Ok(())
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<()> {
+        log::trace!(target: "ser", "serializing i64: {v}");
+        self.write_byte(Type::SInt.tag());
+        self.write_varint(v as u64);
+        Ok(())
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<()> {
+        log::trace!(target: "ser", "serializing u8: {v}");
+        self.write_bytes(&[Type::U8.tag(), v]);
+        Ok(())
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<()> {
+        log::trace!(target: "ser", "serializing u16: {v}");
+        self.write_byte(Type::Int.tag());
+        self.write_varint(v as u64);
+        Ok(())
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<()> {
+        log::trace!(target: "ser", "serializing u32: {v}");
+        self.write_byte(Type::Int.tag());
+        self.write_varint(v as u64);
+        Ok(())
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<()> {
+        log::trace!(target: "ser", "serializing u64: {v}");
+        self.write_byte(Type::Int.tag());
+        self.write_varint(v);
+        Ok(())
+    }
+
+    fn serialize_f32(self, v: f32) -> Result<()> {
+        log::trace!(target: "ser", "serializing f32: {v}");
+        self.write_byte(Type::F32.tag());
+        self.write_bytes(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_f64(self, v: f64) -> Result<()> {
+        log::trace!(target: "ser", "serializing f64: {v}");
+        self.write_byte(Type::F64.tag());
+        self.write_bytes(&v.to_le_bytes());
+        Ok(())
+    }
+
+    fn serialize_char(self, v: char) -> Result<()> {
+        log::trace!(target: "ser", "serializing char: {v}");
+        self.write_byte(Type::Char.tag());
+        self.write_varint(v as u32 as u64);
+        Ok(())
+    }
+
+    fn serialize_str(self, v: &str) -> Result<()> {
+        log::trace!(target: "ser", "serializing string: {v}");
+        let id = self.strings.add_string(v);
+        log::trace!(target: "ser", "mapped string '{v}' to string id {}", id.to_index());
+        self.write_byte(Type::Str.tag());
+        self.write_varint(id.to_index() as u64);
+        Ok(())
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<()> {
+        log::trace!(target: "ser", "serializing {} bytes", v.len());
+        self.write_byte(Type::Bytes.tag());
+        self.write_varint(v.len() as u64);
+        self.write_bytes(v);
+        Ok(())
+    }
+
+    fn serialize_none(self) -> Result<()> {
+        log::trace!(target: "ser", "serializing None");
+        self.write_byte(Type::None.tag());
+        Ok(())
+    }
+
+    fn serialize_some<T: ?Sized + ser::Serialize>(self, value: &T) -> Result<()> {
+        log::trace!(target: "ser", "serializing Some");
+        self.write_byte(Type::Some.tag());
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<()> {
+        log::trace!(target: "ser", "serializing unit");
+        Ok(())
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<()> {
+        log::trace!(target: "ser", "serializing unit struct '{_name}'");
+        Ok(())
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<()> {
+        log::trace!(target: "ser", "serializing unit variant '{_name}::{_variant}' (index {variant_index})");
+        self.write_byte(Type::UnitVariant.tag());
+        self.write_varint(variant_index as u64);
+        Ok(())
+    }
+
+    fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<()> {
+        log::trace!(target: "ser", "serializing newtype struct '{_name}'");
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        value: &T,
+    ) -> Result<()> {
+        log::trace!(target: "ser", "serializing newtype variant '{_name}::{_variant}' (index {variant_index})");
+        self.write_byte(Type::NewtypeVariant.tag());
+        self.write_varint(variant_index as u64);
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq> {
+        log::trace!(target: "ser", "serializing sequence (len = {len:?})");
+        Ok(SeqSerializer {
+            ser: self,
+            count: len,
+            counted: 0,
+            data: Vec::with_capacity(len.map(|len| len * 8).unwrap_or_default()),
+        })
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        log::trace!(target: "ser", "serializing tuple (len = {_len})");
+        Ok(self)
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        log::trace!(target: "ser", "serializing tuple (len = {_len})");
+        Ok(self)
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        log::trace!(target: "ser", "serializing tuple variant '{_name}::{_variant}' (index = {variant_index})");
+        self.write_byte(Type::TupleVariant.tag());
+        self.write_varint(variant_index as u64);
+        Ok(self)
+    }
+
+    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap> {
+        log::trace!(target: "ser", "serializing map (len = {len:?})");
+        let capacity = len.unwrap_or_default();
+        Ok(MapSerializer {
+            ser: self,
+            count: len,
+            counted: 0,
+            keys: Vec::with_capacity(capacity),
+            values: Vec::with_capacity(capacity),
+        })
+    }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        log::trace!(target: "ser", "serializing struct '{_name}'");
+        Ok(self)
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        log::trace!(target: "ser", "serializing struct variant '{_name}::{_variant}' (index = {variant_index})");
+        self.write_byte(Type::StructVariant.tag());
+        self.write_varint(variant_index as u64);
+        Ok(self)
+    }
+}
+
+#[doc(hidden)]
+pub struct SeqSerializer<'a, 'alloc> {
+    ser: &'a mut BiteSerializer<'alloc>,
+    count: Option<usize>,
+    counted: usize,
+    data: Vec<u8>,
+}
+
+impl<'a, 'alloc> ser::SerializeSeq for SeqSerializer<'a, 'alloc> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
+        log::trace!(target: "ser", "serializing sequence element {}", self.counted + 1);
+        value.serialize(&mut *self.ser)?;
+        self.counted += 1;
+        Ok(())
+    }
+
+    fn end(self) -> Result<()> {
+        log::trace!(target: "ser", "finished serializing sequence");
+        let count = core::cmp::max(self.counted, self.count.unwrap_or(self.counted));
+
+        // Write the type tag first
+        self.ser.write_byte(Type::Seq.tag());
+
+        // Write the seq arity
+        self.ser.write_varint(count as u64);
+
+        // Empty sequences are serialized only as a count
+        if count == 0 {
+            return Ok(());
+        }
+
+        // Write all elements
+        self.ser.write_varint(self.data.len() as u64);
+        self.ser.write_bytes(&self.data);
+        Ok(())
+    }
+}
+
+#[doc(hidden)]
+pub struct MapSerializer<'a, 'alloc> {
+    ser: &'a mut BiteSerializer<'alloc>,
+    count: Option<usize>,
+    counted: usize,
+    keys: Vec<u8>,
+    values: Vec<u8>,
+}
+
+impl<'a, 'alloc> ser::SerializeMap for MapSerializer<'a, 'alloc> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_key<T: ?Sized + ser::Serialize>(&mut self, key: &T) -> Result<()> {
+        log::trace!(target: "ser", "serializing map key {}", self.counted + 1);
+        let pos = self.ser.output.len();
+        key.serialize(&mut *self.ser)?;
+        self.keys.extend_from_slice(&self.ser.output[pos..]);
+        self.ser.output.truncate(pos);
+        self.counted += 1;
+        Ok(())
+    }
+
+    fn serialize_value<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
+        log::trace!(target: "ser", "serializing map value {}", self.counted);
+        let pos = self.ser.output.len();
+        value.serialize(&mut *self.ser)?;
+        self.values.extend_from_slice(&self.ser.output[pos..]);
+        self.ser.output.truncate(pos);
+        Ok(())
+    }
+
+    fn end(self) -> Result<()> {
+        log::trace!(target: "ser", "finished serializing map");
+        let count = core::cmp::max(self.counted, self.count.unwrap_or(self.counted));
+
+        // Write the type tag first
+        self.ser.write_byte(Type::Map.tag());
+
+        // Write the map arity
+        self.ser.write_varint(count as u64);
+
+        // Empty maps are serialized only as a count
+        if count == 0 {
+            return Ok(());
+        }
+
+        // Write all keys
+        self.ser.write_varint(self.keys.len() as u64);
+        self.ser.write_bytes(&self.keys);
+        // Write all values
+        self.ser.write_varint(self.values.len() as u64);
+        self.ser.write_bytes(&self.values);
+        Ok(())
+    }
+}
+
+impl<'a, 'alloc> ser::SerializeTuple for &'a mut BiteSerializer<'alloc> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_element<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
+        log::trace!(target: "ser", "serializing tuple element");
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        log::trace!(target: "ser", "finished serializing tuple");
+        Ok(())
+    }
+}
+
+impl<'a, 'alloc> ser::SerializeTupleStruct for &'a mut BiteSerializer<'alloc> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
+        log::trace!(target: "ser", "serializing tuple field");
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        log::trace!(target: "ser", "finished serializing tuple struct");
+        Ok(())
+    }
+}
+
+impl<'a, 'alloc> ser::SerializeTupleVariant for &'a mut BiteSerializer<'alloc> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self, value: &T) -> Result<()> {
+        log::trace!(target: "ser", "serializing tuple field");
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        log::trace!(target: "ser", "finished serializing tuple variant");
+        Ok(())
+    }
+}
+
+impl<'a, 'alloc> ser::SerializeStruct for &'a mut BiteSerializer<'alloc> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + ser::Serialize>(
+        &mut self,
+        _key: &'static str,
+        value: &T,
+    ) -> Result<()> {
+        log::trace!(target: "ser", "serializing struct field '{_key}'");
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        log::trace!(target: "ser", "finished serializing struct");
+        Ok(())
+    }
+}
+
+impl<'a, 'alloc> ser::SerializeStructVariant for &'a mut BiteSerializer<'alloc> {
+    type Ok = ();
+    type Error = Error;
+
+    fn serialize_field<T: ?Sized + ser::Serialize>(
+        &mut self,
+        _key: &'static str,
+        value: &T,
+    ) -> Result<()> {
+        log::trace!(target: "ser", "serializing struct field '{_key}'");
+        value.serialize(&mut **self)
+    }
+
+    fn end(self) -> Result<()> {
+        log::trace!(target: "ser", "finished serializing struct variant");
+        Ok(())
+    }
+}
+
+/// A typed wrapper around an index value encoded as a u32
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+struct StringId(u32);
+
+impl StringId {
+    #[inline(always)]
+    const fn to_index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+/// The in-memory representation of the string table during serialization.
+///
+/// Strings are automatically de-duplicated during insertion, and ordered lexicographically.
+struct StringTable<'a> {
+    allocator: &'a bumpalo::Bump,
+    strings: indexmap::IndexSet<&'a str>,
+}
+
+impl<'a> StringTable<'a> {
+    fn new(allocator: &'a bumpalo::Bump) -> Self {
+        Self { allocator, strings: Default::default() }
+    }
+
+    pub fn len(&self) -> usize {
+        self.strings.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.strings.is_empty()
+    }
+
+    pub fn size_in_bytes(&self) -> usize {
+        self.strings.iter().map(|k| k.len()).sum()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &str> {
+        self.strings.iter().copied()
+    }
+
+    /// Insert `s` into the string table, if not already present, and return the associated
+    /// [StringId].
+    ///
+    /// The returned [StringId] represents the index of the string in the encoded strings table,
+    /// which will be resolved to a `&str` during deserialization.
+    pub fn add_string(&mut self, s: &str) -> StringId {
+        if let Some(id) = self.strings.get_index_of(s) {
+            return StringId(id as u32);
+        }
+
+        let id = StringId(self.strings.len() as u32);
+        let s = self.allocator.alloc_str(s);
+        self.strings.insert(s);
+        debug_assert_eq!(id.to_index(), self.strings.get_index_of(s).unwrap());
+        id
+    }
+}

--- a/crates/utils/bite/src/tests.rs
+++ b/crates/utils/bite/src/tests.rs
@@ -1,0 +1,78 @@
+use super::*;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct Unit;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct Newtype(u64);
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Person {
+    name: String,
+    age: u32,
+    email: Option<String>,
+    #[serde(skip)]
+    address: Option<String>,
+    #[serde(skip_serializing_if = "Metadata::is_empty")]
+    metadata: Metadata,
+    _unit: Unit,
+    _newtype: Newtype,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, PartialEq)]
+struct Metadata {
+    metadata: BTreeMap<String, String>,
+}
+impl Metadata {
+    #[inline]
+    fn new(entries: impl IntoIterator<Item = (String, String)>) -> Self {
+        Self { metadata: BTreeMap::from_iter(entries) }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.metadata.is_empty()
+    }
+}
+
+#[test]
+fn test_roundtrip_all() {
+    let _ = env_logger::Builder::from_env("MIDEN_LOG").format_timestamp(None).try_init();
+    let person = Person {
+        name: "Alice".to_string(),
+        age: 30,
+        email: Some("alice@example.com".to_string()),
+        address: None,
+        metadata: Metadata::new([
+            ("key".to_string(), "value".to_string()),
+            ("a".to_string(), "b".to_string()),
+        ]),
+        _unit: Unit,
+        _newtype: Newtype(101),
+    };
+
+    let bytes = to_bytes(&person).unwrap();
+    let decoded: Person = from_bytes(&bytes).unwrap();
+
+    assert_eq!(person, decoded);
+}
+
+#[test]
+fn test_roundtrip_with_skipped_field() {
+    let _ = env_logger::Builder::from_env("MIDEN_LOG").format_timestamp(None).try_init();
+    let person = Person {
+        name: "Alice".to_string(),
+        age: 30,
+        email: None,
+        address: None,
+        metadata: Default::default(),
+        _unit: Unit,
+        _newtype: Newtype(101),
+    };
+
+    let bytes = to_bytes(&person).unwrap();
+    let decoded: Person = from_bytes(&bytes).unwrap();
+
+    assert_eq!(person, decoded);
+}

--- a/crates/utils/bite/src/varint.rs
+++ b/crates/utils/bite/src/varint.rs
@@ -1,0 +1,41 @@
+use alloc::vec::Vec;
+
+use super::{Error, Result};
+
+// Encode a u64 value to `buf` as a variable-length integer
+pub fn encode(mut value: u64, buf: &mut Vec<u8>) {
+    loop {
+        if value < 0x80 {
+            buf.push(value as u8);
+            break;
+        }
+        buf.push((value as u8 & 0x7F) | 0x80);
+        value >>= 7;
+    }
+}
+
+// Decode a variable-length encoded integer as a u64 from `buf`
+pub fn decode(buf: &[u8], pos: &mut usize) -> Result<u64> {
+    let mut result = 0u64;
+    let mut shift = 0;
+
+    loop {
+        if *pos >= buf.len() {
+            return Err(Error::UnexpectedEof);
+        }
+
+        let byte = buf[*pos];
+        *pos += 1;
+
+        result |= ((byte & 0x7F) as u64) << shift;
+
+        if byte & 0x80 == 0 {
+            return Ok(result);
+        }
+
+        shift += 7;
+        if shift >= 64 {
+            return Err(Error::InvalidVarint);
+        }
+    }
+}

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -36,6 +36,7 @@ serde = [
     "dep:serde-untagged",
     "dep:miden-bite",
     "miden-assembly-syntax/serde",
+    "miden-core/serde",
 ]
 
 [dependencies]

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -18,12 +18,33 @@ bench = false
 doctest = false
 
 [features]
-default = []
-arbitrary = ["dep:proptest-derive", "dep:proptest", "miden-assembly-syntax/arbitrary"]
+default = ["std", "serde"]
+arbitrary = [
+    "dep:proptest-derive",
+    "dep:proptest",
+    "miden-assembly-syntax/arbitrary",
+]
+std = [
+    "miden-assembly-syntax/std",
+    "miden-bite?/std",
+    "miden-core/std",
+    "serde/std",
+    "thiserror/std",
+]
+serde = [
+    "dep:serde",
+    "dep:serde-untagged",
+    "dep:miden-bite",
+    "miden-assembly-syntax/serde",
+]
 
 [dependencies]
 derive_more = { version = "2.0", features = ["from"] }
 miden-assembly-syntax.workspace = true
+miden-bite = { workspace = true, optional = true }
 miden-core.workspace = true
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde-untagged = { workspace = true, optional = true }
+thiserror.workspace = true

--- a/package/src/artifact.rs
+++ b/package/src/artifact.rs
@@ -3,6 +3,9 @@ use alloc::sync::Arc;
 use miden_assembly_syntax::Library;
 use miden_core::{Program, Word, mast::MastForest};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 // MAST ARTIFACT
 // ================================================================================================
 
@@ -10,6 +13,7 @@ use miden_core::{Program, Word, mast::MastForest};
 ///
 /// This type is used in compilation pipelines to abstract over the type of output requested.
 #[derive(Debug, Clone, Eq, PartialEq, derive_more::From)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MastArtifact {
     /// A MAST artifact which can be executed by the VM directly
     Executable(Arc<Program>),

--- a/package/src/dependency/mod.rs
+++ b/package/src/dependency/mod.rs
@@ -4,12 +4,17 @@ use miden_core::utils::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
 };
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::Word;
 
 pub(crate) mod resolver;
 
 /// The name of a dependency
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::From)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
 pub struct DependencyName(String);
 
 #[cfg(feature = "arbitrary")]
@@ -42,6 +47,7 @@ impl Deserializable for DependencyName {
 /// A package dependency
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(proptest_derive::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Dependency {
     /// The name of the dependency.
     /// Serves as a human-readable identifier for the dependency and a search hint for the resolver

--- a/package/src/lib.rs
+++ b/package/src/lib.rs
@@ -26,5 +26,5 @@ pub use self::{
             ResolvedDependency,
         },
     },
-    package::{Package, PackageExport, PackageManifest},
+    package::{InvalidSectionIdError, Package, PackageExport, PackageManifest, Section, SectionId},
 };

--- a/package/src/package/manifest.rs
+++ b/package/src/package/manifest.rs
@@ -4,6 +4,9 @@ use core::fmt;
 use miden_assembly_syntax::ast::{QualifiedProcedureName, types::FunctionType};
 use miden_core::{Word, utils::DisplayHex};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::Dependency;
 
 // PACKAGE MANIFEST
@@ -80,6 +83,7 @@ impl PackageManifest {
 /// MASM type attributes are implemented).
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(proptest_derive::Arbitrary))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PackageExport {
     /// The fully-qualified name of the procedure exported by this package
     pub name: QualifiedProcedureName,
@@ -88,6 +92,7 @@ pub struct PackageExport {
     pub digest: Word,
     /// The type signature of the exported procedure
     #[cfg_attr(feature = "arbitrary", proptest(value = "None"))]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub signature: Option<FunctionType>,
 }
 

--- a/package/src/package/mod.rs
+++ b/package/src/package/mod.rs
@@ -1,12 +1,15 @@
 mod manifest;
+mod section;
 mod serialization;
+
+pub use self::manifest::{PackageExport, PackageManifest};
+pub use self::section::{InvalidSectionIdError, Section, SectionId};
 
 use alloc::{format, string::String, sync::Arc, vec::Vec};
 
 use miden_assembly_syntax::{Library, Report, ast::QualifiedProcedureName};
 use miden_core::{Program, Word};
 
-pub use self::manifest::{PackageExport, PackageManifest};
 use crate::MastArtifact;
 
 // PACKAGE
@@ -22,9 +25,9 @@ pub struct Package {
     /// The package manifest, containing the set of exported procedures and their signatures,
     /// if known.
     pub manifest: PackageManifest,
-    /// Serialized `miden-objects::account::AccountComponentMetadata` for the account component
-    /// (name, descrioption, storage,) associated with this package, if any.
-    pub account_component_metadata_bytes: Option<Vec<u8>>,
+    /// The set of custom sections included with the package, e.g. debug information, account
+    /// metadata, etc.
+    pub sections: Vec<Section>,
 }
 
 impl Package {
@@ -98,7 +101,7 @@ impl Package {
                     self.manifest.get_exports_by_digest(&digest).cloned(),
                 )
                 .with_dependencies(self.manifest.dependencies().cloned()),
-                account_component_metadata_bytes: None,
+                sections: self.sections.clone(),
             })
         } else {
             Err(Report::msg(format!(

--- a/package/src/package/mod.rs
+++ b/package/src/package/mod.rs
@@ -10,6 +10,9 @@ use alloc::{format, string::String, sync::Arc, vec::Vec};
 use miden_assembly_syntax::{Library, Report, ast::QualifiedProcedureName};
 use miden_core::{Program, Word};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::MastArtifact;
 
 // PACKAGE
@@ -17,6 +20,7 @@ use crate::MastArtifact;
 
 /// A package containing a [Program]/[Library], and a manifest (exports and dependencies).
 #[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Package {
     /// Name of the package
     pub name: String,
@@ -27,6 +31,7 @@ pub struct Package {
     pub manifest: PackageManifest,
     /// The set of custom sections included with the package, e.g. debug information, account
     /// metadata, etc.
+    #[cfg_attr(feature = "serde", serde(default))]
     pub sections: Vec<Section>,
 }
 

--- a/package/src/package/section.rs
+++ b/package/src/package/section.rs
@@ -1,0 +1,213 @@
+use alloc::{borrow::Cow, string::ToString};
+use core::{fmt, str::FromStr};
+use miden_assembly_syntax::DisplayHex;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// A unique identifier/tag for optional sections of the Miden package format
+///
+/// The following tag ranges are reserved for specific categories of use:
+///
+/// * `0` - unused
+/// * `1..10` - reserved for non-rollup use cases, e.g. debug information
+/// * `10..100` - reserved for rollup use cases, e.g. account component metadata
+/// * `100..254` - reserved for TBD use cases
+/// * `255` - assigned to custom user-defined sections, which must also be uniquely named
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SectionId {
+    //--- CORE SECTIONS
+    /// The section containing debug information (source locations, spans)
+    DebugInfo = 1,
+
+    //--- ROLLUP SECTIONS
+    /// This section provides the encoded metadata for a compiled account component
+    ///
+    /// Currently, this corresponds to the serialized representation of
+    /// `miden-objects::account::AccountComponentMetadata`, i.e. name, descrioption, storage, that
+    /// is associated with this package.
+    AccountComponentMetadata = 10,
+
+    //--- USER-DEFINED SECTIONS
+    Custom(Cow<'static, str>) = 255,
+}
+
+impl TryFrom<u8> for SectionId {
+    type Error = InvalidSectionIdError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::DebugInfo),
+            10 => Ok(Self::AccountComponentMetadata),
+            _ => Err(InvalidSectionIdError::Tag(value)),
+        }
+    }
+}
+
+impl SectionId {
+    pub fn custom(name: impl AsRef<str>) -> Result<Self, InvalidSectionIdError> {
+        let name = name.as_ref();
+        if !name.starts_with(|c: char| c.is_ascii_alphabetic() || c == '_') {
+            return Err(InvalidSectionIdError::InvalidStart);
+        }
+        if name.contains(|c: char| !c.is_ascii_alphanumeric() && !matches!(c, '.' | '_' | '-')) {
+            return Err(InvalidSectionIdError::InvalidCharacter);
+        }
+        Ok(Self::Custom(name.to_string().into()))
+    }
+
+    pub const fn tag(&self) -> u8 {
+        // SAFETY: This is safe because we have given this enum a
+        // primitive representation with #[repr(u8)], with the first
+        // field of the underlying union-of-structs the discriminant
+        //
+        // See the section on "accessing the numeric value of the discriminant"
+        // here: https://doc.rust-lang.org/std/mem/fn.discriminant.html
+        unsafe { *(self as *const Self).cast::<u8>() }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidSectionIdError {
+    #[error("invalid section id: cannot be empty")]
+    Empty,
+    #[error(
+        "invalid section id: contains invalid characters, only the set [a-z0-9._-] are allowed"
+    )]
+    InvalidCharacter,
+    #[error("invalid section id: must start with a character in the set [a-z_]")]
+    InvalidStart,
+    #[error("invalid section id: {0} is not recognized or is incomplete")]
+    Tag(u8),
+}
+
+impl FromStr for SectionId {
+    type Err = InvalidSectionIdError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "debug_info" => Ok(Self::DebugInfo),
+            "account_component_metadata" => Ok(Self::AccountComponentMetadata),
+            custom => Self::custom(custom),
+        }
+    }
+}
+
+impl fmt::Display for SectionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DebugInfo => f.write_str("debug_info"),
+            Self::AccountComponentMetadata => f.write_str("account_component_metadata"),
+            Self::Custom(custom) => f.write_str(custom.as_ref()),
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Section {
+    pub id: SectionId,
+    pub data: Cow<'static, [u8]>,
+}
+
+impl fmt::Debug for Section {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let verbose = f.alternate();
+        let mut builder = f.debug_struct("Section");
+        builder.field("id", &format_args!("{}", &self.id));
+        if verbose {
+            builder.field("data", &format_args!("{}", DisplayHex(&self.data))).finish()
+        } else {
+            builder.field("data", &format_args!("{} bytes", self.data.len())).finish()
+        }
+    }
+}
+
+impl Section {
+    pub fn new<B>(id: SectionId, data: B) -> Self
+    where
+        B: Into<Cow<'static, [u8]>>,
+    {
+        Self { id, data: data.into() }
+    }
+
+    /// Returns true if this section is empty, i.e. has no data
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Returns the size in bytes of this section's data
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for SectionId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::{SeqAccess, Unexpected};
+
+        const DEBUG_INFO: u8 = SectionId::DebugInfo.tag();
+        const ACCOUNT_COMPONENT_METADATA: u8 = SectionId::AccountComponentMetadata.tag();
+        const CUSTOM: u8 = SectionId::Custom(Cow::Borrowed("")).tag();
+
+        serde_untagged::UntaggedEnumVisitor::new()
+            .expecting("a valid section id")
+            .string(|s| Self::from_str(s).map_err(serde::de::Error::custom))
+            .u8(|tag| match tag {
+                DEBUG_INFO => Ok(Self::DebugInfo),
+                ACCOUNT_COMPONENT_METADATA => Ok(Self::AccountComponentMetadata),
+                CUSTOM => Err(serde::de::Error::custom("expected a custom section name")),
+                other => Err(serde::de::Error::invalid_value(
+                    Unexpected::Unsigned(other as u64),
+                    &"a valid section id tag",
+                )),
+            })
+            .seq(|mut seq| {
+                let tag = seq
+                    .next_element::<u8>()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &"a section id tag"))?;
+                match tag {
+                    DEBUG_INFO => Ok(Self::DebugInfo),
+                    ACCOUNT_COMPONENT_METADATA => Ok(Self::AccountComponentMetadata),
+                    CUSTOM => seq
+                        .next_element::<&str>()?
+                        .ok_or_else(|| {
+                            serde::de::Error::invalid_length(1, &"a custom section name")
+                        })
+                        .and_then(|s| Self::custom(s).map_err(serde::de::Error::custom)),
+                    other => Err(serde::de::Error::invalid_value(
+                        Unexpected::Unsigned(other as u64),
+                        &"a valid section id tag",
+                    )),
+                }
+            })
+            .deserialize(deserializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for SectionId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeTupleVariant;
+        let tag = self.tag() as u32;
+        match self {
+            Self::DebugInfo => serializer.serialize_unit_variant("SectionId", tag, "DebugInfo"),
+            Self::AccountComponentMetadata => {
+                serializer.serialize_unit_variant("SectionId", tag, "AccountComponentMetadata")
+            },
+            Self::Custom(custom) => {
+                let mut tuple =
+                    serializer.serialize_tuple_variant("SectionId", tag, "Custom", 1)?;
+                tuple.serialize_field(&custom.as_ref())?;
+                tuple.end()
+            },
+        }
+    }
+}

--- a/package/src/package/section.rs
+++ b/package/src/package/section.rs
@@ -1,4 +1,8 @@
-use alloc::{borrow::Cow, string::ToString};
+use alloc::{
+    borrow::{Cow, ToOwned},
+    format,
+    string::ToString,
+};
 use core::{fmt, str::FromStr};
 use miden_assembly_syntax::DisplayHex;
 
@@ -142,6 +146,79 @@ impl Section {
     }
 }
 
+impl miden_core::utils::Serializable for Section {
+    fn write_into<W: miden_core::utils::ByteWriter>(&self, target: &mut W) {
+        target.write_u8(self.id.tag());
+        match &self.id {
+            SectionId::DebugInfo | SectionId::AccountComponentMetadata => (),
+            SectionId::Custom(custom) => {
+                target.write_usize(custom.len());
+                target.write_bytes(custom.as_bytes());
+            },
+        }
+        target.write_usize(self.len());
+        target.write_bytes(&self.data);
+    }
+}
+
+impl miden_core::utils::Deserializable for Section {
+    fn read_from<R: miden_core::utils::ByteReader>(
+        source: &mut R,
+    ) -> Result<Self, miden_core::utils::DeserializationError> {
+        const DEBUG_INFO: u8 = SectionId::DebugInfo.tag();
+        const ACCOUNT_COMPONENT_METADATA: u8 = SectionId::AccountComponentMetadata.tag();
+        const CUSTOM: u8 = SectionId::Custom(Cow::Borrowed("")).tag();
+
+        let tag = source.read_u8()?;
+        let id = match tag {
+            DEBUG_INFO => SectionId::DebugInfo,
+            ACCOUNT_COMPONENT_METADATA => SectionId::AccountComponentMetadata,
+            CUSTOM => {
+                let len = source.read_usize()?;
+                let bytes = source.read_slice(len)?;
+                let name = core::str::from_utf8(bytes).map_err(|err| {
+                    miden_core::utils::DeserializationError::InvalidValue(format!(
+                        "invalid utf-8 in section name: {err}"
+                    ))
+                })?;
+                SectionId::Custom(Cow::Owned(name.to_owned()))
+            },
+            other => {
+                return Err(miden_core::utils::DeserializationError::InvalidValue(format!(
+                    "unknown section id: {other}"
+                )));
+            },
+        };
+
+        let len = source.read_usize()?;
+        let bytes = source.read_slice(len)?;
+        Ok(Section { id, data: Cow::Owned(bytes.to_owned()) })
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for SectionId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeTupleVariant;
+        let tag = self.tag() as u32;
+        match self {
+            Self::DebugInfo => serializer.serialize_unit_variant("SectionId", tag, "DebugInfo"),
+            Self::AccountComponentMetadata => {
+                serializer.serialize_unit_variant("SectionId", tag, "AccountComponentMetadata")
+            },
+            Self::Custom(custom) => {
+                let mut tuple =
+                    serializer.serialize_tuple_variant("SectionId", tag, "Custom", 1)?;
+                tuple.serialize_field(&custom.as_ref())?;
+                tuple.end()
+            },
+        }
+    }
+}
+
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for SectionId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -186,28 +263,5 @@ impl<'de> serde::Deserialize<'de> for SectionId {
                 }
             })
             .deserialize(deserializer)
-    }
-}
-
-#[cfg(feature = "serde")]
-impl serde::Serialize for SectionId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        use serde::ser::SerializeTupleVariant;
-        let tag = self.tag() as u32;
-        match self {
-            Self::DebugInfo => serializer.serialize_unit_variant("SectionId", tag, "DebugInfo"),
-            Self::AccountComponentMetadata => {
-                serializer.serialize_unit_variant("SectionId", tag, "AccountComponentMetadata")
-            },
-            Self::Custom(custom) => {
-                let mut tuple =
-                    serializer.serialize_tuple_variant("SectionId", tag, "Custom", 1)?;
-                tuple.serialize_field(&custom.as_ref())?;
-                tuple.end()
-            },
-        }
     }
 }

--- a/package/src/package/serialization.rs
+++ b/package/src/package/serialization.rs
@@ -34,7 +34,7 @@
 //!       - `name` (`String`)
 //!       - `digest` (`Word`)
 
-use alloc::{borrow::Cow, collections::BTreeMap, format, string::String, sync::Arc, vec::Vec};
+use alloc::{collections::BTreeMap, format, string::String, sync::Arc, vec::Vec};
 
 use miden_assembly_syntax::{
     Library,
@@ -48,7 +48,7 @@ use miden_core::{
 
 use crate::{Dependency, MastArtifact, Package, PackageExport, PackageManifest};
 
-use super::{Section, SectionId};
+use super::Section;
 
 // CONSTANTS
 // ================================================================================================
@@ -88,13 +88,7 @@ impl Serializable for Package {
         // Write custom sections
         target.write_usize(self.sections.len());
         for section in self.sections.iter() {
-            target.write_u8(section.id.tag());
-            if let SectionId::Custom(name) = &section.id {
-                target.write_usize(name.len());
-                target.write_bytes(name.as_bytes());
-            }
-            target.write_usize(section.data.len());
-            target.write_bytes(&section.data);
+            section.write_into(target);
         }
     }
 }
@@ -129,20 +123,8 @@ impl Deserializable for Package {
         let num_sections = source.read_usize()?;
         let mut sections = Vec::with_capacity(num_sections);
         for _ in 0..num_sections {
-            let id = source.read_u8()?;
-            let id = if id == SectionId::Custom(Cow::Borrowed("")).tag() {
-                let name_len = source.read_usize()?;
-                let name = source.read_string(name_len)?;
-                SectionId::Custom(name.into())
-            } else {
-                SectionId::try_from(id).map_err(|_| {
-                    DeserializationError::InvalidValue(format!("unknown custom section id: {id}"))
-                })?
-            };
-
-            let len = source.read_usize()?;
-            let bytes = source.read_slice(len)?.to_vec();
-            sections.push(Section { id, data: Cow::Owned(bytes) });
+            let section = Section::read_from(source)?;
+            sections.push(section);
         }
 
         Ok(Self { name, mast, manifest, sections })
@@ -186,6 +168,110 @@ impl Deserializable for MastArtifact {
 
 // PACKAGE MANIFEST SERIALIZATION/DESERIALIZATION
 // ================================================================================================
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for PackageManifest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        struct PackageExports<'a>(&'a BTreeMap<QualifiedProcedureName, PackageExport>);
+
+        impl serde::Serialize for PackageExports<'_> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                use serde::ser::SerializeSeq;
+
+                let mut serializer = serializer.serialize_seq(Some(self.0.len()))?;
+                for value in self.0.values() {
+                    serializer.serialize_element(value)?;
+                }
+                serializer.end()
+            }
+        }
+
+        let mut serializer = serializer.serialize_struct("PackageManifest", 2)?;
+        serializer.serialize_field("exports", &PackageExports(&self.exports))?;
+        serializer.serialize_field("dependencies", &self.dependencies)?;
+        serializer.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for PackageManifest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum Field {
+            Exports,
+            Dependencies,
+        }
+
+        struct PackageManifestVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for PackageManifestVisitor {
+            type Value = PackageManifest;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                formatter.write_str("struct PackageManifest")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let exports = seq
+                    .next_element::<Vec<PackageExport>>()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
+                let dependencies = seq
+                    .next_element::<Vec<Dependency>>()?
+                    .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
+                Ok(PackageManifest::new(exports).with_dependencies(dependencies))
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut exports = None;
+                let mut dependencies = None;
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        Field::Exports => {
+                            if exports.is_some() {
+                                return Err(serde::de::Error::duplicate_field("exports"));
+                            }
+                            exports = Some(map.next_value::<Vec<PackageExport>>()?);
+                        },
+                        Field::Dependencies => {
+                            if dependencies.is_some() {
+                                return Err(serde::de::Error::duplicate_field("dependencies"));
+                            }
+                            dependencies = Some(map.next_value::<Vec<Dependency>>()?);
+                        },
+                    }
+                }
+                let exports = exports.ok_or_else(|| serde::de::Error::missing_field("exports"))?;
+                let dependencies =
+                    dependencies.ok_or_else(|| serde::de::Error::missing_field("dependencies"))?;
+                Ok(PackageManifest::new(exports).with_dependencies(dependencies))
+            }
+        }
+
+        deserializer.deserialize_struct(
+            "PackageManifest",
+            &["exports", "dependencies"],
+            PackageManifestVisitor,
+        )
+    }
+}
 
 impl Serializable for PackageManifest {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {

--- a/package/src/package/serialization.rs
+++ b/package/src/package/serialization.rs
@@ -34,7 +34,7 @@
 //!       - `name` (`String`)
 //!       - `digest` (`Word`)
 
-use alloc::{collections::BTreeMap, format, string::String, sync::Arc, vec::Vec};
+use alloc::{borrow::Cow, collections::BTreeMap, format, string::String, sync::Arc, vec::Vec};
 
 use miden_assembly_syntax::{
     Library,
@@ -47,6 +47,8 @@ use miden_core::{
 };
 
 use crate::{Dependency, MastArtifact, Package, PackageExport, PackageManifest};
+
+use super::{Section, SectionId};
 
 // CONSTANTS
 // ================================================================================================
@@ -63,7 +65,7 @@ const MAGIC_LIBRARY: &[u8; 4] = b"LIB\0";
 /// The format version.
 ///
 /// If future modifications are made to this format, the version should be incremented by 1.
-const VERSION: [u8; 3] = [1, 0, 0];
+const VERSION: [u8; 3] = [2, 0, 0];
 
 // PACKAGE SERIALIZATION/DESERIALIZATION
 // ================================================================================================
@@ -83,8 +85,17 @@ impl Serializable for Package {
         // Write manifest
         self.manifest.write_into(target);
 
-        // Write optional account component metadata
-        self.account_component_metadata_bytes.write_into(target);
+        // Write custom sections
+        target.write_usize(self.sections.len());
+        for section in self.sections.iter() {
+            target.write_u8(section.id.tag());
+            if let SectionId::Custom(name) = &section.id {
+                target.write_usize(name.len());
+                target.write_bytes(name.as_bytes());
+            }
+            target.write_usize(section.data.len());
+            target.write_bytes(&section.data);
+        }
     }
 }
 
@@ -114,15 +125,27 @@ impl Deserializable for Package {
         // Read manifest
         let manifest = PackageManifest::read_from(source)?;
 
-        // Read optional account component metadata
-        let account_component_metadata_bytes: Option<Vec<u8>> = Deserializable::read_from(source)?;
+        // Read custom sections
+        let num_sections = source.read_usize()?;
+        let mut sections = Vec::with_capacity(num_sections);
+        for _ in 0..num_sections {
+            let id = source.read_u8()?;
+            let id = if id == SectionId::Custom(Cow::Borrowed("")).tag() {
+                let name_len = source.read_usize()?;
+                let name = source.read_string(name_len)?;
+                SectionId::Custom(name.into())
+            } else {
+                SectionId::try_from(id).map_err(|_| {
+                    DeserializationError::InvalidValue(format!("unknown custom section id: {id}"))
+                })?
+            };
 
-        Ok(Self {
-            name,
-            mast,
-            manifest,
-            account_component_metadata_bytes,
-        })
+            let len = source.read_usize()?;
+            let bytes = source.read_slice(len)?.to_vec();
+            sections.push(Section { id, data: Cow::Owned(bytes) });
+        }
+
+        Ok(Self { name, mast, manifest, sections })
     }
 }
 

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -56,5 +56,5 @@ winter-air.workspace = true
 winter-fri.workspace = true
 
 [build-dependencies]
-env_logger = "0.11"
+env_logger.workspace = true
 miden-assembly = { workspace = true, features = ["std"] }


### PR DESCRIPTION
This PR does the following:

* Implements support for custom sections in the package format, these can contain arbitrary data, and are either tagged with a well-known ID, or a user-defined name
* Prototype implementation of a new binary serialization format based on `serde`, which I've called BITE, see the `miden-bite` crate for more
* Implemented `serde`-based serialization for most core types to enable side-by-side comparison of existing serialization infra and `serde`. This hasn't been fully optimized yet, so some types are still not necessarily encoded as efficiently as they could be

This is in draft status until I finish adding some tests and cleaning up a few of the type serialization impls.