### PR TITLE
feat(host): make `get_mast_forest` async again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Removed unused `PushU8List`, `PushU16List`, `PushU32List` and `PushFeltList` instructions ([#2057](https://github.com/0xMiden/miden-vm/pull/2057)).
 - Removed dedicated `PushU8`, `PushU16`, `PushU32`, `PushFelt`, and `PushWord` assembly instructions. These have been replaced with the generic `Push<Immediate>` instruction which supports all the same functionality through the `IntValue` enum (U8, U16, U32, Felt, Word) ([#2066](https://github.com/0xMiden/miden-vm/issues/2066)).
 - [BREAKING] Update miden-crypto dependency to v0.16 (#[2079](https://github.com/0xMiden/miden-vm/pull/2079))
+- Made `get_mast_forest()` async again for `AsyncHost` now that basic conditional async support is in place ([#2060](https://github.com/0xMiden/miden-vm/issues/2060)).
 
 ## 0.17.0 (2025-08-06)
 

--- a/miden-vm/tests/integration/operations/decorators/mod.rs
+++ b/miden-vm/tests/integration/operations/decorators/mod.rs
@@ -23,11 +23,6 @@ pub struct TestHost {
 }
 
 impl BaseHost for TestHost {
-    fn get_mast_forest(&self, _node_digest: &Word) -> Option<Arc<MastForest>> {
-        // Empty MAST forest store
-        None
-    }
-
     fn get_label_and_source_file(
         &self,
         location: &Location,
@@ -57,6 +52,11 @@ impl BaseHost for TestHost {
 }
 
 impl SyncHost for TestHost {
+    fn get_mast_forest(&self, _node_digest: &Word) -> Option<Arc<MastForest>> {
+        // Empty MAST forest store
+        None
+    }
+
     fn on_event(
         &mut self,
         _process: &ProcessState,

--- a/miden-vm/tests/integration/operations/decorators/mod.rs
+++ b/miden-vm/tests/integration/operations/decorators/mod.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use miden_core::DebugOptions;
 use miden_debug_types::{DefaultSourceManager, Location, SourceFile, SourceManager, SourceSpan};
 use miden_processor::{
-    AdviceMutation, AsyncHost, BaseHost, EventError, ExecutionError, MastForest, ProcessState,
-    SyncHost,
+    AdviceMutation, AsyncHost, BaseHost, EventError, ExecutionError, FutureMaybeSend, MastForest,
+    ProcessState, SyncHost,
 };
 use miden_prover::Word;
 
@@ -68,11 +68,19 @@ impl SyncHost for TestHost {
 }
 
 impl AsyncHost for TestHost {
+    #[allow(clippy::manual_async_fn)]
+    fn get_mast_forest(
+        &self,
+        _node_digest: &Word,
+    ) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
+        async move { None }
+    }
+    #[allow(clippy::manual_async_fn)]
     fn on_event(
         &mut self,
         _process: &ProcessState<'_>,
         event_id: u32,
-    ) -> impl Future<Output = Result<Vec<AdviceMutation>, EventError>> + Send {
+    ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
         self.event_handler.push(event_id);
         async move { Ok(Vec::new()) }
     }

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -1151,8 +1151,8 @@ impl FastProcessor {
     where
         E: ErrorContext,
     {
-        let mast_forest = host
-            .get_mast_forest(&node_digest)
+        let mast_forest = AsyncHost::get_mast_forest(host, &node_digest)
+            .await
             .ok_or_else(|| get_mast_forest_failed(node_digest, err_ctx))?;
 
         // We limit the parts of the program that can be called externally to procedure

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -1151,7 +1151,8 @@ impl FastProcessor {
     where
         E: ErrorContext,
     {
-        let mast_forest = AsyncHost::get_mast_forest(host, &node_digest)
+        let mast_forest = host
+            .get_mast_forest(&node_digest)
             .await
             .ok_or_else(|| get_mast_forest_failed(node_digest, err_ctx))?;
 

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -293,10 +293,7 @@ where
     S: SourceManagerSync,
 {
     #[allow(clippy::manual_async_fn)]
-    fn get_mast_forest(
-        &self, 
-        node_digest: &Word
-    ) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
+    fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
         let result = <Self as BaseHost>::get_mast_forest(self, node_digest);
         async move { result }
     }

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -7,8 +7,8 @@ use pretty_assertions::assert_eq;
 
 use super::*;
 use crate::{
-    AdviceMutation, AsyncHost, BaseHost, EventError, MastForestStore, MemMastForestStore,
-    MemoryAddress, ProcessState, SyncHost,
+    AdviceMutation, AsyncHost, BaseHost, EventError, FutureMaybeSend, MastForestStore,
+    MemMastForestStore, MemoryAddress, ProcessState, SyncHost,
 };
 
 #[test]
@@ -292,6 +292,14 @@ impl<S> AsyncHost for ConsistencyHost<S>
 where
     S: SourceManagerSync,
 {
+    #[allow(clippy::manual_async_fn)]
+    fn get_mast_forest(
+        &self, 
+        node_digest: &Word
+    ) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
+        let result = <Self as BaseHost>::get_mast_forest(self, node_digest);
+        async move { result }
+    }
     // Note: clippy complains about this not using the `async` keyword, but if we use `async`, it
     // doesn't compile.
     #[allow(clippy::manual_async_fn)]
@@ -299,7 +307,7 @@ where
         &mut self,
         _process: &ProcessState<'_>,
         _event_id: u32,
-    ) -> impl Future<Output = Result<Vec<AdviceMutation>, EventError>> + Send {
+    ) -> impl FutureMaybeSend<Result<Vec<AdviceMutation>, EventError>> {
         let _ = (_process, _event_id);
         async move { Ok(Vec::new()) }
     }

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -250,10 +250,6 @@ impl<S> BaseHost for ConsistencyHost<S>
 where
     S: SourceManager,
 {
-    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
-        self.store.get(node_digest)
-    }
-
     fn get_label_and_source_file(
         &self,
         location: &Location,
@@ -279,6 +275,10 @@ impl<S> SyncHost for ConsistencyHost<S>
 where
     S: SourceManager,
 {
+    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
+        self.store.get(node_digest)
+    }
+
     fn on_event(
         &mut self,
         _process: &ProcessState<'_>,
@@ -294,7 +294,7 @@ where
 {
     #[allow(clippy::manual_async_fn)]
     fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
-        let result = <Self as BaseHost>::get_mast_forest(self, node_digest);
+        let result = <Self as SyncHost>::get_mast_forest(self, node_digest);
         async move { result }
     }
     // Note: clippy complains about this not using the `async` keyword, but if we use `async`, it

--- a/processor/src/host/default.rs
+++ b/processor/src/host/default.rs
@@ -178,10 +178,7 @@ where
     D: DebugHandler,
     S: SourceManagerSync,
 {
-    fn get_mast_forest(
-        &self, 
-        node_digest: &Word
-    ) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
+    fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
         let result = <Self as BaseHost>::get_mast_forest(self, node_digest);
         async move { result }
     }

--- a/processor/src/host/default.rs
+++ b/processor/src/host/default.rs
@@ -116,10 +116,6 @@ where
     D: DebugHandler,
     S: SourceManager,
 {
-    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
-        self.store.get(node_digest)
-    }
-
     fn get_label_and_source_file(
         &self,
         location: &Location,
@@ -154,6 +150,10 @@ where
     D: DebugHandler,
     S: SourceManager,
 {
+    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>> {
+        self.store.get(node_digest)
+    }
+
     fn on_event(
         &mut self,
         process: &ProcessState,
@@ -179,7 +179,7 @@ where
     S: SourceManagerSync,
 {
     fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
-        let result = <Self as BaseHost>::get_mast_forest(self, node_digest);
+        let result = <Self as SyncHost>::get_mast_forest(self, node_digest);
         async move { result }
     }
 

--- a/processor/src/host/default.rs
+++ b/processor/src/host/default.rs
@@ -178,6 +178,14 @@ where
     D: DebugHandler,
     S: SourceManagerSync,
 {
+    fn get_mast_forest(
+        &self, 
+        node_digest: &Word
+    ) -> impl FutureMaybeSend<Option<Arc<MastForest>>> {
+        let result = <Self as BaseHost>::get_mast_forest(self, node_digest);
+        async move { result }
+    }
+
     fn on_event(
         &mut self,
         process: &ProcessState<'_>,

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -122,6 +122,10 @@ pub trait AsyncHost: BaseHost {
     // Note: we don't use the `async` keyword in this method, since we need to specify the `+ Send`
     // bound to the returned Future, and `async` doesn't allow us to do that.
 
+    /// Returns MAST forest corresponding to the specified digest, or None if the MAST forest for
+    /// this digest could not be found in this host.
+    fn get_mast_forest(&self, node_digest: &Word) -> impl FutureMaybeSend<Option<Arc<MastForest>>>;
+
     /// Handles the event emitted from the VM and provides advice mutations to be applied to
     /// the advice provider.
     fn on_event(

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -60,10 +60,6 @@ pub trait BaseHost {
     // REQUIRED METHODS
     // --------------------------------------------------------------------------------------------
 
-    /// Returns MAST forest corresponding to the specified digest, or None if the MAST forest for
-    /// this digest could not be found in this host.
-    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>>;
-
     /// Returns the [`SourceSpan`] and optional [`SourceFile`] for the provided location.
     fn get_label_and_source_file(
         &self,
@@ -102,6 +98,10 @@ pub trait BaseHost {
 pub trait SyncHost: BaseHost {
     // REQUIRED METHODS
     // --------------------------------------------------------------------------------------------
+
+    /// Returns MAST forest corresponding to the specified digest, or None if the MAST forest for
+    /// this digest could not be found in this host.
+    fn get_mast_forest(&self, node_digest: &Word) -> Option<Arc<MastForest>>;
 
     /// Handles the event emitted from the VM.
     fn on_event(


### PR DESCRIPTION
Closes #2060 

- This PR makes `get_mast_forest` back to an `async API` now that conditional async support is working.