### PR TITLE
Sparse iteration for OpBatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Enhancements
 
 - Added slicing for the word constants ([#2057](https://github.com/0xMiden/miden-vm/pull/2057)).
+- Adds sparse representation for the operation batches ([#1815](https://github.com/0xMiden/miden-vm/issues/1815))
 
 #### Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,6 +1136,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "proptest",
+ "proptest-derive 0.3.0",
  "thiserror 2.0.12",
  "winter-math",
  "winter-rand-utils",
@@ -1207,7 +1208,7 @@ dependencies = [
  "miden-assembly-syntax",
  "miden-core",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.6.0",
 ]
 
 [[package]]
@@ -1233,7 +1234,7 @@ dependencies = [
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "syn",
+ "syn 2.0.104",
  "terminal_size",
  "textwrap",
  "thiserror 2.0.12",
@@ -1247,9 +1248,9 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86a905f3ea65634dd4d1041a4f0fd0a3e77aa4118341d265af1a94339182222f"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1505,9 +1506,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1774,6 +1775,15 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
@@ -1799,13 +1809,33 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "proptest-derive"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
 ]
 
 [[package]]
@@ -1814,7 +1844,7 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.95",
 ]
 
 [[package]]
@@ -1961,12 +1991,12 @@ dependencies = [
  "cfg-if",
  "glob",
  "proc-macro-crate",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn",
+ "syn 2.0.104",
  "unicode-ident",
 ]
 
@@ -2098,9 +2128,9 @@ version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2121,9 +2151,9 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2266,12 +2296,23 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid 0.1.0",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
  "unicode-ident",
 ]
 
@@ -2331,9 +2372,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
  "cfg-if",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2342,9 +2383,9 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
  "test-case-core",
 ]
 
@@ -2383,9 +2424,9 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2394,9 +2435,9 @@ version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2505,9 +2546,9 @@ version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2622,6 +2663,12 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
+name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
@@ -2713,9 +2760,9 @@ checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -2725,7 +2772,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
- "quote",
+ "quote 1.0.40",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2735,9 +2782,9 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2844,9 +2891,9 @@ version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2855,9 +2902,9 @@ version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3177,8 +3224,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3258,7 +3305,7 @@ version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,9 +309,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -479,9 +479,9 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -636,9 +636,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -689,9 +689,9 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -905,9 +905,9 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -956,7 +956,7 @@ dependencies = [
  "sha3",
  "string_cache",
  "term",
- "unicode-xid 0.2.6",
+ "unicode-xid",
  "walkdir",
 ]
 
@@ -1118,7 +1118,7 @@ dependencies = [
  "midenc-hir-type",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.6.0",
+ "proptest-derive",
  "regex",
  "rustc_version 0.4.1",
  "semver 1.0.26",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,9 +309,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -479,9 +479,9 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -636,9 +636,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -689,9 +689,9 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -905,9 +905,9 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "proc-macro2 1.0.95",
+ "quote 1.0.40",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -956,7 +956,7 @@ dependencies = [
  "sha3",
  "string_cache",
  "term",
- "unicode-xid",
+ "unicode-xid 0.2.6",
  "walkdir",
 ]
 
@@ -1118,7 +1118,7 @@ dependencies = [
  "midenc-hir-type",
  "pretty_assertions",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.6.0",
  "regex",
  "rustc_version 0.4.1",
  "semver 1.0.26",
@@ -1136,7 +1136,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "proptest",
- "proptest-derive 0.3.0",
  "thiserror 2.0.12",
  "winter-math",
  "winter-rand-utils",
@@ -1208,7 +1207,7 @@ dependencies = [
  "miden-assembly-syntax",
  "miden-core",
  "proptest",
- "proptest-derive 0.6.0",
+ "proptest-derive",
 ]
 
 [[package]]
@@ -1234,7 +1233,7 @@ dependencies = [
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "syn 2.0.104",
+ "syn",
  "terminal_size",
  "textwrap",
  "thiserror 2.0.12",
@@ -1248,9 +1247,9 @@ version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86a905f3ea65634dd4d1041a4f0fd0a3e77aa4118341d265af1a94339182222f"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1506,9 +1505,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1775,15 +1774,6 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
@@ -1809,33 +1799,13 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
-]
-
-[[package]]
-name = "proptest-derive"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1844,7 +1814,7 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
- "proc-macro2 1.0.95",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1991,12 +1961,12 @@ dependencies = [
  "cfg-if",
  "glob",
  "proc-macro-crate",
- "proc-macro2 1.0.95",
- "quote 1.0.40",
+ "proc-macro2",
+ "quote",
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn 2.0.104",
+ "syn",
  "unicode-ident",
 ]
 
@@ -2128,9 +2098,9 @@ version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2151,9 +2121,9 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2296,23 +2266,12 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -2372,9 +2331,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2383,9 +2342,9 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
  "test-case-core",
 ]
 
@@ -2424,9 +2383,9 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2435,9 +2394,9 @@ version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2546,9 +2505,9 @@ version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2663,12 +2622,6 @@ checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
@@ -2760,9 +2713,9 @@ checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2772,7 +2725,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
- "quote 1.0.40",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -2782,9 +2735,9 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2891,9 +2844,9 @@ version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2902,9 +2855,9 @@ version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3224,8 +3177,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
 dependencies = [
- "quote 1.0.40",
- "syn 2.0.104",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3305,7 +3258,7 @@ version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
- "proc-macro2 1.0.95",
- "quote 1.0.40",
- "syn 2.0.104",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/assembly/src/snapshots/miden_assembly__tests__adv_has_map_key.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__adv_has_map_key.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block emit(652777600) assert(0) end
+    basic_block emit(652777600) assert(0) noop noop noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__advmap_push.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__advmap_push.snap
@@ -3,5 +3,15 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block push(2) push(2) push(2) push(2) emit(574478993) assert(0) end
+    basic_block
+        push(2)
+        push(2)
+        push(2)
+        push(2)
+        emit(574478993)
+        assert(0)
+        noop
+        noop
+        noop
+    end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__advmap_push_nokey.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__advmap_push_nokey.snap
@@ -10,5 +10,8 @@ begin
         push(6740431856120851931)
         emit(574478993)
         assert(0)
+        noop
+        noop
+        noop
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__assert_eq_with_code.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__assert_eq_with_code.snap
@@ -10,5 +10,8 @@ begin
         assert(15491226248792286710)
         eq
         assert(15491226248792286710)
+        noop
+        noop
+        noop
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__assert_eqw_with_code.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__assert_eqw_with_code.snap
@@ -37,5 +37,8 @@ begin
         assert(15491226248792286710)
         eq
         assert(15491226248792286710)
+        noop
+        noop
+        noop
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__assert_with_code.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__assert_with_code.snap
@@ -7,5 +7,11 @@ begin
         assert(0)
         assert(15491226248792286710)
         assert(15491226248792286710)
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__asserts_and_mpverify_with_code_in_duplicate_procedure.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__asserts_and_mpverify_with_code_in_duplicate_procedure.snap
@@ -48,5 +48,6 @@ begin
         mpverify(17575088163785490049)
         mpverify(17575088163785490049)
         mpverify(13948122101519563734)
+        noop
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__assertz_with_code.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__assertz_with_code.snap
@@ -10,5 +10,8 @@ begin
         assert(15491226248792286710)
         eqz
         assert(15491226248792286710)
+        noop
+        noop
+        noop
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__basic_block_and_simple_if_false-2.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__basic_block_and_simple_if_false-2.snap
@@ -4,11 +4,11 @@ expression: program
 ---
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop noop noop noop noop noop noop end
         if.true
-            basic_block noop end
+            basic_block noop noop noop noop noop noop noop noop noop end
         else
-            basic_block add end
+            basic_block add noop noop noop noop noop noop noop noop end
         end
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__basic_block_and_simple_if_false.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__basic_block_and_simple_if_false.snap
@@ -4,11 +4,11 @@ expression: program
 ---
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop noop noop noop noop noop noop end
         if.true
-            basic_block mul end
+            basic_block mul noop noop noop noop noop noop noop noop end
         else
-            basic_block add end
+            basic_block add noop noop noop noop noop noop noop noop end
         end
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__basic_block_and_simple_if_true-2.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__basic_block_and_simple_if_true-2.snap
@@ -4,11 +4,11 @@ expression: program
 ---
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop noop noop noop noop noop noop end
         if.true
-            basic_block add end
+            basic_block add noop noop noop noop noop noop noop noop end
         else
-            basic_block noop end
+            basic_block noop noop noop noop noop noop noop noop noop end
         end
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__basic_block_and_simple_if_true.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__basic_block_and_simple_if_true.snap
@@ -4,11 +4,11 @@ expression: program
 ---
 begin
     join
-        basic_block push(2) push(3) end
+        basic_block push(2) push(3) noop noop noop noop noop noop noop end
         if.true
-            basic_block add end
+            basic_block add noop noop noop noop noop noop noop noop end
         else
-            basic_block mul end
+            basic_block mul noop noop noop noop noop noop noop noop end
         end
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__can_push_constant_word.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__can_push_constant_word.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block push(2) push(3) push(4) push(5) end
+    basic_block push(2) push(3) push(4) push(5) noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__comment_after_program.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__comment_after_program.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block pad incr push(2) add end
+    basic_block pad incr push(2) add noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__comment_before_program.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__comment_before_program.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block pad incr push(2) add end
+    basic_block pad incr push(2) add noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__comment_in_nested_control_blocks.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__comment_in_nested_control_blocks.snap
@@ -5,25 +5,65 @@ expression: program
 begin
     join
         join
-            basic_block pad incr push(2) end
+            basic_block pad incr push(2) noop noop noop noop noop noop end
             if.true
                 join
-                    basic_block add end
+                    basic_block add noop noop noop noop noop noop noop noop end
                     while.true
-                        basic_block push(7) push(11) add end
+                        basic_block
+                            push(7)
+                            push(11)
+                            add
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                        end
                     end
                 end
             else
                 join
-                    basic_block mul push(8) push(8) end
+                    basic_block
+                        mul
+                        push(8)
+                        push(8)
+                        noop
+                        noop
+                        noop
+                        noop
+                        noop
+                        noop
+                    end
                     if.true
-                        basic_block mul end
+                        basic_block
+                            mul
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                        end
                     else
-                        basic_block noop end
+                        basic_block
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                        end
                     end
                 end
             end
         end
-        basic_block push(3) add end
+        basic_block push(3) add noop noop noop noop noop noop noop end
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__comment_simple.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__comment_simple.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block pad incr push(2) add end
+    basic_block pad incr push(2) add noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__constant_alphanumeric_expression.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__constant_alphanumeric_expression.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block push(21) end
+    basic_block push(21) noop noop noop noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__constant_field_division.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__constant_field_division.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block push(2) end
+    basic_block push(2) noop noop noop noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__constant_hexadecimal_value.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__constant_hexadecimal_value.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block push(255) end
+    basic_block push(255) noop noop noop noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__constant_numeric_expression.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__constant_numeric_expression.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block push(26) end
+    basic_block push(26) noop noop noop noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__decorators_basic_block.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__decorators_basic_block.snap
@@ -3,5 +3,18 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block trace(0) add trace(1) mul trace(2) end
+    basic_block
+        trace(0)
+        add
+        trace(1)
+        mul
+        trace(2)
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+    end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__decorators_join_and_split.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__decorators_join_and_split.snap
@@ -6,15 +6,63 @@ begin
     join
         trace(0) trace(1)
         if.true
-            basic_block trace(2) add trace(3) end
+            basic_block
+                trace(2)
+                add
+                trace(3)
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+            end
         else
-            basic_block trace(4) mul trace(5) end
+            basic_block
+                trace(4)
+                mul
+                trace(5)
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+            end
         end
         trace(6)
         if.true
-            basic_block trace(7) push(42) trace(8) end
+            basic_block
+                trace(7)
+                push(42)
+                trace(8)
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+            end
         else
-            basic_block trace(9) push(22) trace(10) end
+            basic_block
+                trace(9)
+                push(22)
+                trace(10)
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+            end
         end
     end
     trace(11)

--- a/assembly/src/snapshots/miden_assembly__tests__decorators_repeat_one_basic_block.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__decorators_repeat_one_basic_block.snap
@@ -3,5 +3,18 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block trace(0) add add trace(1) mul mul trace(2) end
+    basic_block
+        trace(0)
+        add
+        add
+        trace(1)
+        mul
+        mul
+        trace(2)
+        noop
+        noop
+        noop
+        noop
+        noop
+    end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__decorators_repeat_split.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__decorators_repeat_split.snap
@@ -6,15 +6,63 @@ begin
     join
         trace(0)
         if.true
-            basic_block trace(1) push(42) trace(2) end
+            basic_block
+                trace(1)
+                push(42)
+                trace(2)
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+            end
         else
-            basic_block trace(3) push(22) trace(3) end
+            basic_block
+                trace(3)
+                push(22)
+                trace(3)
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+            end
         end
         trace(4)
         if.true
-            basic_block trace(1) push(42) trace(2) end
+            basic_block
+                trace(1)
+                push(42)
+                trace(2)
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+            end
         else
-            basic_block trace(3) push(22) trace(3) end
+            basic_block
+                trace(3)
+                push(22)
+                trace(3)
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+                noop
+            end
         end
         trace(4)
     end

--- a/assembly/src/snapshots/miden_assembly__tests__empty_if_true_then_branch.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__empty_if_true_then_branch.snap
@@ -4,8 +4,8 @@ expression: program
 ---
 begin
     if.true
-        basic_block noop end
+        basic_block noop noop noop noop noop noop noop noop noop end
     else
-        basic_block noop end
+        basic_block noop noop noop noop noop noop noop noop noop end
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__module_alias.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__module_alias.snap
@@ -4,7 +4,7 @@ expression: program
 ---
 begin
     join
-        basic_block pad incr pad push(2) pad end
+        basic_block pad incr pad push(2) pad noop noop noop noop end
         external.0x3cff5b58a573dc9d25fd3c57130cc57e5b1b381dc58b5ae3594b390c59835e63
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__mtree_verify_with_code.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__mtree_verify_with_code.snap
@@ -7,5 +7,11 @@ begin
         mpverify(0)
         mpverify(13948122101519563734)
         mpverify(17575088163785490049)
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__multiple_constants_push.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__multiple_constants_push.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block push(21) push(64) push(44) push(72) end
+    basic_block push(21) push(64) push(44) push(72) noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__nested_control_blocks.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__nested_control_blocks.snap
@@ -5,25 +5,65 @@ expression: program
 begin
     join
         join
-            basic_block push(2) push(3) end
+            basic_block push(2) push(3) noop noop noop noop noop noop noop end
             if.true
                 join
-                    basic_block add end
+                    basic_block add noop noop noop noop noop noop noop noop end
                     while.true
-                        basic_block push(7) push(11) add end
+                        basic_block
+                            push(7)
+                            push(11)
+                            add
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                        end
                     end
                 end
             else
                 join
-                    basic_block mul push(8) push(8) end
+                    basic_block
+                        mul
+                        push(8)
+                        push(8)
+                        noop
+                        noop
+                        noop
+                        noop
+                        noop
+                        noop
+                    end
                     if.true
-                        basic_block mul end
+                        basic_block
+                            mul
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                        end
                     else
-                        basic_block noop end
+                        basic_block
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                            noop
+                        end
                     end
                 end
             end
         end
-        basic_block push(3) add end
+        basic_block push(3) add noop noop noop noop noop noop noop end
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__program_with_nested_procedure.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__program_with_nested_procedure.snap
@@ -12,11 +12,15 @@ begin
         mul
         push(11)
         push(5)
+        noop
         push(3)
         push(7)
         mul
         add
         neg
         add
+        noop
+        noop
+        noop
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__program_with_one_import_and_hex_call.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__program_with_one_import_and_hex_call.snap
@@ -5,7 +5,7 @@ expression: program
 begin
     join
         join
-            basic_block push(4) push(3) end
+            basic_block push(4) push(3) noop noop noop noop noop noop noop end
             external.0xc2545da99d3a1f3f38d957c7893c44d78998d8ea8b11aba7e22c8c2b2a213dae
         end
         call.0x20234ee941e53a15886e733cc8e041198c6e90d2a16ea18ce1030e8c3596dd38

--- a/assembly/src/snapshots/miden_assembly__tests__program_with_one_procedure.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__program_with_one_procedure.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block push(2) push(3) add push(3) push(7) mul end
+    basic_block push(2) push(3) add push(3) push(7) mul noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__program_with_proc_locals.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__program_with_proc_locals.snap
@@ -13,12 +13,68 @@ begin
         fmpadd
         mstore
         drop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
         add
         push(18446744069414584317)
         fmpadd
         mload
         mul
+        noop
+        noop
+        noop
+        noop
         push(18446744069414584317)
         fmpupdate
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__program_with_reexported_custom_alias_in_same_library.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__program_with_reexported_custom_alias_in_same_library.snap
@@ -5,7 +5,7 @@ expression: program
 begin
     join
         join
-            basic_block push(4) push(3) end
+            basic_block push(4) push(3) noop noop noop noop noop noop noop end
             external.0xb9691da1d9b4b364aca0a0990e9f04c446a2faa622c8dd0d8831527dbec61393
         end
         external.0xcb08c107c81c582788cbf63c99f6b455e11b33bb98ca05fe1cfa17c087dfa8f1

--- a/assembly/src/snapshots/miden_assembly__tests__program_with_reexported_proc_in_another_library.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__program_with_reexported_proc_in_another_library.snap
@@ -5,7 +5,7 @@ expression: program
 begin
     join
         join
-            basic_block push(4) push(3) end
+            basic_block push(4) push(3) noop noop noop noop noop noop noop end
             external.0xb9691da1d9b4b364aca0a0990e9f04c446a2faa622c8dd0d8831527dbec61393
         end
         external.0xcb08c107c81c582788cbf63c99f6b455e11b33bb98ca05fe1cfa17c087dfa8f1

--- a/assembly/src/snapshots/miden_assembly__tests__program_with_reexported_proc_in_same_library.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__program_with_reexported_proc_in_same_library.snap
@@ -5,7 +5,7 @@ expression: program
 begin
     join
         join
-            basic_block push(4) push(3) end
+            basic_block push(4) push(3) noop noop noop noop noop noop noop end
             external.0xb9691da1d9b4b364aca0a0990e9f04c446a2faa622c8dd0d8831527dbec61393
         end
         external.0xcb08c107c81c582788cbf63c99f6b455e11b33bb98ca05fe1cfa17c087dfa8f1

--- a/assembly/src/snapshots/miden_assembly__tests__push_word_slice.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__push_word_slice.snap
@@ -11,7 +11,16 @@ begin
         push(12)
         push(8)
         push(9)
+        noop
+        noop
         push(6)
         push(7)
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
     end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__repeat_basic_blocks_merged.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__repeat_basic_blocks_merged.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block mul add add add add add end
+    basic_block mul add add add add add noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__simple_constant.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__simple_constant.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block push(7) end
+    basic_block push(7) noop noop noop noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__simple_instructions-2.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__simple_instructions-2.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block push(10) push(50) push(2) u32madd drop end
+    basic_block push(10) push(50) push(2) u32madd drop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__simple_instructions-3.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__simple_instructions-3.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block push(10) push(50) push(2) u32add3 drop end
+    basic_block push(10) push(50) push(2) u32add3 drop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__simple_instructions.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__simple_instructions.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block pad eqz assert(0) end
+    basic_block pad eqz assert(0) noop noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__single_basic_block.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__single_basic_block.snap
@@ -3,5 +3,5 @@ source: assembly/src/tests.rs
 expression: program
 ---
 begin
-    basic_block pad incr push(2) add end
+    basic_block pad incr push(2) add noop noop noop noop noop end
 end

--- a/assembly/src/snapshots/miden_assembly__tests__u32assert2_with_code.snap
+++ b/assembly/src/snapshots/miden_assembly__tests__u32assert2_with_code.snap
@@ -7,5 +7,11 @@ begin
         u32assert2(0)
         u32assert2(15491226248792286710)
         u32assert2(15491226248792286710)
+        noop
+        noop
+        noop
+        noop
+        noop
+        noop
     end
 end

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,4 +41,5 @@ winter-utils.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
+proptest-derive = { version = "0.3", default-features = false }
 winter-rand-utils.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,5 +41,4 @@ winter-utils.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-proptest-derive = { version = "0.3", default-features = false }
 winter-rand-utils.workspace = true

--- a/core/src/mast/node/basic_block_node/csr.rs
+++ b/core/src/mast/node/basic_block_node/csr.rs
@@ -1,0 +1,310 @@
+use alloc::vec::Vec;
+use core::ops::Index;
+
+/// CSR format sparse matrix, We follow the names used by scipy.
+/// Detailed explanation here: <https://stackoverflow.com/questions/52299420/scipy-csr-matrix-understand-indptr>
+#[derive(Debug)]
+pub struct SparseMatrix<F: Copy + Default> {
+    /// all non-zero values in the matrix
+    pub data: Vec<F>,
+    /// column indices
+    pub indices: Vec<usize>,
+    /// row information
+    pub indptr: Vec<usize>,
+    /// number of columns
+    pub cols: usize,
+    /// default value for sparse elements (required for Index trait)
+    pub default: F,
+}
+
+impl<F: Copy + Default + PartialEq> SparseMatrix<F> {
+    /// 0x0 empty matrix
+    pub fn empty() -> Self {
+        Self {
+            data: vec![],
+            indices: vec![],
+            indptr: vec![0],
+            cols: 0,
+            default: F::default(),
+        }
+    }
+
+    /// Add a new empty row to the matrix
+    fn add_row(&mut self) {
+        let current_len = self.data.len();
+        self.indptr.push(current_len);
+    }
+
+    /// number of non-zero entries
+    pub fn len(&self) -> usize {
+        *self.indptr.last().unwrap()
+    }
+
+    /// empty matrix
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn num_rows(&self) -> usize {
+        self.indptr.len() - 1
+    }
+
+    pub fn num_cols(&self) -> usize {
+        self.cols
+    }
+
+    /// returns a custom iterator over non-zero values
+    pub fn iter(&self) -> NonZeroIter<'_, F> {
+        NonZeroIter {
+            matrix: self,
+            row: 0,
+            i: 0,
+            nnz: *self.indptr.last().unwrap(),
+        }
+    }
+
+    /// Get the element at (row, col), returning F::default() if not found
+    pub fn get(&self, row: usize, col: usize) -> F {
+        let row_start = self.indptr[row];
+        let row_end = self.indptr[row + 1];
+
+        // Handle empty rows
+        if row_start == row_end {
+            return F::default();
+        }
+
+        // Binary search for the column index
+        let slice = &self.indices[row_start..row_end];
+        match slice.binary_search(&col) {
+            Ok(pos) => self.data[row_start + pos],
+            Err(_) => F::default(),
+        }
+    }
+
+    /// Set the element at (row, col) - returns the old value or None if was zero
+    pub fn set(&mut self, row: usize, col: usize, value: F) -> Option<F> {
+        // Ensure we have enough rows
+        while self.num_rows() <= row {
+            self.add_row();
+        }
+
+        let row_start = self.indptr[row];
+        let row_end = self.indptr[row + 1];
+
+        // Handle empty rows
+        if row_start == row_end {
+            // Element not found, need to insert
+            if value != F::default() {
+                self.insert_element_at(row, row_start, col, value);
+            }
+            return None;
+        }
+
+        // Binary search for the column index
+        let slice = &self.indices[row_start..row_end];
+        match slice.binary_search(&col) {
+            Ok(pos) => {
+                let abs_pos = row_start + pos;
+                let old_value = self.data[abs_pos];
+                // If setting to zero, remove the element
+                if value == F::default() {
+                    self.remove_element_at(row, abs_pos);
+                    Some(old_value)
+                } else {
+                    self.data[abs_pos] = value;
+                    Some(old_value)
+                }
+            },
+            Err(insert_pos) => {
+                // Add new element if not zero
+                if value != F::default() {
+                    self.insert_element_at(row, row_start + insert_pos, col, value);
+                    None
+                } else {
+                    None
+                }
+            },
+        }
+    }
+
+    /// Remove an element at the specified absolute position
+    fn remove_element_at(&mut self, row: usize, abs_pos: usize) {
+        // Remove from data and indices
+        self.data.remove(abs_pos);
+        self.indices.remove(abs_pos);
+
+        // Update indptr for all subsequent rows
+        for i in (row + 1)..self.indptr.len() {
+            self.indptr[i] -= 1;
+        }
+    }
+
+    /// Insert a new element at the specified absolute position
+    fn insert_element_at(&mut self, row: usize, abs_pos: usize, col: usize, value: F) {
+        // Insert into data and indices
+        self.data.insert(abs_pos, value);
+        self.indices.insert(abs_pos, col);
+
+        // Update indptr for all subsequent rows
+        for i in (row + 1)..self.indptr.len() {
+            self.indptr[i] += 1;
+        }
+    }
+
+    /// Iterator over all matrix elements (including zeros) in row-major order
+    pub fn iter_dense(&self) -> DenseIter<'_, F> {
+        DenseIter::new(self)
+    }
+
+    /// Iterator over non-zero elements with (row, col, value)
+    pub fn iter_nonzero(&self) -> NonZeroIter<'_, F> {
+        self.iter()
+    }
+}
+
+/// Iterator for dense matrix elements (including zeros) in row-major order
+#[derive(Debug)]
+pub struct DenseIter<'a, F: Copy + Default + PartialEq> {
+    matrix: &'a SparseMatrix<F>,
+    row: usize,
+    col: usize,
+    row_start: usize,
+    row_end: usize,
+    current_idx: usize,
+}
+
+impl<'a, F: Default> DenseIter<'a, F> {
+    fn new(matrix: &'a SparseMatrix<F>) -> Self {
+        let row_start = if matrix.num_rows() > 0 { matrix.indptr[0] } else { 0 };
+        let row_end = if matrix.num_rows() > 0 { matrix.indptr[1] } else { 0 };
+        DenseIter { 
+            matrix, 
+            row: 0, 
+            col: 0, 
+            row_start, 
+            row_end, 
+            current_idx: row_start 
+        }
+    }
+}
+
+impl<'a, F: Copy + Default + PartialEq> Iterator for DenseIter<'a, F> {
+    type Item = F;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.row >= self.matrix.num_rows() {
+            return None;
+        }
+
+        let value = if self.current_idx < self.row_end {
+            let actual_col = self.matrix.indices[self.current_idx];
+            
+            if actual_col == self.col {
+                // Found the element we're looking for
+                let result = self.matrix.data[self.current_idx];
+                self.current_idx += 1;
+                self.col += 1;
+                result
+            } else if actual_col > self.col {
+                // No element at this column position, return default
+                self.col += 1;
+                F::default()
+            } else {
+                // This shouldn't happen due to CSR ordering - indices should be sorted
+                self.current_idx += 1;
+                self.col += 1;
+                F::default()
+            }
+        } else {
+            // No more elements in this row, return default
+            self.col += 1;
+            F::default()
+        };
+
+        // Move to next row if we've finished this row
+        if self.col >= self.matrix.num_cols() {
+            self.col = 0;
+            self.row += 1;
+            
+            // Update row pointers for the new row
+            if self.row < self.matrix.num_rows() {
+                self.row_start = self.matrix.indptr[self.row];
+                self.row_end = self.matrix.indptr[self.row + 1];
+                self.current_idx = self.row_start;
+            }
+        }
+
+        Some(value)
+    }
+}
+
+/// Iterator for sparse matrix (non-zero elements with row/column indices)
+#[derive(Debug)]
+pub struct NonZeroIter<'a, F: Default> {
+    matrix: &'a SparseMatrix<F>,
+    row: usize,
+    i: usize,
+    nnz: usize,
+}
+
+impl<'a, F: Copy + Default> Iterator for NonZeroIter<'a, F> {
+    type Item = (usize, usize, F);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i >= self.nnz {
+            return None;
+        }
+
+        let row = self.row;
+        let col = self.matrix.indices[self.i];
+        let val = self.matrix.data[self.i];
+
+        self.i += 1;
+
+        // Advance to the next row if we've moved past the current row's data
+        while self.row < self.matrix.num_rows() - 1 && self.i >= self.matrix.indptr[self.row + 1] {
+            self.row += 1;
+        }
+
+        Some((row, col, val))
+    }
+}
+
+impl<F: Copy + Default + PartialEq> std::ops::Index<usize> for SparseMatrix<F> {
+    type Output = F;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        // Calculate row and col from the linear index (row-major order)
+        let rows = self.num_rows();
+        let cols = self.num_cols();
+        
+        if rows == 0 || cols == 0 {
+            return &self.default;
+        }
+        
+        let row = index / cols;
+        let col = index % cols;
+        
+        // Handle case where index is out of bounds
+        if row >= rows {
+            return &self.default;
+        }
+        
+        // Get the element at (row, col), returning default if not found
+        // Use the same logic as the get method but more efficient for single access
+        let row_start = self.indptr[row];
+        let row_end = self.indptr[row + 1];
+
+        // Handle empty rows
+        if row_start == row_end {
+            return &self.default;
+        }
+
+        // Binary search for the column index
+        let slice = &self.indices[row_start..row_end];
+        match slice.binary_search(&col) {
+            Ok(pos) => &self.data[row_start + pos],
+            Err(_) => &self.default,
+        }
+    }
+}

