### PR TITLE
chore: fix build and lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ insta = { version = "1.43", default-features = false, features = [
     "colors",
 ] }
 log = { version = "0.4", default-features = false }
-paste = { version = "1.0", default-feature = false }
+paste = { version = "1.0", default-features = false }
 proptest = { version = "1.7", default-features = false, features = [
     "no_std",
     "alloc",

--- a/prover/src/gpu/metal/tests.rs
+++ b/prover/src/gpu/metal/tests.rs
@@ -244,13 +244,13 @@ where
 {
     if use_rpx {
         ExecutionProver::new(
-            ProvingOptions::with_128_bit_security_rpx(),
+            ProvingOptions::with_128_bit_security(HashFunction::Rpx256),
             StackInputs::default(),
             StackOutputs::default(),
         )
     } else {
         ExecutionProver::new(
-            ProvingOptions::with_128_bit_security(true),
+            ProvingOptions::with_128_bit_security(HashFunction::Rpo256),
             StackInputs::default(),
             StackOutputs::default(),
         )


### PR DESCRIPTION
#2098 broke the build under the `metal` feature - not sure why `make clippy` in the CI didn't catch it?

Also fixes a typo from #2094.