### PR TITLE
refactor: rename decoder "hasher state" to "shared columns"

### DIFF
--- a/air/src/trace/decoder/mod.rs
+++ b/air/src/trace/decoder/mod.rs
@@ -19,26 +19,34 @@ pub const NUM_OP_BITS: usize = Operation::OP_BITS;
 /// Location of operation bits columns in the decoder trace.
 pub const OP_BITS_RANGE: Range<usize> = range(OP_BITS_OFFSET, NUM_OP_BITS);
 
-// TODO: probably rename "hasher state" to something like "shared columns".
+/// Index at which shared columns start in the decoder trace.
+pub const SHARED_COLUMNS_OFFSET: usize = OP_BITS_RANGE.end;
 
-/// Index at which hasher state columns start in the decoder trace.
-pub const HASHER_STATE_OFFSET: usize = OP_BITS_RANGE.end;
-
-/// Number of hasher columns in the decoder trace.
-pub const NUM_HASHER_COLUMNS: usize = 8;
+/// Number of shared columns in the decoder trace.
+pub const NUM_SHARED_COLUMNS: usize = 8;
 
 /// Number of helper registers available to user ops.
 pub const NUM_USER_OP_HELPERS: usize = 6;
 
 /// Index at which helper registers available to user ops start.
 /// The first two helper registers are used by the decoder itself.
-pub const USER_OP_HELPERS_OFFSET: usize = HASHER_STATE_OFFSET + 2;
+pub const USER_OP_HELPERS_OFFSET: usize = SHARED_COLUMNS_OFFSET + 2;
 
-/// Location of hasher columns in the decoder trace.
-pub const HASHER_STATE_RANGE: Range<usize> = range(HASHER_STATE_OFFSET, NUM_HASHER_COLUMNS);
+/// Location of shared columns in the decoder trace.
+pub const SHARED_COLUMNS_RANGE: Range<usize> = range(SHARED_COLUMNS_OFFSET, NUM_SHARED_COLUMNS);
+
+// Backward compatibility aliases
+#[deprecated(note = "Use SHARED_COLUMNS_OFFSET instead")]
+pub const HASHER_STATE_OFFSET: usize = SHARED_COLUMNS_OFFSET;
+
+#[deprecated(note = "Use NUM_SHARED_COLUMNS instead")]
+pub const NUM_HASHER_COLUMNS: usize = NUM_SHARED_COLUMNS;
+
+#[deprecated(note = "Use SHARED_COLUMNS_RANGE instead")]
+pub const HASHER_STATE_RANGE: Range<usize> = SHARED_COLUMNS_RANGE;
 
 /// Index of the in_span column in the decoder trace.
-pub const IN_SPAN_COL_IDX: usize = HASHER_STATE_RANGE.end;
+pub const IN_SPAN_COL_IDX: usize = SHARED_COLUMNS_RANGE.end;
 
 /// Index of the operation group count column in the decoder trace.
 pub const GROUP_COUNT_COL_IDX: usize = IN_SPAN_COL_IDX + 1;
@@ -78,16 +86,16 @@ pub const OP_BITS_EXTRA_COLS_RANGE: Range<usize> =
     range(OP_BITS_EXTRA_COLS_OFFSET, NUM_OP_BITS_EXTRA_COLS);
 
 /// Index of a flag column which indicates whether an ending block is a body of a loop.
-pub const IS_LOOP_BODY_FLAG_COL_IDX: usize = HASHER_STATE_RANGE.start + 4;
+pub const IS_LOOP_BODY_FLAG_COL_IDX: usize = SHARED_COLUMNS_RANGE.start + 4;
 
 /// Index of a flag column which indicates whether an ending block is a LOOP block.
-pub const IS_LOOP_FLAG_COL_IDX: usize = HASHER_STATE_RANGE.start + 5;
+pub const IS_LOOP_FLAG_COL_IDX: usize = SHARED_COLUMNS_RANGE.start + 5;
 
 /// Index of a flag column which indicates whether an ending block is a CALL or DYNCALL block.
-pub const IS_CALL_FLAG_COL_IDX: usize = HASHER_STATE_RANGE.start + 6;
+pub const IS_CALL_FLAG_COL_IDX: usize = SHARED_COLUMNS_RANGE.start + 6;
 
 /// Index of a flag column which indicates whether an ending block is a SYSCALL block.
-pub const IS_SYSCALL_FLAG_COL_IDX: usize = HASHER_STATE_RANGE.start + 7;
+pub const IS_SYSCALL_FLAG_COL_IDX: usize = SHARED_COLUMNS_RANGE.start + 7;
 
 // --- Column accessors in the auxiliary columns --------------------------------------------------
 
@@ -102,5 +110,6 @@ pub const P3_COL_IDX: usize = DECODER_AUX_TRACE_OFFSET + 2;
 
 // --- GLOBALLY-INDEXED DECODER COLUMN ACCESSORS --------------------------------------------------
 pub const DECODER_OP_BITS_OFFSET: usize = super::DECODER_TRACE_OFFSET + OP_BITS_OFFSET;
+pub const DECODER_SHARED_COLUMNS_OFFSET: usize = super::DECODER_TRACE_OFFSET + SHARED_COLUMNS_OFFSET;
 pub const DECODER_USER_OP_HELPERS_OFFSET: usize =
     super::DECODER_TRACE_OFFSET + USER_OP_HELPERS_OFFSET;

--- a/processor/src/decoder/mod.rs
+++ b/processor/src/decoder/mod.rs
@@ -5,7 +5,7 @@ use miden_air::{
     trace::{
         chiplets::hasher::DIGEST_LEN,
         decoder::{
-            NUM_HASHER_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS, NUM_OP_BITS_EXTRA_COLS,
+            NUM_SHARED_COLUMNS, NUM_OP_BATCH_FLAGS, NUM_OP_BITS, NUM_OP_BITS_EXTRA_COLS,
             OP_BATCH_1_GROUPS, OP_BATCH_2_GROUPS, OP_BATCH_4_GROUPS, OP_BATCH_8_GROUPS,
         },
     },
@@ -526,7 +526,7 @@ impl Process {
 ///   because hasher addresses are guaranteed to be unique.
 /// * op_bits columns b0 through b6 are used to encode an operation to be executed by the VM. Each
 ///   of these columns contains a single binary value, which together form a single opcode.
-/// * Hasher state columns h0 through h7. These are multi purpose columns used as follows:
+/// * Shared columns h0 through h7. These are multi purpose columns used as follows:
 ///   - When starting decoding of a new code block (e.g., via JOIN, SPLIT, LOOP, SPAN operations)
 ///     these columns are used for providing inputs for the current block's hash computations.
 ///   - When finishing decoding of a code block (i.e., via END operation), these columns are used to


### PR DESCRIPTION
## Describe your changes
Renames decoder trace columns from "hasher state" to "shared columns" for better accuracy.
### Changes:
- Renamed constants: `HASHER_STATE_*` → `SHARED_COLUMNS_*`
- Renamed functions: `decoder_hasher_state*()` → `decoder_shared_columns*()`
- Updated struct field: `hasher_trace` → `shared_columns_trace`
- Added deprecated aliases for backward compatibility

Resolves the TODO comment in `air/src/trace/decoder/mod.rs`.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'