### PR TITLE
refactor: behavior of MastNode instances as a trait, existing boilerplate macro-generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [BREAKING] Implement support for `event("event_name")` in MASM (#[2068](https://github.com/0xMiden/miden-vm/issues/2068)).
 - Improved representation of `OPbatches` to include padding Noop by default, simplifying fast iteration over program instructions in the processor ([#1815](https://github.com/0xMiden/miden-vm/issues/1815)).
 - Rename `program_execution` benchmark to `program_execution_for_trace`, and benchmark `FastProcessor::execute_for_trace()` instead of `Process::execute()` (#[2131](https://github.com/0xMiden/miden-vm/pull/2131))
+- Refactored `MastNode` to eliminate boilerplate dispatch code ([#2127](https://github.com/0xMiden/miden-vm/pull/2127)).
 
 ## 0.17.1 (2025-08-29)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1141,7 @@ dependencies = [
 name = "miden-core"
 version = "0.18.0"
 dependencies = [
+ "enum_dispatch",
  "insta",
  "miden-crypto",
  "miden-debug-types",

--- a/assembly-syntax/src/library/mod.rs
+++ b/assembly-syntax/src/library/mod.rs
@@ -2,7 +2,7 @@ use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 
 use miden_core::{
     AdviceMap, Kernel, Word,
-    mast::{MastForest, MastNodeId},
+    mast::{MastForest, MastNodeId, MastNodeTrait},
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 use midenc_hir_type::{FunctionType, Type};

--- a/assembly-syntax/src/library/mod.rs
+++ b/assembly-syntax/src/library/mod.rs
@@ -2,7 +2,7 @@ use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 
 use miden_core::{
     AdviceMap, Kernel, Word,
-    mast::{MastForest, MastNodeId, MastNodeTrait},
+    mast::{MastForest, MastNodeExt, MastNodeId},
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 use midenc_hir_type::{FunctionType, Type};

--- a/assembly/src/assembler.rs
+++ b/assembly/src/assembler.rs
@@ -13,7 +13,7 @@ use miden_assembly_syntax::{
 };
 use miden_core::{
     AssemblyOp, Decorator, Felt, Kernel, Operation, Program, WORD_SIZE, Word,
-    mast::{DecoratorId, MastNodeId, MastNodeTrait},
+    mast::{DecoratorId, MastNodeExt, MastNodeId},
 };
 
 use crate::{

--- a/assembly/src/assembler.rs
+++ b/assembly/src/assembler.rs
@@ -13,7 +13,7 @@ use miden_assembly_syntax::{
 };
 use miden_core::{
     AssemblyOp, Decorator, Felt, Kernel, Operation, Program, WORD_SIZE, Word,
-    mast::{DecoratorId, MastNodeId},
+    mast::{DecoratorId, MastNodeId, MastNodeTrait},
 };
 
 use crate::{

--- a/assembly/src/instruction/procedures.rs
+++ b/assembly/src/instruction/procedures.rs
@@ -3,7 +3,10 @@ use miden_assembly_syntax::{
     ast::{InvocationTarget, InvokeKind},
     diagnostics::Report,
 };
-use miden_core::{Operation, mast::MastNodeId};
+use miden_core::{
+    Operation,
+    mast::{MastNodeId, MastNodeTrait},
+};
 use smallvec::SmallVec;
 
 use crate::{

--- a/assembly/src/instruction/procedures.rs
+++ b/assembly/src/instruction/procedures.rs
@@ -5,7 +5,7 @@ use miden_assembly_syntax::{
 };
 use miden_core::{
     Operation,
-    mast::{MastNodeId, MastNodeTrait},
+    mast::{MastNodeExt, MastNodeId},
 };
 use smallvec::SmallVec;
 

--- a/assembly/src/mast_forest_builder.rs
+++ b/assembly/src/mast_forest_builder.rs
@@ -8,8 +8,8 @@ use core::ops::{Index, IndexMut};
 use miden_core::{
     AdviceMap, Decorator, DecoratorList, Felt, Operation, Word,
     mast::{
-        DecoratorFingerprint, DecoratorId, MastForest, MastNode, MastNodeFingerprint, MastNodeId,
-        MastNodeTrait, Remapping, SubtreeIterator,
+        DecoratorFingerprint, DecoratorId, MastForest, MastNode, MastNodeExt, MastNodeFingerprint,
+        MastNodeId, Remapping, SubtreeIterator,
     },
 };
 

--- a/assembly/src/mast_forest_builder.rs
+++ b/assembly/src/mast_forest_builder.rs
@@ -9,7 +9,7 @@ use miden_core::{
     AdviceMap, Decorator, DecoratorList, Felt, Operation, Word,
     mast::{
         DecoratorFingerprint, DecoratorId, MastForest, MastNode, MastNodeFingerprint, MastNodeId,
-        Remapping, SubtreeIterator,
+        MastNodeTrait, Remapping, SubtreeIterator,
     },
 };
 

--- a/assembly/src/mast_forest_merger_tests.rs
+++ b/assembly/src/mast_forest_merger_tests.rs
@@ -1,4 +1,4 @@
-use miden_core::mast::{MastForest, MastForestRootMap, MastNodeTrait};
+use miden_core::mast::{MastForest, MastForestRootMap, MastNodeExt};
 
 use crate::{
     Assembler,

--- a/assembly/src/mast_forest_merger_tests.rs
+++ b/assembly/src/mast_forest_merger_tests.rs
@@ -1,4 +1,4 @@
-use miden_core::mast::{MastForest, MastForestRootMap};
+use miden_core::mast::{MastForest, MastForestRootMap, MastNodeTrait};
 
 use crate::{
     Assembler,

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -8,7 +8,7 @@ use miden_assembly_syntax::{
 };
 use miden_core::{
     Operation, Program, Word, assert_matches,
-    mast::{MastNode, MastNodeId},
+    mast::{MastNode, MastNodeId, MastNodeTrait},
     utils::{Deserializable, Serializable, string_to_event_id},
 };
 use miden_mast_package::{MastArtifact, MastForest, Package, PackageExport, PackageManifest};

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -8,7 +8,7 @@ use miden_assembly_syntax::{
 };
 use miden_core::{
     Operation, Program, Word, assert_matches,
-    mast::{MastNode, MastNodeId, MastNodeTrait},
+    mast::{MastNode, MastNodeExt, MastNodeId},
     utils::{Deserializable, Serializable, string_to_event_id},
 };
 use miden_mast_package::{MastArtifact, MastForest, Package, PackageExport, PackageManifest};

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,7 +35,7 @@ miden-debug-types.workspace = true
 miden-formatting.workspace = true
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-enum_dispatch = "0.3.12"
+enum_dispatch = { version =  "0.3" }
 thiserror.workspace = true
 winter-math.workspace = true
 winter-utils.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,6 +35,7 @@ miden-debug-types.workspace = true
 miden-formatting.workspace = true
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
+enum_dispatch = "0.3.12"
 thiserror.workspace = true
 winter-math.workspace = true
 winter-utils.workspace = true

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -4,7 +4,7 @@ use miden_crypto::hash::blake::Blake3Digest;
 
 use crate::mast::{
     DecoratorId, MastForest, MastForestError, MastNode, MastNodeFingerprint, MastNodeId,
-    MultiMastForestIteratorItem, MultiMastForestNodeIter, node::MastNodeTrait,
+    MultiMastForestIteratorItem, MultiMastForestNodeIter, node::MastNodeExt,
 };
 
 #[cfg(test)]

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -4,7 +4,7 @@ use miden_crypto::hash::blake::Blake3Digest;
 
 use crate::mast::{
     DecoratorId, MastForest, MastForestError, MastNode, MastNodeFingerprint, MastNodeId,
-    MultiMastForestIteratorItem, MultiMastForestNodeIter,
+    MultiMastForestIteratorItem, MultiMastForestNodeIter, node::MastNodeTrait,
 };
 
 #[cfg(test)]

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -9,8 +9,9 @@ use core::{
 };
 mod node;
 pub use node::{
-    BasicBlockNode, CallNode, DynNode, ExternalNode, JoinNode, LoopNode, MastNode, MastNodeExt,
-    MastNodeTrait, OP_BATCH_SIZE, OP_GROUP_SIZE, OpBatch, OperationOrDecorator, SplitNode,
+    BasicBlockNode, CallNode, DynNode, ExternalNode, JoinNode, LoopNode, MastNode,
+    MastNodeErrorContext, MastNodeExt, OP_BATCH_SIZE, OP_GROUP_SIZE, OpBatch, OperationOrDecorator,
+    SplitNode,
 };
 
 use crate::{

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -10,7 +10,7 @@ use core::{
 mod node;
 pub use node::{
     BasicBlockNode, CallNode, DynNode, ExternalNode, JoinNode, LoopNode, MastNode, MastNodeExt,
-    OP_BATCH_SIZE, OP_GROUP_SIZE, OpBatch, OperationOrDecorator, SplitNode,
+    MastNodeTrait, OP_BATCH_SIZE, OP_GROUP_SIZE, OpBatch, OperationOrDecorator, SplitNode,
 };
 
 use crate::{

--- a/core/src/mast/multi_forest_node_iterator.rs
+++ b/core/src/mast/multi_forest_node_iterator.rs
@@ -5,7 +5,7 @@ use alloc::{
 
 use crate::{
     Word,
-    mast::{MastForest, MastForestError, MastNode, MastNodeId},
+    mast::{MastForest, MastForestError, MastNode, MastNodeId, node::MastNodeTrait},
 };
 
 type ForestIndex = usize;

--- a/core/src/mast/multi_forest_node_iterator.rs
+++ b/core/src/mast/multi_forest_node_iterator.rs
@@ -5,7 +5,7 @@ use alloc::{
 
 use crate::{
     Word,
-    mast::{MastForest, MastForestError, MastNode, MastNodeId, node::MastNodeTrait},
+    mast::{MastForest, MastForestError, MastNode, MastNodeId, node::MastNodeExt},
 };
 
 type ForestIndex = usize;

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -14,7 +14,7 @@ mod op_batch;
 pub use op_batch::OpBatch;
 use op_batch::OpBatchAccumulator;
 
-use super::{MastNodeExt, MastNodeTrait};
+use super::{MastNodeErrorContext, MastNodeExt};
 
 #[cfg(test)]
 mod tests;
@@ -264,7 +264,7 @@ impl BasicBlockNode {
     }
 }
 
-impl MastNodeExt for BasicBlockNode {
+impl MastNodeErrorContext for BasicBlockNode {
     fn decorators(&self) -> impl Iterator<Item = (usize, DecoratorId)> {
         self.decorators.iter().copied()
     }
@@ -289,7 +289,7 @@ impl BasicBlockNode {
 // MAST NODE TRAIT IMPLEMENTATION
 // ================================================================================================
 
-impl MastNodeTrait for BasicBlockNode {
+impl MastNodeExt for BasicBlockNode {
     /// Returns a commitment to this basic block.
     fn digest(&self) -> Word {
         self.digest

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -7,7 +7,7 @@ use miden_formatting::prettier::PrettyPrint;
 use crate::{
     DecoratorIterator, DecoratorList, Operation,
     chiplets::hasher,
-    mast::{DecoratorId, MastForest, MastForestError},
+    mast::{DecoratorId, MastForest, MastForestError, MastNodeId, Remapping},
 };
 
 mod op_batch;
@@ -153,11 +153,6 @@ impl BasicBlockNode {
 // ------------------------------------------------------------------------------------------------
 /// Public accessors
 impl BasicBlockNode {
-    /// Returns a commitment to this basic block.
-    pub fn digest(&self) -> Word {
-        self.digest
-    }
-
     /// Returns a reference to the operation batches in this basic block.
     pub fn op_batches(&self) -> &[OpBatch] {
         &self.op_batches
@@ -295,8 +290,9 @@ impl BasicBlockNode {
 // ================================================================================================
 
 impl MastNodeTrait for BasicBlockNode {
+    /// Returns a commitment to this basic block.
     fn digest(&self) -> Word {
-        self.digest()
+        self.digest
     }
 
     fn before_enter(&self) -> &[DecoratorId] {
@@ -325,6 +321,22 @@ impl MastNodeTrait for BasicBlockNode {
 
     fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn PrettyPrint + 'a> {
         Box::new(BasicBlockNode::to_pretty_print(self, mast_forest))
+    }
+
+    fn remap_children(&self, _remapping: &Remapping) -> Self {
+        self.clone()
+    }
+
+    fn has_children(&self) -> bool {
+        false
+    }
+
+    fn append_children_to(&self, _target: &mut Vec<MastNodeId>) {
+        // No children for basic blocks
+    }
+
+    fn domain(&self) -> Felt {
+        Self::DOMAIN
     }
 }
 

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::{fmt, mem, ops::Index};
 
 use miden_crypto::{Felt, Word, ZERO};
@@ -14,7 +14,7 @@ mod op_batch;
 pub use op_batch::OpBatch;
 use op_batch::OpBatchAccumulator;
 
-use super::MastNodeExt;
+use super::{MastNodeExt, MastNodeTrait};
 
 #[cfg(test)]
 mod tests;
@@ -288,6 +288,43 @@ impl BasicBlockNode {
         mast_forest: &'a MastForest,
     ) -> impl PrettyPrint + 'a {
         BasicBlockNodePrettyPrint { block_node: self, mast_forest }
+    }
+}
+
+// MAST NODE TRAIT IMPLEMENTATION
+// ================================================================================================
+
+impl MastNodeTrait for BasicBlockNode {
+    fn digest(&self) -> Word {
+        self.digest()
+    }
+
+    fn before_enter(&self) -> &[DecoratorId] {
+        &[]
+    }
+
+    fn after_exit(&self) -> &[DecoratorId] {
+        &[]
+    }
+
+    fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
+        self.prepend_decorators(decorator_ids);
+    }
+
+    fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_decorators(decorator_ids);
+    }
+
+    fn remove_decorators(&mut self) {
+        self.remove_decorators();
+    }
+
+    fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {
+        Box::new(BasicBlockNode::to_display(self, mast_forest))
+    }
+
+    fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn PrettyPrint + 'a> {
+        Box::new(BasicBlockNode::to_pretty_print(self, mast_forest))
     }
 }
 

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -7,7 +7,7 @@ use miden_formatting::{
     prettier::{Document, PrettyPrint, const_text, nl, text},
 };
 
-use super::{MastNodeExt, MastNodeTrait};
+use super::{MastNodeErrorContext, MastNodeExt};
 use crate::{
     OPCODE_CALL, OPCODE_SYSCALL,
     chiplets::hasher,
@@ -194,7 +194,7 @@ impl CallNode {
     }
 }
 
-impl MastNodeExt for CallNode {
+impl MastNodeErrorContext for CallNode {
     fn decorators(&self) -> impl Iterator<Item = (usize, DecoratorId)> {
         self.before_enter.iter().chain(&self.after_exit).copied().enumerate()
     }
@@ -295,7 +295,7 @@ impl fmt::Display for CallNodePrettyPrint<'_> {
 // MAST NODE TRAIT IMPLEMENTATION
 // ================================================================================================
 
-impl MastNodeTrait for CallNode {
+impl MastNodeExt for CallNode {
     /// Returns a commitment to this Call node.
     ///
     /// The commitment is computed as a hash of the callee and an empty word ([ZERO; 4]) in the

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 use miden_crypto::{Felt, Word};
@@ -7,7 +7,7 @@ use miden_formatting::{
     prettier::{Document, PrettyPrint, const_text, nl, text},
 };
 
-use super::MastNodeExt;
+use super::{MastNodeExt, MastNodeTrait};
 use crate::{
     OPCODE_CALL, OPCODE_SYSCALL,
     chiplets::hasher,
@@ -289,5 +289,42 @@ impl fmt::Display for CallNodePrettyPrint<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use crate::prettier::PrettyPrint;
         self.pretty_print(f)
+    }
+}
+
+// MAST NODE TRAIT IMPLEMENTATION
+// ================================================================================================
+
+impl MastNodeTrait for CallNode {
+    fn digest(&self) -> Word {
+        self.digest()
+    }
+
+    fn before_enter(&self) -> &[DecoratorId] {
+        self.before_enter()
+    }
+
+    fn after_exit(&self) -> &[DecoratorId] {
+        self.after_exit()
+    }
+
+    fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_before_enter(decorator_ids);
+    }
+
+    fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_after_exit(decorator_ids);
+    }
+
+    fn remove_decorators(&mut self) {
+        self.remove_decorators();
+    }
+
+    fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {
+        Box::new(CallNode::to_display(self, mast_forest))
+    }
+
+    fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn PrettyPrint + 'a> {
+        Box::new(CallNode::to_pretty_print(self, mast_forest))
     }
 }

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use miden_crypto::{Felt, Word};
 use miden_formatting::prettier::{Document, PrettyPrint, const_text, nl};
 
-use super::{MastNodeExt, MastNodeTrait};
+use super::{MastNodeErrorContext, MastNodeExt};
 use crate::{
     OPCODE_DYN, OPCODE_DYNCALL,
     mast::{DecoratorId, MastForest, MastNodeId, Remapping},
@@ -85,7 +85,7 @@ impl DynNode {
     }
 }
 
-impl MastNodeExt for DynNode {
+impl MastNodeErrorContext for DynNode {
     fn decorators(&self) -> impl Iterator<Item = (usize, DecoratorId)> {
         self.before_enter.iter().chain(&self.after_exit).copied().enumerate()
     }
@@ -178,7 +178,7 @@ impl fmt::Display for DynNodePrettyPrint<'_> {
 // MAST NODE TRAIT IMPLEMENTATION
 // ================================================================================================
 
-impl MastNodeTrait for DynNode {
+impl MastNodeExt for DynNode {
     /// Returns a commitment to a Dyn node.
     ///
     /// The commitment is computed by hashing two empty words ([ZERO; 4]) in the domain defined

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -1,10 +1,10 @@
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 use miden_crypto::{Felt, Word};
 use miden_formatting::prettier::{Document, PrettyPrint, const_text, nl};
 
-use super::MastNodeExt;
+use super::{MastNodeExt, MastNodeTrait};
 use crate::{
     OPCODE_DYN, OPCODE_DYNCALL,
     mast::{DecoratorId, MastForest},
@@ -214,8 +214,42 @@ impl fmt::Display for DynNodePrettyPrint<'_> {
     }
 }
 
-// TESTS
+// MAST NODE TRAIT IMPLEMENTATION
 // ================================================================================================
+
+impl MastNodeTrait for DynNode {
+    fn digest(&self) -> Word {
+        self.digest()
+    }
+
+    fn before_enter(&self) -> &[DecoratorId] {
+        self.before_enter()
+    }
+
+    fn after_exit(&self) -> &[DecoratorId] {
+        self.after_exit()
+    }
+
+    fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_before_enter(decorator_ids);
+    }
+
+    fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_after_exit(decorator_ids);
+    }
+
+    fn remove_decorators(&mut self) {
+        self.remove_decorators();
+    }
+
+    fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {
+        Box::new(DynNode::to_display(self, mast_forest))
+    }
+
+    fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn PrettyPrint + 'a> {
+        Box::new(DynNode::to_pretty_print(self, mast_forest))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 use miden_crypto::Word;
@@ -7,7 +7,7 @@ use miden_formatting::{
     prettier::{Document, PrettyPrint, const_text, nl, text},
 };
 
-use super::MastNodeExt;
+use super::{MastNodeExt, MastNodeTrait};
 use crate::mast::{DecoratorId, MastForest};
 
 // EXTERNAL NODE
@@ -162,5 +162,42 @@ impl fmt::Display for ExternalNodePrettyPrint<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use crate::prettier::PrettyPrint;
         self.pretty_print(f)
+    }
+}
+
+// MAST NODE TRAIT IMPLEMENTATION
+// ================================================================================================
+
+impl MastNodeTrait for ExternalNode {
+    fn digest(&self) -> Word {
+        self.digest()
+    }
+
+    fn before_enter(&self) -> &[DecoratorId] {
+        self.before_enter()
+    }
+
+    fn after_exit(&self) -> &[DecoratorId] {
+        self.after_exit()
+    }
+
+    fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_before_enter(decorator_ids);
+    }
+
+    fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_after_exit(decorator_ids);
+    }
+
+    fn remove_decorators(&mut self) {
+        self.remove_decorators();
+    }
+
+    fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {
+        Box::new(ExternalNode::to_display(self, mast_forest))
+    }
+
+    fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn PrettyPrint + 'a> {
+        Box::new(ExternalNode::to_pretty_print(self, mast_forest))
     }
 }

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -7,7 +7,7 @@ use miden_formatting::{
     prettier::{Document, PrettyPrint, const_text, nl, text},
 };
 
-use super::{MastNodeExt, MastNodeTrait};
+use super::{MastNodeErrorContext, MastNodeExt};
 use crate::mast::{DecoratorId, MastForest, MastNodeId, Remapping};
 
 // EXTERNAL NODE
@@ -59,7 +59,7 @@ impl ExternalNode {
     }
 }
 
-impl MastNodeExt for ExternalNode {
+impl MastNodeErrorContext for ExternalNode {
     fn decorators(&self) -> impl Iterator<Item = (usize, DecoratorId)> {
         self.before_enter.iter().chain(&self.after_exit).copied().enumerate()
     }
@@ -151,7 +151,7 @@ impl fmt::Display for ExternalNodePrettyPrint<'_> {
 // MAST NODE TRAIT IMPLEMENTATION
 // ================================================================================================
 
-impl MastNodeTrait for ExternalNode {
+impl MastNodeExt for ExternalNode {
     /// Returns the commitment to the MAST node referenced by this external node.
     ///
     /// The hash of an external node is the hash of the procedure it represents, such that an

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -227,16 +227,29 @@ impl fmt::Display for JoinNodePrettyPrint<'_> {
 // ================================================================================================
 
 impl MastNodeTrait for JoinNode {
+    /// Returns a commitment to this Join node.
+    ///
+    /// The commitment is computed as a hash of the `first` and `second` child node in the domain
+    /// defined by [Self::DOMAIN] - i.e.,:
+    /// ```
+    /// # use miden_core::mast::JoinNode;
+    /// # use miden_crypto::{Word, hash::rpo::Rpo256 as Hasher};
+    /// # let first_child_digest = Word::default();
+    /// # let second_child_digest = Word::default();
+    /// Hasher::merge_in_domain(&[first_child_digest, second_child_digest], JoinNode::DOMAIN);
+    /// ```
     fn digest(&self) -> Word {
-        self.digest()
+        self.digest
     }
 
+    /// Returns the decorators to be executed before this node is executed.
     fn before_enter(&self) -> &[DecoratorId] {
-        self.before_enter()
+        &self.before_enter
     }
 
+    /// Returns the decorators to be executed after this node is executed.
     fn after_exit(&self) -> &[DecoratorId] {
-        self.after_exit()
+        &self.after_exit
     }
 
     fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
@@ -257,5 +270,25 @@ impl MastNodeTrait for JoinNode {
 
     fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn PrettyPrint + 'a> {
         Box::new(JoinNode::to_pretty_print(self, mast_forest))
+    }
+
+    fn remap_children(&self, remapping: &Remapping) -> Self {
+        let mut node = self.clone();
+        node.children[0] = node.children[0].remap(remapping);
+        node.children[1] = node.children[1].remap(remapping);
+        node
+    }
+
+    fn has_children(&self) -> bool {
+        true
+    }
+
+    fn append_children_to(&self, target: &mut Vec<MastNodeId>) {
+        target.push(self.first());
+        target.push(self.second());
+    }
+
+    fn domain(&self) -> Felt {
+        Self::DOMAIN
     }
 }

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -3,7 +3,7 @@ use core::fmt;
 
 use miden_crypto::{Felt, Word};
 
-use super::{MastNodeExt, MastNodeTrait};
+use super::{MastNodeErrorContext, MastNodeExt};
 use crate::{
     OPCODE_JOIN,
     chiplets::hasher,
@@ -136,7 +136,7 @@ impl JoinNode {
     }
 }
 
-impl MastNodeExt for JoinNode {
+impl MastNodeErrorContext for JoinNode {
     fn decorators(&self) -> impl Iterator<Item = (usize, DecoratorId)> {
         self.before_enter.iter().chain(&self.after_exit).copied().enumerate()
     }
@@ -226,7 +226,7 @@ impl fmt::Display for JoinNodePrettyPrint<'_> {
 // MAST NODE TRAIT IMPLEMENTATION
 // ================================================================================================
 
-impl MastNodeTrait for JoinNode {
+impl MastNodeExt for JoinNode {
     /// Returns a commitment to this Join node.
     ///
     /// The commitment is computed as a hash of the `first` and `second` child node in the domain

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -1,9 +1,9 @@
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 use miden_crypto::{Felt, Word};
 
-use super::MastNodeExt;
+use super::{MastNodeExt, MastNodeTrait};
 use crate::{
     OPCODE_JOIN,
     chiplets::hasher,
@@ -220,5 +220,42 @@ impl fmt::Display for JoinNodePrettyPrint<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use crate::prettier::PrettyPrint;
         self.pretty_print(f)
+    }
+}
+
+// MAST NODE TRAIT IMPLEMENTATION
+// ================================================================================================
+
+impl MastNodeTrait for JoinNode {
+    fn digest(&self) -> Word {
+        self.digest()
+    }
+
+    fn before_enter(&self) -> &[DecoratorId] {
+        self.before_enter()
+    }
+
+    fn after_exit(&self) -> &[DecoratorId] {
+        self.after_exit()
+    }
+
+    fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_before_enter(decorator_ids);
+    }
+
+    fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_after_exit(decorator_ids);
+    }
+
+    fn remove_decorators(&mut self) {
+        self.remove_decorators();
+    }
+
+    fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {
+        Box::new(JoinNode::to_display(self, mast_forest))
+    }
+
+    fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn PrettyPrint + 'a> {
+        Box::new(JoinNode::to_pretty_print(self, mast_forest))
     }
 }

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -237,4 +237,22 @@ impl MastNodeTrait for LoopNode {
     fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn PrettyPrint + 'a> {
         Box::new(LoopNode::to_pretty_print(self, mast_forest))
     }
+
+    fn remap_children(&self, remapping: &Remapping) -> Self {
+        let mut node = self.clone();
+        node.body = node.body.remap(remapping);
+        node
+    }
+
+    fn has_children(&self) -> bool {
+        true
+    }
+
+    fn append_children_to(&self, target: &mut Vec<MastNodeId>) {
+        target.push(self.body());
+    }
+
+    fn domain(&self) -> Felt {
+        Self::DOMAIN
+    }
 }

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use miden_crypto::{Felt, Word};
 use miden_formatting::prettier::PrettyPrint;
 
-use super::{MastNodeExt, MastNodeTrait};
+use super::{MastNodeErrorContext, MastNodeExt};
 use crate::{
     OPCODE_LOOP,
     chiplets::hasher,
@@ -124,7 +124,7 @@ impl LoopNode {
     }
 }
 
-impl MastNodeExt for LoopNode {
+impl MastNodeErrorContext for LoopNode {
     fn decorators(&self) -> impl Iterator<Item = (usize, DecoratorId)> {
         self.before_enter.iter().chain(&self.after_exit).copied().enumerate()
     }
@@ -205,7 +205,7 @@ impl fmt::Display for LoopNodePrettyPrint<'_> {
 // MAST NODE TRAIT IMPLEMENTATION
 // ================================================================================================
 
-impl MastNodeTrait for LoopNode {
+impl MastNodeExt for LoopNode {
     fn digest(&self) -> Word {
         self.digest()
     }

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -1,10 +1,10 @@
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 use miden_crypto::{Felt, Word};
 use miden_formatting::prettier::PrettyPrint;
 
-use super::MastNodeExt;
+use super::{MastNodeExt, MastNodeTrait};
 use crate::{
     OPCODE_LOOP,
     chiplets::hasher,
@@ -199,5 +199,42 @@ impl fmt::Display for LoopNodePrettyPrint<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use crate::prettier::PrettyPrint;
         self.pretty_print(f)
+    }
+}
+
+// MAST NODE TRAIT IMPLEMENTATION
+// ================================================================================================
+
+impl MastNodeTrait for LoopNode {
+    fn digest(&self) -> Word {
+        self.digest()
+    }
+
+    fn before_enter(&self) -> &[DecoratorId] {
+        self.before_enter()
+    }
+
+    fn after_exit(&self) -> &[DecoratorId] {
+        self.after_exit()
+    }
+
+    fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_before_enter(decorator_ids);
+    }
+
+    fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_after_exit(decorator_ids);
+    }
+
+    fn remove_decorators(&mut self) {
+        self.remove_decorators();
+    }
+
+    fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {
+        Box::new(LoopNode::to_display(self, mast_forest))
+    }
+
+    fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn PrettyPrint + 'a> {
+        Box::new(LoopNode::to_pretty_print(self, mast_forest))
     }
 }

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 
 #[enum_dispatch]
-pub trait MastNodeTrait {
+pub trait MastNodeExt {
     /// Returns a commitment/hash of the node.
     fn digest(&self) -> Word;
 
@@ -76,7 +76,7 @@ pub trait MastNodeTrait {
 // MAST NODE
 // ================================================================================================
 
-#[enum_dispatch(MastNodeTrait)]
+#[enum_dispatch(MastNodeExt)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MastNode {
     Block(BasicBlockNode),
@@ -268,7 +268,7 @@ impl MastNode {
 // ===============================================================================================
 
 /// A trait for extending the functionality of all [`MastNode`]s.
-pub trait MastNodeExt: Send + Sync {
+pub trait MastNodeErrorContext: Send + Sync {
     // REQUIRED METHODS
     // -------------------------------------------------------------------------------------------
 

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use miden_crypto::{Felt, Word};
 use miden_formatting::prettier::PrettyPrint;
 
-use super::{MastNodeExt, MastNodeTrait};
+use super::{MastNodeErrorContext, MastNodeExt};
 use crate::{
     OPCODE_SPLIT,
     chiplets::hasher,
@@ -138,7 +138,7 @@ impl SplitNode {
     }
 }
 
-impl MastNodeExt for SplitNode {
+impl MastNodeErrorContext for SplitNode {
     fn decorators(&self) -> impl Iterator<Item = (usize, DecoratorId)> {
         self.before_enter.iter().chain(&self.after_exit).copied().enumerate()
     }
@@ -221,7 +221,7 @@ impl fmt::Display for SplitNodePrettyPrint<'_> {
 // MAST NODE TRAIT IMPLEMENTATION
 // ================================================================================================
 
-impl MastNodeTrait for SplitNode {
+impl MastNodeExt for SplitNode {
     fn digest(&self) -> Word {
         self.digest()
     }

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -253,4 +253,24 @@ impl MastNodeTrait for SplitNode {
     fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn PrettyPrint + 'a> {
         Box::new(SplitNode::to_pretty_print(self, mast_forest))
     }
+
+    fn remap_children(&self, remapping: &Remapping) -> Self {
+        let mut node = self.clone();
+        node.branches[0] = node.branches[0].remap(remapping);
+        node.branches[1] = node.branches[1].remap(remapping);
+        node
+    }
+
+    fn has_children(&self) -> bool {
+        true
+    }
+
+    fn append_children_to(&self, target: &mut Vec<MastNodeId>) {
+        target.push(self.on_true());
+        target.push(self.on_false());
+    }
+
+    fn domain(&self) -> Felt {
+        Self::DOMAIN
+    }
 }

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -1,10 +1,10 @@
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 
 use miden_crypto::{Felt, Word};
 use miden_formatting::prettier::PrettyPrint;
 
-use super::MastNodeExt;
+use super::{MastNodeExt, MastNodeTrait};
 use crate::{
     OPCODE_SPLIT,
     chiplets::hasher,
@@ -215,5 +215,42 @@ impl fmt::Display for SplitNodePrettyPrint<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use crate::prettier::PrettyPrint;
         self.pretty_print(f)
+    }
+}
+
+// MAST NODE TRAIT IMPLEMENTATION
+// ================================================================================================
+
+impl MastNodeTrait for SplitNode {
+    fn digest(&self) -> Word {
+        self.digest()
+    }
+
+    fn before_enter(&self) -> &[DecoratorId] {
+        self.before_enter()
+    }
+
+    fn after_exit(&self) -> &[DecoratorId] {
+        self.after_exit()
+    }
+
+    fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_before_enter(decorator_ids);
+    }
+
+    fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
+        self.append_after_exit(decorator_ids);
+    }
+
+    fn remove_decorators(&mut self) {
+        self.remove_decorators();
+    }
+
+    fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {
+        Box::new(SplitNode::to_display(self, mast_forest))
+    }
+
+    fn to_pretty_print<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn PrettyPrint + 'a> {
+        Box::new(SplitNode::to_pretty_print(self, mast_forest))
     }
 }

--- a/core/src/mast/node_fingerprint.rs
+++ b/core/src/mast/node_fingerprint.rs
@@ -7,7 +7,7 @@ use miden_crypto::hash::{
 
 use crate::{
     Operation, Word,
-    mast::{DecoratorId, MastForest, MastForestError, MastNode, MastNodeId},
+    mast::{DecoratorId, MastForest, MastForestError, MastNode, MastNodeId, node::MastNodeTrait},
 };
 
 // MAST NODE EQUALITY

--- a/core/src/mast/node_fingerprint.rs
+++ b/core/src/mast/node_fingerprint.rs
@@ -7,7 +7,7 @@ use miden_crypto::hash::{
 
 use crate::{
     Operation, Word,
-    mast::{DecoratorId, MastForest, MastForestError, MastNode, MastNodeId, node::MastNodeTrait},
+    mast::{DecoratorId, MastForest, MastForestError, MastNode, MastNodeId, node::MastNodeExt},
 };
 
 // MAST NODE EQUALITY

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -2,7 +2,10 @@ use alloc::vec::Vec;
 
 use super::{NodeDataOffset, basic_blocks::BasicBlockDataDecoder};
 use crate::{
-    mast::{BasicBlockNode, CallNode, JoinNode, LoopNode, MastNode, MastNodeId, SplitNode, Word},
+    mast::{
+        BasicBlockNode, CallNode, JoinNode, LoopNode, MastNode, MastNodeId, SplitNode, Word,
+        node::MastNodeTrait,
+    },
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -4,7 +4,7 @@ use super::{NodeDataOffset, basic_blocks::BasicBlockDataDecoder};
 use crate::{
     mast::{
         BasicBlockNode, CallNode, JoinNode, LoopNode, MastNode, MastNodeId, SplitNode, Word,
-        node::MastNodeTrait,
+        node::MastNodeExt,
     },
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -51,7 +51,7 @@ use string_table::StringTable;
 use super::{DecoratorId, MastForest, MastNode, MastNodeId};
 use crate::{
     AdviceMap,
-    mast::node::MastNodeTrait,
+    mast::node::MastNodeExt,
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -51,6 +51,7 @@ use string_table::StringTable;
 use super::{DecoratorId, MastForest, MastNode, MastNodeId};
 use crate::{
     AdviceMap,
+    mast::node::MastNodeTrait,
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 

--- a/core/src/mast/tests.rs
+++ b/core/src/mast/tests.rs
@@ -8,7 +8,7 @@ use winter_rand_utils::prng_array;
 use crate::{
     Felt, Kernel, ProgramInfo, Word,
     chiplets::hasher,
-    mast::DynNode,
+    mast::{DynNode, MastNodeTrait},
     utils::{Deserializable, Serializable},
 };
 

--- a/core/src/mast/tests.rs
+++ b/core/src/mast/tests.rs
@@ -8,7 +8,7 @@ use winter_rand_utils::prng_array;
 use crate::{
     Felt, Kernel, ProgramInfo, Word,
     chiplets::hasher,
-    mast::{DynNode, MastNodeTrait},
+    mast::{DynNode, MastNodeExt},
     utils::{Deserializable, Serializable},
 };
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -8,7 +8,7 @@ use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError,
 use super::Kernel;
 use crate::{
     AdviceMap,
-    mast::{MastForest, MastNode, MastNodeId, MastNodeTrait},
+    mast::{MastForest, MastNode, MastNodeExt, MastNodeId},
     utils::ToElements,
 };
 

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -8,7 +8,7 @@ use winter_utils::{ByteReader, ByteWriter, Deserializable, DeserializationError,
 use super::Kernel;
 use crate::{
     AdviceMap,
-    mast::{MastForest, MastNode, MastNodeId},
+    mast::{MastForest, MastNode, MastNodeId, MastNodeTrait},
     utils::ToElements,
 };
 

--- a/miden-vm/tests/integration/operations/io_ops/env_ops.rs
+++ b/miden-vm/tests/integration/operations/io_ops/env_ops.rs
@@ -1,6 +1,6 @@
 use miden_core::{
     Operation,
-    mast::{MastForest, MastNode, MastNodeTrait},
+    mast::{MastForest, MastNode, MastNodeExt},
 };
 use miden_debug_types::{SourceLanguage, SourceManager};
 use miden_processor::FMP_MIN;

--- a/miden-vm/tests/integration/operations/io_ops/env_ops.rs
+++ b/miden-vm/tests/integration/operations/io_ops/env_ops.rs
@@ -1,6 +1,6 @@
 use miden_core::{
     Operation,
-    mast::{MastForest, MastNode},
+    mast::{MastForest, MastNode, MastNodeTrait},
 };
 use miden_debug_types::{SourceLanguage, SourceManager};
 use miden_processor::FMP_MIN;

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -7,7 +7,7 @@ use miden_core::{
     ONE, Operation, ZERO,
     chiplets::hasher,
     crypto::merkle::{MerkleTree, NodeIndex},
-    mast::{MastForest, MastNode},
+    mast::{MastForest, MastNode, MastNodeTrait},
 };
 use miden_utils_testing::rand::rand_array;
 

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -7,7 +7,7 @@ use miden_core::{
     ONE, Operation, ZERO,
     chiplets::hasher,
     crypto::merkle::{MerkleTree, NodeIndex},
-    mast::{MastForest, MastNode, MastNodeTrait},
+    mast::{MastForest, MastNode, MastNodeExt},
 };
 use miden_utils_testing::rand::rand_array;
 

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -15,7 +15,7 @@ use miden_core::mast::OP_GROUP_SIZE;
 use miden_core::{
     AssemblyOp,
     mast::{
-        BasicBlockNode, CallNode, DynNode, JoinNode, LoopNode, MastForest, MastNodeTrait,
+        BasicBlockNode, CallNode, DynNode, JoinNode, LoopNode, MastForest, MastNodeExt,
         OP_BATCH_SIZE, SplitNode,
     },
     stack::MIN_STACK_DEPTH,

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -15,7 +15,8 @@ use miden_core::mast::OP_GROUP_SIZE;
 use miden_core::{
     AssemblyOp,
     mast::{
-        BasicBlockNode, CallNode, DynNode, JoinNode, LoopNode, MastForest, OP_BATCH_SIZE, SplitNode,
+        BasicBlockNode, CallNode, DynNode, JoinNode, LoopNode, MastForest, MastNodeTrait,
+        OP_BATCH_SIZE, SplitNode,
     },
     stack::MIN_STACK_DEPTH,
 };

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -12,7 +12,7 @@ use miden_air::trace::{
 };
 use miden_core::{
     EMPTY_WORD, ONE, Program, WORD_SIZE, ZERO, assert_matches,
-    mast::{BasicBlockNode, MastForest, MastNode, MastNodeId, OP_BATCH_SIZE},
+    mast::{BasicBlockNode, MastForest, MastNode, MastNodeId, MastNodeTrait, OP_BATCH_SIZE},
 };
 use miden_utils_testing::rand::rand_value;
 use rstest::rstest;

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -12,7 +12,7 @@ use miden_air::trace::{
 };
 use miden_core::{
     EMPTY_WORD, ONE, Program, WORD_SIZE, ZERO, assert_matches,
-    mast::{BasicBlockNode, MastForest, MastNode, MastNodeId, MastNodeTrait, OP_BATCH_SIZE},
+    mast::{BasicBlockNode, MastForest, MastNode, MastNodeExt, MastNodeId, OP_BATCH_SIZE},
 };
 use miden_utils_testing::rand::rand_value;
 use rstest::rstest;

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -3,7 +3,7 @@ use alloc::{sync::Arc, vec::Vec};
 use miden_air::RowIndex;
 use miden_core::{
     Felt, QuadFelt, Word,
-    mast::{DecoratorId, MastForest, MastNodeExt, MastNodeId},
+    mast::{DecoratorId, MastForest, MastNodeErrorContext, MastNodeId},
     stack::MIN_STACK_DEPTH,
     utils::to_hex,
 };
@@ -508,7 +508,11 @@ pub struct ErrorContextImpl {
 
 impl ErrorContextImpl {
     #[allow(dead_code)]
-    pub fn new(mast_forest: &MastForest, node: &impl MastNodeExt, host: &impl BaseHost) -> Self {
+    pub fn new(
+        mast_forest: &MastForest,
+        node: &impl MastNodeErrorContext,
+        host: &impl BaseHost,
+    ) -> Self {
         let (label, source_file) =
             Self::precalc_label_and_source_file(None, mast_forest, node, host);
         Self { label, source_file }
@@ -517,7 +521,7 @@ impl ErrorContextImpl {
     #[allow(dead_code)]
     pub fn new_with_op_idx(
         mast_forest: &MastForest,
-        node: &impl MastNodeExt,
+        node: &impl MastNodeErrorContext,
         host: &impl BaseHost,
         op_idx: usize,
     ) -> Self {
@@ -530,7 +534,7 @@ impl ErrorContextImpl {
     fn precalc_label_and_source_file(
         op_idx: Option<usize>,
         mast_forest: &MastForest,
-        node: &impl MastNodeExt,
+        node: &impl MastNodeErrorContext,
         host: &impl BaseHost,
     ) -> (SourceSpan, Option<Arc<SourceFile>>) {
         node.get_assembly_op(mast_forest, op_idx)

--- a/processor/src/fast/call_and_dyn.rs
+++ b/processor/src/fast/call_and_dyn.rs
@@ -3,7 +3,7 @@ use alloc::{sync::Arc, vec::Vec};
 use miden_air::Felt;
 use miden_core::{
     Program, ZERO,
-    mast::{CallNode, MastForest, MastNodeId, MastNodeTrait},
+    mast::{CallNode, MastForest, MastNodeExt, MastNodeId},
     stack::MIN_STACK_DEPTH,
     utils::range,
 };

--- a/processor/src/fast/call_and_dyn.rs
+++ b/processor/src/fast/call_and_dyn.rs
@@ -3,7 +3,7 @@ use alloc::{sync::Arc, vec::Vec};
 use miden_air::Felt;
 use miden_core::{
     Program, ZERO,
-    mast::{CallNode, MastForest, MastNodeId},
+    mast::{CallNode, MastForest, MastNodeId, MastNodeTrait},
     stack::MIN_STACK_DEPTH,
     utils::range,
 };

--- a/processor/src/fast/external.rs
+++ b/processor/src/fast/external.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 
-use miden_core::mast::{ExternalNode, MastForest, MastNodeId};
+use miden_core::mast::{ExternalNode, MastForest, MastNodeExt, MastNodeId};
 
 use crate::{
     AsyncHost, ExecutionError,

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -5,7 +5,7 @@ use memory::Memory;
 use miden_air::RowIndex;
 use miden_core::{
     Decorator, EMPTY_WORD, Felt, Program, StackOutputs, WORD_SIZE, Word, ZERO,
-    mast::{MastForest, MastNode, MastNodeId},
+    mast::{MastForest, MastNode, MastNodeId, MastNodeTrait},
     stack::MIN_STACK_DEPTH,
     utils::range,
 };

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -5,7 +5,7 @@ use memory::Memory;
 use miden_air::RowIndex;
 use miden_core::{
     Decorator, EMPTY_WORD, Felt, Program, StackOutputs, WORD_SIZE, Word, ZERO,
-    mast::{MastForest, MastNode, MastNodeId, MastNodeTrait},
+    mast::{MastForest, MastNode, MastNodeExt, MastNodeId},
     stack::MIN_STACK_DEPTH,
     utils::range,
 };

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -19,7 +19,7 @@ pub use miden_core::{
     StackInputs, StackOutputs, WORD_SIZE, Word, ZERO,
     crypto::merkle::SMT_DEPTH,
     errors::InputError,
-    mast::{MastForest, MastNode, MastNodeId},
+    mast::{MastForest, MastNode, MastNodeId, MastNodeTrait},
     sys_events::SystemEvent,
     utils::DeserializationError,
 };

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -19,7 +19,7 @@ pub use miden_core::{
     StackInputs, StackOutputs, WORD_SIZE, Word, ZERO,
     crypto::merkle::SMT_DEPTH,
     errors::InputError,
-    mast::{MastForest, MastNode, MastNodeId, MastNodeTrait},
+    mast::{MastForest, MastNode, MastNodeExt, MastNodeId},
     sys_events::SystemEvent,
     utils::DeserializationError,
 };

--- a/processor/src/trace/tests/decoder.rs
+++ b/processor/src/trace/tests/decoder.rs
@@ -4,7 +4,7 @@ use miden_air::trace::{
 };
 use miden_core::{
     FieldElement, ONE, Operation, Program, Word, ZERO,
-    mast::{MastForest, MastNode},
+    mast::{MastForest, MastNode, MastNodeTrait},
 };
 use miden_utils_testing::rand::rand_array;
 

--- a/processor/src/trace/tests/decoder.rs
+++ b/processor/src/trace/tests/decoder.rs
@@ -4,7 +4,7 @@ use miden_air::trace::{
 };
 use miden_core::{
     FieldElement, ONE, Operation, Program, Word, ZERO,
-    mast::{MastForest, MastNode, MastNodeTrait},
+    mast::{MastForest, MastNode, MastNodeExt},
 };
 use miden_utils_testing::rand::rand_array;
 


### PR DESCRIPTION
This PR implements a `MastNodeTrait` to gather key methods that were previously implemented as instance methods on the `MastNode` enum's variants, like `digest`, the `append_X` methods, the `Y_children` methods, and `domain`. This change leverages the `enum_dispatch` macro to make dispatching to those variants automatic, providing a more maintainable and extensible architecture.

## The Problem

Previously, methods related to node children, digest, domain, etc were implemented individually, and then led to match expressions on the `MastNode` enum which dispatched to conventional methods on each of the variants. This approach had several limitations:

1. **Implicit Logic**: All MastNode variants had a bunch of methods they were all required to implement, but by convention only, see for example #2108,
2. **Maintenance Burden**: Adding new node types required updating multiple match expressions, and similar dispatch logic was repeated across different operations,
3. **Extensibility Challenges**: Extending the system with new node types required touching existing dispatch code.

## Solution

We've moved these methods into the `MastNodeTrait` and used `#[enum_dispatch]` to automatically generate the boilerplate dispatch implementations for all node types. This preserves type safety, and involves no dynamic dispatch (`dyn`) and therefore pays none of the associated costs.

## Benefits for Future Extensibility

### Adding New Node Types

When adding a new MAST node type in the future:

1. Define the struct with its specific fields in its own file,
2. Implement `MastNodeTrait` for the new node type,
3. Add to the `MastNode` enum under a new variant name, profit.

The compiler will automatically ensure all trait methods are implemented, eliminating the need to update central match expressions, or modify existing dispatch logic.

### Example: Adding a hypothetical `ParNode`

```rust
#[derive(Debug, Clone, PartialEq, Eq)]
pub struct ParNode {
    children: [MastNodeId; 4],  // 4 children in parallel
    // ... other fields ...
}

impl MastNodeTrait for ParNode {
    // ... other methods
    fn has_children(&self) -> bool { true }
    fn append_children_to(&self, target: &mut Vec<MastNodeId>) {
        target.extend_from_slice(&self.children);
    }
    fn remap_children(&self, remapping: &Remapping) -> Self {
        // Apply remapping to all 4 children
        // ...
    }
    fn domain(&self) -> Felt { Self::DOMAIN }
}

// Add to enum
#[enum_dispatch(MastNodeTrait)]
pub enum MastNode {
    // ... existing variants ...
    Par(ParNode),
}
```

### Adding new behaviors (methods)

1. add the method to the trait,
2. add the implementations to the trait implementations,
3. use the method on `MastNode`, profit.

## Technical details

- (trivia) This is a practical application of solving the expression problem in Rust, and old OP/FP problem originally by Phil Wadler in 1998 in a [java-genericity email](http://homepages.inf.ed.ac.uk/wadler/papers/expression/expression.txt). 
- The `MastNodeExt` trait can not be merged with `MastNodeTrait`, because it involves a generic return type, which makes it impossible to have an enum (`MastNode`) dispatch to several distinct instantiations of this type => the enum_dispatch macro is irrelevant for it.
- In a very similar situation, I have assumed that resorting to dynamic dispatch for pretty-print/display is OK from a performance PoV. This might not actually be the case, please let me know.

## TODO
- [ ] bike-shed on a proper name for `MastNodeTrait`
