### PR TITLE
ci: be specific about which toolchain to install & use

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Bench for all features
         run: |
-          rustup update --no-self-update
+          rustup +stable update --no-self-update
+          rustup default stable
           make check-bench
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,6 @@ jobs:
       - name: Build for no-std
         run: |
           rustup update --no-self-update ${{ matrix.toolchain }}
-          rustup target add wasm32-unknown-unknown
+          rustup +${{ matrix.toolchain }} target add wasm32-unknown-unknown
+          rustup default ${{ matrix.toolchain }}
           make build-no-std

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,5 +41,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build docs
         run: |
-          rustup update --no-self-update
+          rustup +stable update --no-self-update
+          rustup default stable
           make doc


### PR DESCRIPTION
This aims at making sure the target installed in e.g. the build workflow matches what's then used. 
Aims at addressing [build failures](https://github.com/0xMiden/miden-vm/actions/runs/17900500488/job/50892829648).