### PR TITLE
fix: incorrect doc for lookup_node_by_fingerprint

### DIFF
--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -339,7 +339,8 @@ impl MastForestMerger {
     // HELPERS
     // ================================================================================================
 
-    /// Returns a slice of nodes in the merged forest which have the given `mast_root`.
+    /// Returns the ID of the node in the merged forest that matches the given
+    /// fingerprint, if any.
     fn lookup_node_by_fingerprint(&self, fingerprint: &MastNodeFingerprint) -> Option<MastNodeId> {
         self.node_id_by_hash.get(fingerprint).copied()
     }


### PR DESCRIPTION
Correct the doc comment to describe returning Option<MastNodeId> for a given MastNodeFingerprint
The previous wording incorrectly mentioned returning a slice of nodes and referenced a non-existent mast_root parameter