### PR TITLE
feat(CLI): add `multicall` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Removed dedicated `PushU8`, `PushU16`, `PushU32`, `PushFelt`, and `PushWord` assembly instructions. These have been replaced with the generic `Push<Immediate>` instruction which supports all the same functionality through the `IntValue` enum (U8, U16, U32, Felt, Word) ([#2066](https://github.com/0xMiden/miden-vm/issues/2066)).
 - [BREAKING] Update miden-crypto dependency to v0.16 (#[2079](https://github.com/0xMiden/miden-vm/pull/2079))
 - Made `get_mast_forest()` async again for `AsyncHost` now that basic conditional async support is in place ([#2060](https://github.com/0xMiden/miden-vm/issues/2060)).
+- Added `multicall` support for the CLI ([#1141](https://github.com/0xMiden/miden-vm/pull/2081))
 
 ## 0.17.0 (2025-08-06)
 

--- a/miden-vm/src/main.rs
+++ b/miden-vm/src/main.rs
@@ -1,4 +1,6 @@
-use clap::Parser;
+use std::ffi::OsString;
+
+use clap::{FromArgMatches, Parser, Subcommand};
 use miden_assembly::diagnostics::Report;
 #[cfg(feature = "tracing-forest")]
 use tracing_forest::ForestLayer;
@@ -20,9 +22,50 @@ pub(crate) mod utils;
     version,
     rename_all = "kebab-case"
 )]
+#[command(multicall(true))]
+pub struct MidenVmCli {
+    #[command(subcommand)]
+    behavior: Behavior,
+}
+
+impl From<MidenVmCli> for Cli {
+    fn from(value: MidenVmCli) -> Self {
+        match value.behavior {
+            Behavior::MidenVm { cli } => cli,
+            Behavior::External(args) => Cli::parse_from(args).set_external(),
+        }
+    }
+}
+
+#[derive(Debug, Subcommand)]
+#[command(rename_all = "kebab-case")]
+enum Behavior {
+    /// The Miden VM CLI.
+    MidenVm {
+        #[command(flatten)]
+        cli: Cli,
+    },
+
+    /// Used when the Miden VM CLI is called under a different name, like
+    /// when it is called from [Midenup](https://github.com/0xMiden/midenup).
+    /// Vec<OsString> holds the "raw" arguments passed to the command line,
+    /// analogous to `argv`.
+    #[command(external_subcommand)]
+    External(Vec<OsString>),
+}
+
+#[derive(Parser, Debug)]
+#[command(name = "miden-client")]
 pub struct Cli {
     #[command(subcommand)]
     action: Actions,
+
+    /// Indicates whether the vm's CLI is being called directly, or externally
+    /// under an alias (like in the case of
+    /// [Midenup](https://github.com/0xMiden/midenup).
+    #[arg(skip)]
+    #[allow(unused)]
+    external: bool,
 }
 
 /// CLI actions
@@ -54,12 +97,20 @@ impl Cli {
             Actions::Repl(repl) => repl.execute(),
         }
     }
+
+    fn set_external(mut self) -> Self {
+        self.external = true;
+        self
+    }
 }
 
 /// Executable entry point
 pub fn main() -> Result<(), Report> {
     // read command-line args
-    let cli = Cli::parse();
+    let cli = <MidenVmCli as clap::CommandFactory>::command();
+    let matches = cli.get_matches();
+    let parsed = MidenVmCli::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
+    let cli: Cli = parsed.into();
 
     initialize_diagnostics();
 
@@ -105,5 +156,39 @@ fn initialize_diagnostics() {
     #[cfg(not(feature = "std"))]
     {
         let _ = reporting::set_hook(Box::new(|_| Box::new(ReportHandlerOpts::new().build())));
+    }
+}
+
+// TESTS
+// ================================================================================================
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    /// Check that the VM recognizes when it is being called under an alias.
+    fn test_mutlicall() {
+        // Direct call
+        let miden_vm_command =
+            MidenVmCli::try_parse_from(["miden-vm", "repl"]).expect("failed to parse commands");
+
+        assert!(matches!(
+            miden_vm_command.behavior,
+            Behavior::MidenVm { cli: Cli { external: false, .. } }
+        ));
+
+        let cli: Cli = miden_vm_command.into();
+        assert!(matches!(cli, Cli { external: false, .. }));
+
+        // External call
+
+        // This recreates how the vm would be called from midenup
+        let external =
+            MidenVmCli::try_parse_from(["miden vm", "repl"]).expect("failed to parse commands");
+
+        assert!(matches!(external.behavior, Behavior::External(_)));
+
+        let cli: Cli = external.into();
+        assert!(matches!(cli, Cli { external: true, .. }));
     }
 }


### PR DESCRIPTION
## Describe your changes

This PR makes the VM's CLI multicall compatible. With this, the CLI is now aware of whether it is being called under the `miden-vm` name or a different one. This is used in midenup's invocation of the vm, which is done under the `miden vm` command.

The `Cli` struct now stores this information, in the `external` field; however, this is not currently being used.

Multicall awareness is being tracked in this issue (https://github.com/0xMiden/midenup/issues/70) in midenup.

## Checklist before requesting a review
- [X] Repo forked and branch created from `next` according to naming convention.
- [X] Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- [X] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.