### PR TITLE
refactor: remove `VmStateIterator` and introduce `TraceDebugger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Removed dedicated `PushU8`, `PushU16`, `PushU32`, `PushFelt`, and `PushWord` assembly instructions. These have been replaced with the generic `Push<Immediate>` instruction which supports all the same functionality through the `IntValue` enum (U8, U16, U32, Felt, Word) ([#2066](https://github.com/0xMiden/miden-vm/issues/2066)).
 - [BREAKING] Update miden-crypto dependency to v0.16 (#[2079](https://github.com/0xMiden/miden-vm/pull/2079))
 - Made `get_mast_forest()` async again for `AsyncHost` now that basic conditional async support is in place ([#2060](https://github.com/0xMiden/miden-vm/issues/2060)).
+- Removed `VmStateIterator` and replaced it with the new `TraceDebugger` abstraction ([#1861](https://github.com/0xMiden/miden-vm/issues/1861)).
 
 ## 0.17.0 (2025-08-06)
 

--- a/assembly/README.md
+++ b/assembly/README.md
@@ -169,7 +169,7 @@ end
 
 ### Debug Mode
 
-The assembler can be instantiated in debug mode. Compiling a program with such an assembler retains source mappings between assembly instructions and VM operations. Thus, when such a program is executed using the `execute_iter()` function of the [processor](../processor), it is possible to correlate each
+The assembler can be instantiated in debug mode. Compiling a program with such an assembler retains source mappings between assembly instructions and VM operations. Thus, when such a program is executed using the debugger via the `execute_debugger()` function of the [processor](../processor), it is possible to correlate each
 instruction with the source code that it is derived from. You can do this as
 shown below:
 

--- a/assembly/src/instruction/mod.rs
+++ b/assembly/src/instruction/mod.rs
@@ -47,7 +47,7 @@ impl Assembler {
                 // statements, loops, etc. However, `exec` instructions are compiled away and not
                 // added to the trace, so we should ignore them. Theoretically, we
                 // could probably add them anyways, but it currently breaks the
-                // `VmStateIterator`.
+                // `TraceDebugger`.
                 if !matches!(instruction.inner(), &Instruction::Exec(_)) {
                     let asm_op_id = maybe_asm_op_id.expect("no asmop decorator");
 

--- a/crates/utils/testing/src/lib.rs
+++ b/crates/utils/testing/src/lib.rs
@@ -29,7 +29,7 @@ pub use miden_core::{
 use miden_core::{ProgramInfo, chiplets::hasher::apply_permutation};
 pub use miden_processor::{
     AdviceInputs, AdviceProvider, BaseHost, ContextId, ExecutionError, ExecutionOptions,
-    ExecutionTrace, Process, ProcessState, VmStateIterator,
+    ExecutionTrace, Process, ProcessState, TraceDebugger,
 };
 use miden_processor::{AdviceMutation, DefaultHost, EventError, Program, fast::FastProcessor};
 use miden_prover::utils::range;
@@ -419,9 +419,9 @@ impl Test {
     }
 
     /// Compiles the test's source to a Program and executes it with the tests inputs. Returns a
-    /// VmStateIterator that allows us to iterate through each clock cycle and inspect the process
+    /// TraceDebugger that allows us to iterate through each clock cycle and inspect the process
     /// state.
-    pub fn execute_iter(&self) -> VmStateIterator {
+    pub fn execute_iter(&self) -> TraceDebugger {
         let (program, host) = self.get_program_and_host();
         let mut host = host.with_source_manager(self.source_manager.clone());
 
@@ -442,7 +442,7 @@ impl Test {
                 "inconsistent program hash"
             );
         }
-        VmStateIterator::new(process, result)
+        TraceDebugger::new(process, result)
     }
 
     /// Returns the last state of the stack after executing a test.

--- a/miden-vm/README.md
+++ b/miden-vm/README.md
@@ -36,7 +36,7 @@ Miden crate exposes several functions which can be used to execute programs, gen
 
 ### Executing programs
 
-To execute a program on Miden VM, you can use either `execute()` or `execute_iter()` functions. The `execute()` function takes the following arguments:
+To execute a program on Miden VM, you can use either `execute()` or the debugger via `execute_debugger()` functions. The `execute()` function takes the following arguments:
 
 - `program: &Program` - a reference to a Miden program to be executed.
 - `stack_inputs: StackInputs` - a set of public inputs with which to execute the program.
@@ -45,13 +45,13 @@ To execute a program on Miden VM, you can use either `execute()` or `execute_ite
 
 The function returns a `Result<ExecutionTrace, ExecutionError>` which will contain the execution trace of the program if the execution was successful, or an error, if the execution failed. Internally, the VM then passes this execution trace to the prover to generate a proof of a correct execution of the program.
 