--- a/core/src/mast/node/basic_block_node/csr.rs
+++ b/core/src/mast/node/basic_block_node/csr.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 /// This format is optimized for matrices where non-zero elements appear
 /// contiguously in the first columns of each row.
 // To represent an OpBatch, should be used with # cols = GROUP_SIZE, # rows = BATCH_SIZE
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SparseMatrix<F: Default> {
     /// Non-zero values in row-major order
     pub data: Vec<F>,
@@ -82,7 +82,7 @@ impl<F: Default> SparseMatrix<F> {
     }
 
     /// Adds a new empty row to the matrix
-    fn add_row(&mut self) {
+    pub(crate) fn add_row(&mut self) {
         let current_len = self.data.len();
         self.indptr.push(current_len);
     }

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -347,8 +347,8 @@ impl<'a> OperationOrDecoratorIterator<'a> {
         Self {
             node,
             batch_index: 0,
-            op_index_in_batch: 0,
             op_index: 0,
+            op_index_in_batch: 0,
             decorator_list_next_index: 0,
         }
     }
@@ -369,7 +369,8 @@ impl<'a> Iterator for OperationOrDecoratorIterator<'a> {
 
         // If no decorator needs to be executed, then execute the operation
         if let Some(batch) = self.node.op_batches.get(self.batch_index) {
-            if let Some(operation) = batch.ops.get(self.op_index_in_batch) {
+            if self.op_index_in_batch < batch.ops.num_rows() * batch.ops.num_cols() {
+                let operation = &batch.ops[self.op_index_in_batch];
                 self.op_index_in_batch += 1;
                 self.op_index += 1;
 

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -10,6 +10,11 @@ use crate::{
     mast::{DecoratorId, MastForest, MastForestError},
 };
 
+// TODO(huitseeker): clean up elements that are not used in this module
+// once #1776/#1815 is fixed.
+#[allow(dead_code)]
+pub(crate) mod csr;
+
 mod op_batch;
 pub use op_batch::OpBatch;
 use op_batch::OpBatchAccumulator;

--- a/core/src/mast/node/basic_block_node/op_batch.rs
+++ b/core/src/mast/node/basic_block_node/op_batch.rs
@@ -10,7 +10,7 @@ use crate::mast::node::basic_block_node::csr::SparseMatrix;
 /// operations or a single immediate value.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OpBatch {
-    pub(super) ops: SparseMatrix<Operation>,
+    pub(super) ops: SparseMatrix<Operation, GROUP_SIZE>,
     pub(super) groups: [Felt; BATCH_SIZE],
     pub(super) op_counts: [usize; BATCH_SIZE],
     pub(super) num_groups: usize,
@@ -52,7 +52,7 @@ impl OpBatch {
 /// An accumulator used in construction of operation batches.
 pub(super) struct OpBatchAccumulator {
     /// A list of operations in this batch, including decorators.
-    ops: SparseMatrix<Operation>,
+    ops: SparseMatrix<Operation, GROUP_SIZE>,
     /// Values of operation groups, including immediate values.
     groups: [Felt; BATCH_SIZE],
     /// Number of non-decorator operations in each operation group. Operation count for groups
@@ -74,7 +74,7 @@ impl OpBatchAccumulator {
         Self {
             // By default, we use SparseMatrix in clobbering_mode == false, meaning we let the user
             // insert Operation::Noop if they so wish.
-            ops: SparseMatrix::new(vec![], vec![0], GROUP_SIZE, false),
+            ops: SparseMatrix::new(vec![], vec![0], false),
             groups: [ZERO; BATCH_SIZE],
             op_counts: [0; BATCH_SIZE],
             group: 0,

--- a/core/src/mast/node/basic_block_node/op_batch.rs
+++ b/core/src/mast/node/basic_block_node/op_batch.rs
@@ -65,7 +65,7 @@ pub(super) struct OpBatchAccumulator {
     op_idx: usize,
     /// index of the current group in the batch.
     group_idx: usize,
-    // Index of the next free group in the batch.
+    /// Index of the next free group in the batch.
     next_group_idx: usize,
 }
 

--- a/core/src/mast/node/basic_block_node/tests/csr_tests.rs
+++ b/core/src/mast/node/basic_block_node/tests/csr_tests.rs
@@ -5,7 +5,7 @@ use crate::mast::node::basic_block_node::csr::{SparseMatrix, SparseMatrixError};
 #[test]
 fn test_empty_matrix() {
     // Verify that an empty matrix has zero dimensions and is marked as empty
-    let matrix = SparseMatrix::<i32>::empty();
+    let matrix = SparseMatrix::<i32>::empty(true);
     assert_eq!(matrix.num_rows(), 0);
     assert_eq!(matrix.num_cols(), 0);
     assert!(matrix.is_empty());
@@ -17,7 +17,7 @@ fn test_matrix_creation() {
     // Verify that a matrix created with data has correct dimensions and contains all elements
     let data = vec![1, 2, 3, 4];
     let indptr = vec![0, 2, 4]; // 2 rows, with 2 elements each
-    let matrix = SparseMatrix::new(data, indptr, 4);
+    let matrix = SparseMatrix::new(data, indptr, 4, true);
 
     assert_eq!(matrix.num_rows(), 2);
     assert_eq!(matrix.num_cols(), 4);
@@ -30,7 +30,7 @@ fn test_get_existing_element() {
     // Verify that existing elements can be retrieved correctly
     let data = vec![1, 2, 3, 4];
     let indptr = vec![0, 2, 4];
-    let matrix = SparseMatrix::new(data, indptr, 4);
+    let matrix = SparseMatrix::new(data, indptr, 4, true);
 
     assert_eq!(matrix.get(0, 0), 1);
     assert_eq!(matrix.get(0, 1), 2);
@@ -43,7 +43,7 @@ fn test_get_missing_element() {
     // Verify that missing elements return the default value (0 for i32)
     let data = vec![1, 2, 3, 4];
     let indptr = vec![0, 2, 4];
-    let matrix = SparseMatrix::new(data, indptr, 4);
+    let matrix = SparseMatrix::new(data, indptr, 4, true);
 
     assert_eq!(matrix.get(0, 2), 0);
     assert_eq!(matrix.get(0, 3), 0);
@@ -55,7 +55,7 @@ fn test_insert() {
     // Verify that insertions work correctly and update data/indptr appropriately
     let data = vec![1, 2, 3, 4];
     let indptr = vec![0, 2, 4];
-    let mut matrix = SparseMatrix::new(data, indptr, 4);
+    let mut matrix = SparseMatrix::new(data, indptr, 4, true);
 
     assert_eq!(matrix.insert(0, 5).unwrap(), 2);
     assert_eq!(matrix.data, vec![1, 2, 5, 3, 4]);
@@ -71,7 +71,7 @@ fn test_insert_full() {
     // Verify that inserting into a full row returns the appropriate error
     let data = vec![1, 2, 3, 4];
     let indptr = vec![0, 4];
-    let mut matrix = SparseMatrix::new(data, indptr, 4);
+    let mut matrix = SparseMatrix::new(data, indptr, 4, true);
 
     assert_matches!(matrix.insert(0, 5).unwrap_err(), SparseMatrixError::FullRow(0));
 }
@@ -81,7 +81,7 @@ fn test_iter_nonzero() {
     // Verify that the non-zero iterator returns all elements in row-major order
     let data = vec![1, 2, 3, 4];
     let indptr = vec![0, 2, 4];
-    let matrix = SparseMatrix::new(data, indptr, 4);
+    let matrix = SparseMatrix::new(data, indptr, 4, true);
 
     let mut iter = matrix.iter_nonzero();
     assert_eq!(iter.next(), Some((0, 0, 1)));
@@ -96,7 +96,7 @@ fn test_iter_dense() {
     // Verify that the dense iterator returns all elements including zeros in row-major order
     let data = vec![1, 2, 3, 4];
     let indptr = vec![0, 2, 4];
-    let matrix = SparseMatrix::new(data, indptr, 4);
+    let matrix = SparseMatrix::new(data, indptr, 4, true);
 
     let mut iter = matrix.iter_dense();
     assert_eq!(iter.next(), Some(1)); // row 0, col 0
@@ -124,7 +124,7 @@ fn test_sparse_matrix_with_non_default_zero() {
 
     let data = vec![TestStruct(1), TestStruct(2)];
     let indptr = vec![0, 2]; // 1 row only
-    let matrix = SparseMatrix::new(data, indptr, 2);
+    let matrix = SparseMatrix::new(data, indptr, 2, true);
 
     assert_eq!(matrix.num_rows(), 1);
     assert_eq!(matrix.get(0, 0), TestStruct(1));
@@ -134,7 +134,7 @@ fn test_sparse_matrix_with_non_default_zero() {
 #[test]
 fn test_sparse_matrix_large() {
     // Verify that larger matrices work correctly with sparse insertion and iteration
-    let mut matrix = SparseMatrix::<i32>::empty();
+    let mut matrix = SparseMatrix::<i32>::empty(true);
     matrix.cols = 10;
     matrix.indptr = vec![0; 11]; // 10 rows + 1
 
@@ -181,7 +181,7 @@ fn test_index_trait() {
     // Verify that Index trait implementation matches dense iteration in row-major order
     let data = vec![1, 2, 3, 4];
     let indptr = vec![0, 2, 4];
-    let matrix = SparseMatrix::new(data, indptr, 4);
+    let matrix = SparseMatrix::new(data, indptr, 4, true);
 
     let dense_elements: Vec<_> = matrix.iter_dense().collect();
 
@@ -218,10 +218,129 @@ fn test_index_trait_non_default() {
 
     let data = vec![TestStruct(1), TestStruct(2)];
     let indptr = vec![0, 2];
-    let matrix = SparseMatrix::new(data, indptr, 2);
+    let matrix = SparseMatrix::new(data, indptr, 2, true);
 
     assert_eq!(matrix[0], TestStruct(1)); // row 0, col 0
     assert_eq!(matrix[1], TestStruct(2)); // row 0, col 1
     assert_eq!(matrix[2], TestStruct(-999)); // row 1, col 0 (missing)
     assert_eq!(matrix[3], TestStruct(-999)); // row 1, col 1 (missing)
+}
+
+#[test]
+fn test_clobbering_mode_simple() {
+    // Simple test to understand current behavior
+    let mut matrix = SparseMatrix::<i32>::empty(true);
+    matrix.cols = 3;
+
+    assert_eq!(matrix.insert(0, 1).unwrap(), 0); // Insert value 1
+    assert_eq!(matrix.data, vec![1]);
+
+    assert_eq!(matrix.insert(0, 0).unwrap(), 1); // Insert default 0
+    assert_eq!(matrix.data, vec![1]); // Should be ignored
+
+    assert_eq!(matrix.insert(0, 2).unwrap(), 1); // Insert value 2 - this should be col 1
+    assert_eq!(matrix.data, vec![1, 2]);
+}
+
+#[test]
+fn test_clobbering_mode_default() {
+    // Verify that clobbering mode defaults to true (default behavior)
+    let mut matrix = SparseMatrix::<i32>::empty(true);
+    matrix.cols = 4;
+
+    // Insert non-default values
+    assert_eq!(matrix.insert(0, 1).unwrap(), 0); // Insert at col 0
+    assert_eq!(matrix.data, vec![1]);
+
+    assert_eq!(matrix.insert(0, 2).unwrap(), 1); // Insert at col 1
+    assert_eq!(matrix.data, vec![1, 2]);
+
+    // Insert default value (should be ignored)
+    assert_eq!(matrix.insert(0, 0).unwrap(), 2); // Try to insert default at col 2
+    assert_eq!(matrix.data, vec![1, 2]); // Should be ignored
+
+    assert_eq!(matrix.get(0, 0), 1); // Col 0 has value
+    assert_eq!(matrix.get(0, 1), 2); // Col 1 has value  
+    assert_eq!(matrix.get(0, 2), 0); // Col 2 is default (not stored)
+}
+
+#[test]
+fn test_clobbering_mode_enabled() {
+    // Verify that clobbering mode true ignores default values
+    let data = vec![1, 2];
+    let indptr = vec![0, 2];
+    let mut matrix = SparseMatrix::with_clobbering_mode(data, indptr, 4, true);
+
+    // Inserting default values should be ignored
+    assert_eq!(matrix.insert(0, 0).unwrap(), 2); // Try to insert default at col 2 (ignored)
+    assert_eq!(matrix.insert(0, 3).unwrap(), 2); // Insert non-default at col 2 (current row length)
+
+    assert_eq!(matrix.data, vec![1, 2, 3]); // No default added, but 3 added
+    assert_eq!(matrix.get(0, 2), 3); // Col 2 now has the value 3
+}
+
+#[test]
+fn test_clobbering_mode_disabled() {
+    // Verify that clobbering mode false stores default values
+    let data = vec![1, 2];
+    let indptr = vec![0, 2];
+    let mut matrix = SparseMatrix::with_clobbering_mode(data, indptr, 6, false);
+
+    // Inserting default values should be stored
+    assert_eq!(matrix.insert(0, 0).unwrap(), 2); // Insert default at col 2
+    assert_eq!(matrix.insert(0, 0).unwrap(), 3); // Insert default at col 3
+    assert_eq!(matrix.insert(0, 0).unwrap(), 4); // Insert default at col 4
+    assert_eq!(matrix.insert(0, 5).unwrap(), 5); // Insert non-default at col 5
+
+    assert_eq!(matrix.data, vec![1, 2, 0, 0, 0, 5]); // Default values are stored
+    assert_eq!(matrix.get(0, 2), 0); // Stored default value at col 2
+    assert_eq!(matrix.get(0, 3), 0); // Stored default value at col 3
+    assert_eq!(matrix.get(0, 4), 0); // Stored default value at col 4
+}
+
+#[test]
+fn test_clobbering_mode_dense_iterator() {
+    // Verify that dense iterator works correctly with different clobbering modes
+    let data = vec![1];
+    let indptr = vec![0, 1];
+
+    // With clobbering mode enabled
+    let matrix_enabled = SparseMatrix::with_clobbering_mode(data.clone(), indptr.clone(), 4, true);
+    let elements_enabled: Vec<_> = matrix_enabled.iter_dense().collect();
+    assert_eq!(elements_enabled, vec![1, 0, 0, 0]); // Default values not stored
+
+    // With clobbering mode disabled
+    let mut matrix_disabled = SparseMatrix::with_clobbering_mode(data, indptr, 4, false);
+    matrix_disabled.insert(0, 0).unwrap(); // Insert default value
+    let elements_disabled: Vec<_> = matrix_disabled.iter_dense().collect();
+    assert_eq!(elements_disabled, vec![1, 0, 0, 0]); // Default value stored in data
+}
+
+#[test]
+fn test_clobbering_mode_non_default_types() {
+    // Verify that clobbering mode works with non-default zero values
+    #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+    struct TestStruct(i32);
+
+    impl Default for TestStruct {
+        fn default() -> Self {
+            TestStruct(-999)
+        }
+    }
+
+    // With clobbering mode enabled (default)
+    let data = vec![TestStruct(1)];
+    let indptr = vec![0, 1];
+    let mut matrix_enabled = SparseMatrix::with_clobbering_mode(data, indptr, 3, true);
+
+    assert_eq!(matrix_enabled.insert(0, TestStruct(-999)).unwrap(), 1); // Should be ignored
+    assert_eq!(matrix_enabled.data, vec![TestStruct(1)]); // No default added
+
+    // With clobbering mode disabled
+    let data = vec![TestStruct(1)];
+    let indptr = vec![0, 1];
+    let mut matrix_disabled = SparseMatrix::with_clobbering_mode(data, indptr, 3, false);
+
+    assert_eq!(matrix_disabled.insert(0, TestStruct(-999)).unwrap(), 1); // Should be stored
+    assert_eq!(matrix_disabled.data, vec![TestStruct(1), TestStruct(-999)]); // Default added
 }

--- a/core/src/mast/node/basic_block_node/tests/csr_tests.rs
+++ b/core/src/mast/node/basic_block_node/tests/csr_tests.rs
@@ -1,0 +1,260 @@
+use std::vec::Vec;
+
+use crate::mast::node::basic_block_node::csr::SparseMatrix;
+
+#[test]
+fn test_empty_matrix() {
+    let matrix = SparseMatrix::<i32>::empty();
+    assert_eq!(matrix.num_rows(), 0);
+    assert_eq!(matrix.num_cols(), 0);
+    assert!(matrix.is_empty());
+    assert_eq!(matrix.len(), 0);
+}
+
+#[test]
+fn test_matrix_creation() {
+    let data = vec![1, 2, 3, 4];
+    let indices = vec![0, 2, 1, 3];
+    let indptr = vec![0, 2, 4]; // 2 rows, with 2 elements each
+    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+
+    assert_eq!(matrix.num_rows(), 2);
+    assert_eq!(matrix.num_cols(), 4);
+    assert_eq!(matrix.len(), 4);
+    assert!(!matrix.is_empty());
+}
+
+#[test]
+fn test_get_existing_element() {
+    let data = vec![1, 2, 3, 4];
+    let indices = vec![0, 2, 1, 3];
+    let indptr = vec![0, 2, 4];
+    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+
+    assert_eq!(matrix.get(0, 0), 1);
+    assert_eq!(matrix.get(0, 2), 2);
+    assert_eq!(matrix.get(1, 1), 3);
+    assert_eq!(matrix.get(1, 3), 4);
+}
+
+#[test]
+fn test_get_missing_element() {
+    let data = vec![1, 2, 3, 4];
+    let indices = vec![0, 2, 1, 3];
+    let indptr = vec![0, 2, 4];
+    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+
+    assert_eq!(matrix.get(0, 1), 0);
+    assert_eq!(matrix.get(0, 3), 0);
+    assert_eq!(matrix.get(1, 0), 0);
+    assert_eq!(matrix.get(1, 2), 0);
+}
+
+#[test]
+fn test_set_existing_element() {
+    let data = vec![1, 2, 3, 4];
+    let indices = vec![0, 2, 1, 3];
+    let indptr = vec![0, 2, 4];
+    let mut matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+
+    assert_eq!(matrix.set(0, 0, 5), Some(1));
+    assert_eq!(matrix.get(0, 0), 5);
+    assert_eq!(matrix.set(1, 3, 6), Some(4));
+    assert_eq!(matrix.get(1, 3), 6);
+}
+
+#[test]
+fn test_set_new_element() {
+    let data = vec![1, 2, 3, 4];
+    let indices = vec![0, 2, 1, 3];
+    let indptr = vec![0, 2, 4];
+    let mut matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+
+    assert_eq!(matrix.set(0, 1, 10), None);
+    assert_eq!(matrix.get(0, 1), 10);
+    assert_eq!(matrix.len(), 5);
+
+    // Check that data and indices are updated correctly
+    assert_eq!(matrix.data, vec![1, 10, 2, 3, 4]);
+    assert_eq!(matrix.indices, vec![0, 1, 2, 1, 3]);
+    assert_eq!(matrix.indptr, vec![0, 3, 5]);
+}
+
+#[test]
+fn test_set_to_zero() {
+    let data = vec![1, 2, 3, 4];
+    let indices = vec![0, 2, 1, 3];
+    let indptr = vec![0, 2, 4];
+    let mut matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+
+    assert_eq!(matrix.set(0, 0, 0), Some(1));
+    assert_eq!(matrix.get(0, 0), 0);
+    // The length should decrease by 1 when we set an element to zero
+    assert_eq!(matrix.len(), 3);
+
+    // Check that element was removed
+    // With binary search and proper removal, the indptr should be updated correctly
+    assert_eq!(matrix.data, vec![2, 3, 4]);
+    assert_eq!(matrix.indices, vec![2, 1, 3]);
+    assert_eq!(matrix.indptr, vec![0, 1, 3]);
+}
+
+#[test]
+fn test_iter_nonzero() {
+    let data = vec![1, 2, 3, 4];
+    let indices = vec![0, 2, 1, 3];
+    let indptr = vec![0, 2, 4];
+    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+
+    let mut iter = matrix.iter();
+    assert_eq!(iter.next(), Some((0, 0, 1)));
+    assert_eq!(iter.next(), Some((0, 2, 2)));
+    assert_eq!(iter.next(), Some((1, 1, 3)));
+    assert_eq!(iter.next(), Some((1, 3, 4)));
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn test_iter_dense() {
+    let data = vec![1, 2, 3, 4];
+    let indices = vec![0, 2, 1, 3];
+    let indptr = vec![0, 2, 4];
+    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+
+    let mut iter = matrix.iter_dense();
+    assert_eq!(iter.next(), Some(1)); // row 0, col 0
+    assert_eq!(iter.next(), Some(0)); // row 0, col 1 (missing, default)zz
+    assert_eq!(iter.next(), Some(2)); // row 0, col 2
+    assert_eq!(iter.next(), Some(0)); // row 0, col 3 (missing, default)
+    assert_eq!(iter.next(), Some(0)); // row 1, col 0 (missing, default)
+    assert_eq!(iter.next(), Some(3)); // row 1, col 1
+    assert_eq!(iter.next(), Some(0)); // row 1, col 2 (missing, default)
+    assert_eq!(iter.next(), Some(4)); // row 1, col 3
+    assert_eq!(iter.next(), None);
+}
+
+#[test]
+fn test_sparse_matrix_with_non_default_zero() {
+    #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+    struct TestStruct(i32);
+
+    impl Default for TestStruct {
+        fn default() -> Self {
+            TestStruct(-999)
+        }
+    }
+
+    let data = vec![TestStruct(1), TestStruct(2)];
+    let indices = vec![0, 1];
+    let indptr = vec![0, 2]; // 1 row only
+    let matrix = SparseMatrix { data, indices, indptr, cols: 2, default: TestStruct(-999) };
+
+    assert_eq!(matrix.num_rows(), 1);
+    assert_eq!(matrix.get(0, 0), TestStruct(1));
+    assert_eq!(matrix.get(0, 1), TestStruct(2));
+
+    // Test out of bounds rows should also return default
+    // Note: This should work as long as we don't panic on invalid row access
+    // The matrix has 1 row, but we can still query row 1 (which will be empty)
+}
+
+#[test]
+fn test_sparse_matrix_large() {
+    let mut matrix = SparseMatrix::<i32>::empty();
+    // Set up for a 10x10 matrix
+    matrix.cols = 10;
+
+    // Initialize indptr for 10 rows
+    matrix.indptr = vec![0; 11]; // 10 rows + 1
+    matrix.default = 0;
+
+    // Create a 10x10 matrix with some elements
+    matrix.set(0, 0, 1);
+    matrix.set(0, 5, 2);
+    matrix.set(3, 3, 3);
+    matrix.set(5, 1, 4);
+    matrix.set(7, 8, 5);
+    matrix.set(9, 9, 6);
+
+    assert_eq!(matrix.num_rows(), 10);
+    assert_eq!(matrix.num_cols(), 10);
+    assert_eq!(matrix.len(), 6);
+
+    // Test some elements
+    assert_eq!(matrix.get(0, 0), 1);
+    assert_eq!(matrix.get(0, 5), 2);
+    assert_eq!(matrix.get(3, 3), 3);
+    assert_eq!(matrix.get(5, 1), 4);
+    assert_eq!(matrix.get(7, 8), 5);
+    assert_eq!(matrix.get(9, 9), 6);
+
+    // Test missing elements
+    assert_eq!(matrix.get(0, 1), 0);
+    assert_eq!(matrix.get(2, 2), 0);
+    assert_eq!(matrix.get(4, 4), 0);
+
+    // Test dense iteration
+    let elements: Vec<_> = matrix.iter_dense().collect();
+    assert_eq!(elements.len(), 100);
+
+    // Check some specific positions
+    assert_eq!(elements[0], 1); // row 0, col 0
+    assert_eq!(elements[5], 2); // row 0, col 5
+    assert_eq!(elements[35], 0); // row 3, col 5 (should be 0)
+    assert_eq!(elements[33], 3); // row 3, col 3
+    assert_eq!(elements[51], 4); // row 5, col 1
+    assert_eq!(elements[87], 0); // row 8, col 7 (should be 0)
+    assert_eq!(elements[98], 0); // row 9, col 8 (should be 0)
+    assert_eq!(elements[99], 6); // row 9, col 9
+}
+
+#[test]
+fn test_index_trait() {
+    let data = vec![1, 2, 3, 4];
+    let indices = vec![0, 2, 1, 3];
+    let indptr = vec![0, 2, 4];
+    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+
+    // Test that Index returns the same values as DenseIter in row-major order
+    let dense_elements: Vec<_> = matrix.iter_dense().collect();
+    
+    for i in 0..matrix.num_rows() * matrix.num_cols() {
+        assert_eq!(matrix[i], dense_elements[i]);
+    }
+    
+    // Test specific elements
+    assert_eq!(matrix[0], 1);  // row 0, col 0
+    assert_eq!(matrix[1], 0);  // row 0, col 1 (missing)
+    assert_eq!(matrix[2], 2);  // row 0, col 2
+    assert_eq!(matrix[3], 0);  // row 0, col 3 (missing)
+    assert_eq!(matrix[4], 0);  // row 1, col 0 (missing)
+    assert_eq!(matrix[5], 3);  // row 1, col 1
+    assert_eq!(matrix[6], 0);  // row 1, col 2 (missing)
+    assert_eq!(matrix[7], 4);  // row 1, col 3
+    
+    // Test out of bounds
+    assert_eq!(matrix[8], 0);  // beyond matrix bounds
+}
+
+#[test]
+fn test_index_trait_non_default() {
+    #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+    struct TestStruct(i32);
+
+    impl Default for TestStruct {
+        fn default() -> Self {
+            TestStruct(-999)
+        }
+    }
+
+    let data = vec![TestStruct(1), TestStruct(2)];
+    let indices = vec![0, 1];
+    let indptr = vec![0, 2];
+    let matrix = SparseMatrix { data, indices, indptr, cols: 2, default: TestStruct(-999) };
+
+    // Test Index with non-default values
+    assert_eq!(matrix[0], TestStruct(1));  // row 0, col 0
+    assert_eq!(matrix[1], TestStruct(2));  // row 0, col 1
+    assert_eq!(matrix[2], TestStruct(-999));  // row 1, col 0 (missing)
+    assert_eq!(matrix[3], TestStruct(-999));  // row 1, col 1 (missing)
+}

--- a/core/src/mast/node/basic_block_node/tests/csr_tests.rs
+++ b/core/src/mast/node/basic_block_node/tests/csr_tests.rs
@@ -1,9 +1,10 @@
 use std::vec::Vec;
 
-use crate::mast::node::basic_block_node::csr::SparseMatrix;
+use crate::mast::node::basic_block_node::csr::{SparseMatrix, SparseMatrixError};
 
 #[test]
 fn test_empty_matrix() {
+    // Verify that an empty matrix has zero dimensions and is marked as empty
     let matrix = SparseMatrix::<i32>::empty();
     assert_eq!(matrix.num_rows(), 0);
     assert_eq!(matrix.num_cols(), 0);
@@ -13,10 +14,10 @@ fn test_empty_matrix() {
 
 #[test]
 fn test_matrix_creation() {
+    // Verify that a matrix created with data has correct dimensions and contains all elements
     let data = vec![1, 2, 3, 4];
-    let indices = vec![0, 2, 1, 3];
     let indptr = vec![0, 2, 4]; // 2 rows, with 2 elements each
-    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+    let matrix = SparseMatrix::new(data, indptr, 4);
 
     assert_eq!(matrix.num_rows(), 2);
     assert_eq!(matrix.num_cols(), 4);
@@ -26,115 +27,92 @@ fn test_matrix_creation() {
 
 #[test]
 fn test_get_existing_element() {
+    // Verify that existing elements can be retrieved correctly
     let data = vec![1, 2, 3, 4];
-    let indices = vec![0, 2, 1, 3];
     let indptr = vec![0, 2, 4];
-    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+    let matrix = SparseMatrix::new(data, indptr, 4);
 
     assert_eq!(matrix.get(0, 0), 1);
-    assert_eq!(matrix.get(0, 2), 2);
-    assert_eq!(matrix.get(1, 1), 3);
-    assert_eq!(matrix.get(1, 3), 4);
+    assert_eq!(matrix.get(0, 1), 2);
+    assert_eq!(matrix.get(1, 0), 3);
+    assert_eq!(matrix.get(1, 1), 4);
 }
 
 #[test]
 fn test_get_missing_element() {
+    // Verify that missing elements return the default value (0 for i32)
     let data = vec![1, 2, 3, 4];
-    let indices = vec![0, 2, 1, 3];
     let indptr = vec![0, 2, 4];
-    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+    let matrix = SparseMatrix::new(data, indptr, 4);
 
-    assert_eq!(matrix.get(0, 1), 0);
+    assert_eq!(matrix.get(0, 2), 0);
     assert_eq!(matrix.get(0, 3), 0);
-    assert_eq!(matrix.get(1, 0), 0);
     assert_eq!(matrix.get(1, 2), 0);
 }
 
 #[test]
-fn test_set_existing_element() {
+fn test_insert() {
+    // Verify that insertions work correctly and update data/indptr appropriately
     let data = vec![1, 2, 3, 4];
-    let indices = vec![0, 2, 1, 3];
     let indptr = vec![0, 2, 4];
-    let mut matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+    let mut matrix = SparseMatrix::new(data, indptr, 4);
 
-    assert_eq!(matrix.set(0, 0, 5), Some(1));
-    assert_eq!(matrix.get(0, 0), 5);
-    assert_eq!(matrix.set(1, 3, 6), Some(4));
-    assert_eq!(matrix.get(1, 3), 6);
-}
-
-#[test]
-fn test_set_new_element() {
-    let data = vec![1, 2, 3, 4];
-    let indices = vec![0, 2, 1, 3];
-    let indptr = vec![0, 2, 4];
-    let mut matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
-
-    assert_eq!(matrix.set(0, 1, 10), None);
-    assert_eq!(matrix.get(0, 1), 10);
-    assert_eq!(matrix.len(), 5);
-
-    // Check that data and indices are updated correctly
-    assert_eq!(matrix.data, vec![1, 10, 2, 3, 4]);
-    assert_eq!(matrix.indices, vec![0, 1, 2, 1, 3]);
+    assert_eq!(matrix.insert(0, 5).unwrap(), 2);
+    assert_eq!(matrix.data, vec![1, 2, 5, 3, 4]);
     assert_eq!(matrix.indptr, vec![0, 3, 5]);
+
+    assert_eq!(matrix.insert(1, 8).unwrap(), 2);
+    assert_eq!(matrix.data, vec![1, 2, 5, 3, 4, 8]);
+    assert_eq!(matrix.indptr, vec![0, 3, 6]);
 }
 
 #[test]
-fn test_set_to_zero() {
+fn test_insert_full() {
+    // Verify that inserting into a full row returns the appropriate error
     let data = vec![1, 2, 3, 4];
-    let indices = vec![0, 2, 1, 3];
-    let indptr = vec![0, 2, 4];
-    let mut matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+    let indptr = vec![0, 4];
+    let mut matrix = SparseMatrix::new(data, indptr, 4);
 
-    assert_eq!(matrix.set(0, 0, 0), Some(1));
-    assert_eq!(matrix.get(0, 0), 0);
-    // The length should decrease by 1 when we set an element to zero
-    assert_eq!(matrix.len(), 3);
-
-    // Check that element was removed
-    // With binary search and proper removal, the indptr should be updated correctly
-    assert_eq!(matrix.data, vec![2, 3, 4]);
-    assert_eq!(matrix.indices, vec![2, 1, 3]);
-    assert_eq!(matrix.indptr, vec![0, 1, 3]);
+    assert_matches!(matrix.insert(0, 5).unwrap_err(), SparseMatrixError::FullRow(0));
 }
 
 #[test]
 fn test_iter_nonzero() {
+    // Verify that the non-zero iterator returns all elements in row-major order
     let data = vec![1, 2, 3, 4];
-    let indices = vec![0, 2, 1, 3];
     let indptr = vec![0, 2, 4];
-    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+    let matrix = SparseMatrix::new(data, indptr, 4);
 
-    let mut iter = matrix.iter();
+    let mut iter = matrix.iter_nonzero();
     assert_eq!(iter.next(), Some((0, 0, 1)));
-    assert_eq!(iter.next(), Some((0, 2, 2)));
-    assert_eq!(iter.next(), Some((1, 1, 3)));
-    assert_eq!(iter.next(), Some((1, 3, 4)));
+    assert_eq!(iter.next(), Some((0, 1, 2)));
+    assert_eq!(iter.next(), Some((1, 0, 3)));
+    assert_eq!(iter.next(), Some((1, 1, 4)));
     assert_eq!(iter.next(), None);
 }
 
 #[test]
 fn test_iter_dense() {
+    // Verify that the dense iterator returns all elements including zeros in row-major order
     let data = vec![1, 2, 3, 4];
-    let indices = vec![0, 2, 1, 3];
     let indptr = vec![0, 2, 4];
-    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+    let matrix = SparseMatrix::new(data, indptr, 4);
 
     let mut iter = matrix.iter_dense();
     assert_eq!(iter.next(), Some(1)); // row 0, col 0
-    assert_eq!(iter.next(), Some(0)); // row 0, col 1 (missing, default)zz
-    assert_eq!(iter.next(), Some(2)); // row 0, col 2
+    assert_eq!(iter.next(), Some(2)); // row 0, col 1
+    assert_eq!(iter.next(), Some(0)); // row 0, col 2 (missing, default)
     assert_eq!(iter.next(), Some(0)); // row 0, col 3 (missing, default)
-    assert_eq!(iter.next(), Some(0)); // row 1, col 0 (missing, default)
-    assert_eq!(iter.next(), Some(3)); // row 1, col 1
+    assert_eq!(iter.next(), Some(3)); // row 1, col 0
+    assert_eq!(iter.next(), Some(4)); // row 1, col 1
     assert_eq!(iter.next(), Some(0)); // row 1, col 2 (missing, default)
-    assert_eq!(iter.next(), Some(4)); // row 1, col 3
+    assert_eq!(iter.next(), Some(0)); // row 1, col 3 (missing, default)
     assert_eq!(iter.next(), None);
 }
 
 #[test]
 fn test_sparse_matrix_with_non_default_zero() {
+    // Verify that matrices with non-default zero values work correctly
     #[derive(Debug, PartialEq, Eq, Copy, Clone)]
     struct TestStruct(i32);
 
@@ -145,99 +123,90 @@ fn test_sparse_matrix_with_non_default_zero() {
     }
 
     let data = vec![TestStruct(1), TestStruct(2)];
-    let indices = vec![0, 1];
     let indptr = vec![0, 2]; // 1 row only
-    let matrix = SparseMatrix { data, indices, indptr, cols: 2, default: TestStruct(-999) };
+    let matrix = SparseMatrix::new(data, indptr, 2);
 
     assert_eq!(matrix.num_rows(), 1);
     assert_eq!(matrix.get(0, 0), TestStruct(1));
     assert_eq!(matrix.get(0, 1), TestStruct(2));
-
-    // Test out of bounds rows should also return default
-    // Note: This should work as long as we don't panic on invalid row access
-    // The matrix has 1 row, but we can still query row 1 (which will be empty)
 }
 
 #[test]
 fn test_sparse_matrix_large() {
+    // Verify that larger matrices work correctly with sparse insertion and iteration
     let mut matrix = SparseMatrix::<i32>::empty();
-    // Set up for a 10x10 matrix
     matrix.cols = 10;
-
-    // Initialize indptr for 10 rows
     matrix.indptr = vec![0; 11]; // 10 rows + 1
-    matrix.default = 0;
 
-    // Create a 10x10 matrix with some elements
-    matrix.set(0, 0, 1);
-    matrix.set(0, 5, 2);
-    matrix.set(3, 3, 3);
-    matrix.set(5, 1, 4);
-    matrix.set(7, 8, 5);
-    matrix.set(9, 9, 6);
+    // Insert elements at various rows
+    assert_eq!(matrix.insert(0, 1).unwrap(), 0);
+    assert_eq!(matrix.insert(0, 2).unwrap(), 1);
+    assert_eq!(matrix.insert(3, 3).unwrap(), 0);
+    assert_eq!(matrix.insert(5, 4).unwrap(), 0);
+    assert_eq!(matrix.insert(7, 5).unwrap(), 0);
+    assert_eq!(matrix.insert(9, 6).unwrap(), 0);
 
     assert_eq!(matrix.num_rows(), 10);
     assert_eq!(matrix.num_cols(), 10);
     assert_eq!(matrix.len(), 6);
 
-    // Test some elements
+    // Test element access
     assert_eq!(matrix.get(0, 0), 1);
-    assert_eq!(matrix.get(0, 5), 2);
-    assert_eq!(matrix.get(3, 3), 3);
-    assert_eq!(matrix.get(5, 1), 4);
-    assert_eq!(matrix.get(7, 8), 5);
-    assert_eq!(matrix.get(9, 9), 6);
-
-    // Test missing elements
-    assert_eq!(matrix.get(0, 1), 0);
-    assert_eq!(matrix.get(2, 2), 0);
-    assert_eq!(matrix.get(4, 4), 0);
+    assert_eq!(matrix.get(0, 1), 2);
+    assert_eq!(matrix.get(3, 0), 3);
+    assert_eq!(matrix.get(5, 0), 4);
+    assert_eq!(matrix.get(7, 0), 5);
+    assert_eq!(matrix.get(9, 0), 6);
+    assert_eq!(matrix.get(0, 2), 0); // missing
+    assert_eq!(matrix.get(2, 0), 0); // missing
+    assert_eq!(matrix.get(4, 0), 0); // missing
 
     // Test dense iteration
     let elements: Vec<_> = matrix.iter_dense().collect();
     assert_eq!(elements.len(), 100);
 
-    // Check some specific positions
+    // Verify specific positions in row-major order
     assert_eq!(elements[0], 1); // row 0, col 0
-    assert_eq!(elements[5], 2); // row 0, col 5
-    assert_eq!(elements[35], 0); // row 3, col 5 (should be 0)
-    assert_eq!(elements[33], 3); // row 3, col 3
-    assert_eq!(elements[51], 4); // row 5, col 1
-    assert_eq!(elements[87], 0); // row 8, col 7 (should be 0)
-    assert_eq!(elements[98], 0); // row 9, col 8 (should be 0)
-    assert_eq!(elements[99], 6); // row 9, col 9
+    assert_eq!(elements[1], 2); // row 0, col 1
+    assert_eq!(elements[25], 0); // row 2, col 5
+    assert_eq!(elements[30], 3); // row 3, col 0
+    assert_eq!(elements[50], 4); // row 5, col 0
+    assert_eq!(elements[87], 0); // row 8, col 7
+    assert_eq!(elements[98], 0); // row 9, col 8
+    assert_eq!(elements[90], 6); // row 9, col 0
 }
 
 #[test]
 fn test_index_trait() {
+    // Verify that Index trait implementation matches dense iteration in row-major order
     let data = vec![1, 2, 3, 4];
-    let indices = vec![0, 2, 1, 3];
     let indptr = vec![0, 2, 4];
-    let matrix = SparseMatrix { data, indices, indptr, cols: 4, default: 0 };
+    let matrix = SparseMatrix::new(data, indptr, 4);
 
-    // Test that Index returns the same values as DenseIter in row-major order
     let dense_elements: Vec<_> = matrix.iter_dense().collect();
-    
+
+    // Index should match dense iteration for all positions
     for i in 0..matrix.num_rows() * matrix.num_cols() {
         assert_eq!(matrix[i], dense_elements[i]);
     }
-    
-    // Test specific elements
-    assert_eq!(matrix[0], 1);  // row 0, col 0
-    assert_eq!(matrix[1], 0);  // row 0, col 1 (missing)
-    assert_eq!(matrix[2], 2);  // row 0, col 2
-    assert_eq!(matrix[3], 0);  // row 0, col 3 (missing)
-    assert_eq!(matrix[4], 0);  // row 1, col 0 (missing)
-    assert_eq!(matrix[5], 3);  // row 1, col 1
-    assert_eq!(matrix[6], 0);  // row 1, col 2 (missing)
-    assert_eq!(matrix[7], 4);  // row 1, col 3
-    
-    // Test out of bounds
-    assert_eq!(matrix[8], 0);  // beyond matrix bounds
+
+    // Test specific index positions
+    assert_eq!(matrix[0], 1); // row 0, col 0
+    assert_eq!(matrix[1], 2); // row 0, col 1
+    assert_eq!(matrix[2], 0); // row 0, col 2 (missing)
+    assert_eq!(matrix[3], 0); // row 0, col 3 (missing)
+    assert_eq!(matrix[4], 3); // row 1, col 0
+    assert_eq!(matrix[5], 4); // row 1, col 1
+    assert_eq!(matrix[6], 0); // row 1, col 2 (missing)
+    assert_eq!(matrix[7], 0); // row 1, col 3 (missing)
+
+    // Test out of bounds access
+    assert_eq!(matrix[8], 0); // beyond matrix bounds
 }
 
 #[test]
 fn test_index_trait_non_default() {
+    // Verify that Index trait works correctly with non-default zero values
     #[derive(Debug, PartialEq, Eq, Copy, Clone)]
     struct TestStruct(i32);
 
@@ -248,13 +217,11 @@ fn test_index_trait_non_default() {
     }
 
     let data = vec![TestStruct(1), TestStruct(2)];
-    let indices = vec![0, 1];
     let indptr = vec![0, 2];
-    let matrix = SparseMatrix { data, indices, indptr, cols: 2, default: TestStruct(-999) };
+    let matrix = SparseMatrix::new(data, indptr, 2);
 
-    // Test Index with non-default values
-    assert_eq!(matrix[0], TestStruct(1));  // row 0, col 0
-    assert_eq!(matrix[1], TestStruct(2));  // row 0, col 1
-    assert_eq!(matrix[2], TestStruct(-999));  // row 1, col 0 (missing)
-    assert_eq!(matrix[3], TestStruct(-999));  // row 1, col 1 (missing)
+    assert_eq!(matrix[0], TestStruct(1)); // row 0, col 0
+    assert_eq!(matrix[1], TestStruct(2)); // row 0, col 1
+    assert_eq!(matrix[2], TestStruct(-999)); // row 1, col 0 (missing)
+    assert_eq!(matrix[3], TestStruct(-999)); // row 1, col 1 (missing)
 }

--- a/core/src/mast/node/basic_block_node/tests/mod.rs
+++ b/core/src/mast/node/basic_block_node/tests/mod.rs
@@ -1,3 +1,4 @@
+mod csr_tests;
 use proptest::prelude::*;
 
 use super::*;
@@ -457,7 +458,8 @@ proptest! {
     /// - Operations are correctly distributed across batches and groups.
     #[test]
     fn test_batch_creation_invariants(ops in op_sequence_strategy(50)) {
-        let (batches, _) = super::batch_and_hash_ops(ops.clone());
+        let ops_len = ops.len();
+        let (batches, _) = super::batch_and_hash_ops(ops);
 
         // A basic block contains one or more batches
         assert!(!batches.is_empty(), "There should be at least one batch");
@@ -474,7 +476,7 @@ proptest! {
         }
 
         // Note: total_ops_from_batches should be >= ops.len() because NOOPs may be added
-        assert!(total_ops_from_batches >= ops.len(), "Total operations from batches should be >= input operations");
+        assert!(total_ops_from_batches >= ops_len, "Total operations from batches should be >= input operations");
 
         // Verify that operation counts in each batch don't exceed group limits
         for batch in &batches {
@@ -531,15 +533,13 @@ proptest! {
             current_group_ops = 0; // Reset for each batch
         }
     }
-}
 
-proptest! {
     /// Test NOOP insertion rules:
     /// - NOOPs are used to fill a group or batch when necessary
     /// - Groups should be filled to exactly 9 operations when finalized
     #[test]
     fn test_noop_insertion(ops in op_sequence_strategy(25)) {
-        let (batches, _) = super::batch_and_hash_ops(ops.clone());
+        let (batches, _) = super::batch_and_hash_ops(ops);
 
         let mut op_idx = 0;
 

--- a/core/src/mast/node/basic_block_node/tests/mod.rs
+++ b/core/src/mast/node/basic_block_node/tests/mod.rs
@@ -114,7 +114,7 @@ fn batch_ops() {
     assert_eq!(1, batches.len());
 
     let batch = &batches[0];
-    assert_eq!(ops, batch.ops);
+    assert_eq!(ops, batch.ops.data);
     assert_eq!(1, batch.num_groups());
 
     let mut batch_groups = [ZERO; BATCH_SIZE];
@@ -130,7 +130,7 @@ fn batch_ops() {
     assert_eq!(1, batches.len());
 
     let batch = &batches[0];
-    assert_eq!(ops, batch.ops);
+    assert_eq!(ops, batch.ops.data);
     assert_eq!(1, batch.num_groups());
 
     let mut batch_groups = [ZERO; BATCH_SIZE];
@@ -146,7 +146,7 @@ fn batch_ops() {
     assert_eq!(1, batches.len());
 
     let batch = &batches[0];
-    assert_eq!(ops, batch.ops);
+    assert_eq!(ops, batch.ops.data);
     assert_eq!(2, batch.num_groups());
 
     let mut batch_groups = [ZERO; BATCH_SIZE];
@@ -172,7 +172,7 @@ fn batch_ops() {
     assert_eq!(1, batches.len());
 
     let batch = &batches[0];
-    assert_eq!(ops, batch.ops);
+    assert_eq!(ops, batch.ops.data);
     assert_eq!(8, batch.num_groups());
 
     let batch_groups = [
@@ -207,7 +207,7 @@ fn batch_ops() {
     assert_eq!(2, batches.len());
 
     let batch0 = &batches[0];
-    assert_eq!(ops[..9], batch0.ops);
+    assert_eq!(ops[..9], batch0.ops.data);
     assert_eq!(7, batch0.num_groups());
 
     let batch0_groups = [
@@ -225,7 +225,7 @@ fn batch_ops() {
     assert_eq!([9_usize, 0, 0, 0, 0, 0, 0, 0], batch0.op_counts);
 
     let batch1 = &batches[1];
-    assert_eq!(vec![ops[9]], batch1.ops);
+    assert_eq!(vec![ops[9]], batch1.ops.data);
     assert_eq!(2, batch1.num_groups());
 
     let mut batch1_groups = [ZERO; BATCH_SIZE];
@@ -256,7 +256,7 @@ fn batch_ops() {
     assert_eq!(1, batches.len());
 
     let batch = &batches[0];
-    assert_eq!(ops, batch.ops);
+    assert_eq!(ops, batch.ops.data);
     assert_eq!(4, batch.num_groups());
 
     let batch_groups = [
@@ -290,7 +290,7 @@ fn batch_ops() {
     assert_eq!(1, batches.len());
 
     let batch = &batches[0];
-    assert_eq!(ops, batch.ops);
+    assert_eq!(ops, batch.ops.data);
     assert_eq!(3, batch.num_groups());
 
     let batch_groups = [
@@ -324,7 +324,7 @@ fn batch_ops() {
     assert_eq!(1, batches.len());
 
     let batch = &batches[0];
-    assert_eq!(ops, batch.ops);
+    assert_eq!(ops, batch.ops.data);
     assert_eq!(4, batch.num_groups());
 
     let batch_groups = [
@@ -369,7 +369,7 @@ fn batch_ops() {
     assert_eq!(2, batches.len());
 
     let batch0 = &batches[0];
-    assert_eq!(ops[..17], batch0.ops);
+    assert_eq!(ops[..17], batch0.ops.data);
     assert_eq!(7, batch0.num_groups());
 
     let batch0_groups = [
@@ -387,7 +387,7 @@ fn batch_ops() {
     assert_eq!([9_usize, 0, 0, 0, 0, 0, 8, 0], batch0.op_counts);
 
     let batch1 = &batches[1];
-    assert_eq!(ops[17..], batch1.ops);
+    assert_eq!(ops[17..], batch1.ops.data);
     assert_eq!(2, batch1.num_groups());
 
     let batch1_groups = [build_group(&ops[17..]), Felt::new(6), ZERO, ZERO, ZERO, ZERO, ZERO, ZERO];
@@ -433,7 +433,11 @@ fn operation_or_decorator_iterator() {
     // after last operation
     assert_eq!(iterator.next(), Some(OperationOrDecorator::Decorator(&DecoratorId(3))));
     assert_eq!(iterator.next(), Some(OperationOrDecorator::Decorator(&DecoratorId(4))));
-    assert_eq!(iterator.next(), None);
+    assert_eq!(iterator.next(), Some(OperationOrDecorator::Operation(&Operation::Noop)));
+    assert_eq!(iterator.next(), Some(OperationOrDecorator::Operation(&Operation::Noop)));
+    assert_eq!(iterator.next(), Some(OperationOrDecorator::Operation(&Operation::Noop)));
+    assert_eq!(iterator.next(), Some(OperationOrDecorator::Operation(&Operation::Noop)));
+    assert_eq!(iterator.next(), Some(OperationOrDecorator::Operation(&Operation::Noop)));
 }
 
 // TEST HELPERS

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -129,11 +129,12 @@ pub(super) mod opcode_constants {
 // ================================================================================================
 
 /// A set of native VM operations which take exactly one cycle to execute.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 #[repr(u8)]
 pub enum Operation {
     // ----- system operations -------------------------------------------------------------------
     /// Advances cycle counter, but does not change the state of user stack.
+    #[default]
     Noop = OPCODE_NOOP,
 
     /// Pops the stack; if the popped value is not 1, execution fails.


### PR DESCRIPTION
This introduces: 
1. a few more proptests for the construction of batches,
2. a simplified [CSR (aka Yale)](https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format)) representation for batches, where the sparse element is `Operation::Noop`. 
3. this representation is used to implement two traits:
- the [Index trait](https://doc.rust-lang.org/std/ops/trait.Index.html), that allows indexing in the fully-padded OpBatch representation, as if it was a vector,
- the [Iterator trait](https://doc.rust-lang.org/std/iter/trait.Iterator.html) that allows iterating through the fully padded representation. This is accessed through `(opb: OpBatch).ops.iter_dense()`
4. we then use this in the `OperationOrDecoratorIterator` iterator to iterate over the padded representation. The load-bearing change is the following:
```rust
 // If no decorator needs to be executed, then execute the operation
 if let Some(batch) = self.node.op_batches.get(self.batch_index) {
-    if let Some(operation) = batch.ops.get(self.op_index_in_batch) {
-        ...
+    if self.op_index_in_batch < batch.ops.num_rows() * batch.ops.num_cols() {
+        let operation = &batch.ops[self.op_index_in_batch];
         self.op_index_in_batch += 1;
 }
```

One test to read is `test_groups_ops_coherence`, which basically guarantees the padding operations and the group Felts agree on the contents of the dense iteration (3. above)