### PR TITLE
fix: script crashes and improve variable defaults

### DIFF
--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -3,17 +3,19 @@ set -u
 
 CHANGELOG_FILE="${1:-CHANGELOG.md}"
 
-if [ "${NO_CHANGELOG_LABEL}" = "true" ]; then
+if [ "${NO_CHANGELOG_LABEL:-}" = "true" ]; then
     # 'no changelog' set, so finish successfully
     echo "\"no changelog\" label has been set"
     exit 0
 else
     # a changelog check is required
     # fail if the diff is empty
-    if git diff --exit-code "origin/${BASE_REF}" -- "${CHANGELOG_FILE}"; then
-        >&2 echo "Changes should come with an entry in the \"CHANGELOG.md\" file. This behavior
-can be overridden by using the \"no changelog\" label, which is used for changes
-that are trivial / explicitely stated not to require a changelog entry."
+    if git diff --exit-code "origin/${BASE_REF:-main}" -- "${CHANGELOG_FILE}"; then
+        >&2 cat <<EOF
+Changes should come with an entry in the "CHANGELOG.md" file. This behavior
+can be overridden by using the "no changelog" label, which is used for changes
+that are trivial / explicitly stated not to require a changelog entry.
+EOF
         exit 1
     fi
 


### PR DESCRIPTION
## Describe your changes

updated the script to prevent crashes when `set -u` is enabled.

* `${NO_CHANGELOG_LABEL}` → `${NO_CHANGELOG_LABEL:-}` to avoid errors if the variable is unset.
* `${BASE_REF}` → `${BASE_REF:-main}` so the script defaults to the main branch.
* Replaced multiline `echo` with `cat <<EOF ... EOF` for proper line breaks.

now the script runs safely even with strict variable checking.
