### PR TITLE
docs: fix ext2mul formulas (c1 = a0*b1 + a1*b0) and use mod p in ext2inv

### DIFF
--- a/docs/src/user_docs/assembly/field_operations.md
+++ b/docs/src/user_docs/assembly/field_operations.md
@@ -60,7 +60,7 @@ The arithmetic operations below are performed in a 64-bit [prime field](https://
 | ---------------------------------- | --------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------- |
 | ext2add <br> - *(5 cycles)*   <br> | [b1, b0, a1, a0, ...] | [c1, c0, ...]   | $c1 \leftarrow (a1 + b1) \mod p$ and <br> $c0 \leftarrow (a0 + b0) \mod p$                                          |
 | ext2sub <br> - *(7 cycles)*   <br> | [b1, b0, a1, a0, ...] | [c1, c0, ...]   | $c1 \leftarrow (a1 - b1) \mod p$ and <br> $c0 \leftarrow (a0 - b0) \mod p$                                          |
-| ext2mul <br> - *(3 cycles)*   <br> | [b1, b0, a1, a0, ...] | [c1, c0, ...]   | $c1 \leftarrow (a0 + a1) * (b0 + b1) \mod p$ and <br> $c0 \leftarrow (a0 * b0) - 2 * (a1 * b1) \mod p$              |
+| ext2mul <br> - *(3 cycles)*   <br> | [b1, b0, a1, a0, ...] | [c1, c0, ...]   | $c1 \leftarrow a0 b1 + a1 b0 \mod p$ and <br> $c0 \leftarrow a0 b0 - 2 a1 b1 \mod p$              |
 | ext2neg <br> - *(4 cycles)*   <br> | [a1, a0, ...]         | [a1', a0', ...] | $a1' \leftarrow -a1$ and $a0' \leftarrow -a0$                                                                       |
-| ext2inv <br> - *(8 cycles)*   <br> | [a1, a0, ...]         | [a1', a0', ...] | $a' \leftarrow a^{-1} \mod q$ <br> Fails if $a = 0$                                                                 |
+| ext2inv <br> - *(8 cycles)*   <br> | [a1, a0, ...]         | [a1', a0', ...] | $a' \leftarrow a^{-1} \mod p$ <br> Fails if $a = 0$                                                                 |
 | ext2div <br> - *(11 cycles)*  <br> | [b1, b0, a1, a0, ...] | [c1, c0,]       | $c \leftarrow a * b^{-1}$ fails if $b=0$, where multiplication and inversion are as defined by the operations above |

--- a/docs/src/user_docs/assembly/instruction_reference.md
+++ b/docs/src/user_docs/assembly/instruction_reference.md
@@ -52,9 +52,9 @@ This page provides a comprehensive reference for Miden Assembly instructions.
 | ----------- | --------------------- | --------------- | ------ | ------------------------------------------------------------------------------------------- |
 | `ext2add`   | `[b1, b0, a1, a0, ...]` | `[c1, c0, ...]`   | 5      | $c_1 = (a_1 + b_1) \bmod p$ <br> $c_0 = (a_0 + b_0) \bmod p$                                       |
 | `ext2sub`   | `[b1, b0, a1, a0, ...]` | `[c1, c0, ...]`   | 7      | $c_1 = (a_1 - b_1) \bmod p$ <br> $c_0 = (a_0 - b_0) \bmod p$                                       |
-| `ext2mul`   | `[b1, b0, a1, a0, ...]` | `[c1, c0, ...]`   | 3      | $c_1 = (a_0 + a_1) (b_0 + b_1) \bmod p$ <br> $c_0 = (a_0 b_0) - 2 (a_1 b_1) \bmod p$           |
+| `ext2mul`   | `[b1, b0, a1, a0, ...]` | `[c1, c0, ...]`   | 3      | $c_1 = a_0 \cdot b_1 + a_1 \cdot b_0 \bmod p$ <br> $c_0 = a_0 \cdot b_0 - 2 \cdot a_1 \cdot b_1 \bmod p$           |
 | `ext2neg`   | `[a1, a0, ...]`         | `[a1', a0', ...]` | 4      | $a_1' = -a_1$ <br> $a_0' = -a_0$                                                               |
-| `ext2inv`   | `[a1, a0, ...]`         | `[a1', a0', ...]` | 8      | $a' = a^{-1} \bmod q$. Fails if $a = 0$.                                                       |
+| `ext2inv`   | `[a1, a0, ...]`         | `[a1', a0', ...]` | 8      | $a' = a^{-1} \bmod p$. Fails if $a = 0$.                                                       |
 | `ext2div`   | `[b1, b0, a1, a0, ...]` | `[c1, c0, ...]`   | 11     | $c = a \cdot b^{-1}$. Fails if $b = 0$. Multiplication and inversion are as defined previously. |
 
 ## U32 Operations


### PR DESCRIPTION
## Describe your changes
Closes #2179 

Aligns `ext2mul` with the implementation of quadratic extension multiplication (α² = −2):

c₀ = a₀·b₀ − 2·a₁·b₁

c₁ = a₀·b₁ + a₁·b₀
Replaces a stray `\bmod q` with `\bmod p` in `ext2inv` to match the page’s base-field definition.



## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'