### PR TITLE
update cycle counts for word::gt and word::lte

### DIFF
--- a/stdlib/asm/word.masm
+++ b/stdlib/asm/word.masm
@@ -73,7 +73,7 @@ end
 #! Inputs:  [RHS, LHS]
 #! Outputs: [is_lhs_greater]
 #!
-#! Cycles: 121
+#! Cycles: 117
 export.gt
     # => [r_3, r_2, r_1, r_0, l_3, l_2, l_1, l_0]
     exec.arrange_words_adjacent
@@ -186,7 +186,7 @@ end
 #! Inputs:  [RHS, LHS]
 #! Outputs: [is_lhs_less_or_equal]
 #!
-#! Cycles: 122
+#! Cycles: 118
 export.lte
     exec.gt
     not


### PR DESCRIPTION
## Describe your changes
While working on https://github.com/0xMiden/miden-vm/pull/2114 I noticed that cycle counts for `word::gt` and `word::lte` were off.

Also, not sure what causes this, but when I measure it like below (compare clk and subtract 2), sometimes I get 117, sometimes 118, depending on the call site.
```
export.gt
    clk debug.stack.1 drop
    
    ...procedure implementation...
    
    clk debug.stack.1 drop
end
```

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'