### PR TITLE
fix: advice_map loading in test framework for the fast processor

### DIFF
--- a/crates/utils/testing/src/lib.rs
+++ b/crates/utils/testing/src/lib.rs
@@ -14,7 +14,6 @@ use alloc::{
     vec::Vec,
 };
 
-use miden_air::RowIndex;
 use miden_assembly::{KernelLibrary, Library, Parse, diagnostics::reporting::PrintDiagnostic};
 pub use miden_assembly::{
     LibraryPath,
@@ -29,11 +28,11 @@ pub use miden_core::{
     utils::{IntoBytes, ToElements, group_slice_elements},
 };
 use miden_core::{EventId, ProgramInfo, chiplets::hasher::apply_permutation};
-use miden_processor::{AdviceError, DefaultHost, EventHandler, Program, fast::FastProcessor};
 pub use miden_processor::{
     AdviceInputs, AdviceProvider, BaseHost, ContextId, ExecutionError, ExecutionOptions,
     ExecutionTrace, Process, ProcessState, VmStateIterator,
 };
+use miden_processor::{DefaultHost, EventHandler, Program, fast::FastProcessor};
 use miden_prover::utils::range;
 pub use miden_prover::{MerkleTreeVC, ProvingOptions, prove};
 pub use miden_verifier::{AcceptableOptions, VerifierError, verify};
@@ -114,21 +113,6 @@ macro_rules! expect_exec_error_matches {
         match $test.execute() {
             Ok(_) => panic!("expected execution to fail @ {}:{}", file!(), line!()),
             Err(error) => ::miden_core::assert_matches!(error, $( $pattern )|+ $( if $guard )?),
-        }
-    };
-}
-
-/// Merges the program advice map with the given inputs, and error-check
-macro_rules! merge_advice_map {
-    ($program:expr, $inputs:expr) => {
-        let advice_map_result = $program.mast_forest().advice_map();
-        if let Err((existing_entry, new_value)) = $inputs.map.merge(advice_map_result) {
-            let err = AdviceError::MapKeyAlreadyPresent {
-                key: existing_entry.0,
-                prev_values: existing_entry.1.iter().copied().collect(),
-                new_values: new_value.iter().copied().collect(),
-            };
-            return Err(ExecutionError::advice_error(err, RowIndex::from(0), &()));
         }
     };
 }
