### PR TITLE
ci: fix clippy warning with latest Rust nightly

### DIFF
--- a/air/src/proof.rs
+++ b/air/src/proof.rs
@@ -104,12 +104,6 @@ pub enum HashFunction {
     Poseidon2 = 0x04,
 }
 
-impl Default for HashFunction {
-    fn default() -> Self {
-        Self::Blake3_192
-    }
-}
-
 impl HashFunction {
     /// Returns the collision resistance level (in bits) of this hash function.
     pub const fn collision_resistance(&self) -> u32 {
@@ -199,7 +193,7 @@ impl ExecutionProof {
     pub fn new_dummy() -> Self {
         ExecutionProof {
             proof: Proof::new_dummy(),
-            hash_fn: HashFunction::default(),
+            hash_fn: HashFunction::Blake3_192,
         }
     }
 }

--- a/processor/src/chiplets/ace/tests/mod.rs
+++ b/processor/src/chiplets/ace/tests/mod.rs
@@ -277,6 +277,7 @@ fn generate_memory(circuit: &EncodedCircuit, inputs: &[QuadFelt]) -> Vec<Word> {
 }
 
 /// Given an EvaluationContext
+#[allow(clippy::needless_range_loop)]
 fn verify_trace(context: &CircuitEvaluation, num_read_rows: usize, num_eval_rows: usize) {
     let num_rows = num_read_rows + num_eval_rows;
     let mut columns: Vec<_> = (0..ACE_CHIPLET_NUM_COLS).map(|_| vec![ZERO; num_rows]).collect();

--- a/processor/src/chiplets/bitwise/tests.rs
+++ b/processor/src/chiplets/bitwise/tests.rs
@@ -16,6 +16,7 @@ fn bitwise_init() {
 }
 
 #[test]
+#[allow(clippy::needless_range_loop)]
 fn bitwise_and() {
     let mut bitwise = Bitwise::new();
 
@@ -59,6 +60,7 @@ fn bitwise_and() {
 }
 
 #[test]
+#[allow(clippy::needless_range_loop)]
 fn bitwise_xor() {
     let mut bitwise = Bitwise::new();
 
@@ -102,6 +104,7 @@ fn bitwise_xor() {
 }
 
 #[test]
+#[allow(clippy::needless_range_loop)]
 fn bitwise_multiple() {
     let mut bitwise = Bitwise::new();
 
@@ -199,6 +202,7 @@ fn build_trace(bitwise: Bitwise, num_rows: usize) -> Vec<Vec<Felt>> {
 fn check_decomposition(trace: &[Vec<Felt>], start: usize, a: u64, b: u64) {
     let mut bit_offset = 28;
 
+    #[allow(clippy::needless_range_loop)]
     for i in start..start + 8 {
         let a = a >> bit_offset;
         let b = b >> bit_offset;

--- a/processor/src/chiplets/kernel_rom/tests.rs
+++ b/processor/src/chiplets/kernel_rom/tests.rs
@@ -57,6 +57,7 @@ fn kernel_rom_no_access() {
 }
 
 #[test]
+#[allow(clippy::needless_range_loop)]
 fn kernel_rom_with_access() {
     let kernel = build_kernel();
     let mut rom = KernelRom::new(kernel);
@@ -98,6 +99,7 @@ fn kernel_rom_with_access() {
 }
 
 #[test]
+#[allow(clippy::needless_range_loop)]
 fn kernel_rom_with_single_access() {
     let kernel = build_kernel();
     let mut rom = KernelRom::new(kernel);

--- a/processor/src/chiplets/tests.rs
+++ b/processor/src/chiplets/tests.rs
@@ -147,6 +147,7 @@ fn build_trace(
 /// of the hasher trace.
 fn validate_hasher_trace(trace: &ChipletsTrace, start: usize, end: usize) {
     // The selectors should match the hasher selectors
+    #[allow(clippy::needless_range_loop)]
     for row in start..end {
         // The selectors should match the selectors for the hasher segment
         assert_eq!(ZERO, trace[0][row]);

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -772,6 +772,7 @@ fn loop_node_repeat() {
 
 #[test]
 #[rustfmt::skip]
+#[allow(clippy::needless_range_loop)]
 fn call_block() {
     // build a program which looks like this:
     //
@@ -983,6 +984,7 @@ fn call_block() {
 
 #[test]
 #[rustfmt::skip]
+#[allow(clippy::needless_range_loop)]
 fn syscall_block() {
     // build a program which looks like this:
     //


### PR DESCRIPTION
## Describe your changes

The latest version of clippy in Rust nightly causes failures with the `lint` CI check.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](./CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'