### PR TITLE
fix: improve error handling in stack serialization

### DIFF
--- a/core/src/stack/inputs.rs
+++ b/core/src/stack/inputs.rs
@@ -105,9 +105,9 @@ impl Deserializable for StackInputs {
         let mut elements = source.read_many::<Felt>(num_elements.into())?;
         elements.reverse();
 
-        StackInputs::new(elements).map_err(|_| {
+        StackInputs::new(elements).map_err(|err| {
             DeserializationError::InvalidValue(format!(
-                "number of stack elements should not be greater than {MIN_STACK_DEPTH}, but {num_elements} was found",
+                "failed to create stack inputs: {err}",
             ))
         })
     }

--- a/core/src/stack/inputs.rs
+++ b/core/src/stack/inputs.rs
@@ -106,9 +106,7 @@ impl Deserializable for StackInputs {
         elements.reverse();
 
         StackInputs::new(elements).map_err(|err| {
-            DeserializationError::InvalidValue(format!(
-                "failed to create stack inputs: {err}",
-            ))
+            DeserializationError::InvalidValue(format!("failed to create stack inputs: {err}",))
         })
     }
 }

--- a/core/src/stack/outputs.rs
+++ b/core/src/stack/outputs.rs
@@ -138,9 +138,9 @@ impl Deserializable for StackOutputs {
 
         let elements = source.read_many::<Felt>(num_elements.into())?;
 
-        StackOutputs::new(elements).map_err(|_| {
+        StackOutputs::new(elements).map_err(|err| {
             DeserializationError::InvalidValue(format!(
-                "number of stack elements should not be greater than {MIN_STACK_DEPTH}, but {num_elements} was found",
+                "failed to create stack outputs: {err}",
             ))
         })
     }

--- a/core/src/stack/outputs.rs
+++ b/core/src/stack/outputs.rs
@@ -139,9 +139,7 @@ impl Deserializable for StackOutputs {
         let elements = source.read_many::<Felt>(num_elements.into())?;
 
         StackOutputs::new(elements).map_err(|err| {
-            DeserializationError::InvalidValue(format!(
-                "failed to create stack outputs: {err}",
-            ))
+            DeserializationError::InvalidValue(format!("failed to create stack outputs: {err}",))
         })
     }
 }


### PR DESCRIPTION
## Describe your changes

Improve error message specificity in StackInputs and StackOutputs deserialization.

Previously, the deserialization methods would always assume length exceeded errors when calling the new() constructor failed, ignoring other possible error types like DuplicateAdviceRoot or NotFieldElement for InputError, and InvalidStackElement or OutputSizeTooBig for OutputError.

This change preserves the original error information by forwarding the actual error message instead of creating a generic one, making debugging easier for users.

Changes:
- core/src/stack/inputs.rs: Use actual error in deserialization error message
- core/src/stack/outputs.rs: Use actual error in deserialization error message