### PR TITLE
Introduce `Tracer` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added slicing for the word constants ([#2057](https://github.com/0xMiden/miden-vm/pull/2057)).
 - Added ability to declare word-sized constants from strings ([#2073](https://github.com/0xMiden/miden-vm/pull/2073)).
 - Added `FastProcessor::execute_for_trace()`, which outputs a series of checkpoints necessary to build the trace in parallel ([#2023](https://github.com/0xMiden/miden-vm/pull/2023))
+- Introduce `Tracer` trait to allow different ways of tracing program execution, including no tracing ([#2101](https://github.com/0xMiden/miden-vm/pull/2101))
 
 #### Changes
 

--- a/processor/src/fast/circuit_eval.rs
+++ b/processor/src/fast/circuit_eval.rs
@@ -6,6 +6,7 @@ use crate::{
     ContextId, ExecutionError,
     chiplets::{CircuitEvaluation, MAX_NUM_ACE_WIRES, PTR_OFFSET_ELEM, PTR_OFFSET_WORD},
     errors::{AceError, ErrorContext},
+    fast::tracer::NoopTracer,
 };
 
 impl FastProcessor {
@@ -86,21 +87,21 @@ pub fn eval_circuit_fast_(
 
     let mut ptr = ptr;
     // perform READ operations
-    // Note: we don't pass in the trace_state_builder, because the parallel trace generation skips
-    // the circuit evaluation completely
+    // Note: we pass in a `NoopTracer`, because the parallel trace generation skips the circuit
+    // evaluation completely
     for _ in 0..num_read_rows {
         let word = mem
-            .read_word(ctx, ptr, clk, err_ctx, &mut None)
+            .read_word(ctx, ptr, clk, err_ctx, &mut NoopTracer)
             .map_err(ExecutionError::MemoryError)?;
         evaluation_context.do_read(ptr, word)?;
         ptr += PTR_OFFSET_WORD;
     }
     // perform EVAL operations
-    // Note: we don't pass in the trace_state_builder, because the parallel trace generation skips
-    // the circuit evaluation completely
+    // Note: we pass in a `NoopTracer`, because the parallel trace generation skips the circuit
+    // evaluation completely
     for _ in 0..num_eval_rows {
         let instruction = mem
-            .read_element(ctx, ptr, err_ctx, &mut None)
+            .read_element(ctx, ptr, err_ctx, &mut NoopTracer)
             .map_err(ExecutionError::MemoryError)?;
         evaluation_context.do_eval(ptr, instruction, err_ctx)?;
         ptr += PTR_OFFSET_ELEM;

--- a/processor/src/fast/horner_ops.rs
+++ b/processor/src/fast/horner_ops.rs
@@ -3,7 +3,7 @@ use core::array;
 use miden_core::{Felt, QuadFelt};
 
 use super::FastProcessor;
-use crate::{ErrorContext, ExecutionError};
+use crate::{ErrorContext, ExecutionError, fast::tracer::Tracer};
 
 // CONSTANTS
 // ================================================================================================
@@ -17,13 +17,14 @@ impl FastProcessor {
     #[inline(always)]
     pub fn op_horner_eval_base(
         &mut self,
+        tracer: &mut impl Tracer,
         err_ctx: &impl ErrorContext,
     ) -> Result<(), ExecutionError> {
         // read the values of the coefficients, over the base field, from the stack
         let coeffs = self.get_coeffs_as_base_elements();
 
         // read the evaluation point alpha from memory
-        let alpha = self.get_evaluation_point(err_ctx)?;
+        let alpha = self.get_evaluation_point(tracer, err_ctx)?;
 
         // compute the updated accumulator value
         let (acc_new1, acc_new0) = {
@@ -49,13 +50,14 @@ impl FastProcessor {
     #[inline(always)]
     pub fn op_horner_eval_ext(
         &mut self,
+        tracer: &mut impl Tracer,
         err_ctx: &impl ErrorContext,
     ) -> Result<(), ExecutionError> {
         // read the values of the coefficients, over the base field, from the stack
         let coef = self.get_coeffs_as_quad_ext_elements();
 
         // read the evaluation point alpha from memory
-        let alpha = self.get_evaluation_point(err_ctx)?;
+        let alpha = self.get_evaluation_point(tracer, err_ctx)?;
 
         // compute the updated accumulator value
         let (acc_new1, acc_new0) = {
@@ -101,13 +103,14 @@ impl FastProcessor {
     /// Returns the evaluation point.
     fn get_evaluation_point(
         &mut self,
+        tracer: &mut impl Tracer,
         err_ctx: &impl ErrorContext,
     ) -> Result<QuadFelt, ExecutionError> {
         let (alpha_0, alpha_1) = {
             let addr = self.stack_get(ALPHA_ADDR_INDEX);
             let word = self
                 .memory
-                .read_word(self.ctx, addr, self.clk, err_ctx, &mut self.trace_state_builder)
+                .read_word(self.ctx, addr, self.clk, err_ctx, tracer)
                 .map_err(ExecutionError::MemoryError)?;
 
             (word[0], word[1])

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -19,20 +19,19 @@ use crate::{
     ProcessState, SYSCALL_FMP_MIN,
     chiplets::Ace,
     continuation_stack::{Continuation, ContinuationStack},
-    decoder::block_stack::{self, BlockType},
     err_ctx,
     fast::{
-        trace_state::{
-            CoreTraceState, DecoderState, ExecutionContextSystemInfo, NodeExecutionState,
-            SystemState,
-        },
+        trace_state::{CoreTraceState, NodeExecutionState},
         trace_state_builder::CoreTraceStateBuilder,
+        tracer::NoopTracer,
     },
 };
 
 mod memory;
 pub mod trace_state;
 mod trace_state_builder;
+mod tracer;
+pub use tracer::Tracer;
 
 // Ops
 mod circuit_eval;
@@ -74,10 +73,6 @@ const DOUBLE_WORD_SIZE: Felt = Felt::new(8);
 
 /// The number of rows per core trace fragment.
 pub const NUM_ROWS_PER_CORE_FRAGMENT: usize = 1024;
-
-/// The number of rows in the execution trace required to compute a permutation of Rescue Prime
-/// Optimized.
-const HASH_CYCLE_LEN: Felt = Felt::new(miden_air::trace::chiplets::hasher::HASH_CYCLE_LEN as u64);
 
 /// A fast processor which doesn't generate any trace.
 ///
@@ -154,9 +149,6 @@ pub struct FastProcessor {
 
     /// Whether to enable debug statements and tracing.
     in_debug_mode: bool,
-
-    /// Builder of [CoreTraceState]s, used for generating corresponding trace fragments.
-    trace_state_builder: Option<CoreTraceStateBuilder>,
 }
 
 impl FastProcessor {
@@ -223,7 +215,6 @@ impl FastProcessor {
             call_stack: Vec::new(),
             ace: Ace::default(),
             in_debug_mode,
-            trace_state_builder: None,
         }
     }
 
@@ -324,7 +315,7 @@ impl FastProcessor {
         program: &Program,
         host: &mut impl AsyncHost,
     ) -> Result<(StackOutputs, AdviceProvider), ExecutionError> {
-        let stack_outputs = self.execute_impl(program, host).await?;
+        let stack_outputs = self.execute_impl(program, host, &mut NoopTracer).await?;
 
         Ok((stack_outputs, self.advice))
     }
@@ -336,22 +327,29 @@ impl FastProcessor {
         program: &Program,
         host: &mut impl AsyncHost,
     ) -> Result<(StackOutputs, AdviceProvider, Vec<CoreTraceState>), ExecutionError> {
-        self.trace_state_builder = Some(CoreTraceStateBuilder::default());
-        let stack_outputs = self.execute_impl(program, host).await?;
+        let mut tracer = CoreTraceStateBuilder::default();
+        let stack_outputs = self.execute_impl(program, host, &mut tracer).await?;
 
-        Ok((
-            stack_outputs,
-            self.advice,
-            self.trace_state_builder
-                .expect("Trace state builder expected to be initialized when executing for trace")
-                .into_core_trace_states(),
-        ))
+        Ok((stack_outputs, self.advice, tracer.into_core_trace_states()))
+    }
+
+    /// Executes the given program with the provided tracer and returns the stack outputs, and the
+    /// advice provider.
+    pub async fn execute_with_tracer(
+        mut self,
+        program: &Program,
+        host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
+    ) -> Result<(StackOutputs, AdviceProvider), ExecutionError> {
+        let stack_outputs = self.execute_impl(program, host, tracer).await?;
+        Ok((stack_outputs, self.advice))
     }
 
     async fn execute_impl(
         &mut self,
         program: &Program,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<StackOutputs, ExecutionError> {
         let mut continuation_stack = ContinuationStack::new(program);
         let mut current_forest = program.mast_forest().clone();
@@ -370,6 +368,7 @@ impl FastProcessor {
                                 host,
                                 &mut continuation_stack,
                                 &current_forest,
+                                tracer,
                             )
                             .await?
                         },
@@ -379,6 +378,7 @@ impl FastProcessor {
                             &current_forest,
                             &mut continuation_stack,
                             host,
+                            tracer,
                         )?,
                         MastNode::Split(split_node) => self.start_split_node(
                             split_node,
@@ -386,6 +386,7 @@ impl FastProcessor {
                             &current_forest,
                             &mut continuation_stack,
                             host,
+                            tracer,
                         )?,
                         MastNode::Loop(loop_node) => self.start_loop_node(
                             loop_node,
@@ -393,6 +394,7 @@ impl FastProcessor {
                             &current_forest,
                             &mut continuation_stack,
                             host,
+                            tracer,
                         )?,
                         MastNode::Call(call_node) => self.start_call_node(
                             call_node,
@@ -401,14 +403,15 @@ impl FastProcessor {
                             &current_forest,
                             &mut continuation_stack,
                             host,
+                            tracer,
                         )?,
-                        MastNode::Dyn(dyn_node) => {
+                        MastNode::Dyn(_) => {
                             self.start_dyn_node(
-                                dyn_node.is_dyncall(),
                                 node_id,
                                 &mut current_forest,
                                 &mut continuation_stack,
                                 host,
+                                tracer,
                             )
                             .await?
                         },
@@ -418,26 +421,47 @@ impl FastProcessor {
                                 &mut current_forest,
                                 &mut continuation_stack,
                                 host,
+                                tracer,
                             )
                             .await?
                         },
                     }
                 },
-                Continuation::FinishJoin(node_id) => {
-                    self.finish_join_node(node_id, &current_forest, &mut continuation_stack, host)?
-                },
-                Continuation::FinishSplit(node_id) => {
-                    self.finish_split_node(node_id, &current_forest, &mut continuation_stack, host)?
-                },
-                Continuation::FinishLoop(node_id) => {
-                    self.finish_loop_node(node_id, &current_forest, &mut continuation_stack, host)?
-                },
-                Continuation::FinishCall(node_id) => {
-                    self.finish_call_node(node_id, &current_forest, &mut continuation_stack, host)?
-                },
-                Continuation::FinishDyn(node_id) => {
-                    self.finish_dyn_node(node_id, &current_forest, &mut continuation_stack, host)?
-                },
+                Continuation::FinishJoin(node_id) => self.finish_join_node(
+                    node_id,
+                    &current_forest,
+                    &mut continuation_stack,
+                    host,
+                    tracer,
+                )?,
+                Continuation::FinishSplit(node_id) => self.finish_split_node(
+                    node_id,
+                    &current_forest,
+                    &mut continuation_stack,
+                    host,
+                    tracer,
+                )?,
+                Continuation::FinishLoop(node_id) => self.finish_loop_node(
+                    node_id,
+                    &current_forest,
+                    &mut continuation_stack,
+                    host,
+                    tracer,
+                )?,
+                Continuation::FinishCall(node_id) => self.finish_call_node(
+                    node_id,
+                    &current_forest,
+                    &mut continuation_stack,
+                    host,
+                    tracer,
+                )?,
+                Continuation::FinishDyn(node_id) => self.finish_dyn_node(
+                    node_id,
+                    &current_forest,
+                    &mut continuation_stack,
+                    host,
+                    tracer,
+                )?,
                 Continuation::EnterForest(previous_forest) => {
                     // Restore the previous forest
                     current_forest = previous_forest;
@@ -471,8 +495,10 @@ impl FastProcessor {
         current_forest: &Arc<MastForest>,
         continuation_stack: &mut ContinuationStack,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
-        self.check_extract_trace_state(
+        tracer.start_clock_cycle(
+            self,
             NodeExecutionState::Start(node_id),
             continuation_stack,
             current_forest,
@@ -485,17 +511,9 @@ impl FastProcessor {
         continuation_stack.push_start_node(join_node.second());
         continuation_stack.push_start_node(join_node.first());
 
-        // In tracing mode, record the control block on the block stack
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            let block_addr = trace_state_builder.hasher.record_hash_control_block();
-            let parent_addr =
-                trace_state_builder.block_stack.push(block_addr, BlockType::Join(false), None);
-            trace_state_builder.block_stack_replay.record_node_start(parent_addr);
-        }
-
         // Corresponds to the row inserted for the JOIN operation added
         // to the trace.
-        self.increment_clk();
+        self.increment_clk(tracer);
 
         Ok(())
     }
@@ -508,21 +526,18 @@ impl FastProcessor {
         current_forest: &Arc<MastForest>,
         continuation_stack: &mut ContinuationStack,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
-        self.check_extract_trace_state(
+        tracer.start_clock_cycle(
+            self,
             NodeExecutionState::End(node_id),
             continuation_stack,
             current_forest,
         );
 
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            let block_info = trace_state_builder.block_stack.pop();
-            trace_state_builder.record_node_end(&block_info);
-        }
-
         // Corresponds to the row inserted for the END operation added
         // to the trace.
-        self.increment_clk();
+        self.increment_clk(tracer);
 
         self.execute_after_exit_decorators(node_id, current_forest, host)
     }
@@ -536,8 +551,10 @@ impl FastProcessor {
         current_forest: &Arc<MastForest>,
         continuation_stack: &mut ContinuationStack,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
-        self.check_extract_trace_state(
+        tracer.start_clock_cycle(
+            self,
             NodeExecutionState::Start(node_id),
             continuation_stack,
             current_forest,
@@ -549,7 +566,7 @@ impl FastProcessor {
         let condition = self.stack_get(0);
 
         // drop the condition from the stack
-        self.decrement_stack_size();
+        self.decrement_stack_size(tracer);
 
         // execute the appropriate branch
         continuation_stack.push_finish_split(node_id);
@@ -562,17 +579,9 @@ impl FastProcessor {
             return Err(ExecutionError::not_binary_value_if(condition, &err_ctx));
         };
 
-        // In tracing mode, record the control block on the block stack
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            let block_addr = trace_state_builder.hasher.record_hash_control_block();
-            let parent_addr =
-                trace_state_builder.block_stack.push(block_addr, BlockType::Split, None);
-            trace_state_builder.block_stack_replay.record_node_start(parent_addr);
-        }
-
         // Corresponds to the row inserted for the SPLIT operation added
         // to the trace.
-        self.increment_clk();
+        self.increment_clk(tracer);
 
         Ok(())
     }
@@ -585,20 +594,18 @@ impl FastProcessor {
         current_forest: &Arc<MastForest>,
         continuation_stack: &mut ContinuationStack,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
-        self.check_extract_trace_state(
+        tracer.start_clock_cycle(
+            self,
             NodeExecutionState::End(node_id),
             continuation_stack,
             current_forest,
         );
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            let block_info = trace_state_builder.block_stack.pop();
-            trace_state_builder.record_node_end(&block_info);
-        }
 
         // Corresponds to the row inserted for the END operation added
         // to the trace.
-        self.increment_clk();
+        self.increment_clk(tracer);
 
         self.execute_after_exit_decorators(node_id, current_forest, host)
     }
@@ -612,8 +619,10 @@ impl FastProcessor {
         current_forest: &Arc<MastForest>,
         continuation_stack: &mut ContinuationStack,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
-        self.check_extract_trace_state(
+        tracer.start_clock_cycle(
+            self,
             NodeExecutionState::Start(current_node_id),
             continuation_stack,
             current_forest,
@@ -625,7 +634,7 @@ impl FastProcessor {
         let condition = self.stack_get(0);
 
         // drop the condition from the stack
-        self.decrement_stack_size();
+        self.decrement_stack_size(tracer);
 
         // execute the loop body as long as the condition is true
         if condition == ONE {
@@ -634,53 +643,25 @@ impl FastProcessor {
             continuation_stack.push_finish_loop(current_node_id);
             continuation_stack.push_start_node(loop_node.body());
 
-            // In tracing mode, record the control block on the block stack
-            if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-                let block_addr = trace_state_builder.hasher.record_hash_control_block();
-                let enter_loop = true;
-                let parent_addr = trace_state_builder.block_stack.push(
-                    block_addr,
-                    BlockType::Loop(enter_loop),
-                    None,
-                );
-                trace_state_builder.block_stack_replay.record_node_start(parent_addr);
-            }
-
             // Corresponds to the row inserted for the LOOP operation added
             // to the trace.
-            self.increment_clk();
+            self.increment_clk(tracer);
         } else if condition == ZERO {
             // Start and exit the loop immediately - corresponding to adding a LOOP and END row
             // immediately since there is no body to execute.
 
-            // In tracing mode, record the control block on the block stack
-            if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-                let block_addr = trace_state_builder.hasher.record_hash_control_block();
-                let enter_loop = false;
-                let parent_addr = trace_state_builder.block_stack.push(
-                    block_addr,
-                    BlockType::Loop(enter_loop),
-                    None,
-                );
-                trace_state_builder.block_stack_replay.record_node_start(parent_addr);
-            }
-
             // Increment the clock, corresponding to the LOOP operation
-            self.increment_clk();
+            self.increment_clk(tracer);
 
-            self.check_extract_trace_state(
+            tracer.start_clock_cycle(
+                self,
                 NodeExecutionState::End(current_node_id),
                 continuation_stack,
                 current_forest,
             );
 
-            if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-                let block_info = trace_state_builder.block_stack.pop();
-                trace_state_builder.record_node_end(&block_info);
-            }
-
             // Increment the clock, corresponding to the END operation added to the trace.
-            self.increment_clk();
+            self.increment_clk(tracer);
         } else {
             let err_ctx = err_ctx!(current_forest, loop_node, host);
             return Err(ExecutionError::not_binary_value_loop(condition, &err_ctx));
@@ -696,6 +677,7 @@ impl FastProcessor {
         current_forest: &Arc<MastForest>,
         continuation_stack: &mut ContinuationStack,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
         // This happens after loop body execution
         // Check condition again to see if we should continue looping
@@ -704,36 +686,33 @@ impl FastProcessor {
 
         if condition == ONE {
             // Add REPEAT row and continue looping
-            self.check_extract_trace_state(
+            tracer.start_clock_cycle(
+                self,
                 NodeExecutionState::LoopRepeat(current_node_id),
                 continuation_stack,
                 current_forest,
             );
 
             // Drop the condition from the stack (on the REPEAT instruction)
-            self.decrement_stack_size();
+            self.decrement_stack_size(tracer);
 
             continuation_stack.push_finish_loop(current_node_id);
             continuation_stack.push_start_node(loop_node.body());
 
             // Corresponds to the REPEAT operation added to the trace.
-            self.increment_clk();
+            self.increment_clk(tracer);
         } else if condition == ZERO {
             // Exit the loop - add END row
-            self.check_extract_trace_state(
+            tracer.start_clock_cycle(
+                self,
                 NodeExecutionState::End(current_node_id),
                 continuation_stack,
                 current_forest,
             );
-            self.decrement_stack_size();
-
-            if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-                let block_info = trace_state_builder.block_stack.pop();
-                trace_state_builder.record_node_end(&block_info);
-            }
+            self.decrement_stack_size(tracer);
 
             // Corresponds to the END operation added to the trace.
-            self.increment_clk();
+            self.increment_clk(tracer);
             self.execute_after_exit_decorators(current_node_id, current_forest, host)?;
         } else {
             let err_ctx = err_ctx!(current_forest, loop_node, host);
@@ -743,6 +722,7 @@ impl FastProcessor {
     }
 
     /// Executes a Call node from the start.
+    #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     fn start_call_node(
         &mut self,
@@ -752,8 +732,10 @@ impl FastProcessor {
         current_forest: &Arc<MastForest>,
         continuation_stack: &mut ContinuationStack,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
-        self.check_extract_trace_state(
+        tracer.start_clock_cycle(
+            self,
             NodeExecutionState::Start(current_node_id),
             continuation_stack,
             current_forest,
@@ -770,47 +752,12 @@ impl FastProcessor {
             return Err(ExecutionError::CallInSyscall(instruction));
         }
 
-        // In tracing mode, record the control block on the block stack
-        if self.trace_state_builder.is_some() {
-            let overflow_addr = self
-                .trace_state_builder
-                .as_ref()
-                .unwrap()
-                .overflow_table
-                .last_update_clk_in_current_ctx();
-            let ctx_info = block_stack::ExecutionContextInfo::new(
-                self.ctx,
-                self.caller_hash,
-                self.fmp,
-                self.stack_depth(),
-                overflow_addr,
-            );
-
-            let trace_state_builder = self.trace_state_builder.as_mut().unwrap();
-            let block_addr = trace_state_builder.hasher.record_hash_control_block();
-            if call_node.is_syscall() {
-                let parent_addr = trace_state_builder.block_stack.push(
-                    block_addr,
-                    BlockType::SysCall,
-                    Some(ctx_info),
-                );
-                trace_state_builder.block_stack_replay.record_node_start(parent_addr);
-            } else {
-                let parent_addr = trace_state_builder.block_stack.push(
-                    block_addr,
-                    BlockType::Call,
-                    Some(ctx_info),
-                );
-                trace_state_builder.block_stack_replay.record_node_start(parent_addr);
-            }
-        }
-
         let callee_hash = current_forest
             .get_node_by_id(call_node.callee())
             .ok_or(ExecutionError::MastNodeNotFoundInForest { node_id: call_node.callee() })?
             .digest();
 
-        self.save_context_and_truncate_stack();
+        self.save_context_and_truncate_stack(tracer);
 
         if call_node.is_syscall() {
             // check if the callee is in the kernel
@@ -836,7 +783,7 @@ impl FastProcessor {
         continuation_stack.push_start_node(call_node.callee());
 
         // Corresponds to the CALL or SYSCALL operation added to the trace.
-        self.increment_clk();
+        self.increment_clk(tracer);
 
         Ok(())
     }
@@ -849,8 +796,10 @@ impl FastProcessor {
         current_forest: &Arc<MastForest>,
         continuation_stack: &mut ContinuationStack,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
-        self.check_extract_trace_state(
+        tracer.start_clock_cycle(
+            self,
             NodeExecutionState::End(node_id),
             continuation_stack,
             current_forest,
@@ -862,22 +811,10 @@ impl FastProcessor {
         // context of the
         // system registers and the operand stack to what it was prior
         // to the call.
-        self.restore_context(&err_ctx)?;
-
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            let block_info = trace_state_builder.block_stack.pop();
-            trace_state_builder.record_node_end(&block_info);
-
-            let exec_ctx = block_info.ctx_info.unwrap();
-            trace_state_builder.record_execution_context(ExecutionContextSystemInfo {
-                parent_ctx: exec_ctx.parent_ctx,
-                parent_fn_hash: exec_ctx.parent_fn_hash,
-                parent_fmp: exec_ctx.parent_fmp,
-            });
-        }
+        self.restore_context(tracer, &err_ctx)?;
 
         // Corresponds to the row inserted for the END operation added to the trace.
-        self.increment_clk();
+        self.increment_clk(tracer);
         self.execute_after_exit_decorators(node_id, current_forest, host)
     }
 
@@ -885,13 +822,14 @@ impl FastProcessor {
     #[inline(always)]
     async fn start_dyn_node(
         &mut self,
-        is_dyncall: bool,
         current_node_id: MastNodeId,
         current_forest: &mut Arc<MastForest>,
         continuation_stack: &mut ContinuationStack,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
-        self.check_extract_trace_state(
+        tracer.start_clock_cycle(
+            self,
             NodeExecutionState::Start(current_node_id),
             continuation_stack,
             current_forest,
@@ -899,57 +837,6 @@ impl FastProcessor {
 
         // Execute decorators that should be executed before entering the node
         self.execute_before_enter_decorators(current_node_id, current_forest, host)?;
-
-        // In tracing mode, record the control block on the block stack
-        if self.trace_state_builder.is_some() {
-            let block_addr =
-                self.trace_state_builder.as_mut().unwrap().hasher.record_hash_control_block();
-
-            if is_dyncall {
-                let overflow_addr = self
-                    .trace_state_builder
-                    .as_ref()
-                    .unwrap()
-                    .overflow_table
-                    .last_update_clk_in_current_ctx();
-                // Note: the stack depth to record is the `current_stack_depth - 1` due to the
-                // semantics of DYNCALL. That is, the top of the stack contains the memory address
-                // to where the address to dynamically call is located. Then, the DYNCALL operation
-                // performs a drop, and records the stack depth after the drop as the beginning of
-                // the new context. For more information, look at the docs for how the constraints
-                // are designed; it's a bit tricky but it works.
-                let stack_depth_after_drop = self.stack_depth() - 1;
-                let ctx_info = block_stack::ExecutionContextInfo::new(
-                    self.ctx,
-                    self.caller_hash,
-                    self.fmp,
-                    stack_depth_after_drop,
-                    overflow_addr,
-                );
-
-                let parent_addr = self.trace_state_builder.as_mut().unwrap().block_stack.push(
-                    block_addr,
-                    BlockType::Dyncall,
-                    Some(ctx_info),
-                );
-                self.trace_state_builder
-                    .as_mut()
-                    .unwrap()
-                    .block_stack_replay
-                    .record_node_start(parent_addr);
-            } else {
-                let parent_addr = self.trace_state_builder.as_mut().unwrap().block_stack.push(
-                    block_addr,
-                    BlockType::Dyn,
-                    None,
-                );
-                self.trace_state_builder
-                    .as_mut()
-                    .unwrap()
-                    .block_stack_replay
-                    .record_node_start(parent_addr);
-            }
-        }
 
         // Corresponds to the row inserted for the DYN or DYNCALL operation
         // added to the trace.
@@ -967,16 +854,16 @@ impl FastProcessor {
         let callee_hash = {
             let mem_addr = self.stack_get(0);
             self.memory
-                .read_word(self.ctx, mem_addr, self.clk, &err_ctx, &mut self.trace_state_builder)
+                .read_word(self.ctx, mem_addr, self.clk, &err_ctx, tracer)
                 .map_err(ExecutionError::MemoryError)?
         };
 
         // Drop the memory address from the stack. This needs to be done before saving the context.
-        self.decrement_stack_size();
+        self.decrement_stack_size(tracer);
 
         // For dyncall, save the context and reset it.
         if dyn_node.is_dyncall() {
-            self.save_context_and_truncate_stack();
+            self.save_context_and_truncate_stack(tracer);
             // The value for the new context is defined to be the value of the clock cycle for the
             // following operation.
             self.ctx = (self.clk + 1).into();
@@ -1018,7 +905,7 @@ impl FastProcessor {
 
         // Increment the clock, corresponding to the row inserted for the DYN or DYNCALL operation
         // added to the trace.
-        self.increment_clk();
+        self.increment_clk(tracer);
 
         Ok(())
     }
@@ -1031,8 +918,10 @@ impl FastProcessor {
         current_forest: &Arc<MastForest>,
         continuation_stack: &mut ContinuationStack,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
-        self.check_extract_trace_state(
+        tracer.start_clock_cycle(
+            self,
             NodeExecutionState::End(node_id),
             continuation_stack,
             current_forest,
@@ -1042,26 +931,12 @@ impl FastProcessor {
         let err_ctx = err_ctx!(current_forest, dyn_node, host);
         // For dyncall, restore the context.
         if dyn_node.is_dyncall() {
-            self.restore_context(&err_ctx)?;
-        }
-
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            let block_info = trace_state_builder.block_stack.pop();
-            trace_state_builder.record_node_end(&block_info);
-
-            if dyn_node.is_dyncall() {
-                let exec_ctx = block_info.ctx_info.unwrap();
-                trace_state_builder.record_execution_context(ExecutionContextSystemInfo {
-                    parent_ctx: exec_ctx.parent_ctx,
-                    parent_fn_hash: exec_ctx.parent_fn_hash,
-                    parent_fmp: exec_ctx.parent_fmp,
-                });
-            }
+            self.restore_context(tracer, &err_ctx)?;
         }
 
         // Corresponds to the row inserted for the END operation added to
         // the trace.
-        self.increment_clk();
+        self.increment_clk(tracer);
         self.execute_after_exit_decorators(node_id, current_forest, host)
     }
 
@@ -1069,28 +944,28 @@ impl FastProcessor {
     #[inline(always)]
     async fn execute_external_node(
         &mut self,
-        node_id: MastNodeId,
+        external_node_id: MastNodeId,
         current_forest: &mut Arc<MastForest>,
         continuation_stack: &mut ContinuationStack,
         host: &mut impl AsyncHost,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
         // Execute decorators that should be executed before entering the node
-        self.execute_before_enter_decorators(node_id, current_forest, host)?;
+        self.execute_before_enter_decorators(external_node_id, current_forest, host)?;
 
-        let external_node = current_forest[node_id].unwrap_external();
-        let (root_id, new_mast_forest) = self.resolve_external_node(external_node, host).await?;
+        let external_node = current_forest[external_node_id].unwrap_external();
+        let (resolved_node_id, new_mast_forest) =
+            self.resolve_external_node(external_node, host).await?;
 
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            trace_state_builder.external.record_resolution(root_id, new_mast_forest.clone());
-        }
+        tracer.record_external_node_resolution(resolved_node_id, &new_mast_forest);
 
         // Push current forest to the continuation stack so that we can return to it
         continuation_stack.push_enter_forest(current_forest.clone());
 
         // Push the root node of the external MAST forest onto the continuation stack.
-        continuation_stack.push_start_node(root_id);
+        continuation_stack.push_start_node(resolved_node_id);
 
-        self.execute_after_exit_decorators(node_id, current_forest, host)?;
+        self.execute_after_exit_decorators(external_node_id, current_forest, host)?;
 
         // Update the current forest to the new MAST forest.
         *current_forest = new_mast_forest;
@@ -1101,6 +976,7 @@ impl FastProcessor {
     // Note: when executing individual ops, we do not increment the clock by 1 at every iteration
     // for performance reasons (~25% performance drop). Hence, `self.clk` cannot be used directly to
     // determine the number of operations executed in a program.
+    #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     async fn execute_basic_block_node(
         &mut self,
@@ -1110,8 +986,10 @@ impl FastProcessor {
         host: &mut impl AsyncHost,
         continuation_stack: &mut ContinuationStack,
         current_forest: &Arc<MastForest>,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
-        self.check_extract_trace_state(
+        tracer.start_clock_cycle(
+            self,
             NodeExecutionState::Start(node_id),
             continuation_stack,
             current_forest,
@@ -1120,16 +998,8 @@ impl FastProcessor {
         // Execute decorators that should be executed before entering the node
         self.execute_before_enter_decorators(node_id, program, host)?;
 
-        // In tracing mode, record the basic block on the block stack
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            let block_addr = trace_state_builder.hasher.record_hash_basic_block(basic_block_node);
-            let parent_addr =
-                trace_state_builder.block_stack.push(block_addr, BlockType::Span, None);
-            trace_state_builder.block_stack_replay.record_node_start(parent_addr);
-        }
-
         // Corresponds to the row inserted for the SPAN operation added to the trace.
-        self.increment_clk();
+        self.increment_clk(tracer);
 
         let mut batch_offset_in_block = 0;
         let mut op_batches = basic_block_node.op_batches().iter();
@@ -1148,6 +1018,7 @@ impl FastProcessor {
                 host,
                 continuation_stack,
                 current_forest,
+                tracer,
             )
             .await?;
             batch_offset_in_block += first_op_batch.ops().len();
@@ -1157,7 +1028,8 @@ impl FastProcessor {
         for (batch_index_minus_1, op_batch) in op_batches.enumerate() {
             // RESPAN
             {
-                self.check_extract_trace_state(
+                tracer.start_clock_cycle(
+                    self,
                     NodeExecutionState::Respan {
                         node_id,
                         batch_index: batch_index_minus_1 + 1,
@@ -1166,12 +1038,8 @@ impl FastProcessor {
                     current_forest,
                 );
 
-                if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-                    trace_state_builder.block_stack.peek_mut().addr += HASH_CYCLE_LEN;
-                }
-
                 // Corresponds to the RESPAN operation added to the trace.
-                self.increment_clk();
+                self.increment_clk(tracer);
             }
 
             self.execute_op_batch(
@@ -1185,24 +1053,21 @@ impl FastProcessor {
                 host,
                 continuation_stack,
                 current_forest,
+                tracer,
             )
             .await?;
             batch_offset_in_block += op_batch.ops().len();
         }
 
-        self.check_extract_trace_state(
+        tracer.start_clock_cycle(
+            self,
             NodeExecutionState::End(node_id),
             continuation_stack,
             current_forest,
         );
 
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            let block_info = trace_state_builder.block_stack.pop();
-            trace_state_builder.record_node_end(&block_info);
-        }
-
         // Corresponds to the row inserted for the END operation added to the trace.
-        self.increment_clk();
+        self.increment_clk(tracer);
 
         // execute any decorators which have not been executed during span ops execution; this can
         // happen for decorators appearing after all operations in a block. these decorators are
@@ -1232,6 +1097,7 @@ impl FastProcessor {
         host: &mut impl AsyncHost,
         continuation_stack: &mut ContinuationStack,
         current_forest: &Arc<MastForest>,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
         let op_counts = batch.op_counts();
         let mut op_idx_in_group = 0;
@@ -1262,7 +1128,8 @@ impl FastProcessor {
 
             // if in trace mode, check if we need to record a trace state before executing the
             // operation
-            self.check_extract_trace_state(
+            tracer.start_clock_cycle(
+                self,
                 NodeExecutionState::BasicBlock {
                     node_id,
                     batch_index,
@@ -1292,12 +1159,12 @@ impl FastProcessor {
                 },
                 _ => {
                     // if the operation is not an Emit, we execute it normally
-                    self.execute_op(op, op_idx_in_block, program, host, &err_ctx)?;
+                    self.execute_op(op, op_idx_in_block, program, host, &err_ctx, tracer)?;
                 },
             }
 
             // Increment clock after executing the operation
-            self.increment_clk();
+            self.increment_clk(tracer);
 
             // if the operation carries an immediate value, the value is stored at the next group
             // pointer; so, we advance the pointer to the following group
@@ -1318,7 +1185,8 @@ impl FastProcessor {
                     num_noops_inserted_in_batch += 1;
 
                     // If in tracing mode, check if we need to record a trace state.
-                    self.check_extract_trace_state(
+                    tracer.start_clock_cycle(
+                        self,
                         NodeExecutionState::BasicBlock {
                             node_id,
                             batch_index,
@@ -1330,7 +1198,7 @@ impl FastProcessor {
                     );
 
                     // Increment the clk to account for the NOOP inserted at runtime
-                    self.increment_clk();
+                    self.increment_clk(tracer);
                 }
 
                 // then, move to the next group and reset operation index
@@ -1347,28 +1215,23 @@ impl FastProcessor {
         // corresponds to incrementing the clock by the number of empty op groups (i.e. 1 NOOP
         // executed per missing op group).
         let num_noops_to_execute = num_batch_groups - group_idx;
-        if self.trace_state_builder.is_some() {
-            // In tracing mode, we need to call `increment_clk()` once for each NOOP, in case
-            // we need to extract a batch after one of the NOOPs.
-            let num_ops_in_batch = batch.ops().len() + num_noops_inserted_in_batch;
 
-            for noop_idx in 0..num_noops_to_execute {
-                self.check_extract_trace_state(
-                    NodeExecutionState::BasicBlock {
-                        node_id,
-                        batch_index,
-                        op_idx_in_batch: num_ops_in_batch + noop_idx,
-                    },
-                    continuation_stack,
-                    current_forest,
-                );
+        // We need to call `increment_clk()` once for each NOOP, in case we need to extract a batch
+        // after one of the NOOPs.
+        let num_ops_in_batch = batch.ops().len() + num_noops_inserted_in_batch;
+        for noop_idx in 0..num_noops_to_execute {
+            tracer.start_clock_cycle(
+                self,
+                NodeExecutionState::BasicBlock {
+                    node_id,
+                    batch_index,
+                    op_idx_in_batch: num_ops_in_batch + noop_idx,
+                },
+                continuation_stack,
+                current_forest,
+            );
 
-                self.increment_clk();
-            }
-        } else {
-            // Note: it is safe to increment `clk` here directly instead of through
-            // `increment_clk()`, since we checked that we are not in tracing mode.
-            self.clk += num_noops_to_execute as u32;
+            self.increment_clk(tracer);
         }
 
         Ok(())
@@ -1447,6 +1310,7 @@ impl FastProcessor {
         program: &MastForest,
         host: &mut impl AsyncHost,
         err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
         if self.bounds_check_counter == 0 {
             let err_str = if self.stack_top_idx - MIN_STACK_DEPTH == 0 {
@@ -1462,12 +1326,14 @@ impl FastProcessor {
             Operation::Noop => {
                 // do nothing
             },
-            Operation::Assert(err_code) => self.op_assert(*err_code, host, program, err_ctx)?,
+            Operation::Assert(err_code) => {
+                self.op_assert(*err_code, host, program, err_ctx, tracer)?
+            },
             Operation::FmpAdd => self.op_fmpadd(),
-            Operation::FmpUpdate => self.op_fmpupdate()?,
-            Operation::SDepth => self.op_sdepth(),
+            Operation::FmpUpdate => self.op_fmpupdate(tracer)?,
+            Operation::SDepth => self.op_sdepth(tracer),
             Operation::Caller => self.op_caller()?,
-            Operation::Clk => self.op_clk()?,
+            Operation::Clk => self.op_clk(tracer)?,
             Operation::Emit(_event_id) => {
                 panic!("emit instruction requires async, so is not supported by execute_op()")
             },
@@ -1488,46 +1354,46 @@ impl FastProcessor {
             Operation::Halt => unreachable!("control flow operation"),
 
             // ----- field operations -------------------------------------------------------------
-            Operation::Add => self.op_add()?,
+            Operation::Add => self.op_add(tracer)?,
             Operation::Neg => self.op_neg()?,
-            Operation::Mul => self.op_mul()?,
+            Operation::Mul => self.op_mul(tracer)?,
             Operation::Inv => self.op_inv(err_ctx)?,
             Operation::Incr => self.op_incr()?,
-            Operation::And => self.op_and(err_ctx)?,
-            Operation::Or => self.op_or(err_ctx)?,
+            Operation::And => self.op_and(tracer, err_ctx)?,
+            Operation::Or => self.op_or(tracer, err_ctx)?,
             Operation::Not => self.op_not(err_ctx)?,
-            Operation::Eq => self.op_eq()?,
+            Operation::Eq => self.op_eq(tracer)?,
             Operation::Eqz => self.op_eqz()?,
             Operation::Expacc => self.op_expacc(),
             Operation::Ext2Mul => self.op_ext2mul(),
 
             // ----- u32 operations ---------------------------------------------------------------
-            Operation::U32split => self.op_u32split(),
-            Operation::U32add => self.op_u32add(err_ctx)?,
-            Operation::U32add3 => self.op_u32add3(err_ctx)?,
-            Operation::U32sub => self.op_u32sub(op_idx, err_ctx)?,
-            Operation::U32mul => self.op_u32mul(err_ctx)?,
-            Operation::U32madd => self.op_u32madd(err_ctx)?,
-            Operation::U32div => self.op_u32div(err_ctx)?,
-            Operation::U32and => self.op_u32and(err_ctx)?,
-            Operation::U32xor => self.op_u32xor(err_ctx)?,
-            Operation::U32assert2(err_code) => self.op_u32assert2(*err_code, err_ctx)?,
+            Operation::U32split => self.op_u32split(tracer),
+            Operation::U32add => self.op_u32add(err_ctx, tracer)?,
+            Operation::U32add3 => self.op_u32add3(err_ctx, tracer)?,
+            Operation::U32sub => self.op_u32sub(op_idx, err_ctx, tracer)?,
+            Operation::U32mul => self.op_u32mul(err_ctx, tracer)?,
+            Operation::U32madd => self.op_u32madd(err_ctx, tracer)?,
+            Operation::U32div => self.op_u32div(err_ctx, tracer)?,
+            Operation::U32and => self.op_u32and(err_ctx, tracer)?,
+            Operation::U32xor => self.op_u32xor(err_ctx, tracer)?,
+            Operation::U32assert2(err_code) => self.op_u32assert2(*err_code, err_ctx, tracer)?,
 
             // ----- stack manipulation -----------------------------------------------------------
-            Operation::Pad => self.op_pad(),
-            Operation::Drop => self.decrement_stack_size(),
-            Operation::Dup0 => self.dup_nth(0),
-            Operation::Dup1 => self.dup_nth(1),
-            Operation::Dup2 => self.dup_nth(2),
-            Operation::Dup3 => self.dup_nth(3),
-            Operation::Dup4 => self.dup_nth(4),
-            Operation::Dup5 => self.dup_nth(5),
-            Operation::Dup6 => self.dup_nth(6),
-            Operation::Dup7 => self.dup_nth(7),
-            Operation::Dup9 => self.dup_nth(9),
-            Operation::Dup11 => self.dup_nth(11),
-            Operation::Dup13 => self.dup_nth(13),
-            Operation::Dup15 => self.dup_nth(15),
+            Operation::Pad => self.op_pad(tracer),
+            Operation::Drop => self.decrement_stack_size(tracer),
+            Operation::Dup0 => self.dup_nth(0, tracer),
+            Operation::Dup1 => self.dup_nth(1, tracer),
+            Operation::Dup2 => self.dup_nth(2, tracer),
+            Operation::Dup3 => self.dup_nth(3, tracer),
+            Operation::Dup4 => self.dup_nth(4, tracer),
+            Operation::Dup5 => self.dup_nth(5, tracer),
+            Operation::Dup6 => self.dup_nth(6, tracer),
+            Operation::Dup7 => self.dup_nth(7, tracer),
+            Operation::Dup9 => self.dup_nth(9, tracer),
+            Operation::Dup11 => self.dup_nth(11, tracer),
+            Operation::Dup13 => self.dup_nth(13, tracer),
+            Operation::Dup15 => self.dup_nth(15, tracer),
             Operation::Swap => self.op_swap(),
             Operation::SwapW => self.swapw_nth(1),
             Operation::SwapW2 => self.swapw_nth(2),
@@ -1547,27 +1413,29 @@ impl FastProcessor {
             Operation::MovDn6 => self.rotate_right(7),
             Operation::MovDn7 => self.rotate_right(8),
             Operation::MovDn8 => self.rotate_right(9),
-            Operation::CSwap => self.op_cswap(err_ctx)?,
-            Operation::CSwapW => self.op_cswapw(err_ctx)?,
+            Operation::CSwap => self.op_cswap(err_ctx, tracer)?,
+            Operation::CSwapW => self.op_cswapw(err_ctx, tracer)?,
 
             // ----- input / output ---------------------------------------------------------------
-            Operation::Push(element) => self.op_push(*element),
-            Operation::AdvPop => self.op_advpop(err_ctx)?,
-            Operation::AdvPopW => self.op_advpopw(err_ctx)?,
-            Operation::MLoadW => self.op_mloadw(err_ctx)?,
-            Operation::MStoreW => self.op_mstorew(err_ctx)?,
-            Operation::MLoad => self.op_mload(err_ctx)?,
-            Operation::MStore => self.op_mstore(err_ctx)?,
-            Operation::MStream => self.op_mstream(err_ctx)?,
-            Operation::Pipe => self.op_pipe(err_ctx)?,
+            Operation::Push(element) => self.op_push(*element, tracer),
+            Operation::AdvPop => self.op_advpop(err_ctx, tracer)?,
+            Operation::AdvPopW => self.op_advpopw(err_ctx, tracer)?,
+            Operation::MLoadW => self.op_mloadw(err_ctx, tracer)?,
+            Operation::MStoreW => self.op_mstorew(err_ctx, tracer)?,
+            Operation::MLoad => self.op_mload(err_ctx, tracer)?,
+            Operation::MStore => self.op_mstore(err_ctx, tracer)?,
+            Operation::MStream => self.op_mstream(err_ctx, tracer)?,
+            Operation::Pipe => self.op_pipe(err_ctx, tracer)?,
 
             // ----- cryptographic operations -----------------------------------------------------
-            Operation::HPerm => self.op_hperm(),
-            Operation::MpVerify(err_code) => self.op_mpverify(*err_code, program, err_ctx)?,
-            Operation::MrUpdate => self.op_mrupdate(err_ctx)?,
-            Operation::FriE2F4 => self.op_fri_ext2fold4()?,
-            Operation::HornerBase => self.op_horner_eval_base(err_ctx)?,
-            Operation::HornerExt => self.op_horner_eval_ext(err_ctx)?,
+            Operation::HPerm => self.op_hperm(tracer),
+            Operation::MpVerify(err_code) => {
+                self.op_mpverify(*err_code, program, tracer, err_ctx)?
+            },
+            Operation::MrUpdate => self.op_mrupdate(tracer, err_ctx)?,
+            Operation::FriE2F4 => self.op_fri_ext2fold4(tracer)?,
+            Operation::HornerBase => self.op_horner_eval_base(tracer, err_ctx)?,
+            Operation::HornerExt => self.op_horner_eval_ext(tracer, err_ctx)?,
             Operation::EvalCircuit => self.op_eval_circuit(err_ctx)?,
         }
 
@@ -1579,12 +1447,10 @@ impl FastProcessor {
 
     /// Increments the clock by 1.
     #[inline(always)]
-    fn increment_clk(&mut self) {
+    fn increment_clk(&mut self, tracer: &mut impl Tracer) {
         self.clk += 1_u32;
 
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            trace_state_builder.overflow_table.advance_clock();
-        }
+        tracer.increment_clk();
     }
 
     async fn load_mast_forest<E>(
@@ -1649,19 +1515,8 @@ impl FastProcessor {
     ///
     /// The bottom of the stack is never affected by this operation.
     #[inline(always)]
-    fn increment_stack_size(&mut self) {
-        {
-            // Get around the borrow checker by using a temporary variable.
-            let overflow_value = if self.trace_state_builder.is_some() {
-                Some(self.stack_get(15))
-            } else {
-                None
-            };
-
-            if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-                trace_state_builder.overflow_table.push(overflow_value.unwrap());
-            }
-        }
+    fn increment_stack_size(&mut self, tracer: &mut impl Tracer) {
+        tracer.increment_stack_size(self);
 
         self.stack_top_idx += 1;
         self.update_bounds_check_counter();
@@ -1672,17 +1527,8 @@ impl FastProcessor {
     /// The bottom of the stack is only decremented in cases where the stack depth would become less
     /// than 16.
     #[inline(always)]
-    fn decrement_stack_size(&mut self) {
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            // Record the popped value for replay, if present
-            if let Some(popped_value) = trace_state_builder.overflow_table.pop() {
-                let new_overflow_addr =
-                    trace_state_builder.overflow_table.last_update_clk_in_current_ctx();
-                trace_state_builder
-                    .overflow_replay
-                    .record_pop_overflow(popped_value, new_overflow_addr);
-            }
-        }
+    fn decrement_stack_size(&mut self, tracer: &mut impl Tracer) {
+        tracer.decrement_stack_size();
 
         self.stack_top_idx -= 1;
         self.stack_bot_idx = min(self.stack_bot_idx, self.stack_top_idx - MIN_STACK_DEPTH);
@@ -1723,7 +1569,7 @@ impl FastProcessor {
 
     /// Saves the current execution context and truncates the stack to 16 elements in preparation to
     /// start a new execution context.
-    fn save_context_and_truncate_stack(&mut self) {
+    fn save_context_and_truncate_stack(&mut self, tracer: &mut impl Tracer) {
         let overflow_stack = if self.stack_size() > MIN_STACK_DEPTH {
             // save the overflow stack, and zero out the buffer.
             //
@@ -1747,9 +1593,7 @@ impl FastProcessor {
             fmp: self.fmp,
         });
 
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            trace_state_builder.overflow_table.start_context();
-        }
+        tracer.start_context();
     }
 
     /// Restores the execution context to the state it was in before the last `call`, `syscall` or
@@ -1760,7 +1604,11 @@ impl FastProcessor {
     /// # Errors
     /// - Returns an error if the overflow stack is larger than the space available in the stack
     ///   buffer.
-    fn restore_context(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
+    fn restore_context(
+        &mut self,
+        tracer: &mut impl Tracer,
+        err_ctx: &impl ErrorContext,
+    ) -> Result<(), ExecutionError> {
         // when a call/dyncall/syscall node ends, stack depth must be exactly 16.
         if self.stack_size() > MIN_STACK_DEPTH {
             return Err(ExecutionError::invalid_stack_depth_on_return(self.stack_size(), err_ctx));
@@ -1791,60 +1639,9 @@ impl FastProcessor {
         self.in_syscall = false;
         self.caller_hash = ctx_info.fn_hash;
 
-        if let Some(ref mut trace_state_builder) = self.trace_state_builder {
-            trace_state_builder.overflow_table.restore_context();
-            trace_state_builder.overflow_replay.record_restore_context_overflow_addr(
-                MIN_STACK_DEPTH + trace_state_builder.overflow_table.num_elements_in_current_ctx(),
-                trace_state_builder.overflow_table.last_update_clk_in_current_ctx(),
-            );
-        }
+        tracer.restore_context();
 
         Ok(())
-    }
-
-    /// Checks if the trace state should be extracted and stored, and does so if necessary.
-    ///
-    /// This method must be called at the start of each clock cycle *before* applying any mutation
-    /// to the processor state.
-    fn check_extract_trace_state(
-        &mut self,
-        execution_state: NodeExecutionState,
-        continuation_stack: &mut ContinuationStack,
-        current_forest: &Arc<MastForest>,
-    ) {
-        if self.trace_state_builder.is_some()
-            && self.clk.as_usize().is_multiple_of(NUM_ROWS_PER_CORE_FRAGMENT)
-        {
-            let stack_top: [Felt; MIN_STACK_DEPTH] = self.stack_top().try_into().unwrap();
-            let decoder_state = {
-                let trace_state_builder = self.trace_state_builder.as_ref().unwrap();
-                if trace_state_builder.block_stack.is_empty() {
-                    DecoderState { current_addr: ZERO, parent_addr: ZERO }
-                } else {
-                    let block_info = trace_state_builder.block_stack.peek();
-
-                    DecoderState {
-                        current_addr: block_info.addr,
-                        parent_addr: block_info.parent_addr,
-                    }
-                }
-            };
-
-            self.trace_state_builder.as_mut().unwrap().start_new_trace_state(
-                SystemState {
-                    clk: self.clk,
-                    ctx: self.ctx,
-                    fmp: self.fmp,
-                    in_syscall: self.in_syscall,
-                    fn_hash: self.caller_hash,
-                },
-                decoder_state,
-                stack_top,
-                continuation_stack.clone(),
-                execution_state,
-                current_forest.clone(),
-            );
-        }
     }
 
     // TESTING
@@ -1865,6 +1662,7 @@ impl FastProcessor {
         Ok(stack_outputs)
     }
 
+    /// Convenience sync wrapper to [Self::execute_for_trace] for testing purposes.
     #[cfg(any(test, feature = "testing"))]
     pub fn execute_for_trace_sync(
         self,
@@ -1887,7 +1685,7 @@ impl FastProcessor {
         // Create a new Tokio runtime and block on the async execution
         let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
 
-        rt.block_on(self.execute_impl(program, host))
+        rt.block_on(self.execute_impl(program, host, &mut NoopTracer))
     }
 }
 

--- a/processor/src/fast/stack_ops.rs
+++ b/processor/src/fast/stack_ops.rs
@@ -1,12 +1,12 @@
 use miden_core::{WORD_SIZE, ZERO};
 
-use super::FastProcessor;
+use super::{FastProcessor, tracer::Tracer};
 use crate::{ErrorContext, ExecutionError};
 
 impl FastProcessor {
     /// Analogous to `Process::op_pad`.
-    pub fn op_pad(&mut self) {
-        self.increment_stack_size();
+    pub fn op_pad(&mut self, tracer: &mut impl Tracer) {
+        self.increment_stack_size(tracer);
         self.stack_write(0, ZERO);
     }
 
@@ -76,9 +76,9 @@ impl FastProcessor {
     ///
     /// The size of the stack is incremented by 1.
     #[inline(always)]
-    pub fn dup_nth(&mut self, n: usize) {
+    pub fn dup_nth(&mut self, n: usize, tracer: &mut impl Tracer) {
         let to_dup = self.stack_get(n);
-        self.increment_stack_size();
+        self.increment_stack_size(tracer);
         self.stack_write(0, to_dup);
     }
 
@@ -98,9 +98,13 @@ impl FastProcessor {
     }
 
     /// Analogous to `Process::op_cswap`.
-    pub fn op_cswap(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
+    pub fn op_cswap(
+        &mut self,
+        err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
+    ) -> Result<(), ExecutionError> {
         let condition = self.stack_get(0);
-        self.decrement_stack_size();
+        self.decrement_stack_size(tracer);
 
         match condition.as_int() {
             0 => {
@@ -118,9 +122,13 @@ impl FastProcessor {
     }
 
     /// Analogous to `Process::op_cswapw`.
-    pub fn op_cswapw(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
+    pub fn op_cswapw(
+        &mut self,
+        err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
+    ) -> Result<(), ExecutionError> {
         let condition = self.stack_get(0);
-        self.decrement_stack_size();
+        self.decrement_stack_size(tracer);
 
         match condition.as_int() {
             0 => {

--- a/processor/src/fast/sys_ops.rs
+++ b/processor/src/fast/sys_ops.rs
@@ -1,6 +1,6 @@
 use miden_core::{Felt, mast::MastForest, sys_events::SystemEvent};
 
-use super::{ExecutionError, FastProcessor, ONE};
+use super::{ExecutionError, FastProcessor, ONE, tracer::Tracer};
 use crate::{
     AsyncHost, BaseHost, ErrorContext, FMP_MIN,
     operations::sys_ops::sys_event_handlers::handle_system_event, system::FMP_MAX,
@@ -15,6 +15,7 @@ impl FastProcessor {
         host: &mut impl BaseHost,
         program: &MastForest,
         err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
         if self.stack_get(0) != ONE {
             let process = &mut self.state();
@@ -27,7 +28,7 @@ impl FastProcessor {
                 err_ctx,
             ));
         }
-        self.decrement_stack_size();
+        self.decrement_stack_size(tracer);
         Ok(())
     }
 
@@ -40,7 +41,7 @@ impl FastProcessor {
     }
 
     /// Analogous to `Process::op_fmpupdate`.
-    pub fn op_fmpupdate(&mut self) -> Result<(), ExecutionError> {
+    pub fn op_fmpupdate(&mut self, tracer: &mut impl Tracer) -> Result<(), ExecutionError> {
         let top = self.stack_get(0);
 
         let new_fmp = self.fmp + top;
@@ -50,14 +51,14 @@ impl FastProcessor {
         }
 
         self.fmp = new_fmp;
-        self.decrement_stack_size();
+        self.decrement_stack_size(tracer);
         Ok(())
     }
 
     /// Analogous to `Process::op_sdepth`.
-    pub fn op_sdepth(&mut self) {
+    pub fn op_sdepth(&mut self, tracer: &mut impl Tracer) {
         let depth = self.stack_depth();
-        self.increment_stack_size();
+        self.increment_stack_size(tracer);
         self.stack_write(0, depth.into());
     }
 
@@ -74,8 +75,8 @@ impl FastProcessor {
     }
 
     /// Analogous to `Process::op_clk`.
-    pub fn op_clk(&mut self) -> Result<(), ExecutionError> {
-        self.increment_stack_size();
+    pub fn op_clk(&mut self, tracer: &mut impl Tracer) -> Result<(), ExecutionError> {
+        self.increment_stack_size(tracer);
         self.stack_write(0, self.clk.into());
         Ok(())
     }

--- a/processor/src/fast/tests/memory.rs
+++ b/processor/src/fast/tests/memory.rs
@@ -101,7 +101,7 @@ fn test_mstorew_success() {
 
     // Ensure that the memory was correctly modified
     assert_eq!(
-        processor.memory.read_word(ctx, addr, clk, &(), &mut None).unwrap(),
+        processor.memory.read_word(ctx, addr, clk, &(), &mut NoopTracer).unwrap(),
         word_to_store.into()
     );
 }
@@ -124,7 +124,10 @@ fn test_mstore_success(#[case] addr: u32, #[case] value_to_store: u32) {
 
     // Ensure that the memory was correctly modified
     let word_addr = addr - (addr % WORD_SIZE as u32);
-    let word = processor.memory.read_word(ctx, word_addr.into(), clk, &(), &mut None).unwrap();
+    let word = processor
+        .memory
+        .read_word(ctx, word_addr.into(), clk, &(), &mut NoopTracer)
+        .unwrap();
     assert_eq!(word[addr as usize % WORD_SIZE], value_to_store);
 }
 

--- a/processor/src/fast/trace_state.rs
+++ b/processor/src/fast/trace_state.rs
@@ -393,12 +393,12 @@ impl MemoryReplay {
     // --------------------------------------------------------------------------------
 
     /// Records a read element from memory
-    pub fn record_element(&mut self, element: Felt, addr: Felt) {
+    pub fn record_read_element(&mut self, element: Felt, addr: Felt) {
         self.elements_read.push_back((addr, element));
     }
 
     /// Records a read word from memory
-    pub fn record_word(&mut self, word: Word, addr: Felt) {
+    pub fn record_read_word(&mut self, word: Word, addr: Felt) {
         self.words_read.push_back((addr, word));
     }
 
@@ -658,7 +658,7 @@ impl StackOverflowReplay {
 // NODE EXECUTION STATE
 // ================================================================================================
 
-/// Specifies the execution state of a node when starting fragment generation.
+/// Specifies the execution state of a node.
 ///
 /// Each MAST node has at least 2 different states associated with it: processing the START and END
 /// nodes (e.g. JOIN and END in the case of [miden_core::mast::JoinNode]). Some have more; for

--- a/processor/src/fast/tracer.rs
+++ b/processor/src/fast/tracer.rs
@@ -1,0 +1,188 @@
+use alloc::sync::Arc;
+
+use miden_core::{
+    Felt, Word,
+    crypto::merkle::MerklePath,
+    mast::{MastForest, MastNodeId},
+};
+
+use crate::{
+    continuation_stack::ContinuationStack,
+    fast::{FastProcessor, trace_state::NodeExecutionState},
+};
+
+/// A trait for tracing the execution of a [FastProcessor].
+pub trait Tracer {
+    /// Signals the start of a new clock cycle.
+    ///
+    /// This is guaranteed to be called before executing the operation at the given clock cycle.
+    /// Additionally, [miden_core::mast::ExternalNode] nodes are guaranteed to be resolved before
+    /// this method is called.
+    fn start_clock_cycle(
+        &mut self,
+        processor: &FastProcessor,
+        execution_state: NodeExecutionState,
+        continuation_stack: &mut ContinuationStack,
+        current_forest: &Arc<MastForest>,
+    );
+
+    /// When execution encounters a [miden_core::mast::ExternalNode], the external node gets
+    /// resolved to the MAST node it refers to in the new MAST forest. Hence, a clock cycle where
+    /// execution encounters an external node effectively has 2 nodes associated with it.
+    /// [Tracer::start_clock_cycle] is called on the resolved node (i.e. *not* the external node).
+    /// This method is called on the external node before it is resolved, and hence is guaranteed to
+    /// be called before [Tracer::start_clock_cycle] for clock cycles involving an external node.
+    fn record_external_node_resolution(&mut self, node_id: MastNodeId, forest: &Arc<MastForest>);
+
+    // HASHER METHODS
+    // -----------------------------------------------
+
+    /// Records the result of a call to `Hasher::permute()`.
+    fn record_hasher_permute(&mut self, hashed_state: [Felt; 12]);
+
+    /// Records the result of a call to `Hasher::build_merkle_root()`.
+    fn record_hasher_build_merkle_root(&mut self, path: &MerklePath, root: Word);
+
+    /// Records the result of a call to `Hasher::update_merkle_root()`.
+    fn record_hasher_update_merkle_root(
+        &mut self,
+        path: &MerklePath,
+        old_root: Word,
+        new_root: Word,
+    );
+
+    // MEMORY METHODS
+    // -----------------------------------------------
+
+    /// Records the element read from memory at the given address.
+    fn record_memory_read_element(&mut self, element: Felt, addr: Felt);
+
+    /// Records the word read from memory at the given address.
+    fn record_memory_read_word(&mut self, word: Word, addr: Felt);
+
+    // ADVICE PROVIDER METHODS
+    // -----------------------------------------------
+
+    /// Records the value returned by a [crate::host::advice::AdviceProvider::pop_stack] operation.
+    fn record_advice_pop_stack(&mut self, value: Felt);
+    /// Records the value returned by a [crate::host::advice::AdviceProvider::pop_stack_word]
+    /// operation.
+    fn record_advice_pop_stack_word(&mut self, word: Word);
+    /// Records the value returned by a [crate::host::advice::AdviceProvider::pop_stack_dword]
+    /// operation.
+    fn record_advice_pop_stack_dword(&mut self, words: [Word; 2]);
+
+    // MISCELLANEOUS
+    // -----------------------------------------------
+
+    /// Signals that the processor clock is being incremented.
+    fn increment_clk(&mut self);
+
+    /// Signals that the stack depth is incremented as a result of pushing a new element.
+    fn increment_stack_size(&mut self, processor: &FastProcessor);
+
+    /// Signals that the stack depth is decremented as a result of popping an element off the stack.
+    ///
+    /// Note that if the stack depth is already [miden_core::stack::MIN_STACK_DEPTH], then the stack
+    /// depth is unchanged; the top element is popped off, and a ZERO is shifted in at the bottom.
+    fn decrement_stack_size(&mut self);
+
+    /// Signals the start of a new execution context, as a result of a CALL, SYSCALL or DYNCALL
+    /// operation being executed.
+    fn start_context(&mut self);
+
+    /// Signals the end of an execution context, as a result of an END operation associated with a
+    /// CALL, SYSCALL or DYNCALL.
+    fn restore_context(&mut self);
+}
+
+/// A [Tracer] that does nothing.
+pub struct NoopTracer;
+
+impl Tracer for NoopTracer {
+    #[inline(always)]
+    fn start_clock_cycle(
+        &mut self,
+        _processor: &FastProcessor,
+        _execution_state: NodeExecutionState,
+        _continuation_stack: &mut ContinuationStack,
+        _current_forest: &Arc<MastForest>,
+    ) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn record_external_node_resolution(&mut self, _node_id: MastNodeId, _forest: &Arc<MastForest>) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn record_hasher_permute(&mut self, _hashed_state: [Felt; 12]) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn record_hasher_build_merkle_root(&mut self, _path: &MerklePath, _root: Word) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn record_hasher_update_merkle_root(
+        &mut self,
+        _path: &MerklePath,
+        _old_root: Word,
+        _new_root: Word,
+    ) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn record_memory_read_element(&mut self, _element: Felt, _addr: Felt) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn record_memory_read_word(&mut self, _word: Word, _addr: Felt) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn record_advice_pop_stack(&mut self, _value: Felt) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn record_advice_pop_stack_word(&mut self, _word: Word) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn record_advice_pop_stack_dword(&mut self, _words: [Word; 2]) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn increment_clk(&mut self) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn increment_stack_size(&mut self, _processor: &FastProcessor) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn decrement_stack_size(&mut self) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn start_context(&mut self) {
+        // do nothing
+    }
+
+    #[inline(always)]
+    fn restore_context(&mut self) {
+        // do nothing
+    }
+}

--- a/processor/src/fast/u32_ops.rs
+++ b/processor/src/fast/u32_ops.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use miden_core::{Felt, ZERO};
 use paste::paste;
 
-use super::FastProcessor;
+use super::{FastProcessor, tracer::Tracer};
 use crate::{ErrorContext, ExecutionError, utils::split_element};
 
 const U32_MAX: u64 = u32::MAX as u64;
@@ -35,18 +35,22 @@ macro_rules! require_u32_operands {
 impl FastProcessor {
     /// Analogous to `Process::op_u32split`.
     #[inline(always)]
-    pub fn op_u32split(&mut self) {
+    pub fn op_u32split(&mut self, tracer: &mut impl Tracer) {
         let top = self.stack_get(0);
         let (hi, lo) = split_element(top);
 
-        self.increment_stack_size();
+        self.increment_stack_size(tracer);
         self.stack_write(0, hi);
         self.stack_write(1, lo);
     }
 
     /// Analogous to `Process::op_u32add`.
-    pub fn op_u32add(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
-        self.u32_pop2_applyfn_push_lowhigh(|a, b| a + b, err_ctx)
+    pub fn op_u32add(
+        &mut self,
+        err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
+    ) -> Result<(), ExecutionError> {
+        self.u32_pop2_applyfn_push_lowhigh(|a, b| a + b, err_ctx, tracer)
     }
 
     /// Analogous to `Process::op_u32add3`.
@@ -56,14 +60,18 @@ impl FastProcessor {
     ///
     /// The size of the stack is decremented by 1.
     #[inline(always)]
-    pub fn op_u32add3(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
+    pub fn op_u32add3(
+        &mut self,
+        err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
+    ) -> Result<(), ExecutionError> {
         let (c, b, a) = require_u32_operands!(self, [0, 1, 2], err_ctx);
 
         let result = Felt::new(a + b + c);
         let (sum_hi, sum_lo) = split_element(result);
 
         // write the high 32 bits to the new top of the stack, and low 32 bits after
-        self.decrement_stack_size();
+        self.decrement_stack_size(tracer);
         self.stack_write(0, sum_hi);
         self.stack_write(1, sum_lo);
         Ok(())
@@ -75,6 +83,7 @@ impl FastProcessor {
         &mut self,
         op_idx: usize,
         err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
         let op_idx = Felt::from(op_idx as u32);
         self.u32_pop2_applyfn_push_results(
@@ -87,12 +96,17 @@ impl FastProcessor {
                 Ok((first_new, second_new))
             },
             err_ctx,
+            tracer,
         )
     }
 
     /// Analogous to `Process::op_u32mul`.
-    pub fn op_u32mul(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
-        self.u32_pop2_applyfn_push_lowhigh(|a, b| a * b, err_ctx)
+    pub fn op_u32mul(
+        &mut self,
+        err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
+    ) -> Result<(), ExecutionError> {
+        self.u32_pop2_applyfn_push_lowhigh(|a, b| a * b, err_ctx, tracer)
     }
 
     /// Analogous to `Process::op_u32madd`.
@@ -101,14 +115,18 @@ impl FastProcessor {
     /// the result, splits the result into low and high 32-bit values, and pushes these values
     /// back onto the stack.
     #[inline(always)]
-    pub fn op_u32madd(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
+    pub fn op_u32madd(
+        &mut self,
+        err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
+    ) -> Result<(), ExecutionError> {
         let (b, a, c) = require_u32_operands!(self, [0, 1, 2], err_ctx);
 
         let result = Felt::new(a * b + c);
         let (result_hi, result_lo) = split_element(result);
 
         // write the high 32 bits to the new top of the stack, and low 32 bits after
-        self.decrement_stack_size();
+        self.decrement_stack_size(tracer);
         self.stack_write(0, result_hi);
         self.stack_write(1, result_lo);
         Ok(())
@@ -116,7 +134,11 @@ impl FastProcessor {
 
     /// Analogous to `Process::op_u32div`.
     #[inline(always)]
-    pub fn op_u32div(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
+    pub fn op_u32div(
+        &mut self,
+        err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
+    ) -> Result<(), ExecutionError> {
         let clk = self.clk;
         self.u32_pop2_applyfn_push_results(
             ZERO,
@@ -133,19 +155,28 @@ impl FastProcessor {
                 Ok((r, q))
             },
             err_ctx,
+            tracer,
         )
     }
 
     /// Analogous to `Process::op_u32and`.
     #[inline(always)]
-    pub fn op_u32and(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
-        self.u32_pop2_applyfn_push(|a, b| a & b, err_ctx)
+    pub fn op_u32and(
+        &mut self,
+        err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
+    ) -> Result<(), ExecutionError> {
+        self.u32_pop2_applyfn_push(|a, b| a & b, err_ctx, tracer)
     }
 
     /// Analogous to `Process::op_u32xor`.
     #[inline(always)]
-    pub fn op_u32xor(&mut self, err_ctx: &impl ErrorContext) -> Result<(), ExecutionError> {
-        self.u32_pop2_applyfn_push(|a, b| a ^ b, err_ctx)
+    pub fn op_u32xor(
+        &mut self,
+        err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
+    ) -> Result<(), ExecutionError> {
+        self.u32_pop2_applyfn_push(|a, b| a ^ b, err_ctx, tracer)
     }
 
     /// Analogous to `Process::op_u32assert2`.
@@ -154,8 +185,14 @@ impl FastProcessor {
         &mut self,
         err_code: Felt,
         err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
-        self.u32_pop2_applyfn_push_results(err_code, |first, second| Ok((first, second)), err_ctx)
+        self.u32_pop2_applyfn_push_results(
+            err_code,
+            |first, second| Ok((first, second)),
+            err_ctx,
+            tracer,
+        )
     }
 
     // HELPERS
@@ -167,11 +204,12 @@ impl FastProcessor {
         &mut self,
         f: impl FnOnce(u64, u64) -> u64,
         err_ctx: &impl ErrorContext,
+        tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
         let (b, a) = require_u32_operands!(self, [0, 1], err_ctx);
 
         let result = f(a, b);
-        self.decrement_stack_size();
+        self.decrement_stack_size(tracer);
         self.stack_write(0, Felt::new(result));
 
         Ok(())
@@ -192,6 +230,7 @@ impl FastProcessor {
         &mut self,
         f: impl FnOnce(u64, u64) -> u64,
         err_ctx: &impl ErrorContext,
+        _tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
         let (b, a) = require_u32_operands!(self, [0, 1], err_ctx);
 
@@ -213,6 +252,7 @@ impl FastProcessor {
         err_code: Felt,
         f: impl FnOnce(u64, u64) -> Result<(u64, u64), ExecutionError>,
         err_ctx: &impl ErrorContext,
+        _tracer: &mut impl Tracer,
     ) -> Result<(), ExecutionError> {
         let (first_old, second_old) = require_u32_operands!(self, [0, 1], err_code, err_ctx);
 


### PR DESCRIPTION
Closes #2089

Stacked on #2023

Introduces the `Tracer` trait, as discussed in #2089. This also cleaned up the `CoreTraceBuilder`, which was left over from #2023.

This is a fairly mechanical change; the general idea is that in the fast processor, we swapped all "if we have a core trace builder, record X" calls to a `tracer.record_x()` call. We then pass in `NoopTracer` (with an empty body for every method) when executing from `execute()`, and pass in `CoreTraceStateBuilder` when executing from `execute_from_trace()`. 

Note that we added a new method `FastProcessor::execute_with_tracer()`, but leaves the discussed `FastProcessor::step_continuation()` (needed for the debugger) for a subsequent PR.

Performance-wise, we recovered the benchmark performance prior to #2023 (i.e. the hypothesis that the compiler would compile away all calls to the `NoopTracer` is correct). 