### PR TITLE
fix: avoid panics by propagating errors in outputs parsing and proof writing

### DIFF
--- a/miden-vm/src/cli/data.rs
+++ b/miden-vm/src/cli/data.rs
@@ -97,7 +97,12 @@ impl OutputFile {
 
     /// Converts stack output vector to [StackOutputs].
     pub fn stack_outputs(&self) -> Result<StackOutputs, String> {
-        let stack = self.stack.iter().map(|v| v.parse::<u64>().unwrap()).collect::<Vec<u64>>();
+        let stack = self
+            .stack
+            .iter()
+            .map(|v| v.parse::<u64>())
+            .collect::<Result<Vec<u64>, _>>()
+            .map_err(|err| format!("Failed to parse stack output as u64 - {err}"))?;
 
         StackOutputs::try_from_ints(stack)
             .map_err(|e| format!("Construct stack outputs failed {e}"))
@@ -223,7 +228,8 @@ impl ProofFile {
         let proof_bytes = proof.to_bytes();
 
         // write proof bytes to file
-        file.write_all(&proof_bytes).unwrap();
+        file.write_all(&proof_bytes)
+            .map_err(|err| format!("Failed to write proof file `{}` - {}", path.display(), err))?;
 
         Ok(())
     }


### PR DESCRIPTION
Replace unwraps that could crash the CLI on invalid user data or I/O errors.
OutputFile::stack_outputs: map parse::<u64> errors to Result for malformed .outputs.
ProofFile::write: return error on write_all failure instead of panicking.
Aligns with existing Result-based error handling