### PR TITLE
fix: make SourceFileRef::Hash consistent with Eq/Ord

### DIFF
--- a/crates/debug/types/src/source_file.rs
+++ b/crates/debug/types/src/source_file.rs
@@ -303,7 +303,6 @@ impl PartialOrd for SourceFileRef {
 
 impl core::hash::Hash for SourceFileRef {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.span.hash(state);
         self.as_str().hash(state);
     }
 }


### PR DESCRIPTION
Align SourceFileRef hashing with its equality and ordering semantics by removing span from the hash and hashing only the selected string. Previously, PartialEq/Ord compared only as_str(), while Hash mixed in both span and as_str(), violating the Eq/Hash contract and risking incorrect behavior in hash-based collections. This change ensures that equal values produce identical hashes and matches the pattern used by Span<T>.