### PR TITLE
docs: fix multiple broken links across the repository

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 
 ## Checklist before requesting a review
 - Repo forked and branch created from `next` according to naming convention.
-- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
+- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
 - Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 - Relevant issues are linked in the PR description.
 - Tests added for new functionality.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Miden Virtual Machine
 
-[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/miden-vm/blob/main/LICENSE)
+[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/0xMiden/miden-vm/blob/main/LICENSE-MIT)
 [![Test](https://github.com/0xMiden/miden-vm/actions/workflows/test.yml/badge.svg)](https://github.com/0xMiden/miden-vm/actions/workflows/test.yml)
 [![Build](https://github.com/0xMiden/miden-vm/actions/workflows/build.yml/badge.svg)](https://github.com/0xMiden/miden-vm/actions/workflows/build.yml)
 [![RUST_VERSION](https://img.shields.io/badge/rustc-1.88+-lightgray.svg)](https://www.rust-lang.org/tools/install)
@@ -17,7 +17,7 @@ A STARK-based virtual machine.
 Miden VM is a zero-knowledge virtual machine written in Rust. For any program executed on Miden VM, a STARK-based proof of execution is automatically generated. This proof can then be used by anyone to verify that the program was executed correctly without the need for re-executing the program or even knowing the contents of the program.
 
 - If you'd like to learn more about how Miden VM works, check out the [documentation](https://0xMiden.github.io/miden-vm/).
-- If you'd like to start using Miden VM, check out the [miden](miden) crate.
+- If you'd like to start using Miden VM, check out the [miden](https://crates.io/crates/miden) crate.
 - If you'd like to learn more about STARKs, check out the [references](#references) section.
 
 ### Status and features

--- a/core/README.md
+++ b/core/README.md
@@ -2,9 +2,9 @@
 This crate contains core components used by Miden VM. These components include:
 
 * Miden VM instruction set, defined in the [Operation](/../main/core/src/operations/mod.rs) struct.
-* Miden VM program kernel, defined in [Kernel](/../main/core/src/program/mod.rs) struct which contains a set of roots of kernel routines.
-* Miden VM program structure, defined in [Program](/../main/core/src/program/mod.rs) struct and described [here](https://0xMiden.github.io/miden-vm/design/programs.html).
-* Miden VM program metadata, defined in [ProgramInfo](/../main/core/src/program/info.rs) struct which contains a program's MAST root and the kernel used by the program.
+* Miden VM program kernel, defined in [Kernel](https://github.com/0xMiden/miden-vm/blob/main/core/src/kernel.rs) struct which contains a set of roots of kernel routines.
+* Miden VM program structure, defined in [Program](https://github.com/0xMiden/miden-vm/blob/main/core/src/program.rs) struct and described [here](https://0xMiden.github.io/miden-vm/design/programs.html).
+* Miden VM program metadata, defined in [ProgramInfo](https://github.com/0xMiden/miden-vm/blob/main/core/src/program.rs) struct which contains a program's MAST root and the kernel used by the program.
 * Input and output containers for Miden VM programs, defined in [StackInputs](/../main/core/src/stack/inputs.rs) and [StackOutputs](/../main/core/src/stack/outputs.rs) structs.
 * Constants describing the shape of the VM's execution trace.
 * Various minor utility functions used by other VM crates.

--- a/docs/src/design/stack/io_ops.md
+++ b/docs/src/design/stack/io_ops.md
@@ -2,7 +2,7 @@
 In this section we describe the AIR constraints for Miden VM input / output operations. These operations move values between the stack and other components of the VM such as program code (i.e., decoder), memory, and advice provider.
 
 ### PUSH
-The `PUSH` operation pushes the provided immediate value onto the stack non-deterministically (i.e., sets the value of $s_0$ register); it is the responsibility of the [Op Group Table](../decoder/main.md#op-group-table) to ensure that the correct value was pushed on the stack. The semantics of this operation are explained in the [decoder section](../decoder/main.html#handling-immediate-values).
+The `PUSH` operation pushes the provided immediate value onto the stack non-deterministically (i.e., sets the value of $s_0$ register); it is the responsibility of the [Op Group Table](../decoder/main.md#op-group-table) to ensure that the correct value was pushed on the stack. The semantics of this operation are explained in the [decoder section](../decoder/main.md#handling-immediate-values).
 
 The effect of this operation on the rest of the stack is:
 * **Right shift** starting from position $0$.


### PR DESCRIPTION
## Describe your changes
This PR fixes several broken links and incorrect paths across the repository.

Changes include:
- .github/pull_request_template.md
  - `./CONTRIBUTING.md` → `../CONTRIBUTING.md`
  - LICENSE badge: `.../LICENSE` → `.../LICENSE-MIT`
- README.md
  - MIT license badge points to `LICENSE-MIT`
  - `miden` crate link: `[miden](miden)` → `https://crates.io/crates/miden`
- core/README.md
  - Kernel link: `core/src/program/mod.rs` → `core/src/kernel.rs`
  - Program link: `core/src/program/mod.rs` → `core/src/program.rs`
  - ProgramInfo link: `core/src/program/info.rs` → `core/src/program.rs`
- docs/src/design/stack/io_ops.md
  - Decoder section links updated to the correct `decoder/main.md` anchors

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'