### PR TITLE
Fix misleading expect message in range aux trace builder

### DIFF
--- a/processor/src/range/aux_trace.rs
+++ b/processor/src/range/aux_trace.rs
@@ -96,7 +96,7 @@ impl AuxTraceBuilder {
             b_range[b_range_idx] = b_range[clk];
             // include the operation lookups
             for lookup in range_checks.iter() {
-                let value = divisors.get(lookup).expect("invalid lookup value {}");
+                let value = divisors.get(lookup).expect("invalid lookup value");
                 b_range[b_range_idx] -= *value;
             }
         }


### PR DESCRIPTION


### Description
- Replaces an invalid "{}" placeholder in an `expect` message with a clear, static string.
- Improves error diagnostics; `expect` does not perform formatting.



