### PR TITLE
fix(core/serialization): correct StringTable offset type and dedupe Blake3 hash

### DIFF
--- a/core/src/mast/serialization/string_table.rs
+++ b/core/src/mast/serialization/string_table.rs
@@ -11,7 +11,7 @@ use crate::utils::{
 pub struct StringTable {
     data: Vec<u8>,
 
-    table: Vec<StringIndex>,
+    table: Vec<StringDataOffset>,
 
     /// This field is used to allocate an `Arc` for any string in `strings` where the decoder
     /// requests a reference-counted string rather than a fresh allocation as a `String`.
@@ -28,7 +28,7 @@ pub struct StringTable {
 }
 
 impl StringTable {
-    pub fn new(table: Vec<StringIndex>, data: Vec<u8>) -> Self {
+    pub fn new(table: Vec<StringDataOffset>, data: Vec<u8>) -> Self {
         let mut refc_strings = Vec::with_capacity(table.len());
         refc_strings.resize(table.len(), RefCell::new(None));
 
@@ -86,7 +86,8 @@ pub struct StringTableBuilder {
 
 impl StringTableBuilder {
     pub fn add_string(&mut self, string: &str) -> StringIndex {
-        if let Some(str_idx) = self.str_to_index.get(&Blake3_256::hash(string.as_bytes())) {
+        let digest = Blake3_256::hash(string.as_bytes());
+        if let Some(str_idx) = self.str_to_index.get(&digest) {
             // return already interned string
             *str_idx
         } else {
@@ -102,7 +103,7 @@ impl StringTableBuilder {
 
             string.write_into(&mut self.strings_data);
             self.table.push(str_offset);
-            self.str_to_index.insert(Blake3_256::hash(string.as_bytes()), str_idx);
+            self.str_to_index.insert(digest, str_idx);
 
             str_idx
         }


### PR DESCRIPTION
- Change StringTable.table from Vec<StringIndex> to Vec<StringDataOffset> and update new() accordingly.
- Deduplicate Blake3 digest computation in StringTableBuilder::add_string.

These changes are necessary because:

The table actually stores byte offsets into the string data, not indices; using StringIndex was semantically misleading. Aligning the type with its true meaning improves readability and reduces the chance of future maintenance errors. This does not alter the binary format because both aliases are usize.

Computing the Blake3 digest twice when interning a new string is wasteful; precomputing and reusing the digest yields a small performance improvement with zero behavioral change.
