### PR TITLE
ci: workflows follow least privilege

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,6 +2,9 @@
 
 name: bench
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, next]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@
 
 name: build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, next]

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,6 +3,9 @@
 
 name: changelog
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@
 
 name: lint
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, next]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: test on ubuntu-latest


### PR DESCRIPTION
Makes workflows require just the permissions they need.
