### PR TITLE
Add ability to remove decorators from `MastForest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.17.1 (2025-08-29)
+
+- added `MastForest::strip_decorators()` ([#2108](https://github.com/0xMiden/miden-vm/pull/2108)).
+
 ## 0.17.0 (2025-08-06)
 
 #### Enhancements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "criterion",
  "miden-core",
@@ -1060,7 +1060,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "env_logger",
  "log",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "aho-corasick",
  "env_logger",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "logtest",
  "miden-air",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "elsa",
  "miden-air",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stdlib"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "blake3",
  "criterion",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1315,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "lock_api",
  "loom",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "assert_cmd",
  "blake3",

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-air"
-version = "0.17.0"
+version = "0.17.1"
 description = "Algebraic intermediate representation of Miden VM processor"
-documentation = "https://docs.rs/miden-air/0.17.0"
+documentation = "https://docs.rs/miden-air/0.17.1"
 readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["air", "arithmetization", "crypto", "miden"]

--- a/assembly-syntax/Cargo.toml
+++ b/assembly-syntax/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-assembly-syntax"
-version = "0.17.0"
+version = "0.17.1"
 description = "Parsing and semantic analysis of the Miden Assembly language"
-documentation = "https://docs.rs/miden-assembly-syntax/0.17.0"
+documentation = "https://docs.rs/miden-assembly-syntax/0.17.1"
 readme = "README.md"
 categories = ["compilers", "no-std"]
 keywords = ["assembly", "language", "syntax", "miden"]

--- a/assembly/Cargo.toml
+++ b/assembly/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-assembly"
-version = "0.17.0"
+version = "0.17.1"
 description = "Miden VM assembly language"
-documentation = "https://docs.rs/miden-assembly/0.17.0"
+documentation = "https://docs.rs/miden-assembly/0.17.1"
 readme = "README.md"
 categories = ["compilers", "no-std"]
 keywords = ["assembler", "assembly", "language", "miden"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-core"
-version = "0.17.0"
+version = "0.17.1"
 description = "Miden VM core components"
-documentation = "https://docs.rs/miden-core/0.17.0"
+documentation = "https://docs.rs/miden-core/0.17.1"
 readme = "README.md"
 categories = ["emulators", "no-std"]
 keywords = ["instruction-set", "miden", "program"]

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -212,6 +212,14 @@ impl MastForest {
         self[node_id].append_after_exit(decorator_ids)
     }
 
+    /// Removes all decorators from this MAST forest.
+    pub fn strip_decorators(&mut self) {
+        for node in self.nodes.iter_mut() {
+            node.remove_decorators();
+        }
+        self.decorators.truncate(0);
+    }
+
     /// Merges all `forests` into a new [`MastForest`].
     ///
     /// Merging two forests means combining all their constituent parts, i.e. [`MastNode`]s,

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -203,6 +203,7 @@ impl BasicBlockNode {
     }
 }
 
+//-------------------------------------------------------------------------------------------------
 /// Mutators
 impl BasicBlockNode {
     /// Sets the provided list of decorators to be executed before all existing decorators.
@@ -226,6 +227,11 @@ impl BasicBlockNode {
     /// with the given ['DecoratorList'].
     pub fn set_decorators(&mut self, decorator_list: DecoratorList) {
         self.decorators = decorator_list;
+    }
+
+    /// Removes all decorators from this node.
+    pub fn remove_decorators(&mut self) {
+        self.decorators.truncate(0);
     }
 }
 

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -168,6 +168,7 @@ impl CallNode {
     }
 }
 
+//-------------------------------------------------------------------------------------------------
 /// Mutators
 impl CallNode {
     pub fn remap_children(&self, remapping: &Remapping) -> Self {
@@ -184,6 +185,12 @@ impl CallNode {
     /// Sets the list of decorators to be executed after this node.
     pub fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
         self.after_exit.extend_from_slice(decorator_ids);
+    }
+
+    /// Removes all decorators from this node.
+    pub fn remove_decorators(&mut self) {
+        self.before_enter.truncate(0);
+        self.after_exit.truncate(0);
     }
 }
 

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -104,6 +104,7 @@ impl DynNode {
     }
 }
 
+//-------------------------------------------------------------------------------------------------
 /// Mutators
 impl DynNode {
     /// Sets the list of decorators to be executed before this node.
@@ -114,6 +115,12 @@ impl DynNode {
     /// Sets the list of decorators to be executed after this node.
     pub fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
         self.after_exit.extend_from_slice(decorator_ids);
+    }
+
+    /// Removes all decorators from this node.
+    pub fn remove_decorators(&mut self) {
+        self.before_enter.truncate(0);
+        self.after_exit.truncate(0);
     }
 }
 

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -56,6 +56,7 @@ impl ExternalNode {
     }
 }
 
+//-------------------------------------------------------------------------------------------------
 /// Mutators
 impl ExternalNode {
     /// Sets the list of decorators to be executed before this node.
@@ -66,6 +67,12 @@ impl ExternalNode {
     /// Sets the list of decorators to be executed after this node.
     pub fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
         self.after_exit.extend_from_slice(decorator_ids);
+    }
+
+    /// Removes all decorators from this node.
+    pub fn remove_decorators(&mut self) {
+        self.before_enter.truncate(0);
+        self.after_exit.truncate(0);
     }
 }
 

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -109,6 +109,7 @@ impl JoinNode {
     }
 }
 
+//-------------------------------------------------------------------------------------------------
 /// Mutators
 impl JoinNode {
     pub fn remap_children(&self, remapping: &Remapping) -> Self {
@@ -126,6 +127,12 @@ impl JoinNode {
     /// Sets the list of decorators to be executed after this node.
     pub fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
         self.after_exit.extend_from_slice(decorator_ids);
+    }
+
+    /// Removes all decorators from this node.
+    pub fn remove_decorators(&mut self) {
+        self.before_enter.truncate(0);
+        self.after_exit.truncate(0);
     }
 }
 

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -98,6 +98,7 @@ impl LoopNode {
     }
 }
 
+//-------------------------------------------------------------------------------------------------
 /// Mutators
 impl LoopNode {
     pub fn remap_children(&self, remapping: &Remapping) -> Self {
@@ -114,6 +115,12 @@ impl LoopNode {
     /// Sets the list of decorators to be executed after this node.
     pub fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
         self.after_exit.extend_from_slice(decorator_ids);
+    }
+
+    /// Removes all decorators from this node.
+    pub fn remove_decorators(&mut self) {
+        self.before_enter.truncate(0);
+        self.after_exit.truncate(0);
     }
 }
 

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -350,6 +350,7 @@ impl MastNode {
     }
 }
 
+//-------------------------------------------------------------------------------------------------
 /// Mutators
 impl MastNode {
     /// Sets the list of decorators to be executed before this node.
@@ -375,6 +376,18 @@ impl MastNode {
             MastNode::Call(node) => node.append_after_exit(decorator_ids),
             MastNode::Dyn(node) => node.append_after_exit(decorator_ids),
             MastNode::External(node) => node.append_after_exit(decorator_ids),
+        }
+    }
+
+    pub fn remove_decorators(&mut self) {
+        match self {
+            MastNode::Block(node) => node.remove_decorators(),
+            MastNode::Join(node) => node.remove_decorators(),
+            MastNode::Split(node) => node.remove_decorators(),
+            MastNode::Loop(node) => node.remove_decorators(),
+            MastNode::Call(node) => node.remove_decorators(),
+            MastNode::Dyn(node) => node.remove_decorators(),
+            MastNode::External(node) => node.remove_decorators(),
         }
     }
 }

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -111,6 +111,7 @@ impl SplitNode {
     }
 }
 
+//-------------------------------------------------------------------------------------------------
 /// Mutators
 impl SplitNode {
     pub fn remap_children(&self, remapping: &Remapping) -> Self {
@@ -128,6 +129,12 @@ impl SplitNode {
     /// Sets the list of decorators to be executed after this node.
     pub fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
         self.after_exit.extend_from_slice(decorator_ids);
+    }
+
+    /// Removes all decorators from this node.
+    pub fn remove_decorators(&mut self) {
+        self.before_enter.truncate(0);
+        self.after_exit.truncate(0);
     }
 }
 

--- a/crates/debug/types/Cargo.toml
+++ b/crates/debug/types/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-debug-types"
-version = "0.17.0"
+version = "0.17.1"
 description = "Core source-level debugging information types used throughout the Miden toolchain"
-documentation = "https://docs.rs/miden-debug-types/0.17.0"
+documentation = "https://docs.rs/miden-debug-types/0.17.1"
 readme = "README.md"
 categories = ["compilers", "no-std"]
 keywords = ["debugging", "debuginfo", "span"]

--- a/crates/utils/diagnostics/Cargo.toml
+++ b/crates/utils/diagnostics/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-utils-diagnostics"
-version = "0.17.0"
+version = "0.17.1"
 description = "Diagnostic infrastructure used in the Miden assembler and VM"
-documentation = "https://docs.rs/miden-utils-diagnostics/0.17.0"
+documentation = "https://docs.rs/miden-utils-diagnostics/0.17.1"
 readme = "README.md"
 categories = ["compilers", "no-std"]
 keywords = ["diagnostic", "error", "span"]

--- a/crates/utils/sync/Cargo.toml
+++ b/crates/utils/sync/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-utils-sync"
-version = "0.17.0"
+version = "0.17.1"
 description = "no-std compatible locking primitives for the Miden project"
-documentation = "https://docs.rs/miden-utils-sync/0.17.0"
+documentation = "https://docs.rs/miden-utils-sync/0.17.1"
 readme = "README.md"
 categories = ["no-std"]
 edition.workspace = true

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-vm"
-version = "0.17.0"
+version = "0.17.1"
 description = "Miden virtual machine"
-documentation = "https://docs.rs/miden-vm/0.17.0"
+documentation = "https://docs.rs/miden-vm/0.17.1"
 readme = "README.md"
 categories = ["cryptography", "emulators", "no-std"]
 keywords = ["miden", "stark", "virtual-machine", "zkp"]

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-mast-package"
-version = "0.17.0"
+version = "0.17.1"
 description = "Package containing a compiled Miden MAST artifact with declared dependencies and exports"
-documentation = "https://docs.rs/miden-mast-package/0.17.0"
+documentation = "https://docs.rs/miden-mast-package/0.17.1"
 readme = "README.md"
 categories = ["compilers", "no-std"]
 keywords = ["package", "language", "miden"]

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-processor"
-version = "0.17.0"
+version = "0.17.1"
 description = "Miden VM processor"
-documentation = "https://docs.rs/miden-processor/0.17.0"
+documentation = "https://docs.rs/miden-processor/0.17.1"
 readme = "README.md"
 categories = ["emulators", "no-std"]
 keywords = ["miden", "virtual-machine"]

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-prover"
-version = "0.17.0"
+version = "0.17.1"
 description = "Miden VM prover"
-documentation = "https://docs.rs/miden-prover/0.17.0"
+documentation = "https://docs.rs/miden-prover/0.17.1"
 readme = "README.md"
 categories = ["cryptography", "emulators", "no-std"]
 keywords = ["miden", "prover", "stark", "zkp"]

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-stdlib"
-version = "0.17.0"
+version = "0.17.1"
 description = "Miden VM standard library"
-documentation = "https://docs.rs/miden-stdlib/0.17.0"
+documentation = "https://docs.rs/miden-stdlib/0.17.1"
 readme = "README.md"
 categories = ["cryptography", "mathematics"]
 keywords = ["miden", "program", "stdlib"]

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "miden-verifier"
-version = "0.17.0"
+version = "0.17.1"
 description = "Miden VM execution verifier"
-documentation = "https://docs.rs/miden-verifier/0.17.0"
+documentation = "https://docs.rs/miden-verifier/0.17.1"
 readme = "README.md"
 categories = ["cryptography", "no-std"]
 keywords = ["miden", "stark", "verifier", "zkp"]


### PR DESCRIPTION
This PR implements `MastForest::strip_decorators()` function which removes all decorators from the underlying MAST forest. This is needed to help address https://github.com/0xMiden/miden-base/issues/1812. For this reason, the PR is against `main` and I'll make a patch release once this is merged (the changes are non-breaking).

This is not meant as a long-term solution and may change as a result of https://github.com/0xMiden/miden-vm/issues/1580.