### PR TITLE
refactor: MastNode quality of life improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@
 - Abstract away the fast processor's operation execution into a new `Processor` trait ([#2141](https://github.com/0xMiden/miden-vm/pull/2141))
 - [BREAKING] Implemented custom section support in package format, and removed `account_component_metadata` field ([#2071](https://github.com/0xMiden/miden-vm/pull/2071))
 - Move `EMIT` flag to degree 5 bucket ([#2043](https://github.com/0xMiden/miden-vm/issues/2043)).
-- [BREAKING] Move `u64_div`, `falcon_div` and `smtpeek` system events to stdlib ([#1582](https://github.com/0xMiden/miden-vm/issues/1582))
+- [BREAKING] Move `u64_div`, `falcon_div` and `smtpeek` system events to stdlib ([#1582](https://github.com/0xMiden/miden-vm/issues/1582)).
+- [BREAKING] `MastNode` quality of life improvements ([#2152](https://github.com/0xMiden/miden-vm/pull/2152)).
 
 ## 0.17.1 (2025-08-29)
 

--- a/assembly/src/mast_forest_builder.rs
+++ b/assembly/src/mast_forest_builder.rs
@@ -618,7 +618,7 @@ fn should_merge(is_procedure: bool, num_op_batches: usize) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use miden_core::Operation;
+    use miden_core::{Operation, mast::MastNodeErrorContext};
 
     use super::*;
 
@@ -698,13 +698,13 @@ mod tests {
 
         // Check each decorator in the merged block
         let decorators = merged_block.decorators();
-        assert_eq!(decorators.len(), 5); // 3 from block1 + 2 from block2
+        assert_eq!(merged_block.decorators().count(), 5); // 3 from block1 + 2 from block2
 
         // Create a map to track which trace values we've found
         let mut found_traces = std::collections::HashSet::new();
 
         // Check each decorator
-        for &(op_idx, decorator_id) in decorators {
+        for (op_idx, decorator_id) in decorators {
             let decorator = &builder.mast_forest[decorator_id];
 
             match decorator {

--- a/assembly/src/mast_forest_builder.rs
+++ b/assembly/src/mast_forest_builder.rs
@@ -8,8 +8,9 @@ use core::ops::{Index, IndexMut};
 use miden_core::{
     AdviceMap, Decorator, DecoratorList, Felt, Operation, Word,
     mast::{
-        DecoratorFingerprint, DecoratorId, MastForest, MastNode, MastNodeExt, MastNodeFingerprint,
-        MastNodeId, Remapping, SubtreeIterator,
+        BasicBlockNode, CallNode, DecoratorFingerprint, DecoratorId, DynNode, ExternalNode,
+        JoinNode, LoopNode, MastForest, MastNode, MastNodeExt, MastNodeFingerprint, MastNodeId,
+        Remapping, SplitNode, SubtreeIterator,
     },
 };
 
@@ -406,7 +407,8 @@ impl MastForestBuilder {
     /// Note that only one copy of nodes that have the same MAST root and decorators is added to the
     /// MAST forest; two nodes that have the same MAST root and decorators will have the same
     /// [`MastNodeId`].
-    pub fn ensure_node(&mut self, node: MastNode) -> Result<MastNodeId, Report> {
+    pub fn ensure_node(&mut self, node: impl Into<MastNode>) -> Result<MastNodeId, Report> {
+        let node: MastNode = node.into();
         let node_fingerprint = self.fingerprint_for_node(&node);
 
         if let Some(node_id) = self.node_id_by_fingerprint.get(&node_fingerprint) {
@@ -431,7 +433,7 @@ impl MastForestBuilder {
         operations: Vec<Operation>,
         decorators: Option<DecoratorList>,
     ) -> Result<MastNodeId, Report> {
-        let block = MastNode::new_basic_block(operations, decorators)
+        let block = BasicBlockNode::new(operations, decorators)
             .into_diagnostic()
             .wrap_err("assembler failed to add new basic block node")?;
         self.ensure_node(block)
@@ -443,7 +445,7 @@ impl MastForestBuilder {
         left_child: MastNodeId,
         right_child: MastNodeId,
     ) -> Result<MastNodeId, Report> {
-        let join = MastNode::new_join(left_child, right_child, &self.mast_forest)
+        let join = JoinNode::new([left_child, right_child], &self.mast_forest)
             .into_diagnostic()
             .wrap_err("assembler failed to add new join node")?;
         self.ensure_node(join)
@@ -455,7 +457,7 @@ impl MastForestBuilder {
         if_branch: MastNodeId,
         else_branch: MastNodeId,
     ) -> Result<MastNodeId, Report> {
-        let split = MastNode::new_split(if_branch, else_branch, &self.mast_forest)
+        let split = SplitNode::new([if_branch, else_branch], &self.mast_forest)
             .into_diagnostic()
             .wrap_err("assembler failed to add new split node")?;
         self.ensure_node(split)
@@ -463,7 +465,7 @@ impl MastForestBuilder {
 
     /// Adds a loop node to the forest, and returns the [`MastNodeId`] associated with it.
     pub fn ensure_loop(&mut self, body: MastNodeId) -> Result<MastNodeId, Report> {
-        let loop_node = MastNode::new_loop(body, &self.mast_forest)
+        let loop_node = LoopNode::new(body, &self.mast_forest)
             .into_diagnostic()
             .wrap_err("assembler failed to add new loop node")?;
         self.ensure_node(loop_node)
@@ -471,7 +473,7 @@ impl MastForestBuilder {
 
     /// Adds a call node to the forest, and returns the [`MastNodeId`] associated with it.
     pub fn ensure_call(&mut self, callee: MastNodeId) -> Result<MastNodeId, Report> {
-        let call = MastNode::new_call(callee, &self.mast_forest)
+        let call = CallNode::new(callee, &self.mast_forest)
             .into_diagnostic()
             .wrap_err("assembler failed to add new call node")?;
         self.ensure_node(call)
@@ -479,7 +481,7 @@ impl MastForestBuilder {
 
     /// Adds a syscall node to the forest, and returns the [`MastNodeId`] associated with it.
     pub fn ensure_syscall(&mut self, callee: MastNodeId) -> Result<MastNodeId, Report> {
-        let syscall = MastNode::new_syscall(callee, &self.mast_forest)
+        let syscall = CallNode::new_syscall(callee, &self.mast_forest)
             .into_diagnostic()
             .wrap_err("assembler failed to add new syscall node")?;
         self.ensure_node(syscall)
@@ -487,12 +489,12 @@ impl MastForestBuilder {
 
     /// Adds a dyn node to the forest, and returns the [`MastNodeId`] associated with it.
     pub fn ensure_dyn(&mut self) -> Result<MastNodeId, Report> {
-        self.ensure_node(MastNode::new_dyn())
+        self.ensure_node(DynNode::new_dyn())
     }
 
     /// Adds a dyncall node to the forest, and returns the [`MastNodeId`] associated with it.
     pub fn ensure_dyncall(&mut self) -> Result<MastNodeId, Report> {
-        self.ensure_node(MastNode::new_dyncall())
+        self.ensure_node(DynNode::new_dyncall())
     }
 
     /// Adds a node corresponding to the given MAST root, according to how it is linked.
@@ -510,7 +512,7 @@ impl MastForestBuilder {
             }
             Ok(root_id.remap(&self.statically_linked_mast_remapping))
         } else {
-            self.ensure_node(MastNode::new_external(mast_root))
+            self.ensure_node(ExternalNode::new(mast_root))
         }
     }
 

--- a/assembly/src/tests.rs
+++ b/assembly/src/tests.rs
@@ -8,7 +8,7 @@ use miden_assembly_syntax::{
 };
 use miden_core::{
     EventId, Operation, Program, Word, assert_matches,
-    mast::{MastNode, MastNodeExt, MastNodeId},
+    mast::{MastNodeExt, MastNodeId},
     utils::{Deserializable, Serializable},
 };
 use miden_mast_package::{MastArtifact, MastForest, Package, PackageExport, PackageManifest};
@@ -1867,10 +1867,7 @@ fn ensure_correct_procedure_selection_on_collision() -> TestResult {
 
     let (exec_f_node_id, exec_g_node_id) = {
         let split_node_id = program.entrypoint();
-        let split_node = match &program.mast_forest()[split_node_id] {
-            MastNode::Split(split_node) => split_node,
-            _ => panic!("expected split node"),
-        };
+        let split_node = &program.mast_forest()[split_node_id].unwrap_split();
 
         (split_node.on_true(), split_node.on_false())
     };
@@ -3689,10 +3686,7 @@ fn distinguish_grandchildren_correctly() {
 
     let program = context.assemble(program_source).unwrap();
 
-    let join_node = match &program.mast_forest()[program.entrypoint()] {
-        MastNode::Join(node) => node,
-        _ => panic!("expected join node"),
-    };
+    let join_node = &program.mast_forest()[program.entrypoint()].unwrap_join();
 
     // Make sure that both `if.true` blocks compile down to a different MAST node.
     assert_ne!(join_node.first(), join_node.second());

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -118,7 +118,7 @@ pub mod prettier {
 
 mod operations;
 pub use operations::{
-    AssemblyOp, DebugOptions, Decorator, DecoratorIterator, DecoratorList, Operation,
+    AssemblyOp, DebugOptions, Decorator, DecoratorIdIterator, DecoratorList, Operation,
     opcode_constants::*,
 };
 

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -3,8 +3,8 @@ use alloc::{collections::BTreeMap, vec::Vec};
 use miden_crypto::hash::blake::Blake3Digest;
 
 use crate::mast::{
-    DecoratorId, MastForest, MastForestError, MastNode, MastNodeFingerprint, MastNodeId,
-    MultiMastForestIteratorItem, MultiMastForestNodeIter, node::MastNodeExt,
+    DecoratorId, MastForest, MastForestError, MastNode, MastNodeErrorContext, MastNodeFingerprint,
+    MastNodeId, MultiMastForestIteratorItem, MultiMastForestNodeIter, node::MastNodeExt,
 };
 
 #[cfg(test)]
@@ -312,9 +312,8 @@ impl MastForestMerger {
                     Some(
                         basic_block_node
                             .decorators()
-                            .iter()
-                            .map(|(idx, decorator_id)| match map_decorator_id(decorator_id) {
-                                Ok(mapped_decorator) => Ok((*idx, mapped_decorator)),
+                            .map(|(idx, decorator_id)| match map_decorator_id(&decorator_id) {
+                                Ok(mapped_decorator) => Ok((idx, mapped_decorator)),
                                 Err(err) => Err(err),
                             })
                             .collect::<Result<Vec<_>, _>>()?,

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -3,8 +3,9 @@ use alloc::{collections::BTreeMap, vec::Vec};
 use miden_crypto::hash::blake::Blake3Digest;
 
 use crate::mast::{
-    DecoratorId, MastForest, MastForestError, MastNode, MastNodeErrorContext, MastNodeFingerprint,
-    MastNodeId, MultiMastForestIteratorItem, MultiMastForestNodeIter, node::MastNodeExt,
+    BasicBlockNode, CallNode, DecoratorId, DynNode, ExternalNode, JoinNode, LoopNode, MastForest,
+    MastForestError, MastNode, MastNodeErrorContext, MastNodeFingerprint, MastNodeId,
+    MultiMastForestIteratorItem, MultiMastForestNodeIter, SplitNode, node::MastNodeExt,
 };
 
 #[cfg(test)]
@@ -278,34 +279,38 @@ impl MastForestMerger {
 
         // Due to DFS postorder iteration all children of node's should have been inserted before
         // their parents which is why we can `expect` the constructor calls here.
-        let mut mapped_node = match node {
+        let mut mapped_node: MastNode = match node {
             MastNode::Join(join_node) => {
                 let first = map_node_id(join_node.first());
                 let second = map_node_id(join_node.second());
 
-                MastNode::new_join(first, second, &self.mast_forest)
+                JoinNode::new([first, second], &self.mast_forest)
                     .expect("JoinNode children should have been mapped to a lower index")
+                    .into()
             },
             MastNode::Split(split_node) => {
                 let if_branch = map_node_id(split_node.on_true());
                 let else_branch = map_node_id(split_node.on_false());
 
-                MastNode::new_split(if_branch, else_branch, &self.mast_forest)
+                SplitNode::new([if_branch, else_branch], &self.mast_forest)
                     .expect("SplitNode children should have been mapped to a lower index")
+                    .into()
             },
             MastNode::Loop(loop_node) => {
                 let body = map_node_id(loop_node.body());
-                MastNode::new_loop(body, &self.mast_forest)
+                LoopNode::new(body, &self.mast_forest)
                     .expect("LoopNode children should have been mapped to a lower index")
+                    .into()
             },
             MastNode::Call(call_node) => {
                 let callee = map_node_id(call_node.callee());
-                MastNode::new_call(callee, &self.mast_forest)
+                CallNode::new(callee, &self.mast_forest)
                     .expect("CallNode children should have been mapped to a lower index")
+                    .into()
             },
             // Other nodes are simply copied.
             MastNode::Block(basic_block_node) => {
-                MastNode::new_basic_block(
+                BasicBlockNode::new(
                     basic_block_node.operations().copied().collect(),
                     // Operation Indices of decorators stay the same while decorator IDs need to be
                     // mapped.
@@ -320,9 +325,10 @@ impl MastForestMerger {
                     ),
                 )
                 .expect("previously valid BasicBlockNode should still be valid")
+                .into()
             },
-            MastNode::Dyn(_) => MastNode::new_dyn(),
-            MastNode::External(external_node) => MastNode::new_external(external_node.digest()),
+            MastNode::Dyn(_) => DynNode::new_dyn().into(),
+            MastNode::External(external_node) => ExternalNode::new(external_node.digest()).into(),
         };
 
         // Decorators must be handled specially for basic block nodes.

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -1,19 +1,20 @@
 use miden_crypto::{Felt, ONE, Word};
 
 use super::*;
-use crate::{Decorator, Operation};
+use crate::{Decorator, Operation, mast::BasicBlockNode};
 
 fn block_foo() -> MastNode {
-    MastNode::new_basic_block(vec![Operation::Mul, Operation::Add], None).unwrap()
+    BasicBlockNode::new(vec![Operation::Mul, Operation::Add], None).unwrap().into()
 }
 
 fn block_bar() -> MastNode {
-    MastNode::new_basic_block(vec![Operation::And, Operation::Eq], None).unwrap()
+    BasicBlockNode::new(vec![Operation::And, Operation::Eq], None).unwrap().into()
 }
 
 fn block_qux() -> MastNode {
-    MastNode::new_basic_block(vec![Operation::Swap, Operation::Push(ONE), Operation::Eq], None)
+    BasicBlockNode::new(vec![Operation::Swap, Operation::Push(ONE), Operation::Eq], None)
         .unwrap()
+        .into()
 }
 
 /// Asserts that the given forest contains exactly one node with the given digest.
@@ -344,7 +345,7 @@ fn mast_forest_merge_decorators() {
     foo_node_a.append_before_enter(&[deco1_a, deco2_a]);
     let id_foo_a = forest_a.add_node(foo_node_a).unwrap();
 
-    let mut loop_node_a = MastNode::new_loop(id_foo_a, &forest_a).unwrap();
+    let mut loop_node_a = LoopNode::new(id_foo_a, &forest_a).unwrap();
     loop_node_a.append_after_exit(&[deco0_a, deco2_a]);
     let id_loop_a = forest_a.add_node(loop_node_a).unwrap();
 
@@ -362,7 +363,7 @@ fn mast_forest_merge_decorators() {
     let id_foo_b = forest_b.add_node(foo_node_b).unwrap();
 
     // This loop node's decorators are different from the loop node in a.
-    let mut loop_node_b = MastNode::new_loop(id_foo_b, &forest_b).unwrap();
+    let mut loop_node_b = LoopNode::new(id_foo_b, &forest_b).unwrap();
     loop_node_b.append_after_exit(&[deco1_b, deco3_b]);
     let id_loop_b = forest_b.add_node(loop_node_b).unwrap();
 
@@ -529,7 +530,7 @@ fn mast_forest_merge_external_node_with_decorator() {
     let deco1 = forest_a.add_decorator(trace1.clone()).unwrap();
     let deco2 = forest_a.add_decorator(trace2.clone()).unwrap();
 
-    let mut external_node_a = MastNode::new_external(block_foo().digest());
+    let mut external_node_a = ExternalNode::new(block_foo().digest());
     external_node_a.append_before_enter(&[deco1]);
     external_node_a.append_after_exit(&[deco2]);
     let id_external_a = forest_a.add_node(external_node_a).unwrap();
@@ -596,7 +597,7 @@ fn mast_forest_merge_external_node_and_referenced_node_have_decorators() {
     // Build Forest A
     let deco1_a = forest_a.add_decorator(trace1.clone()).unwrap();
 
-    let mut external_node_a = MastNode::new_external(block_foo().digest());
+    let mut external_node_a = ExternalNode::new(block_foo().digest());
     external_node_a.append_before_enter(&[deco1_a]);
     let id_external_a = forest_a.add_node(external_node_a).unwrap();
 
@@ -669,12 +670,12 @@ fn mast_forest_merge_multiple_external_nodes_with_decorator() {
     let deco1_a = forest_a.add_decorator(trace1.clone()).unwrap();
     let deco2_a = forest_a.add_decorator(trace2.clone()).unwrap();
 
-    let mut external_node_a = MastNode::new_external(block_foo().digest());
+    let mut external_node_a = ExternalNode::new(block_foo().digest());
     external_node_a.append_before_enter(&[deco1_a]);
     external_node_a.append_after_exit(&[deco2_a]);
     let id_external_a = forest_a.add_node(external_node_a).unwrap();
 
-    let mut external_node_b = MastNode::new_external(block_foo().digest());
+    let mut external_node_b = ExternalNode::new(block_foo().digest());
     external_node_b.append_before_enter(&[deco1_a]);
     let id_external_b = forest_a.add_node(external_node_b).unwrap();
 

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -402,7 +402,7 @@ fn mast_forest_merge_decorators() {
     };
 
     assert_eq!(
-        merged_foo_block.decorators().as_slice(),
+        &merged_foo_block.decorators().collect::<Vec<_>>()[..],
         &[(0, merged_deco1), (0, merged_deco2)]
     );
 

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -97,13 +97,13 @@ impl MastForest {
     /// Adds a node to the forest, and returns the associated [`MastNodeId`].
     ///
     /// Adding two duplicate nodes will result in two distinct returned [`MastNodeId`]s.
-    pub fn add_node(&mut self, node: MastNode) -> Result<MastNodeId, MastForestError> {
+    pub fn add_node(&mut self, node: impl Into<MastNode>) -> Result<MastNodeId, MastForestError> {
         if self.nodes.len() == Self::MAX_NODES {
             return Err(MastForestError::TooManyNodes);
         }
 
         let new_node_id = MastNodeId(self.nodes.len() as u32);
-        self.nodes.push(node);
+        self.nodes.push(node.into());
 
         Ok(new_node_id)
     }
@@ -114,7 +114,7 @@ impl MastForest {
         operations: Vec<Operation>,
         decorators: Option<DecoratorList>,
     ) -> Result<MastNodeId, MastForestError> {
-        let block = MastNode::new_basic_block(operations, decorators)?;
+        let block = BasicBlockNode::new(operations, decorators)?;
         self.add_node(block)
     }
 
@@ -124,7 +124,7 @@ impl MastForest {
         left_child: MastNodeId,
         right_child: MastNodeId,
     ) -> Result<MastNodeId, MastForestError> {
-        let join = MastNode::new_join(left_child, right_child, self)?;
+        let join = JoinNode::new([left_child, right_child], self)?;
         self.add_node(join)
     }
 
@@ -134,41 +134,41 @@ impl MastForest {
         if_branch: MastNodeId,
         else_branch: MastNodeId,
     ) -> Result<MastNodeId, MastForestError> {
-        let split = MastNode::new_split(if_branch, else_branch, self)?;
+        let split = SplitNode::new([if_branch, else_branch], self)?;
         self.add_node(split)
     }
 
     /// Adds a loop node to the forest, and returns the [`MastNodeId`] associated with it.
     pub fn add_loop(&mut self, body: MastNodeId) -> Result<MastNodeId, MastForestError> {
-        let loop_node = MastNode::new_loop(body, self)?;
+        let loop_node = LoopNode::new(body, self)?;
         self.add_node(loop_node)
     }
 
     /// Adds a call node to the forest, and returns the [`MastNodeId`] associated with it.
     pub fn add_call(&mut self, callee: MastNodeId) -> Result<MastNodeId, MastForestError> {
-        let call = MastNode::new_call(callee, self)?;
+        let call = CallNode::new(callee, self)?;
         self.add_node(call)
     }
 
     /// Adds a syscall node to the forest, and returns the [`MastNodeId`] associated with it.
     pub fn add_syscall(&mut self, callee: MastNodeId) -> Result<MastNodeId, MastForestError> {
-        let syscall = MastNode::new_syscall(callee, self)?;
+        let syscall = CallNode::new_syscall(callee, self)?;
         self.add_node(syscall)
     }
 
     /// Adds a dyn node to the forest, and returns the [`MastNodeId`] associated with it.
     pub fn add_dyn(&mut self) -> Result<MastNodeId, MastForestError> {
-        self.add_node(MastNode::new_dyn())
+        self.add_node(DynNode::new_dyn())
     }
 
     /// Adds a dyncall node to the forest, and returns the [`MastNodeId`] associated with it.
     pub fn add_dyncall(&mut self) -> Result<MastNodeId, MastForestError> {
-        self.add_node(MastNode::new_dyncall())
+        self.add_node(DynNode::new_dyncall())
     }
 
     /// Adds an external node to the forest, and returns the [`MastNodeId`] associated with it.
     pub fn add_external(&mut self, mast_root: Word) -> Result<MastNodeId, MastForestError> {
-        self.add_node(MastNode::new_external(mast_root))
+        self.add_node(ExternalNode::new(mast_root))
     }
 
     /// Marks the given [`MastNodeId`] as being the root of a procedure.
@@ -291,7 +291,7 @@ impl MastForest {
         operations: Vec<Operation>,
         decorators: Vec<(usize, Decorator)>,
     ) -> Result<MastNodeId, MastForestError> {
-        let block = MastNode::new_basic_block_with_raw_decorators(operations, decorators, self)?;
+        let block = BasicBlockNode::new_with_raw_decorators(operations, decorators, self)?;
         self.add_node(block)
     }
 }

--- a/core/src/mast/multi_forest_node_iterator.rs
+++ b/core/src/mast/multi_forest_node_iterator.rs
@@ -319,7 +319,7 @@ pub(crate) enum MultiMastForestIteratorItem {
 mod tests {
 
     use super::*;
-    use crate::{Operation, Word};
+    use crate::{Operation, Word, mast::BasicBlockNode};
 
     fn random_digest() -> Word {
         Word::new([winter_rand_utils::rand_value(); 4])
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn multi_mast_forest_external_dependencies() {
-        let block_foo = MastNode::new_basic_block(vec![Operation::Drop], None).unwrap();
+        let block_foo = BasicBlockNode::new(vec![Operation::Drop], None).unwrap();
         let mut forest_a = MastForest::new();
         let id_foo_a = forest_a.add_external(block_foo.digest()).unwrap();
         let id_call_a = forest_a.add_call(id_foo_a).unwrap();
@@ -468,7 +468,7 @@ mod tests {
     /// Stdlib where this failed on a previous implementation.
     #[test]
     fn multi_mast_forest_child_duplicate() {
-        let block_foo = MastNode::new_basic_block(vec![Operation::Drop], None).unwrap();
+        let block_foo = BasicBlockNode::new(vec![Operation::Drop], None).unwrap();
         let mut forest = MastForest::new();
         let id_foo = forest.add_external(block_foo.digest()).unwrap();
         let id_call1 = forest.add_call(id_foo).unwrap();

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -187,14 +187,6 @@ impl BasicBlockNode {
         num_ops.try_into().expect("basic block contains more than 2^32 operations")
     }
 
-    /// Returns a list of decorators in this basic block node.
-    ///
-    /// Each decorator is accompanied by the operation index specifying the operation prior to
-    /// which the decorator should be executed.
-    pub fn decorators(&self) -> &DecoratorList {
-        &self.decorators
-    }
-
     /// Returns a [`DecoratorIdIterator`] which allows us to iterate through the decorator list of
     /// this basic block node while executing operation batches of this basic block node.
     pub fn decorator_iter(&self) -> DecoratorIdIterator<'_> {

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -7,7 +7,7 @@ use miden_formatting::prettier::PrettyPrint;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    DecoratorIterator, DecoratorList, Operation,
+    DecoratorIdIterator, DecoratorList, Operation,
     chiplets::hasher,
     mast::{DecoratorId, MastForest, MastForestError, MastNodeId, Remapping},
 };
@@ -195,17 +195,17 @@ impl BasicBlockNode {
         &self.decorators
     }
 
-    /// Returns a [`DecoratorIterator`] which allows us to iterate through the decorator list of
+    /// Returns a [`DecoratorIdIterator`] which allows us to iterate through the decorator list of
     /// this basic block node while executing operation batches of this basic block node.
-    pub fn decorator_iter(&self) -> DecoratorIterator<'_> {
-        DecoratorIterator::new(&self.decorators)
+    pub fn decorator_iter(&self) -> DecoratorIdIterator<'_> {
+        DecoratorIdIterator::new(&self.decorators)
     }
 
     /// Returns an iterator which allows us to iterate through the decorator list of
     /// this basic block node with op indexes aligned to the "raw" (un-padded)) op
     /// batches of the basic block node
-    pub fn raw_decorator_iter(&self) -> RawDecoratorIterator<'_> {
-        RawDecoratorIterator::new(&self.decorators, &self.op_batches)
+    pub fn raw_decorator_iter(&self) -> RawDecoratorIdIterator<'_> {
+        RawDecoratorIdIterator::new(&self.decorators, &self.op_batches)
     }
 
     /// Returns an iterator over the operations in the order in which they appear in the program.
@@ -415,7 +415,7 @@ impl fmt::Display for BasicBlockNodePrettyPrint<'_> {
 ///
 /// IOW this makes its `BasicBlockNode::raw_decorators` padding-unaware, or equivalently
 /// "removes" the padding of these decorators
-pub struct RawDecoratorIterator<'a> {
+pub struct RawDecoratorIdIterator<'a> {
     decorators: &'a DecoratorList,
     // cumulative padding offsets per group
     padding_offsets: DecoratorPaddingOffsets,
@@ -423,7 +423,7 @@ pub struct RawDecoratorIterator<'a> {
     idx: usize,
 }
 
-impl<'a> RawDecoratorIterator<'a> {
+impl<'a> RawDecoratorIdIterator<'a> {
     /// Returns a new instance of raw decorator iterator instantiated with the provided decorator
     /// list, tied to the provided op_batches list
     fn new(decorators: &'a DecoratorList, op_batches: &'a [OpBatch]) -> Self {
@@ -434,7 +434,7 @@ impl<'a> RawDecoratorIterator<'a> {
     }
 }
 
-impl<'a> Iterator for RawDecoratorIterator<'a> {
+impl<'a> Iterator for RawDecoratorIdIterator<'a> {
     type Item = (usize, &'a DecoratorId);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -449,7 +449,7 @@ impl<'a> Iterator for RawDecoratorIterator<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for RawDecoratorIterator<'a> {
+impl<'a> ExactSizeIterator for RawDecoratorIdIterator<'a> {
     fn len(&self) -> usize {
         self.decorators.len() - self.idx
     }

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -239,32 +239,10 @@ impl BasicBlockNode {
 //-------------------------------------------------------------------------------------------------
 /// Mutators
 impl BasicBlockNode {
-    /// Sets the provided list of decorators to be executed before all existing decorators.
-    pub fn prepend_decorators(&mut self, decorator_ids: &[DecoratorId]) {
-        let mut new_decorators: DecoratorList =
-            decorator_ids.iter().map(|decorator_id| (0, *decorator_id)).collect();
-        new_decorators.extend(mem::take(&mut self.decorators));
-
-        self.decorators = new_decorators;
-    }
-
-    /// Sets the provided list of decorators to be executed after all existing decorators.
-    pub fn append_decorators(&mut self, decorator_ids: &[DecoratorId]) {
-        let after_last_op_idx = self.num_operations() as usize;
-
-        self.decorators
-            .extend(decorator_ids.iter().map(|&decorator_id| (after_last_op_idx, decorator_id)));
-    }
-
     /// Used to initialize decorators for the [`BasicBlockNode`]. Replaces the existing decorators
     /// with the given ['DecoratorList'].
     pub fn set_decorators(&mut self, decorator_list: DecoratorList) {
         self.decorators = decorator_list;
-    }
-
-    /// Removes all decorators from this node.
-    pub fn remove_decorators(&mut self) {
-        self.decorators.truncate(0);
     }
 }
 
@@ -307,16 +285,26 @@ impl MastNodeExt for BasicBlockNode {
         &[]
     }
 
+    /// Sets the provided list of decorators to be executed before all existing decorators.
     fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
-        self.prepend_decorators(decorator_ids);
+        let mut new_decorators: DecoratorList =
+            decorator_ids.iter().map(|decorator_id| (0, *decorator_id)).collect();
+        new_decorators.extend(mem::take(&mut self.decorators));
+
+        self.decorators = new_decorators;
     }
 
+    /// Sets the provided list of decorators to be executed after all existing decorators.
     fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
-        self.append_decorators(decorator_ids);
+        let after_last_op_idx = self.num_operations() as usize;
+
+        self.decorators
+            .extend(decorator_ids.iter().map(|&decorator_id| (after_last_op_idx, decorator_id)));
     }
 
+    /// Removes all decorators from this node.
     fn remove_decorators(&mut self) {
-        self.remove_decorators();
+        self.decorators.truncate(0);
     }
 
     fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -70,26 +70,6 @@ impl DynNode {
     }
 }
 
-//-------------------------------------------------------------------------------------------------
-/// Mutators
-impl DynNode {
-    /// Sets the list of decorators to be executed before this node.
-    pub fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
-        self.before_enter.extend_from_slice(decorator_ids);
-    }
-
-    /// Sets the list of decorators to be executed after this node.
-    pub fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
-        self.after_exit.extend_from_slice(decorator_ids);
-    }
-
-    /// Removes all decorators from this node.
-    pub fn remove_decorators(&mut self) {
-        self.before_enter.truncate(0);
-        self.after_exit.truncate(0);
-    }
-}
-
 impl MastNodeErrorContext for DynNode {
     fn decorators(&self) -> impl Iterator<Item = (usize, DecoratorId)> {
         self.before_enter.iter().chain(&self.after_exit).copied().enumerate()
@@ -223,16 +203,20 @@ impl MastNodeExt for DynNode {
         &self.after_exit
     }
 
+    /// Sets the list of decorators to be executed before this node.
     fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
-        self.append_before_enter(decorator_ids);
+        self.before_enter.extend_from_slice(decorator_ids);
     }
 
+    /// Sets the list of decorators to be executed after this node.
     fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
-        self.append_after_exit(decorator_ids);
+        self.after_exit.extend_from_slice(decorator_ids);
     }
 
+    /// Removes all decorators from this node.
     fn remove_decorators(&mut self) {
-        self.remove_decorators();
+        self.before_enter.truncate(0);
+        self.after_exit.truncate(0);
     }
 
     fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -44,26 +44,6 @@ impl ExternalNode {
     }
 }
 
-//-------------------------------------------------------------------------------------------------
-/// Mutators
-impl ExternalNode {
-    /// Sets the list of decorators to be executed before this node.
-    pub fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
-        self.before_enter.extend_from_slice(decorator_ids);
-    }
-
-    /// Sets the list of decorators to be executed after this node.
-    pub fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
-        self.after_exit.extend_from_slice(decorator_ids);
-    }
-
-    /// Removes all decorators from this node.
-    pub fn remove_decorators(&mut self) {
-        self.before_enter.truncate(0);
-        self.after_exit.truncate(0);
-    }
-}
-
 impl MastNodeErrorContext for ExternalNode {
     fn decorators(&self) -> impl Iterator<Item = (usize, DecoratorId)> {
         self.before_enter.iter().chain(&self.after_exit).copied().enumerate()
@@ -176,16 +156,20 @@ impl MastNodeExt for ExternalNode {
         &self.after_exit
     }
 
+    /// Sets the list of decorators to be executed before this node.
     fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
-        self.append_before_enter(decorator_ids);
+        self.before_enter.extend_from_slice(decorator_ids);
     }
 
+    /// Sets the list of decorators to be executed after this node.
     fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
-        self.append_after_exit(decorator_ids);
+        self.after_exit.extend_from_slice(decorator_ids);
     }
 
+    /// Removes all decorators from this node.
     fn remove_decorators(&mut self) {
-        self.remove_decorators();
+        self.before_enter.truncate(0);
+        self.after_exit.truncate(0);
     }
 
     fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -77,21 +77,6 @@ impl JoinNode {
 
 /// Public accessors
 impl JoinNode {
-    /// Returns a commitment to this Join node.
-    ///
-    /// The commitment is computed as a hash of the `first` and `second` child node in the domain
-    /// defined by [Self::DOMAIN] - i.e.,:
-    /// ```
-    /// # use miden_core::mast::JoinNode;
-    /// # use miden_crypto::{Word, hash::rpo::Rpo256 as Hasher};
-    /// # let first_child_digest = Word::default();
-    /// # let second_child_digest = Word::default();
-    /// Hasher::merge_in_domain(&[first_child_digest, second_child_digest], JoinNode::DOMAIN);
-    /// ```
-    pub fn digest(&self) -> Word {
-        self.digest
-    }
-
     /// Returns the ID of the node that is to be executed first.
     pub fn first(&self) -> MastNodeId {
         self.children[0]
@@ -101,43 +86,6 @@ impl JoinNode {
     /// defined by the first node completes.
     pub fn second(&self) -> MastNodeId {
         self.children[1]
-    }
-
-    /// Returns the decorators to be executed before this node is executed.
-    pub fn before_enter(&self) -> &[DecoratorId] {
-        &self.before_enter
-    }
-
-    /// Returns the decorators to be executed after this node is executed.
-    pub fn after_exit(&self) -> &[DecoratorId] {
-        &self.after_exit
-    }
-}
-
-//-------------------------------------------------------------------------------------------------
-/// Mutators
-impl JoinNode {
-    pub fn remap_children(&self, remapping: &Remapping) -> Self {
-        let mut node = self.clone();
-        node.children[0] = node.children[0].remap(remapping);
-        node.children[1] = node.children[1].remap(remapping);
-        node
-    }
-
-    /// Sets the list of decorators to be executed before this node.
-    pub fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
-        self.before_enter.extend_from_slice(decorator_ids);
-    }
-
-    /// Sets the list of decorators to be executed after this node.
-    pub fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
-        self.after_exit.extend_from_slice(decorator_ids);
-    }
-
-    /// Removes all decorators from this node.
-    pub fn remove_decorators(&mut self) {
-        self.before_enter.truncate(0);
-        self.after_exit.truncate(0);
     }
 }
 
@@ -256,17 +204,20 @@ impl MastNodeExt for JoinNode {
     fn after_exit(&self) -> &[DecoratorId] {
         &self.after_exit
     }
-
+    /// Sets the list of decorators to be executed before this node.
     fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
-        self.append_before_enter(decorator_ids);
+        self.before_enter.extend_from_slice(decorator_ids);
     }
 
+    /// Sets the list of decorators to be executed after this node.
     fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
-        self.append_after_exit(decorator_ids);
+        self.after_exit.extend_from_slice(decorator_ids);
     }
 
+    /// Removes all decorators from this node.
     fn remove_decorators(&mut self) {
-        self.remove_decorators();
+        self.before_enter.truncate(0);
+        self.after_exit.truncate(0);
     }
 
     fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -73,59 +73,9 @@ impl LoopNode {
 }
 
 impl LoopNode {
-    /// Returns a commitment to this Loop node.
-    ///
-    /// The commitment is computed as a hash of the loop body and an empty word ([ZERO; 4]) in
-    /// the domain defined by [Self::DOMAIN] - i..e,:
-    /// ```
-    /// # use miden_core::mast::LoopNode;
-    /// # use miden_crypto::{Word, hash::rpo::Rpo256 as Hasher};
-    /// # let body_digest = Word::default();
-    /// Hasher::merge_in_domain(&[body_digest, Word::default()], LoopNode::DOMAIN);
-    /// ```
-    pub fn digest(&self) -> Word {
-        self.digest
-    }
-
     /// Returns the ID of the node presenting the body of the loop.
     pub fn body(&self) -> MastNodeId {
         self.body
-    }
-
-    /// Returns the decorators to be executed before this node is executed.
-    pub fn before_enter(&self) -> &[DecoratorId] {
-        &self.before_enter
-    }
-
-    /// Returns the decorators to be executed after this node is executed.
-    pub fn after_exit(&self) -> &[DecoratorId] {
-        &self.after_exit
-    }
-}
-
-//-------------------------------------------------------------------------------------------------
-/// Mutators
-impl LoopNode {
-    pub fn remap_children(&self, remapping: &Remapping) -> Self {
-        let mut node = self.clone();
-        node.body = node.body.remap(remapping);
-        node
-    }
-
-    /// Sets the list of decorators to be executed before this node.
-    pub fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
-        self.before_enter.extend_from_slice(decorator_ids);
-    }
-
-    /// Sets the list of decorators to be executed after this node.
-    pub fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
-        self.after_exit.extend_from_slice(decorator_ids);
-    }
-
-    /// Removes all decorators from this node.
-    pub fn remove_decorators(&mut self) {
-        self.before_enter.truncate(0);
-        self.after_exit.truncate(0);
     }
 }
 
@@ -211,28 +161,43 @@ impl fmt::Display for LoopNodePrettyPrint<'_> {
 // ================================================================================================
 
 impl MastNodeExt for LoopNode {
+    /// Returns a commitment to this Loop node.
+    ///
+    /// The commitment is computed as a hash of the loop body and an empty word ([ZERO; 4]) in
+    /// the domain defined by [Self::DOMAIN] - i..e,:
+    /// ```
+    /// # use miden_core::mast::LoopNode;
+    /// # use miden_crypto::{Word, hash::rpo::Rpo256 as Hasher};
+    /// # let body_digest = Word::default();
+    /// Hasher::merge_in_domain(&[body_digest, Word::default()], LoopNode::DOMAIN);
+    /// ```
     fn digest(&self) -> Word {
-        self.digest()
+        self.digest
     }
 
+    /// Returns the decorators to be executed before this node is executed.
     fn before_enter(&self) -> &[DecoratorId] {
-        self.before_enter()
+        &self.before_enter
     }
 
+    /// Returns the decorators to be executed after this node is executed.
     fn after_exit(&self) -> &[DecoratorId] {
-        self.after_exit()
+        &self.after_exit
     }
-
+    /// Sets the list of decorators to be executed before this node.
     fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
-        self.append_before_enter(decorator_ids);
+        self.before_enter.extend_from_slice(decorator_ids);
     }
 
+    /// Sets the list of decorators to be executed after this node.
     fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
-        self.append_after_exit(decorator_ids);
+        self.after_exit.extend_from_slice(decorator_ids);
     }
 
+    /// Removes all decorators from this node.
     fn remove_decorators(&mut self) {
-        self.remove_decorators();
+        self.before_enter.truncate(0);
+        self.after_exit.truncate(0);
     }
 
     fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -30,9 +30,9 @@ pub use split_node::SplitNode;
 mod loop_node;
 pub use loop_node::LoopNode;
 
-use super::{DecoratorId, MastForestError};
+use super::DecoratorId;
 use crate::{
-    AssemblyOp, Decorator, DecoratorList, Operation,
+    AssemblyOp, Decorator,
     mast::{MastForest, MastNodeId, Remapping},
 };
 
@@ -89,75 +89,6 @@ pub enum MastNode {
     Call(CallNode),
     Dyn(DynNode),
     External(ExternalNode),
-}
-
-// ------------------------------------------------------------------------------------------------
-/// Constructors
-impl MastNode {
-    pub fn new_basic_block(
-        operations: Vec<Operation>,
-        decorators: Option<DecoratorList>,
-    ) -> Result<Self, MastForestError> {
-        let block = BasicBlockNode::new(operations, decorators)?;
-        Ok(Self::Block(block))
-    }
-
-    pub fn new_join(
-        left_child: MastNodeId,
-        right_child: MastNodeId,
-        mast_forest: &MastForest,
-    ) -> Result<Self, MastForestError> {
-        let join = JoinNode::new([left_child, right_child], mast_forest)?;
-        Ok(Self::Join(join))
-    }
-
-    pub fn new_split(
-        if_branch: MastNodeId,
-        else_branch: MastNodeId,
-        mast_forest: &MastForest,
-    ) -> Result<Self, MastForestError> {
-        let split = SplitNode::new([if_branch, else_branch], mast_forest)?;
-        Ok(Self::Split(split))
-    }
-
-    pub fn new_loop(body: MastNodeId, mast_forest: &MastForest) -> Result<Self, MastForestError> {
-        let loop_node = LoopNode::new(body, mast_forest)?;
-        Ok(Self::Loop(loop_node))
-    }
-
-    pub fn new_call(callee: MastNodeId, mast_forest: &MastForest) -> Result<Self, MastForestError> {
-        let call = CallNode::new(callee, mast_forest)?;
-        Ok(Self::Call(call))
-    }
-
-    pub fn new_syscall(
-        callee: MastNodeId,
-        mast_forest: &MastForest,
-    ) -> Result<Self, MastForestError> {
-        let syscall = CallNode::new_syscall(callee, mast_forest)?;
-        Ok(Self::Call(syscall))
-    }
-
-    pub fn new_dyn() -> Self {
-        Self::Dyn(DynNode::new_dyn())
-    }
-    pub fn new_dyncall() -> Self {
-        Self::Dyn(DynNode::new_dyncall())
-    }
-
-    pub fn new_external(mast_root: Word) -> Self {
-        Self::External(ExternalNode::new(mast_root))
-    }
-
-    #[cfg(test)]
-    pub fn new_basic_block_with_raw_decorators(
-        operations: Vec<Operation>,
-        decorators: Vec<(usize, crate::Decorator)>,
-        mast_forest: &mut MastForest,
-    ) -> Result<Self, MastForestError> {
-        let block = BasicBlockNode::new_with_raw_decorators(operations, decorators, mast_forest)?;
-        Ok(Self::Block(block))
-    }
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -80,21 +80,6 @@ impl SplitNode {
 
 /// Public accessors
 impl SplitNode {
-    /// Returns a commitment to this Split node.
-    ///
-    /// The commitment is computed as a hash of the `on_true` and `on_false` child nodes in the
-    /// domain defined by [Self::DOMAIN] - i..e,:
-    /// ```
-    /// # use miden_core::mast::SplitNode;
-    /// # use miden_crypto::{Word, hash::rpo::Rpo256 as Hasher};
-    /// # let on_true_digest = Word::default();
-    /// # let on_false_digest = Word::default();
-    /// Hasher::merge_in_domain(&[on_true_digest, on_false_digest], SplitNode::DOMAIN);
-    /// ```
-    pub fn digest(&self) -> Word {
-        self.digest
-    }
-
     /// Returns the ID of the node which is to be executed if the top of the stack is `1`.
     pub fn on_true(&self) -> MastNodeId {
         self.branches[0]
@@ -103,43 +88,6 @@ impl SplitNode {
     /// Returns the ID of the node which is to be executed if the top of the stack is `0`.
     pub fn on_false(&self) -> MastNodeId {
         self.branches[1]
-    }
-
-    /// Returns the decorators to be executed before this node is executed.
-    pub fn before_enter(&self) -> &[DecoratorId] {
-        &self.before_enter
-    }
-
-    /// Returns the decorators to be executed after this node is executed.
-    pub fn after_exit(&self) -> &[DecoratorId] {
-        &self.after_exit
-    }
-}
-
-//-------------------------------------------------------------------------------------------------
-/// Mutators
-impl SplitNode {
-    pub fn remap_children(&self, remapping: &Remapping) -> Self {
-        let mut node = self.clone();
-        node.branches[0] = node.branches[0].remap(remapping);
-        node.branches[1] = node.branches[1].remap(remapping);
-        node
-    }
-
-    /// Sets the list of decorators to be executed before this node.
-    pub fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
-        self.before_enter.extend_from_slice(decorator_ids);
-    }
-
-    /// Sets the list of decorators to be executed after this node.
-    pub fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
-        self.after_exit.extend_from_slice(decorator_ids);
-    }
-
-    /// Removes all decorators from this node.
-    pub fn remove_decorators(&mut self) {
-        self.before_enter.truncate(0);
-        self.after_exit.truncate(0);
     }
 }
 
@@ -227,28 +175,44 @@ impl fmt::Display for SplitNodePrettyPrint<'_> {
 // ================================================================================================
 
 impl MastNodeExt for SplitNode {
+    /// Returns a commitment to this Split node.
+    ///
+    /// The commitment is computed as a hash of the `on_true` and `on_false` child nodes in the
+    /// domain defined by [Self::DOMAIN] - i..e,:
+    /// ```
+    /// # use miden_core::mast::SplitNode;
+    /// # use miden_crypto::{Word, hash::rpo::Rpo256 as Hasher};
+    /// # let on_true_digest = Word::default();
+    /// # let on_false_digest = Word::default();
+    /// Hasher::merge_in_domain(&[on_true_digest, on_false_digest], SplitNode::DOMAIN);
+    /// ```
     fn digest(&self) -> Word {
-        self.digest()
+        self.digest
     }
 
+    /// Returns the decorators to be executed before this node is executed.
     fn before_enter(&self) -> &[DecoratorId] {
-        self.before_enter()
+        &self.before_enter
     }
 
+    /// Returns the decorators to be executed after this node is executed.
     fn after_exit(&self) -> &[DecoratorId] {
-        self.after_exit()
+        &self.after_exit
     }
-
+    /// Sets the list of decorators to be executed before this node.
     fn append_before_enter(&mut self, decorator_ids: &[DecoratorId]) {
-        self.append_before_enter(decorator_ids);
+        self.before_enter.extend_from_slice(decorator_ids);
     }
 
+    /// Sets the list of decorators to be executed after this node.
     fn append_after_exit(&mut self, decorator_ids: &[DecoratorId]) {
-        self.append_after_exit(decorator_ids);
+        self.after_exit.extend_from_slice(decorator_ids);
     }
 
+    /// Removes all decorators from this node.
     fn remove_decorators(&mut self) {
-        self.remove_decorators();
+        self.before_enter.truncate(0);
+        self.after_exit.truncate(0);
     }
 
     fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {

--- a/core/src/mast/node_fingerprint.rs
+++ b/core/src/mast/node_fingerprint.rs
@@ -7,7 +7,10 @@ use miden_crypto::hash::{
 
 use crate::{
     Operation, Word,
-    mast::{DecoratorId, MastForest, MastForestError, MastNode, MastNodeId, node::MastNodeExt},
+    mast::{
+        DecoratorId, MastForest, MastForestError, MastNode, MastNodeId,
+        node::{MastNodeErrorContext, MastNodeExt},
+    },
 };
 
 // MAST NODE EQUALITY
@@ -57,7 +60,7 @@ impl MastNodeFingerprint {
             MastNode::Block(node) => {
                 let mut bytes_to_hash = Vec::new();
 
-                for &(idx, decorator_id) in node.decorators() {
+                for (idx, decorator_id) in node.decorators() {
                     bytes_to_hash.extend(idx.to_le_bytes());
                     bytes_to_hash.extend(forest[decorator_id].fingerprint().as_bytes());
                 }

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -3,8 +3,8 @@ use alloc::vec::Vec;
 use super::{NodeDataOffset, basic_blocks::BasicBlockDataDecoder};
 use crate::{
     mast::{
-        BasicBlockNode, CallNode, JoinNode, LoopNode, MastNode, MastNodeId, SplitNode, Word,
-        node::MastNodeExt,
+        BasicBlockNode, CallNode, DynNode, ExternalNode, JoinNode, LoopNode, MastNode, MastNodeId,
+        SplitNode, Word, node::MastNodeExt,
     },
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
@@ -79,9 +79,9 @@ impl MastNodeInfo {
                 let syscall = CallNode::new_syscall_unsafe(callee_id, self.digest);
                 Ok(MastNode::Call(syscall))
             },
-            MastNodeType::Dyn => Ok(MastNode::new_dyn()),
-            MastNodeType::Dyncall => Ok(MastNode::new_dyncall()),
-            MastNodeType::External => Ok(MastNode::new_external(self.digest)),
+            MastNodeType::Dyn => Ok(MastNode::Dyn(DynNode::new_dyn())),
+            MastNodeType::Dyncall => Ok(MastNode::Dyn(DynNode::new_dyncall())),
+            MastNodeType::External => Ok(MastNode::External(ExternalNode::new(self.digest))),
         }
     }
 }

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -48,7 +48,7 @@ use alloc::{
 use decorator::{DecoratorDataBuilder, DecoratorInfo};
 use string_table::StringTable;
 
-use super::{DecoratorId, MastForest, MastNode, MastNodeId};
+use super::{DecoratorId, MastForest, MastNode, MastNodeErrorContext, MastNodeId};
 use crate::{
     AdviceMap,
     mast::node::MastNodeExt,
@@ -140,7 +140,8 @@ impl Serializable for MastForest {
                 let ops_offset = if let MastNode::Block(basic_block) = mast_node {
                     let ops_offset = basic_block_data_builder.encode_basic_block(basic_block);
 
-                    basic_block_decorators.push((mast_node_id, basic_block.decorators().clone()));
+                    basic_block_decorators
+                        .push((mast_node_id, basic_block.decorators().collect::<Vec<_>>()));
 
                     ops_offset
                 } else {

--- a/core/src/operations/decorators/mod.rs
+++ b/core/src/operations/decorators/mod.rs
@@ -87,12 +87,12 @@ pub type DecoratorList = Vec<(usize, DecoratorId)>;
 
 /// Iterator used to iterate through the decorator list of a span block
 /// while executing operation batches of a span block.
-pub struct DecoratorIterator<'a> {
+pub struct DecoratorIdIterator<'a> {
     decorators: &'a DecoratorList,
     idx: usize,
 }
 
-impl<'a> DecoratorIterator<'a> {
+impl<'a> DecoratorIdIterator<'a> {
     /// Returns a new instance of decorator iterator instantiated with the provided decorator list.
     pub fn new(decorators: &'a DecoratorList) -> Self {
         Self { decorators, idx: 0 }
@@ -111,7 +111,7 @@ impl<'a> DecoratorIterator<'a> {
     }
 }
 
-impl<'a> Iterator for DecoratorIterator<'a> {
+impl<'a> Iterator for DecoratorIdIterator<'a> {
     type Item = &'a DecoratorId;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -124,7 +124,7 @@ impl<'a> Iterator for DecoratorIterator<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for DecoratorIterator<'a> {
+impl<'a> ExactSizeIterator for DecoratorIdIterator<'a> {
     fn len(&self) -> usize {
         self.decorators.len() - self.idx
     }

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 mod decorators;
-pub use decorators::{AssemblyOp, DebugOptions, Decorator, DecoratorIterator, DecoratorList};
+pub use decorators::{AssemblyOp, DebugOptions, Decorator, DecoratorIdIterator, DecoratorList};
 use opcode_constants::*;
 
 use crate::{

--- a/miden-vm/tests/integration/operations/io_ops/env_ops.rs
+++ b/miden-vm/tests/integration/operations/io_ops/env_ops.rs
@@ -1,6 +1,6 @@
 use miden_core::{
     Operation,
-    mast::{MastForest, MastNode, MastNodeExt},
+    mast::{CallNode, MastForest, MastNode, MastNodeExt},
 };
 use miden_debug_types::{SourceLanguage, SourceManager};
 use miden_processor::FMP_MIN;
@@ -191,7 +191,7 @@ fn build_bar_hash() -> [u64; 4] {
 
     let foo_root_id = mast_forest.add_block(vec![Operation::Caller], None).unwrap();
 
-    let bar_root = MastNode::new_syscall(foo_root_id, &mast_forest).unwrap();
+    let bar_root: MastNode = CallNode::new_syscall(foo_root_id, &mast_forest).unwrap().into();
     let bar_hash: Word = bar_root.digest();
     [
         bar_hash[0].as_int(),

--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -16,6 +16,7 @@ use super::{
     MerklePath, RETURN_HASH, RETURN_STATE, Selectors, TRACE_WIDTH, TraceFragment,
     init_state_from_words,
 };
+use crate::{BasicBlockNode, JoinNode, LoopNode, SplitNode};
 
 // LINEAR HASH TESTS
 // ================================================================================================
@@ -249,19 +250,19 @@ fn hash_memoization_control_blocks() {
 
     let mut mast_forest = MastForest::new();
 
-    let t_branch = MastNode::new_basic_block(vec![Operation::Push(ZERO)], None).unwrap();
+    let t_branch = BasicBlockNode::new(vec![Operation::Push(ZERO)], None).unwrap();
     let t_branch_id = mast_forest.add_node(t_branch.clone()).unwrap();
 
-    let f_branch = MastNode::new_basic_block(vec![Operation::Push(ONE)], None).unwrap();
+    let f_branch = BasicBlockNode::new(vec![Operation::Push(ONE)], None).unwrap();
     let f_branch_id = mast_forest.add_node(f_branch.clone()).unwrap();
 
-    let split1 = MastNode::new_split(t_branch_id, f_branch_id, &mast_forest).unwrap();
+    let split1 = SplitNode::new([t_branch_id, f_branch_id], &mast_forest).unwrap();
     let split1_id = mast_forest.add_node(split1.clone()).unwrap();
 
-    let split2 = MastNode::new_split(t_branch_id, f_branch_id, &mast_forest).unwrap();
+    let split2 = SplitNode::new([t_branch_id, f_branch_id], &mast_forest).unwrap();
     let split2_id = mast_forest.add_node(split2.clone()).unwrap();
 
-    let join_node = MastNode::new_join(split1_id, split2_id, &mast_forest).unwrap();
+    let join_node = JoinNode::new([split1_id, split2_id], &mast_forest).unwrap();
     let _join_node_id = mast_forest.add_node(join_node.clone()).unwrap();
 
     let mut hasher = Hasher::default();
@@ -353,10 +354,9 @@ fn hash_memoization_control_blocks() {
 fn hash_memoization_basic_blocks() {
     // --- basic block with 1 batch ----------------------------------------------------------------
     let basic_block =
-        MastNode::new_basic_block(vec![Operation::Push(Felt::new(10)), Operation::Drop], None)
-            .unwrap();
+        BasicBlockNode::new(vec![Operation::Push(Felt::new(10)), Operation::Drop], None).unwrap();
 
-    hash_memoization_basic_blocks_check(basic_block);
+    hash_memoization_basic_blocks_check(basic_block.into());
 
     // --- basic block with multiple batches -------------------------------------------------------
     let ops = vec![
@@ -397,9 +397,9 @@ fn hash_memoization_basic_blocks() {
         Operation::Drop,
         Operation::Drop,
     ];
-    let basic_block = MastNode::new_basic_block(ops, None).unwrap();
+    let basic_block = BasicBlockNode::new(ops, None).unwrap();
 
-    hash_memoization_basic_blocks_check(basic_block);
+    hash_memoization_basic_blocks_check(basic_block.into());
 }
 
 fn hash_memoization_basic_blocks_check(basic_block: MastNode) {
@@ -426,16 +426,16 @@ fn hash_memoization_basic_blocks_check(basic_block: MastNode) {
         .add_block(vec![Operation::Pad, Operation::Eq, Operation::Not], None)
         .unwrap();
 
-    let loop_block = MastNode::new_loop(loop_body_id, &mast_forest).unwrap();
+    let loop_block = LoopNode::new(loop_body_id, &mast_forest).unwrap();
     let loop_block_id = mast_forest.add_node(loop_block.clone()).unwrap();
 
-    let join2_block = MastNode::new_join(basic_block_1_id, loop_block_id, &mast_forest).unwrap();
+    let join2_block = JoinNode::new([basic_block_1_id, loop_block_id], &mast_forest).unwrap();
     let join2_block_id = mast_forest.add_node(join2_block.clone()).unwrap();
 
     let basic_block_2 = basic_block;
     let basic_block_2_id = mast_forest.add_node(basic_block_2.clone()).unwrap();
 
-    let join1_block = MastNode::new_join(join2_block_id, basic_block_2_id, &mast_forest).unwrap();
+    let join1_block = JoinNode::new([join2_block_id, basic_block_2_id], &mast_forest).unwrap();
 
     let mut hasher = Hasher::default();
     let h1: [Felt; DIGEST_LEN] = join2_block

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -14,8 +14,8 @@ use miden_air::trace::{
 use miden_core::{
     EMPTY_WORD, EventId, ONE, Program, WORD_SIZE, ZERO, assert_matches,
     mast::{
-        BasicBlockNode, CallNode, DynNode, JoinNode, MastForest, MastNode, MastNodeExt,
-        MastNodeId, OP_BATCH_SIZE,
+        BasicBlockNode, CallNode, DynNode, JoinNode, MastForest, MastNode, MastNodeExt, MastNodeId,
+        OP_BATCH_SIZE,
     },
 };
 use miden_utils_testing::rand::rand_value;

--- a/processor/src/decoder/tests.rs
+++ b/processor/src/decoder/tests.rs
@@ -13,7 +13,10 @@ use miden_air::trace::{
 };
 use miden_core::{
     EMPTY_WORD, EventId, ONE, Program, WORD_SIZE, ZERO, assert_matches,
-    mast::{BasicBlockNode, MastForest, MastNode, MastNodeExt, MastNodeId, OP_BATCH_SIZE},
+    mast::{
+        BasicBlockNode, CallNode, DynNode, JoinNode, MastForest, MastNode, MastNodeExt,
+        MastNodeId, OP_BATCH_SIZE,
+    },
 };
 use miden_utils_testing::rand::rand_value;
 use rstest::rstest;
@@ -432,8 +435,8 @@ fn span_block_with_respan() {
 
 #[test]
 fn join_node() {
-    let basic_block1 = MastNode::new_basic_block(vec![Operation::Mul], None).unwrap();
-    let basic_block2 = MastNode::new_basic_block(vec![Operation::Add], None).unwrap();
+    let basic_block1 = BasicBlockNode::new(vec![Operation::Mul], None).unwrap();
+    let basic_block2 = BasicBlockNode::new(vec![Operation::Add], None).unwrap();
     let program = {
         let mut mast_forest = MastForest::new();
 
@@ -498,8 +501,8 @@ fn join_node() {
 
 #[test]
 fn split_node_true() {
-    let basic_block1 = MastNode::new_basic_block(vec![Operation::Mul], None).unwrap();
-    let basic_block2 = MastNode::new_basic_block(vec![Operation::Add], None).unwrap();
+    let basic_block1 = BasicBlockNode::new(vec![Operation::Mul], None).unwrap();
+    let basic_block2 = BasicBlockNode::new(vec![Operation::Add], None).unwrap();
     let program = {
         let mut mast_forest = MastForest::new();
 
@@ -551,8 +554,8 @@ fn split_node_true() {
 
 #[test]
 fn split_node_false() {
-    let basic_block1 = MastNode::new_basic_block(vec![Operation::Mul], None).unwrap();
-    let basic_block2 = MastNode::new_basic_block(vec![Operation::Add], None).unwrap();
+    let basic_block1 = BasicBlockNode::new(vec![Operation::Mul], None).unwrap();
+    let basic_block2 = BasicBlockNode::new(vec![Operation::Add], None).unwrap();
     let program = {
         let mut mast_forest = MastForest::new();
 
@@ -607,7 +610,7 @@ fn split_node_false() {
 
 #[test]
 fn loop_node() {
-    let loop_body = MastNode::new_basic_block(vec![Operation::Pad, Operation::Drop], None).unwrap();
+    let loop_body = BasicBlockNode::new(vec![Operation::Pad, Operation::Drop], None).unwrap();
     let program = {
         let mut mast_forest = MastForest::new();
 
@@ -659,7 +662,7 @@ fn loop_node() {
 
 #[test]
 fn loop_node_skip() {
-    let loop_body = MastNode::new_basic_block(vec![Operation::Pad, Operation::Drop], None).unwrap();
+    let loop_body = BasicBlockNode::new(vec![Operation::Pad, Operation::Drop], None).unwrap();
     let program = {
         let mut mast_forest = MastForest::new();
 
@@ -701,7 +704,7 @@ fn loop_node_skip() {
 
 #[test]
 fn loop_node_repeat() {
-    let loop_body = MastNode::new_basic_block(vec![Operation::Pad, Operation::Drop], None).unwrap();
+    let loop_body = BasicBlockNode::new(vec![Operation::Pad, Operation::Drop], None).unwrap();
     let program = {
         let mut mast_forest = MastForest::new();
 
@@ -791,25 +794,25 @@ fn call_block() {
 
     let mut mast_forest = MastForest::new();
 
-    let first_basic_block = MastNode::new_basic_block(vec![
+    let first_basic_block = BasicBlockNode::new(vec![
         Operation::Push(TWO),
         Operation::FmpUpdate,
         Operation::Pad,
     ], None).unwrap();
     let first_basic_block_id = mast_forest.add_node(first_basic_block.clone()).unwrap();
 
-    let foo_root_node = MastNode::new_basic_block(vec![
+    let foo_root_node = BasicBlockNode::new(vec![
         Operation::Push(ONE), Operation::FmpUpdate
     ], None).unwrap();
     let foo_root_node_id = mast_forest.add_node(foo_root_node.clone()).unwrap();
 
-    let last_basic_block = MastNode::new_basic_block(vec![Operation::FmpAdd, Operation::Swap, Operation::Drop], None).unwrap();
+    let last_basic_block = BasicBlockNode::new(vec![Operation::FmpAdd, Operation::Swap, Operation::Drop], None).unwrap();
     let last_basic_block_id = mast_forest.add_node(last_basic_block.clone()).unwrap();
 
-    let foo_call_node = MastNode::new_call(foo_root_node_id, &mast_forest).unwrap();
+    let foo_call_node = CallNode::new(foo_root_node_id, &mast_forest).unwrap();
     let foo_call_node_id = mast_forest.add_node(foo_call_node.clone()).unwrap();
 
-    let join1_node = MastNode::new_join(first_basic_block_id, foo_call_node_id, &mast_forest).unwrap();
+    let join1_node = JoinNode::new([first_basic_block_id, foo_call_node_id], &mast_forest).unwrap();
     let join1_node_id = mast_forest.add_node(join1_node.clone()).unwrap();
 
     let program_root_id = mast_forest.add_join(join1_node_id, last_basic_block_id).unwrap();
@@ -1011,40 +1014,40 @@ fn syscall_block() {
     let mut mast_forest = MastForest::new();
 
     // build foo procedure body
-    let foo_root = MastNode::new_basic_block(vec![Operation::Push(THREE), Operation::FmpUpdate], None).unwrap();
+    let foo_root = BasicBlockNode::new(vec![Operation::Push(THREE), Operation::FmpUpdate], None).unwrap();
     let foo_root_id = mast_forest.add_node(foo_root.clone()).unwrap();
     mast_forest.make_root(foo_root_id);
     let kernel = Kernel::new(&[foo_root.digest()]).unwrap();
 
     // build bar procedure body
-    let bar_basic_block = MastNode::new_basic_block(vec![Operation::Push(TWO), Operation::FmpUpdate], None).unwrap();
+    let bar_basic_block = BasicBlockNode::new(vec![Operation::Push(TWO), Operation::FmpUpdate], None).unwrap();
     let bar_basic_block_id = mast_forest.add_node(bar_basic_block.clone()).unwrap();
 
-    let foo_call_node = MastNode::new_syscall(foo_root_id, &mast_forest).unwrap();
+    let foo_call_node = CallNode::new_syscall(foo_root_id, &mast_forest).unwrap();
     let foo_call_node_id = mast_forest.add_node(foo_call_node.clone()).unwrap();
 
-    let bar_root_node = MastNode::new_join(bar_basic_block_id, foo_call_node_id, &mast_forest).unwrap();
+    let bar_root_node = JoinNode::new([bar_basic_block_id, foo_call_node_id], &mast_forest).unwrap();
     let bar_root_node_id = mast_forest.add_node(bar_root_node.clone()).unwrap();
     mast_forest.make_root(bar_root_node_id);
 
     // build the program
-    let first_basic_block = MastNode::new_basic_block(vec![
+    let first_basic_block = BasicBlockNode::new(vec![
         Operation::Push(ONE),
         Operation::FmpUpdate,
         Operation::Pad,
     ], None).unwrap();
     let first_basic_block_id = mast_forest.add_node(first_basic_block.clone()).unwrap();
 
-    let last_basic_block = MastNode::new_basic_block(vec![Operation::FmpAdd, Operation::Swap, Operation::Drop], None).unwrap();
+    let last_basic_block = BasicBlockNode::new(vec![Operation::FmpAdd, Operation::Swap, Operation::Drop], None).unwrap();
     let last_basic_block_id = mast_forest.add_node(last_basic_block.clone()).unwrap();
 
-    let bar_call_node = MastNode::new_call(bar_root_node_id, &mast_forest).unwrap();
+    let bar_call_node = CallNode::new(bar_root_node_id, &mast_forest).unwrap();
     let bar_call_node_id = mast_forest.add_node(bar_call_node.clone()).unwrap();
 
-    let inner_join_node = MastNode::new_join(first_basic_block_id, bar_call_node_id, &mast_forest).unwrap();
+    let inner_join_node = JoinNode::new([first_basic_block_id, bar_call_node_id], &mast_forest).unwrap();
     let inner_join_node_id = mast_forest.add_node(inner_join_node.clone()).unwrap();
 
-    let program_root_node = MastNode::new_join(inner_join_node_id, last_basic_block_id, &mast_forest).unwrap();
+    let program_root_node = JoinNode::new([inner_join_node_id, last_basic_block_id], &mast_forest).unwrap();
     let program_root_node_id = mast_forest.add_node(program_root_node.clone()).unwrap();
     mast_forest.make_root(program_root_node_id);
 
@@ -1316,24 +1319,24 @@ fn dyn_block() {
     let mut mast_forest = MastForest::new();
 
     let foo_root_node =
-        MastNode::new_basic_block(vec![Operation::Push(ONE), Operation::Add], None).unwrap();
+        BasicBlockNode::new(vec![Operation::Push(ONE), Operation::Add], None).unwrap();
     let foo_root_node_id = mast_forest.add_node(foo_root_node.clone()).unwrap();
     mast_forest.make_root(foo_root_node_id);
 
-    let mstorew_node = MastNode::new_basic_block(vec![Operation::MStoreW], None).unwrap();
+    let mstorew_node = BasicBlockNode::new(vec![Operation::MStoreW], None).unwrap();
     let mstorew_node_id = mast_forest.add_node(mstorew_node.clone()).unwrap();
 
-    let push_node = MastNode::new_basic_block(vec![PUSH_40_OP], None).unwrap();
+    let push_node = BasicBlockNode::new(vec![PUSH_40_OP], None).unwrap();
     let push_node_id = mast_forest.add_node(push_node.clone()).unwrap();
 
-    let join_node = MastNode::new_join(mstorew_node_id, push_node_id, &mast_forest).unwrap();
+    let join_node = JoinNode::new([mstorew_node_id, push_node_id], &mast_forest).unwrap();
     let join_node_id = mast_forest.add_node(join_node.clone()).unwrap();
 
     // This dyn will point to foo.
-    let dyn_node = MastNode::new_dyn();
+    let dyn_node = DynNode::new_dyn();
     let dyn_node_id = mast_forest.add_node(dyn_node.clone()).unwrap();
 
-    let program_root_node = MastNode::new_join(join_node_id, dyn_node_id, &mast_forest).unwrap();
+    let program_root_node = JoinNode::new([join_node_id, dyn_node_id], &mast_forest).unwrap();
     let program_root_node_id = mast_forest.add_node(program_root_node.clone()).unwrap();
     mast_forest.make_root(program_root_node_id);
 
@@ -1454,18 +1457,19 @@ fn calls_in_syscall(#[case] op: Operation) {
         // add dummy block
         mast_forest.add_block(vec![Operation::Add], None).unwrap();
 
-        let node = match op {
-            Operation::Dyncall => MastNode::new_dyncall(),
-            Operation::Call => MastNode::new_call(
+        let node: MastNode = match op {
+            Operation::Dyncall => DynNode::new_dyncall().into(),
+            Operation::Call => {
+                CallNode::new(MastNodeId::from_u32_safe(0, &mast_forest).unwrap(), &mast_forest)
+                    .unwrap()
+                    .into()
+            },
+            Operation::SysCall => CallNode::new_syscall(
                 MastNodeId::from_u32_safe(0, &mast_forest).unwrap(),
                 &mast_forest,
             )
-            .unwrap(),
-            Operation::SysCall => MastNode::new_syscall(
-                MastNodeId::from_u32_safe(0, &mast_forest).unwrap(),
-                &mast_forest,
-            )
-            .unwrap(),
+            .unwrap()
+            .into(),
             _ => unreachable!(),
         };
 

--- a/processor/src/fast/basic_block.rs
+++ b/processor/src/fast/basic_block.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 
 use miden_core::{
-    DecoratorIterator, EventId, Operation,
+    DecoratorIdIterator, EventId, Operation,
     mast::{BasicBlockNode, MastForest, MastNodeId, OpBatch},
     stack::MIN_STACK_DEPTH,
     sys_events::SystemEvent,
@@ -131,7 +131,7 @@ impl FastProcessor {
         node_id: MastNodeId,
         batch: &OpBatch,
         batch_index: usize,
-        decorators: &mut DecoratorIterator<'_>,
+        decorators: &mut DecoratorIdIterator<'_>,
         batch_offset_in_block: usize,
         program: &MastForest,
         host: &mut impl AsyncHost,

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -24,7 +24,7 @@ pub use miden_core::{
     utils::DeserializationError,
 };
 use miden_core::{
-    Decorator, DecoratorIterator, FieldElement,
+    Decorator, DecoratorIdIterator, FieldElement,
     mast::{
         BasicBlockNode, CallNode, DynNode, ExternalNode, JoinNode, LoopNode, OpBatch, SplitNode,
     },
@@ -604,7 +604,7 @@ impl Process {
         &mut self,
         basic_block: &BasicBlockNode,
         batch: &OpBatch,
-        decorators: &mut DecoratorIterator,
+        decorators: &mut DecoratorIdIterator,
         op_offset: usize,
         program: &MastForest,
         host: &mut impl SyncHost,

--- a/processor/src/trace/tests/decoder.rs
+++ b/processor/src/trace/tests/decoder.rs
@@ -4,7 +4,7 @@ use miden_air::trace::{
 };
 use miden_core::{
     FieldElement, ONE, Operation, Program, Word, ZERO,
-    mast::{MastForest, MastNode, MastNodeExt},
+    mast::{MastForest, MastNodeExt},
 };
 use miden_utils_testing::rand::rand_array;
 
@@ -17,7 +17,7 @@ use super::{
     Felt,
 };
 use crate::{
-    ContextId,
+    BasicBlockNode, ContextId, JoinNode,
     decoder::{BlockHashTableRow, build_op_group},
 };
 
@@ -354,13 +354,13 @@ fn decoder_p2_span_with_respan() {
 fn decoder_p2_join() {
     let mut mast_forest = MastForest::new();
 
-    let basic_block_1 = MastNode::new_basic_block(vec![Operation::Mul], None).unwrap();
+    let basic_block_1 = BasicBlockNode::new(vec![Operation::Mul], None).unwrap();
     let basic_block_1_id = mast_forest.add_node(basic_block_1.clone()).unwrap();
 
-    let basic_block_2 = MastNode::new_basic_block(vec![Operation::Add], None).unwrap();
+    let basic_block_2 = BasicBlockNode::new(vec![Operation::Add], None).unwrap();
     let basic_block_2_id = mast_forest.add_node(basic_block_2.clone()).unwrap();
 
-    let join = MastNode::new_join(basic_block_1_id, basic_block_2_id, &mast_forest).unwrap();
+    let join = JoinNode::new([basic_block_1_id, basic_block_2_id], &mast_forest).unwrap();
     let join_id = mast_forest.add_node(join.clone()).unwrap();
     mast_forest.make_root(join_id);
 
@@ -418,7 +418,7 @@ fn decoder_p2_split_true() {
     // build program
     let mut mast_forest = MastForest::new();
 
-    let basic_block_1 = MastNode::new_basic_block(vec![Operation::Mul], None).unwrap();
+    let basic_block_1 = BasicBlockNode::new(vec![Operation::Mul], None).unwrap();
     let basic_block_1_id = mast_forest.add_node(basic_block_1.clone()).unwrap();
     let basic_block_2_id = mast_forest.add_block(vec![Operation::Add], None).unwrap();
     let split_id = mast_forest.add_split(basic_block_1_id, basic_block_2_id).unwrap();
@@ -470,10 +470,10 @@ fn decoder_p2_split_false() {
     // build program
     let mut mast_forest = MastForest::new();
 
-    let basic_block_1 = MastNode::new_basic_block(vec![Operation::Mul], None).unwrap();
+    let basic_block_1 = BasicBlockNode::new(vec![Operation::Mul], None).unwrap();
     let basic_block_1_id = mast_forest.add_node(basic_block_1.clone()).unwrap();
 
-    let basic_block_2 = MastNode::new_basic_block(vec![Operation::Add], None).unwrap();
+    let basic_block_2 = BasicBlockNode::new(vec![Operation::Add], None).unwrap();
     let basic_block_2_id = mast_forest.add_node(basic_block_2.clone()).unwrap();
 
     let split_id = mast_forest.add_split(basic_block_1_id, basic_block_2_id).unwrap();
@@ -525,13 +525,13 @@ fn decoder_p2_loop_with_repeat() {
     // build program
     let mut mast_forest = MastForest::new();
 
-    let basic_block_1 = MastNode::new_basic_block(vec![Operation::Pad], None).unwrap();
+    let basic_block_1 = BasicBlockNode::new(vec![Operation::Pad], None).unwrap();
     let basic_block_1_id = mast_forest.add_node(basic_block_1.clone()).unwrap();
 
-    let basic_block_2 = MastNode::new_basic_block(vec![Operation::Drop], None).unwrap();
+    let basic_block_2 = BasicBlockNode::new(vec![Operation::Drop], None).unwrap();
     let basic_block_2_id = mast_forest.add_node(basic_block_2.clone()).unwrap();
 
-    let join = MastNode::new_join(basic_block_1_id, basic_block_2_id, &mast_forest).unwrap();
+    let join = JoinNode::new([basic_block_1_id, basic_block_2_id], &mast_forest).unwrap();
     let join_id = mast_forest.add_node(join.clone()).unwrap();
 
     let loop_node_id = mast_forest.add_loop(join_id).unwrap();


### PR DESCRIPTION
**Note: this is a re-opening of #2152 for stacking**

This checkpoints some uncontroversial quality-of-life improvements I've found on the way to #1776. I expect no behaviour changes from this PR. The commits each stand on their own, but to summarize:
- rename `DecoratorIterator`, `RawDecoratorIterator` to better reflect their `Self::Item`,
- removes struct methods where there is a trait method that's an exact replacement (often implemented using that method),
    - technically removes the `BasicBlockNode::(append|prepend)_decorators` methods, happy to deprecate instead,
- uses `MastNodeErrorContext::decorators` instead of `BasicBlockNode::decorators`
    - technically removes the slice-returning `BasicBlockNode::decorators`, happy to deprecate instead,
- relies on existing `From<VariantX> for MastNode` impls instead of ad-hoc constructors,
    - the former are more familiar and do not require learning new APIs,
    - removes the `MastNode::new_variant_x` methods, happy to deprecate instead,
- uses ad-hoc destructors `MastNode::unwrap_x` where reimplemented

I'll mark this change as breaking in the CHANGELOG, however borderline (the changed functions aren't really used much).