### PR TITLE
fix(core): normalize decorator index to u32 in MastNodeFingerprint

### DIFF
--- a/core/src/mast/node_fingerprint.rs
+++ b/core/src/mast/node_fingerprint.rs
@@ -58,6 +58,9 @@ impl MastNodeFingerprint {
                 let mut bytes_to_hash = Vec::new();
 
                 for &(idx, decorator_id) in node.decorators() {
+                    let idx: u32 = idx
+                        .try_into()
+                        .expect("there are more than 2^{32}-1 operations in basic block");
                     bytes_to_hash.extend(idx.to_le_bytes());
                     bytes_to_hash.extend(forest[decorator_id].fingerprint().as_bytes());
                 }


### PR DESCRIPTION
## Describe your changes

- Use u32 for decorator operation index when hashing in MastNodeFingerprint.
- This prevents architecture-dependent fingerprints caused by usize::to_le_bytes() producing 4 or 8 bytes depending on pointer width.
- Other fingerprint inputs already use fixed-width types; this makes decorator-related fingerprints deterministic across 32/64-bit platforms.