### PR TITLE
docs: explain why EMIT must remain high-degree

### DIFF
--- a/docs/src/design/stack/op_constraints.md
+++ b/docs/src/design/stack/op_constraints.md
@@ -304,3 +304,13 @@ f_{imm} = f_{push} + f_{emit} \text{ | degree} = 4
 $$
 
 Note that the `ASSERT`, `MPVERIFY` and other operations have immediate values too. However, these immediate values are not included in the MAST digest, and hence are not considered for the $f_{imm}$ flag.
+
+!!! note
+
+    The `EMIT` operation must remain in the high-degree bucket. Although it could
+    theoretically fit into a lower-degree group, it is part of the immediate
+    value flag (`f_imm`). This flag is constrained by the group count column at
+    degree 7. Because of this dependency, both `PUSH` and `EMIT` together form
+    degree 4, and moving `EMIT` would break the group count constraints. Thus,
+    `EMIT` cannot be reassigned to a lower-degree bucket and must remain
+    high-degree.


### PR DESCRIPTION
## Describe your changes
Closes #2043
This PR adds documentation explaining why the `EMIT` operation must remain in the
high-degree bucket.

- The `EMIT` operation is part of the immediate value flag (`f_imm`).
- The `f_imm` flag is constrained by the group count column at degree 7.
- Because of this dependency, `PUSH` and `EMIT` together form degree 4.
- Moving `EMIT` to a lower-degree bucket would break these group count constraints.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'