### PR TITLE
chore(core): use MIN_STACK_DEPTH for StackOutputs Deref target

### DIFF
--- a/core/src/stack/outputs.rs
+++ b/core/src/stack/outputs.rs
@@ -108,7 +108,7 @@ impl StackOutputs {
 }
 
 impl Deref for StackOutputs {
-    type Target = [Felt; 16];
+    type Target = [Felt; MIN_STACK_DEPTH];
 
     fn deref(&self) -> &Self::Target {
         &self.elements


### PR DESCRIPTION
Replace hardcoded [Felt; 16] in impl Deref for StackOutputs with [Felt; MIN_STACK_DEPTH].
This removes a latent inconsistency: the struct stores [Felt; MIN_STACK_DEPTH], but Deref::Target was fixed to 16. If MIN_STACK_DEPTH changes, the previous code would break or diverge. Using the constant keeps the type aligned with the single source of truth and matches usage across the codebase.