### PR TITLE
docs: document hasher chiplet modules

### DIFF
--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -57,7 +57,15 @@ const IS_FULL_CONSTRAINT_SET: bool = false;
 // PROCESSOR AIR
 // ================================================================================================
 
-/// TODO: add docs
+/// AIR (Algebraic Intermediate Representation) for the Miden VM processor.
+///
+/// This struct defines the algebraic constraints that ensure the correctness of Miden VM
+/// program execution. It implements the Winterfell AIR trait and provides the framework
+/// for generating and verifying STARK proofs of program execution.
+///
+/// The processor AIR consists of multiple constraint domains: system constraints (basic VM
+/// state transitions), stack constraints (operand stack operations), range checker constraints
+/// (field element validation), and chiplet constraints (specialized computation units).
 pub struct ProcessorAir {
     context: AirContext<Felt>,
     stack_inputs: StackInputs,

--- a/air/src/trace/chiplets/hasher.rs
+++ b/air/src/trace/chiplets/hasher.rs
@@ -1,4 +1,8 @@
-//! TODO: add docs
+//! Hasher chiplet execution trace definitions.
+//!
+//! This module defines constants and types for the hasher chiplet's execution trace.
+//! The hasher trace consists of 16 columns: 3 selector columns, 12 state columns 
+//! (4 capacity + 8 rate), and 1 index column for Merkle operations.
 
 use core::ops::Range;
 

--- a/core/src/chiplets/hasher.rs
+++ b/core/src/chiplets/hasher.rs
@@ -1,4 +1,8 @@
-//! TODO: add docs
+//! Hash chiplet interface for Miden VM.
+//!
+//! This module provides pass-through functions for hash-related computations, delegating to the
+//! underlying Rpo256 hash function. All operations are designed to work with the VM's chiplet
+//! architecture for efficient execution and trace generation.
 use miden_crypto::Word as Digest;
 
 use super::Felt;


### PR DESCRIPTION
docs: document hasher chiplet modules

Add module documentation for hasher-related components:
- Hash chiplet interface (core/src/chiplets/hasher.rs)
- ProcessorAir constraints (air/src/lib.rs) 
- Hasher trace definitions (air/src/trace/chiplets/hasher.rs)

Documentation covers 16-column trace structure and core functionality
while maintaining project's concise documentation style.