### PR TITLE
fix: improve !use command parsing to prevent false matches

### DIFF
--- a/miden-vm/src/repl/mod.rs
+++ b/miden-vm/src/repl/mod.rs
@@ -267,7 +267,10 @@ pub fn start_repl(library_paths: &Vec<PathBuf>, use_stdlib: bool) {
                     };
                 } else if line == "!stack" {
                     should_print_stack = true;
-                } else if line.starts_with("!use") {
+                } else if line.trim() == "!use"
+                    || (line.trim().starts_with("!use ")
+                        && line.trim().split_whitespace().count() == 2)
+                {
                     handle_use_command(line, &provided_libraries, &mut imported_modules);
                 } else {
                     rl.add_history_entry(line.clone()).expect("Failed to add a history entry");


### PR DESCRIPTION
## Describe your changes

Fix !use command parsing in REPL to use exact matching instead of starts_with

The previous implementation used line.starts_with("!use") which caused
commands like !user, !used, or !use_something to be incorrectly parsed
as !use commands, resulting in unexpected behavior where these invalid
commands would display the list of available modules instead of being
treated as regular Miden assembly instructions.

This change ensures that only exact !use commands (with or without
module name argument) are processed as REPL commands, maintaining
consistency with other REPL commands that use exact string matching
and preventing user confusion from false command matches.

The fix uses a two-part validation:
- line.trim() == "!use" for commands without arguments
- line.trim().starts_with("!use ") && token_count == 2 for commands with arguments