### PR TITLE
feat: macro-generated serialization tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,7 +320,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -481,7 +490,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -557,7 +566,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -659,7 +668,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -712,7 +721,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -928,7 +937,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1129,12 +1138,14 @@ name = "miden-assembly-syntax"
 version = "0.18.0"
 dependencies = [
  "aho-corasick",
+ "bincode",
  "env_logger",
  "lalrpop",
  "lalrpop-util",
  "log",
  "miden-core",
  "miden-debug-types",
+ "miden-serde-test-macros",
  "miden-utils-diagnostics",
  "midenc-hir-type",
  "pretty_assertions",
@@ -1153,14 +1164,17 @@ dependencies = [
 name = "miden-core"
 version = "0.18.0"
 dependencies = [
+ "bincode",
  "enum_dispatch",
  "insta",
  "miden-crypto",
  "miden-debug-types",
  "miden-formatting",
+ "miden-serde-test-macros",
  "num-derive",
  "num-traits",
  "proptest",
+ "proptest-derive",
  "serde",
  "thiserror 2.0.16",
  "winter-math",
@@ -1262,7 +1276,7 @@ dependencies = [
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "syn",
+ "syn 2.0.106",
  "terminal_size",
  "textwrap",
  "thiserror 2.0.16",
@@ -1278,7 +1292,7 @@ checksum = "86a905f3ea65634dd4d1041a4f0fd0a3e77aa4118341d265af1a94339182222f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1316,6 +1330,19 @@ dependencies = [
  "tracing",
  "winter-maybe-async",
  "winter-prover",
+]
+
+[[package]]
+name = "miden-serde-test-macros"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "proc-macro2",
+ "proptest",
+ "proptest-derive",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1536,7 +1563,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1834,7 +1861,7 @@ checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1995,7 +2022,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn",
+ "syn 2.0.106",
  "unicode-ident",
 ]
 
@@ -2140,7 +2167,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2163,7 +2190,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2306,6 +2333,17 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
@@ -2373,7 +2411,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2384,7 +2422,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "test-case-core",
 ]
 
@@ -2425,7 +2463,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2436,7 +2474,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2547,7 +2585,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2761,7 +2799,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -2783,7 +2821,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2892,7 +2930,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2903,7 +2941,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3224,7 +3262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d31a19dae58475d019850e25b0170e94b16d382fbf6afee9c0e80fdc935e73e"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3306,5 +3344,5 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,15 +159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,7 +1129,6 @@ name = "miden-assembly-syntax"
 version = "0.18.0"
 dependencies = [
  "aho-corasick",
- "bincode",
  "env_logger",
  "lalrpop",
  "lalrpop-util",
@@ -1156,6 +1146,7 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde-untagged",
+ "serde_json",
  "smallvec",
  "thiserror 2.0.16",
 ]
@@ -1164,7 +1155,6 @@ dependencies = [
 name = "miden-core"
 version = "0.18.0"
 dependencies = [
- "bincode",
  "enum_dispatch",
  "insta",
  "miden-crypto",
@@ -1176,6 +1166,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "serde",
+ "serde_json",
  "thiserror 2.0.16",
  "winter-math",
  "winter-rand-utils",
@@ -1336,7 +1327,6 @@ dependencies = [
 name = "miden-serde-test-macros"
 version = "0.1.0"
 dependencies = [
- "bincode",
  "proc-macro2",
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,6 @@ miden-formatting = { version = "0.1", default-features = false }
 midenc-hir-type = { version = "0.1", default-features = false }
 
 # Third-party crates
-# used in miden-serde-test macros, should be replaced with miden-bite
-bincode = { version = "1.3" }
 insta = { version = "1.43", default-features = false, features = [
     "colors",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ miden-core = { path = "./core", version = "0.18", default-features = false }
 miden-debug-types = { path = "./crates/debug/types", version = "0.18", default-features = false }
 miden-mast-package = { path = "./package", version = "0.18", default-features = false }
 miden-processor = { path = "./processor", version = "0.18", default-features = false }
+miden-serde-test-macros = { path = "./crates/utils/serde-test-macros", version = "0.1.0", default-features = false }
 miden-prover = { path = "./prover", version = "0.18", default-features = false }
 miden-stdlib = { path = "./stdlib", version = "0.18", default-features = false }
 miden-utils-diagnostics = { path = "./crates/utils/diagnostics", version = "0.18", default-features = false }
@@ -59,6 +60,8 @@ miden-formatting = { version = "0.1", default-features = false }
 midenc-hir-type = { version = "0.1", default-features = false }
 
 # Third-party crates
+# used in miden-serde-test macros, should be replaced with miden-bite
+bincode = { version = "1.3" }
 insta = { version = "1.43", default-features = false, features = [
     "colors",
 ] }

--- a/assembly-syntax/Cargo.toml
+++ b/assembly-syntax/Cargo.toml
@@ -31,6 +31,7 @@ serde = [
     "midenc-hir-type/serde",
     "semver/serde",
     "smallvec/serde",
+    "dep:serde_json",
 ]
 arbitrary = ["dep:proptest", "dep:proptest-derive", "miden-core/arbitrary"]
 testing = ["arbitrary", "logging"]
@@ -43,11 +44,12 @@ lalrpop-util = { version = "0.22", default-features = false }
 log.workspace = true
 miden-core.workspace = true
 miden-debug-types.workspace = true
+miden-serde-test-macros = { workspace = true }
 miden-utils-diagnostics.workspace = true
 midenc-hir-type.workspace = true
-miden-serde-test-macros = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 regex = { version = "1.10", default-features = false, features = [
     "unicode",
     "perf",
@@ -59,7 +61,6 @@ smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-bincode.workspace = true
 env_logger = "0.11"
 proptest.workspace = true
 pretty_assertions = "1.4"

--- a/assembly-syntax/Cargo.toml
+++ b/assembly-syntax/Cargo.toml
@@ -22,6 +22,7 @@ std = [
     "miden-debug-types/std",
     "miden-utils-diagnostics/std",
     "thiserror/std",
+    "proptest/std",
 ]
 serde = [
     "dep:serde",
@@ -31,7 +32,7 @@ serde = [
     "semver/serde",
     "smallvec/serde",
 ]
-arbitrary = ["dep:proptest", "dep:proptest-derive"]
+arbitrary = ["dep:proptest", "dep:proptest-derive", "miden-core/arbitrary"]
 testing = ["arbitrary", "logging"]
 logging = ["dep:env_logger"]
 
@@ -44,6 +45,7 @@ miden-core.workspace = true
 miden-debug-types.workspace = true
 miden-utils-diagnostics.workspace = true
 midenc-hir-type.workspace = true
+miden-serde-test-macros = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 regex = { version = "1.10", default-features = false, features = [
@@ -57,6 +59,7 @@ smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+bincode.workspace = true
 env_logger = "0.11"
 proptest.workspace = true
 pretty_assertions = "1.4"

--- a/assembly-syntax/src/ast/procedure/name.rs
+++ b/assembly-syntax/src/ast/procedure/name.rs
@@ -31,6 +31,10 @@ use crate::{
 /// to an imported
 #[derive(Clone)]
 #[cfg_attr(feature = "arbitrary", derive(proptest_derive::Arbitrary))]
+#[cfg_attr(
+    all(feature = "serde", feature = "arbitrary"),
+    miden_serde_test_macros::serde_test
+)]
 pub struct QualifiedProcedureName {
     /// The source span associated with this identifier.
     #[cfg_attr(feature = "arbitrary", proptest(value = "SourceSpan::default()"))]
@@ -297,6 +301,10 @@ impl<'de> serde::Deserialize<'de> for QualifiedProcedureName {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(
+    all(feature = "serde", feature = "arbitrary"),
+    miden_serde_test_macros::serde_test
+)]
 pub struct ProcedureName(Ident);
 
 impl ProcedureName {
@@ -517,25 +525,4 @@ impl proptest::prelude::Arbitrary for ProcedureName {
     }
 
     type Strategy = proptest::prelude::BoxedStrategy<Self>;
-}
-
-// TESTS
-// ================================================================================================
-
-/// Tests
-#[cfg(test)]
-mod tests {
-    use miden_core::utils::{Deserializable, Serializable};
-    use proptest::prelude::*;
-
-    use super::ProcedureName;
-
-    proptest! {
-        #[test]
-        fn procedure_name_serialization_roundtrip(path in any::<ProcedureName>()) {
-            let bytes = path.to_bytes();
-            let deserialized = ProcedureName::read_from_bytes(&bytes).unwrap();
-            assert_eq!(path, deserialized);
-        }
-    }
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,6 +29,7 @@ std = [
 ]
 serde = [
     "dep:serde",
+    "dep:serde_json",
     "miden-crypto/serde",
     "miden-debug-types/serde",
     "winter-math/serde",
@@ -47,12 +48,12 @@ num-traits = { version = "0.2", default-features = false }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
+serde_json = { workspace = true, optional = true }
 thiserror.workspace = true
 winter-math.workspace = true
 winter-utils.workspace = true
 
 [dev-dependencies]
-bincode.workspace = true
 insta.workspace = true
 proptest.workspace = true
 winter-rand-utils.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,20 +33,26 @@ serde = [
     "miden-debug-types/serde",
     "winter-math/serde",
 ]
+arbitrary = ["dep:proptest", "dep:proptest-derive"]
+testing = ["arbitrary" ]
 
 [dependencies]
 enum_dispatch = { version =  "0.3" }
 miden-crypto.workspace = true
 miden-debug-types.workspace = true
 miden-formatting.workspace = true
+miden-serde-test-macros = { workspace = true }
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-serde = { workspace = true, optional = true }
+proptest = { workspace = true, optional = true }
+proptest-derive = { workspace = true, optional = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
 thiserror.workspace = true
 winter-math.workspace = true
 winter-utils.workspace = true
 
 [dev-dependencies]
+bincode.workspace = true
 insta.workspace = true
 proptest.workspace = true
 winter-rand-utils.workspace = true

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -572,6 +572,10 @@ impl IndexMut<DecoratorId> for MastForest {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(
+    all(feature = "serde", feature = "arbitrary"),
+    miden_serde_test_macros::serde_test
+)]
 pub struct MastNodeId(u32);
 
 /// Operations that mutate a MAST often produce this mapping between old and new NodeIds.
@@ -671,6 +675,18 @@ impl fmt::Display for MastNodeId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "MastNodeId({})", self.0)
     }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl proptest::prelude::Arbitrary for MastNodeId {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        use proptest::prelude::*;
+        any::<u32>().prop_map(MastNodeId).boxed()
+    }
+
+    type Strategy = proptest::prelude::BoxedStrategy<Self>;
 }
 
 // ITERATOR

--- a/crates/utils/serde-test-macros/Cargo.toml
+++ b/crates/utils/serde-test-macros/Cargo.toml
@@ -25,4 +25,3 @@ proptest-derive.workspace = true
 [dev-dependencies]
 proptest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-bincode = "1.3"

--- a/crates/utils/serde-test-macros/Cargo.toml
+++ b/crates/utils/serde-test-macros/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "miden-serde-test-macros"
+version = "0.1.0"
+description = "Proc macros for serde roundtrip testing in Miden VM"
+readme = "README.md"
+categories = ["development-tools::testing", "no-std"]
+keywords = ["miden", "serde", "testing", "proc-macro"]
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["derive", "extra-traits", "full"] }
+proptest.workspace = true
+proptest-derive.workspace = true
+
+[dev-dependencies]
+proptest = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+bincode = "1.3"

--- a/crates/utils/serde-test-macros/src/lib.rs
+++ b/crates/utils/serde-test-macros/src/lib.rs
@@ -1,0 +1,115 @@
+//! Proc macros for serde roundtrip testing in Miden VM
+//!
+//! This crate provides the `serde_test` macro for generating round-trip serialization tests.
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{ToTokens, quote};
+use syn::{AttributeArgs, Ident, Item, Lit, Meta, MetaList, NestedMeta, Type, parse_macro_input};
+
+/// This macro is used to generate round-trip serialization tests.
+///
+/// By appending `serde_test` to a struct or enum definition, you automatically derive
+/// serialization tests that employ Serde for round-trip testing. The procedure in the generated
+/// tests is:
+/// 1. Instantiate the type being tested
+/// 2. Serialize the instance, ensuring the operation's success
+/// 3. Deserialize the serialized data, comparing the resulting instance with the original one
+///
+/// The type being tested must meet the following requirements:
+/// * Implementations of `Debug` and `PartialEq` traits
+/// * Implementation of `Arbitrary` trait
+/// * Implementations of `Serialize` and `DeserializeOwned` traits
+///
+/// For testing generic types, use the `types(...)` attribute to list type parameters for testing,
+/// separated by commas. For complex types (e.g., ones where type parameters have their own
+/// parameters), enclose them in quotation marks. To test different combinations of type parameters,
+/// `types` can be used multiple times.
+///
+/// # Example
+/// ```
+/// use miden_serde_test_macros::serde_test;
+/// use proptest_derive::Arbitrary;
+/// use serde::{Deserialize, Serialize};
+///
+/// // The macro derives serialization tests using an arbitrary instance.
+/// #[serde_test(types(u64, "Vec<u64>"), types(u32, bool))]
+/// #[derive(Debug, Default, PartialEq, Arbitrary, Serialize, Deserialize)]
+/// struct Generic<T1, T2> {
+///     t1: T1,
+///     t2: T2,
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn serde_test(args: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as AttributeArgs);
+    let input = parse_macro_input!(input as Item);
+
+    let name = match &input {
+        Item::Struct(item) => &item.ident,
+        Item::Enum(item) => &item.ident,
+        _ => panic!("This macro only works on structs and enums"),
+    };
+
+    // Parse arguments.
+    let mut types = Vec::new();
+    for arg in args {
+        match arg {
+            // List arguments (as in #[serde_test(arg(val))])
+            NestedMeta::Meta(Meta::List(MetaList { path, nested, .. })) => match path.get_ident() {
+                Some(id) if *id == "types" => {
+                    let params = nested.iter().map(parse_type).collect::<Vec<_>>();
+                    types.push(quote!(<#name<#(#params),*>>));
+                },
+                _ => panic!("invalid attribute {:?}", path),
+            },
+
+            _ => panic!("invalid argument {:?}", arg),
+        }
+    }
+
+    if types.is_empty() {
+        // If no explicit type parameters were given for us to test with, assume the type under test
+        // takes no type parameters.
+        types.push(quote!(<#name>));
+    }
+
+    let mut output = quote! {
+        #input
+    };
+
+    for (i, ty) in types.into_iter().enumerate() {
+        let serde_test = {
+            let test_name =
+                Ident::new(&format!("test_serde_roundtrip_{}_{}", name, i), Span::mixed_site());
+            quote! {
+                #[cfg(all(feature = "serde", feature = "arbitrary", test))]
+                proptest::proptest!{
+                    #[test]
+                    fn #test_name(obj in proptest::prelude::any::#ty()) {
+                        let buf = bincode::serialize(&obj).unwrap();
+                        assert_eq!(obj, bincode::deserialize::#ty(&buf).unwrap());
+                    }
+                }
+            }
+        };
+
+        output = quote! {
+            #output
+            #serde_test
+        };
+    }
+
+    output.into()
+}
+
+fn parse_type(m: &NestedMeta) -> Type {
+    match m {
+        NestedMeta::Lit(Lit::Str(s)) => syn::parse_str(&s.value()).unwrap(),
+        NestedMeta::Meta(Meta::Path(p)) => syn::parse2(p.to_token_stream()).unwrap(),
+        _ => {
+            panic!("expected type");
+        },
+    }
+}

--- a/crates/utils/serde-test-macros/src/lib.rs
+++ b/crates/utils/serde-test-macros/src/lib.rs
@@ -88,8 +88,8 @@ pub fn serde_test(args: TokenStream, input: TokenStream) -> TokenStream {
                 proptest::proptest!{
                     #[test]
                     fn #test_name(obj in proptest::prelude::any::#ty()) {
-                        let buf = bincode::serialize(&obj).unwrap();
-                        assert_eq!(obj, bincode::deserialize::#ty(&buf).unwrap());
+                        let buf = serde_json::to_vec(&obj).unwrap();
+                        proptest::prop_assert_eq!(obj, serde_json::from_slice::#ty(&buf).unwrap());
                     }
                 }
             }


### PR DESCRIPTION
This PR against #2071 implements a `serde_test` macro that can generate round-trip serialization tests pegged on an implementation of `proptest::prelude::Arbitrary`. This macro:

- supports generic arguments passed as attributes,
- uses ~~`bincode`~~ `serde_json` as the test serializer (I expect this will be replaced by #2130)

=> no more boilerplate tests! (and future tests are easier to define)

## Note

Tests failing here are signal for #2071 (unless I messed up something in my `Arbitrary` impls).

## TODO (after merging this PR)
- [x] make sure the import of the `miden-serde-test-macros` crate is sparse and follows best practices re: features. (I've been fast & loose),
- [x] check CI / Makefile to ensure those feature-gated tests are run (i.e. the failure in the present PR's CI is still observed after tweaking features as per the above),
- [ ] have a better implementation of `Arbitrary` for `LibraryExports` (where the last field isn't always `None`), add one in missing places, e.g. `KernelLibrary`,
- [x] fix failing tests (see #2071 review)