@@ -364,15 +348,11 @@ impl Test {
         let (program, host) = self.get_program_and_host();
         let mut host = host.with_source_manager(self.source_manager.clone());
 
-        // Create a copy of advice inputs and extend them with the program's advice map
-        let mut advice_inputs = self.advice_inputs.clone();
-        merge_advice_map!(program, advice_inputs);
-
         // slow processor
         let mut process = Process::new(
             program.kernel().clone(),
             self.stack_inputs.clone(),
-            advice_inputs,
+            self.advice_inputs.clone(),
             ExecutionOptions::default().with_debugging(self.in_debug_mode),
         );
 
@@ -398,14 +378,10 @@ impl Test {
         let (program, host) = self.get_program_and_host();
         let mut host = host.with_source_manager(self.source_manager.clone());
 
-        // Create a copy of advice inputs and extend them with the program's advice map
-        let mut advice_inputs = self.advice_inputs.clone();
-        merge_advice_map!(program, advice_inputs);
-
         let mut process = Process::new(
             program.kernel().clone(),
             self.stack_inputs.clone(),
-            advice_inputs,
+            self.advice_inputs.clone(),
             ExecutionOptions::default().with_debugging(self.in_debug_mode),
         );
 
@@ -454,31 +430,10 @@ impl Test {
         let (program, host) = self.get_program_and_host();
         let mut host = host.with_source_manager(self.source_manager.clone());
 
-        // Create a copy of advice inputs and extend them with the program's advice map
-        let mut advice_inputs = self.advice_inputs.clone();
-        if let Err((existing_entry, new_value)) =
-            advice_inputs.map.merge(program.mast_forest().advice_map())
-        {
-            let err = AdviceError::MapKeyAlreadyPresent {
-                key: existing_entry.0,
-                prev_values: existing_entry.1.iter().copied().collect(),
-                new_values: new_value.iter().copied().collect(),
-            };
-            let result = Err(ExecutionError::advice_error(err, RowIndex::from(0), &()));
-            self.assert_result_with_fast_processor(&result);
-            let process = Process::new(
-                program.kernel().clone(),
-                self.stack_inputs.clone(),
-                advice_inputs,
-                ExecutionOptions::default().with_debugging(self.in_debug_mode),
-            );
-            return VmStateIterator::new(process, result);
-        }
-
         let mut process = Process::new(
             program.kernel().clone(),
             self.stack_inputs.clone(),
-            advice_inputs,
+            self.advice_inputs.clone(),
             ExecutionOptions::default().with_debugging(self.in_debug_mode),
         );
         let result = process.execute(&program, &mut host);
@@ -549,40 +504,7 @@ impl Test {
         let mut host = host.with_source_manager(self.source_manager.clone());
 
         let stack_inputs: Vec<Felt> = self.stack_inputs.clone().into_iter().rev().collect();
-        let mut advice_inputs: AdviceInputs = self.advice_inputs.clone();
-
-        // Merge the program's advice map into the advice inputs for the fast processor
-        if let Err((existing_entry, new_value)) =
-            advice_inputs.map.merge(program.mast_forest().advice_map())
-        {
-            let err = AdviceError::MapKeyAlreadyPresent {
-                key: existing_entry.0,
-                prev_values: existing_entry.1.iter().copied().collect(),
-                new_values: new_value.iter().copied().collect(),
-            };
-            let fast_error = ExecutionError::advice_error(err, RowIndex::from(0), &());
-            // Both processors should fail with the same advice map error
-            match slow_result {
-                Err(slow_err) => {
-                    // Check if both are advice errors at the same clock cycle
-                    match (&slow_err, &fast_error) {
-                        (
-                            ExecutionError::AdviceError { clk: slow_clk, .. },
-                            ExecutionError::AdviceError { clk: fast_clk, .. },
-                        ) => {
-                            assert_eq!(
-                                slow_clk, fast_clk,
-                                "processors should fail at same clock cycle"
-                            );
-                        },
-                        _ => panic!("processors should produce same error type"),
-                    }
-                },
-                _ => panic!("processors should produce same error type"),
-            }
-            return;
-        }
-
+        let advice_inputs: AdviceInputs = self.advice_inputs.clone();
         let fast_process = FastProcessor::new_with_advice_inputs(&stack_inputs, advice_inputs);
         let fast_result = fast_process.execute_sync(&program, &mut host);
 

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -359,6 +359,11 @@ impl FastProcessor {
         let mut continuation_stack = ContinuationStack::new(program);
         let mut current_forest = program.mast_forest().clone();
 
+        // Merge the program's advice map into the advice provider
+        self.advice
+            .extend_map(current_forest.advice_map())
+            .map_err(|err| ExecutionError::advice_error(err, self.clk, &()))?;
+
         while let Some(continuation) = continuation_stack.pop_continuation() {
             match continuation {
                 Continuation::StartNode(node_id) => {

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -1,3 +1,4 @@
+use alloc::collections::BTreeMap;
 /// Tests in this file make sure that diagnostics presented to the user are as expected.
 use alloc::string::ToString;
 
@@ -7,7 +8,7 @@ use miden_assembly::{
     testing::{TestContext, assert_diagnostic_lines, regex, source_file},
 };
 use miden_core::{
-    AdviceMap, Felt, Word,
+    AdviceMap, Word,
     crypto::merkle::{MerkleStore, MerkleTree},
 };
 use miden_debug_types::{SourceContent, SourceLanguage, SourceManager, Uri};
@@ -23,24 +24,20 @@ use super::*;
 
 #[test]
 fn test_advice_map_inline() {
-    use miden_utils_testing::crypto::MerkleStore;
-    use alloc::collections::BTreeMap;
-
     let source = "\
-adv_map.A=[2,5]
+adv_map.A=[0x01]
 
 begin
   push.A
   adv.push_mapval
-  adv_push.1
-  push.2
-  assert_eq
   dropw
+  adv_push.1
+  push.1
+  assert_eq
 end";
 
-    let advice_map = BTreeMap::from([(Word::new([Felt::new(2), Felt::new(0), Felt::new(0), Felt::new(0)]), vec![Felt::new(2), Felt::new(5)])]);
-    let merkle_store = MerkleStore::new();
-    let build_test = build_test!(source, &[], [], merkle_store, advice_map);
+    // Test framework now automatically loads advice map from program's MAST forest
+    let build_test = build_test!(source, &[], [], MerkleStore::new(), BTreeMap::new());
     build_test.execute().unwrap();
 }
 

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -7,7 +7,7 @@ use miden_assembly::{
     testing::{TestContext, assert_diagnostic_lines, regex, source_file},
 };
 use miden_core::{
-    AdviceMap,
+    AdviceMap, Felt, Word,
     crypto::merkle::{MerkleStore, MerkleTree},
 };
 use miden_debug_types::{SourceContent, SourceLanguage, SourceManager, Uri};
@@ -21,11 +21,13 @@ use super::*;
 // AdviceMap inlined in the script
 // ------------------------------------------------------------------------------------------------
 
-#[ignore] // tracked by https://github.com/0xMiden/miden-vm/issues/1886
 #[test]
 fn test_advice_map_inline() {
+    use miden_utils_testing::crypto::MerkleStore;
+    use alloc::collections::BTreeMap;
+
     let source = "\
-adv_map.A=2
+adv_map.A=[2,5]
 
 begin
   push.A
@@ -36,7 +38,9 @@ begin
   dropw
 end";
 
-    let build_test = build_test!(source);
+    let advice_map = BTreeMap::from([(Word::new([Felt::new(2), Felt::new(0), Felt::new(0), Felt::new(0)]), vec![Felt::new(2), Felt::new(5)])]);
+    let merkle_store = MerkleStore::new();
+    let build_test = build_test!(source, &[], [], merkle_store, advice_map);
     build_test.execute().unwrap();
 }
 

--- a/processor/src/tests.rs
+++ b/processor/src/tests.rs
@@ -1,4 +1,3 @@
-use alloc::collections::BTreeMap;
 /// Tests in this file make sure that diagnostics presented to the user are as expected.
 use alloc::string::ToString;
 
@@ -8,7 +7,7 @@ use miden_assembly::{
     testing::{TestContext, assert_diagnostic_lines, regex, source_file},
 };
 use miden_core::{
-    AdviceMap, Word,
+    AdviceMap,
     crypto::merkle::{MerkleStore, MerkleTree},
 };
 use miden_debug_types::{SourceContent, SourceLanguage, SourceManager, Uri};
@@ -36,8 +35,7 @@ begin
   assert_eq
 end";
 
-    // Test framework now automatically loads advice map from program's MAST forest
-    let build_test = build_test!(source, &[], [], MerkleStore::new(), BTreeMap::new());
+    let build_test = build_test!(source);
     build_test.execute().unwrap();
 }
 


### PR DESCRIPTION
The test framework was not properly loading advice maps from compiled programs' Mastforests into the execution context, causing "advice provider error" failures in tests that use advice maps defined in assembly source.

The slow processor was working correctly because it automatically calls `self.advice.extend_map(program.mast_forest().advice_map())` in `execute_mast_root()`. The fast processor was failing because `assert_result_with_fast_processor()` was creating the FastProcessor with only manually provided advice inputs, without merging the program's compiled advice map.

This merges that advice map. Closes #1886.