### PR TITLE
sorted_array::push_lowerbound_result refactor

### DIFF
--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -899,7 +899,7 @@ impl<'a> ProcessState<'a> {
         &self,
         start_idx: usize,
         end_idx: usize,
-    ) -> Result<(u32, u32), MemoryError> {
+    ) -> Result<core::ops::Range<u32>, MemoryError> {
         let start_addr = self.get_stack_item(start_idx).as_int();
         let end_addr = self.get_stack_item(end_idx).as_int();
 
@@ -914,7 +914,7 @@ impl<'a> ProcessState<'a> {
             return Err(MemoryError::InvalidMemoryRange { start_addr, end_addr });
         }
 
-        Ok((start_addr as u32, end_addr as u32))
+        Ok(start_addr as u32..end_addr as u32)
     }
 
     /// Returns the entire memory state for the specified execution context at the current clock

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -893,6 +893,30 @@ impl<'a> ProcessState<'a> {
         }
     }
 
+    /// Reads (start_addr, end_addr) tuple from the specified elements of the operand stack (
+    /// without modifying the state of the stack), and verifies that memory range is valid.
+    pub fn get_mem_addr_range(
+        &self,
+        start_idx: usize,
+        end_idx: usize,
+    ) -> Result<(u32, u32), MemoryError> {
+        let start_addr = self.get_stack_item(start_idx).as_int();
+        let end_addr = self.get_stack_item(end_idx).as_int();
+
+        if start_addr > u32::MAX as u64 {
+            return Err(MemoryError::address_out_of_bounds(start_addr, &()));
+        }
+        if end_addr > u32::MAX as u64 {
+            return Err(MemoryError::address_out_of_bounds(end_addr, &()));
+        }
+
+        if start_addr > end_addr {
+            return Err(MemoryError::InvalidMemoryRange { start_addr, end_addr });
+        }
+
+        Ok((start_addr as u32, end_addr as u32))
+    }
+
     /// Returns the entire memory state for the specified execution context at the current clock
     /// cycle.
     ///
@@ -949,28 +973,4 @@ pub(crate) fn add_error_ctx_to_external_error(
             },
         },
     }
-}
-
-/// Reads (start_addr, end_addr) tuple from the specified elements of the operand stack (
-/// without modifying the state of the stack), and verifies that memory range is valid.
-pub fn get_mem_addr_range(
-    process: &ProcessState,
-    start_idx: usize,
-    end_idx: usize,
-) -> Result<(u32, u32), MemoryError> {
-    let start_addr = process.get_stack_item(start_idx).as_int();
-    let end_addr = process.get_stack_item(end_idx).as_int();
-
-    if start_addr > u32::MAX as u64 {
-        return Err(MemoryError::address_out_of_bounds(start_addr, &()));
-    }
-    if end_addr > u32::MAX as u64 {
-        return Err(MemoryError::address_out_of_bounds(end_addr, &()));
-    }
-
-    if start_addr > end_addr {
-        return Err(MemoryError::InvalidMemoryRange { start_addr, end_addr });
-    }
-
-    Ok((start_addr as u32, end_addr as u32))
 }

--- a/processor/src/operations/sys_ops/sys_event_handlers.rs
+++ b/processor/src/operations/sys_ops/sys_event_handlers.rs
@@ -60,12 +60,11 @@ fn insert_mem_values_into_adv_map(
     process: &mut ProcessState,
     err_ctx: &impl ErrorContext,
 ) -> Result<(), ExecutionError> {
-    let (start_addr, end_addr) =
-        process.get_mem_addr_range(5, 6).map_err(ExecutionError::MemoryError)?;
+    let addr_range = process.get_mem_addr_range(5, 6).map_err(ExecutionError::MemoryError)?;
     let ctx = process.ctx();
 
-    let mut values = Vec::with_capacity(((end_addr - start_addr) as usize) * WORD_SIZE);
-    for addr in start_addr..end_addr {
+    let mut values = Vec::with_capacity(addr_range.len() * WORD_SIZE);
+    for addr in addr_range {
         let mem_value = process.get_mem_value(ctx, addr).unwrap_or(ZERO);
         values.push(mem_value);
     }

--- a/processor/src/operations/sys_ops/sys_event_handlers.rs
+++ b/processor/src/operations/sys_ops/sys_event_handlers.rs
@@ -5,7 +5,7 @@ use miden_core::{
     sys_events::SystemEvent,
 };
 
-use crate::{ExecutionError, ProcessState, errors::ErrorContext, get_mem_addr_range};
+use crate::{ExecutionError, ProcessState, errors::ErrorContext};
 
 /// The offset of the domain value on the stack in the `hdword_to_map_with_domain` system event.
 /// Offset accounts for the event ID at position 0 on the stack.
@@ -61,7 +61,7 @@ fn insert_mem_values_into_adv_map(
     err_ctx: &impl ErrorContext,
 ) -> Result<(), ExecutionError> {
     let (start_addr, end_addr) =
-        get_mem_addr_range(process, 5, 6).map_err(ExecutionError::MemoryError)?;
+        process.get_mem_addr_range(5, 6).map_err(ExecutionError::MemoryError)?;
     let ctx = process.ctx();
 
     let mut values = Vec::with_capacity(((end_addr - start_addr) as usize) * WORD_SIZE);

--- a/stdlib/src/handlers/sorted_array.rs
+++ b/stdlib/src/handlers/sorted_array.rs
@@ -1,7 +1,7 @@
 use alloc::{vec, vec::Vec};
 
 use miden_core::{EventId, Felt, LexicographicWord, Word};
-use miden_processor::{AdviceMutation, EventError, MemoryError, ProcessState, get_mem_addr_range};
+use miden_processor::{AdviceMutation, EventError, MemoryError, ProcessState};
 
 /// Qualified event names for `lowerbound` events.
 pub const LOWERBOUND_ARRAY_EVENT_NAME: &str = "stdlib::collections::sorted_array::lowerbound_array";
@@ -67,7 +67,7 @@ fn push_lowerbound_result(
 
     // Read inputs from the stack
     let key = LexicographicWord::new(process.get_stack_word(KEY_OFFSET));
-    let (start_addr, end_addr) = get_mem_addr_range(process, START_ADDR_OFFSET, END_ADDR_OFFSET)?;
+    let (start_addr, end_addr) = process.get_mem_addr_range(START_ADDR_OFFSET, END_ADDR_OFFSET)?;
 
     // Validate the start_addr is word-aligned (multiple of 4)
     if start_addr % 4 != 0 {


### PR DESCRIPTION
No changelog required. Addresses a few comments after #2114 was merged:
- https://github.com/0xMiden/miden-vm/pull/2114#discussion_r2365583544
- https://github.com/0xMiden/miden-vm/pull/2114#discussion_r2365584280
- https://github.com/0xMiden/miden-vm/pull/2114#discussion_r2365585634

> A potential small improvement: maybe this could be a method on the ProcessState? It could look something like:
> ```
> impl ProcessState {
>     pub fn get_mem_addr_range(
>         &self,
>         start_idx: usize,
>         end_idx: usize,
>     ) -> Result<Range<MemoryAddress>, MemoryError> {
>         ...
>     }
> }
> ```
> In the above, I've also used Range<MemoryAddress> instead of (u32, u32) for the return value as I think it is a bit more self-describing (and type-safe).

I used `Range<u32>` because `Range<MemoryAddress>` was notoriously difficult to work with: you cannot `for addr in range_object` without implementing `Step` trait on the `MemoryAddress` type (which is unstable).