### PR TITLE
Create program_execution_for_trace benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [BREAKING] `get_stack_word` uses element-aligned indexing instead of word-aligned indexing (#[2068](https://github.com/0xMiden/miden-vm/issues/2068)).
 - [BREAKING] Implement support for `event("event_name")` in MASM (#[2068](https://github.com/0xMiden/miden-vm/issues/2068)).
 - Improved representation of `OPbatches` to include padding Noop by default, simplifying fast iteration over program instructions in the processor ([#1815](https://github.com/0xMiden/miden-vm/issues/1815)).
+- Rename `program_execution` benchmark to `program_execution_for_trace`, and benchmark `FastProcessor::execute_for_trace()` instead of `Process::execute()` (#[2131](https://github.com/0xMiden/miden-vm/pull/2131))
 
 ## 0.17.1 (2025-08-29)
 

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -26,8 +26,8 @@ bench = false
 doctest = false
 
 [[bench]]
-name = "program_execution"
-required-features = ["internal"]
+name = "program_execution_for_trace"
+required-features = ["internal", "no_err_ctx"]
 harness = false
 
 [[bench]]


### PR DESCRIPTION
Follow-up to https://github.com/0xMiden/miden-vm/pull/2023#pullrequestreview-3178901680

Introduces the `program_execution_for_trace` benchmark, which benchmarks `FastProcessor::execute_for_trace()` - the method used to generate trace fragments for parallel trace generation.

Note that we currently still use a trace fragment length of 1024, which negatively impacts the benchmark results. Nevertheless, the `blake3_1to1` benchmark sits at:

- `program_execution_fast`: 1.85ms
  - Representing 262 MHz
- `program_execution_for_trace` (1024 rows per fragment): 4.45ms
  - Representing 109 MHz
- `program_execution_for_trace` (5000 rows per fragment): 4ms
  - Representing 121 MHz