### PR TITLE
fix: run after-exit decorators when skipping loop (condition == 0)

### DIFF
--- a/processor/src/fast/loop.rs
+++ b/processor/src/fast/loop.rs
@@ -65,6 +65,9 @@ impl FastProcessor {
 
             // Increment the clock, corresponding to the END operation added to the trace.
             self.increment_clk(tracer);
+
+            // Execute decorators that should be executed after exiting the node
+            self.execute_after_exit_decorators(current_node_id, current_forest, host)?;
         } else {
             let err_ctx = err_ctx!(current_forest, loop_node, host);
             return Err(ExecutionError::not_binary_value_loop(condition, &err_ctx));


### PR DESCRIPTION
Ensure execute_after_exit_decorators is called in start_loop_node when the loop condition is ZERO (skip body). Previously, after-exit decorators ran only in the finish path or when the loop executed at least once, causing inconsistency with:
- slow executor which always runs after-exit decorators after a node,
- other fast node handlers (join/call/dyn/split/external),
- documented loop semantics (LOOP followed by END when skipping).