### PR TITLE
fix(mast): correct child-vs-parent ID assertions in merger tests

### DIFF
--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -59,28 +59,28 @@ fn assert_child_id_lt_parent_id(forest: &MastForest) -> Result<(), &str> {
     for (mast_node_id, node) in forest.nodes().iter().enumerate() {
         match node {
             MastNode::Join(join_node) => {
-                if !join_node.first().as_usize() < mast_node_id {
+                if join_node.first().as_usize() >= mast_node_id {
                     return Err("join node first child id is not < parent id");
                 };
-                if !join_node.second().as_usize() < mast_node_id {
+                if join_node.second().as_usize() >= mast_node_id {
                     return Err("join node second child id is not < parent id");
                 }
             },
             MastNode::Split(split_node) => {
-                if !split_node.on_true().as_usize() < mast_node_id {
+                if split_node.on_true().as_usize() >= mast_node_id {
                     return Err("split node on true id is not < parent id");
                 }
-                if !split_node.on_false().as_usize() < mast_node_id {
+                if split_node.on_false().as_usize() >= mast_node_id {
                     return Err("split node on false id is not < parent id");
                 }
             },
             MastNode::Loop(loop_node) => {
-                if !loop_node.body().as_usize() < mast_node_id {
+                if loop_node.body().as_usize() >= mast_node_id {
                     return Err("loop node body id is not < parent id");
                 }
             },
             MastNode::Call(call_node) => {
-                if !call_node.callee().as_usize() < mast_node_id {
+                if call_node.callee().as_usize() >= mast_node_id {
                     return Err("call node callee id is not < parent id");
                 }
             },


### PR DESCRIPTION
Replace incorrect uses of '!x < y' with 'x >= y' in assert_child_id_lt_parent_id. The previous code applied bitwise NOT to usize due to Rust operator precedence, so the logical check (child index < parent index) was not actually enforced. This fix makes the invariant explicit and readable, ensuring tests properly validate the DFS postorder guarantee that children have strictly lower IDs than their parents.