-The `execute_iter()` function takes similar arguments (but without the `options`) and returns a `VmStateIterator` . This iterator can be used to iterate over the cycles of the executed program for debug purposes. In fact, when we execute a program using this function, a lot of the debug information is retained and we can get a precise picture of the VM's state at any cycle. Moreover, if the execution results in an error, the `VmStateIterator` can still be used to inspect VM states right up to the cycle at which the error occurred.
+The `execute_debugger()` function takes similar arguments (but without the `options`) and returns a `TraceDebugger`. This can be used to step through the cycles of the executed program for debug purposes. In fact, when we execute a program using this function, a lot of the debug information is retained and we can get a precise picture of the VM's state at any cycle. Moreover, if the execution results in an error, the `TraceDebugger` can still be used to inspect VM states right up to the cycle at which the error occurred.
 
 For example:
 
 ```rust
 use std::sync::Arc;
-use miden_vm::{assembly::DefaultSourceManager, AdviceInputs, Assembler, execute, execute_iter, DefaultHost, Program, StackInputs};
+use miden_vm::{assembly::DefaultSourceManager, AdviceInputs, Assembler, execute, execute_debugger, DefaultHost, Program, StackInputs};
 use miden_processor::ExecutionOptions;
 
 // instantiate the assembler
@@ -76,12 +76,8 @@ let exec_options = ExecutionOptions::default();
 let trace = execute(&program, stack_inputs.clone(), advice_inputs.clone(), &mut host, exec_options).unwrap();
 
 // now, execute the same program in debug mode and iterate over VM states
-for vm_state in execute_iter(
-    &program,
-    stack_inputs,
-    advice_inputs,
-    &mut host,
-) {
+let mut debugger = execute_debugger(&program, stack_inputs, advice_inputs, &mut host);
+while let Some(vm_state) = debugger.step_forward() {
     match vm_state {
         Ok(vm_state) => println!("{:?}", vm_state),
         Err(_) => println!("something went terribly wrong!"),

--- a/miden-vm/src/lib.rs
+++ b/miden-vm/src/lib.rs
@@ -11,8 +11,8 @@ pub use miden_assembly::{
 };
 pub use miden_processor::{
     AdviceInputs, AdviceProvider, AsmOpInfo, AsyncHost, BaseHost, DefaultHost, ExecutionError,
-    ExecutionTrace, Kernel, Operation, Program, ProgramInfo, StackInputs, SyncHost, VmState,
-    VmStateIterator, ZERO, crypto, execute, execute_iter, utils,
+    ExecutionTrace, Kernel, Operation, Program, ProgramInfo, StackInputs, SyncHost, VmState, ZERO,
+    crypto, execute, execute_debugger, utils,
 };
 pub use miden_prover::{
     ExecutionProof, FieldExtension, HashFunction, InputError, Proof, ProvingOptions, StackOutputs,

--- a/miden-vm/src/repl/mod.rs
+++ b/miden-vm/src/repl/mod.rs
@@ -320,9 +320,9 @@ fn execute(
         host.load_library(library.mast_forest()).map_err(|err| format!("{err}"))?;
     }
 
-    let state_iter =
-        miden_processor::execute_iter(&program, stack_inputs, advice_inputs, &mut host);
-    let (system, _, stack, chiplets, err) = state_iter.into_parts();
+    let debugger =
+        miden_processor::execute_debugger(&program, stack_inputs, advice_inputs, &mut host);
+    let (system, _, stack, chiplets, err) = debugger.into_parts();
     if let Some(err) = err {
         return Err(format!("{err}"));
     }

--- a/miden-vm/src/tools/mod.rs
+++ b/miden-vm/src/tools/mod.rs
@@ -246,11 +246,11 @@ where
 {
     let mut execution_details = ExecutionDetails::default();
 
-    let vm_state_iterator =
-        miden_processor::execute_iter(program, stack_inputs, advice_inputs, &mut host);
-    execution_details.set_trace_len_summary(vm_state_iterator.trace_len_summary());
+    let mut debugger =
+        miden_processor::execute_debugger(program, stack_inputs, advice_inputs, &mut host);
+    execution_details.set_trace_len_summary(debugger.trace_len_summary());
 
-    for state in vm_state_iterator {
+    while let Some(state) = debugger.step_forward() {
         let vm_state = state.wrap_err("execution error")?;
         if matches!(vm_state.op, Some(Operation::Noop)) {
             execution_details.incr_noop_count();

--- a/miden-vm/tests/integration/exec_iters.rs
+++ b/miden-vm/tests/integration/exec_iters.rs
@@ -17,7 +17,7 @@ fn test_exec_iter() {
     });
     let test = build_debug_test!(source, &init_stack);
     let path = test.source.uri();
-    let traces = test.execute_iter();
+    let mut debugger = test.execute_iter();
     let fmp = Felt::new(2u64.pow(30));
     let next_fmp = fmp + ONE;
     // TODO: double check this value
@@ -379,7 +379,8 @@ fn test_exec_iter() {
             memory: vec![(1u32.into(), 13_u32.into()), ((2u32.pow(30) + 1).into(), 17_u32.into())],
         },
     ];
-    for (expected, t) in expected_states.iter().zip(traces) {
+    for expected in expected_states.iter() {
+        let t = debugger.step_forward().expect("missing state");
         let state = t.as_ref().unwrap();
         assert_eq!(*expected, *state);
     }

--- a/miden-vm/tests/integration/operations/decorators/asmop.rs
+++ b/miden-vm/tests/integration/operations/decorators/asmop.rs
@@ -1194,7 +1194,7 @@ fn asmop_conditional_execution_test() {
 
 /// This is a helper function to build a vector of [VmStatePartial] from a specified
 /// [TraceDebugger].
-fn build_vm_state(vm_state_iterator: TraceDebugger) -> Vec<VmStatePartial> {
+fn build_vm_state(mut debugger: TraceDebugger) -> Vec<VmStatePartial> {
     let mut vm_state = Vec::new();
     while let Some(state) = debugger.step_forward() {
         let state = state.unwrap();

--- a/miden-vm/tests/integration/operations/decorators/asmop.rs
+++ b/miden-vm/tests/integration/operations/decorators/asmop.rs
@@ -1,6 +1,6 @@
 use miden_core::{AssemblyOp, Felt, Operation};
 use miden_debug_types::Location;
-use miden_processor::{AsmOpInfo, RowIndex, VmStateIterator};
+use miden_processor::{AsmOpInfo, RowIndex, TraceDebugger};
 use miden_utils_testing::{assert_eq, build_debug_test};
 
 #[test]
@@ -1193,14 +1193,15 @@ fn asmop_conditional_execution_test() {
 }
 
 /// This is a helper function to build a vector of [VmStatePartial] from a specified
-/// [VmStateIterator].
-fn build_vm_state(vm_state_iterator: VmStateIterator) -> Vec<VmStatePartial> {
+/// [TraceDebugger].
+fn build_vm_state(vm_state_iterator: TraceDebugger) -> Vec<VmStatePartial> {
     let mut vm_state = Vec::new();
-    for state in vm_state_iterator {
+    while let Some(state) = debugger.step_forward() {
+        let state = state.unwrap();
         vm_state.push(VmStatePartial {
-            clk: state.as_ref().unwrap().clk,
-            asmop: state.as_ref().unwrap().asmop.clone(),
-            op: state.as_ref().unwrap().op,
+            clk: state.clk,
+            asmop: state.asmop.clone(),
+            op: state.op,
         });
     }
     vm_state

--- a/processor/README.md
+++ b/processor/README.md
@@ -11,12 +11,12 @@ The processor exposes two functions which can be used to execute programs: `exec
 
 The function returns a `Result<ExecutionTrace, ExecutionError>` which will contain the execution trace of the program if the execution was successful, or an error, if the execution failed. Internally, the VM then passes this execution trace to the prover to generate a proof of a correct execution of the program.
 
