### PR TITLE
test: un-ignore math::u64_mod::unchecked_shl

### DIFF
--- a/stdlib/tests/math/u64_mod.rs
+++ b/stdlib/tests/math/u64_mod.rs
@@ -828,7 +828,6 @@ fn checked_xor_fail() {
 }
 
 #[test]
-#[ignore]
 fn unchecked_shl() {
     let source = "
         use.std::math::u64


### PR DESCRIPTION
The test seems to have been ignored during the development process of #1194, and its ignore missed in review.
