### PR TITLE
fix(processor): fix debug.adv_stack print order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [BREAKING] Incremented MSRV to 1.90.
 
+#### Fixes
+
+- Fixed `debug.adv_stack` printing in reverse order ([#2205](https://github.com/0xMiden/miden-vm/pull/2205)).
+
 ## 0.18.0 (2025-09-21)
 
 #### Enhancements

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -80,10 +80,11 @@ fn print_vm_adv_stack(process: &ProcessState, n: u16) {
 
     let stack = &stack[..num_items];
 
-    if let Some((last, front)) = stack.split_last() {
+    // Note: `stack` is in reverse order. e.g., `adv_push.1` pushes `stack.last()`.
+    if let Some((last, front)) = stack.split_first() {
         // print all items except for the last one
         println!("Advice Stack state before step {}:", process.clk());
-        for (i, element) in front.iter().enumerate() {
+        for (i, element) in front.iter().rev().enumerate() {
             println!("├── {i:>2}: {element}");
         }
 


### PR DESCRIPTION
## Describe your changes

This makes `debug.adv_stack` print in the same order elements are pushed to the operand stack in. e.g., makes `debug.adv_stack.1` print the same value that `adv_push.1` pushes to the operand stack. I believe this was the case in an earlier version, but I haven't tried to bisect it.

### Given:

```json
{
  "operand_stack": [ ],
  "advice_stack": [
      "1",
      "2",
      "3",
      "4"
  ]
}
```

```ruby
begin
	debug.adv_stack
	adv_push.1 debug.stack.1
	dropw
end
```

### Before:

```
Advice Stack state before step 1:
├──  0: 4
├──  1: 3
├──  2: 2
└──  3: 1

Stack state before step 2:
└──  0: 1

└── (0 more items)
```

### After:

```
Advice Stack state before step 1:
├──  0: 1
├──  1: 2
├──  2: 3
└──  3: 4

Stack state before step 2:
└──  0: 1

└── (0 more items)
```


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'