-The `execute_iter()` function takes similar arguments (but without the `options`) and returns a `VmStateIterator` . This iterator can be used to iterate over the cycles of the executed program for debug purposes. In fact, when we execute a program using this function, a lot of the debug information is retained and we can get a precise picture of the VM's state at any cycle. Moreover, if the execution results in an error, the `VmStateIterator` can still be used to inspect VM states right up to the cycle at which the error occurred.
+The `execute_debugger()` function takes similar arguments (but without the `options`) and returns a `TraceDebugger`. This can be used to step through cycles of the executed program for debug purposes. In fact, when we execute a program using this function, a lot of the debug information is retained and we can get a precise picture of the VM's state at any cycle. Moreover, if the execution results in an error, the `TraceDebugger` can still be used to inspect VM states right up to the cycle at which the error occurred.
 
 For example:
 ```Rust
 use miden_assembly::Assembler;
-use miden_processor::{execute, execute_iter, ExecutionOptions, DefaultHost, StackInputs, };
+use miden_processor::{execute, execute_debugger, ExecutionOptions, DefaultHost, StackInputs, };
 
 // instantiate the assembler
 let assembler = Assembler::default();
@@ -37,7 +37,8 @@ let exec_options = ExecutionOptions::default();
 let trace = execute(&program, stack_inputs.clone(), &mut host, exec_options).unwrap();
 
 // now, execute the same program in debug mode and iterate over VM states
-for vm_state in execute_iter(&program, stack_inputs, &mut host, exec_options) {
+let mut debugger = execute_debugger(&program, stack_inputs, &mut host);
+while let Some(vm_state) = debugger.step_forward() {
     match vm_state {
         Ok(vm_state) => println!("{:?}", vm_state),
         Err(_) => println!("something went terribly wrong!"),

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -79,7 +79,7 @@ pub mod utils;
 mod tests;
 
 mod debug;
-pub use debug::{AsmOpInfo, VmState, VmStateIterator};
+pub use debug::{AsmOpInfo, TraceDebugger, VmState};
 
 // RE-EXPORTS
 // ================================================================================================
@@ -190,14 +190,14 @@ pub fn execute(
     Ok(trace)
 }
 
-/// Returns an iterator which allows callers to step through the execution and inspect VM state at
+/// Returns a debugger which allows callers to step through the execution and inspect VM state at
 /// each execution step.
-pub fn execute_iter(
+pub fn execute_debugger(
     program: &Program,
     stack_inputs: StackInputs,
     advice_inputs: AdviceInputs,
     host: &mut impl SyncHost,
-) -> VmStateIterator {
+) -> TraceDebugger {
     let mut process = Process::new_debug(program.kernel().clone(), stack_inputs, advice_inputs);
     let result = process.execute(program, host);
     if result.is_ok() {
@@ -207,7 +207,7 @@ pub fn execute_iter(
             "inconsistent program hash"
         );
     }
-    VmStateIterator::new(process, result)
+    TraceDebugger::new(process, result)
 }
 
 // PROCESS


### PR DESCRIPTION
Closes #1861 

- As discussed in #1845 and tracked in #1861, `VmStateIterator` was mainly consumed by `midenc-debug` but an iterator abstraction was not ideal for interactive debugging.
- This PR removes `VmStateIterator` and introduces a new `TraceDebugger` abstraction with imperative stepping methods, designed for trace debugging workflows.