### PR TITLE
fix: handling of `Option` and `Result` in `fingerprint_from_parts`

### DIFF
--- a/core/src/mast/node_fingerprint.rs
+++ b/core/src/mast/node_fingerprint.rs
@@ -168,14 +168,16 @@ fn fingerprint_from_parts(
 
     let children_decorator_roots = children_ids
         .iter()
-        .filter_map(|child_id| {
+        .map(|child_id| {
             hash_by_node_id
                 .get(child_id)
                 .ok_or(MastForestError::ChildFingerprintMissing(*child_id))
                 .map(|child_fingerprint| child_fingerprint.decorator_root)
-                .transpose()
         })
-        .collect::<Result<Vec<DecoratorFingerprint>, MastForestError>>()?;
+        .collect::<Result<Vec<Option<DecoratorFingerprint>>, MastForestError>>()?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<DecoratorFingerprint>>();
 
     // Reminder: the `MastNodeFingerprint`'s decorator root will be `None` if and only if there are
     // no decorators attached to the node, and all children have no decorator roots (meaning


### PR DESCRIPTION
## Describe your changes

1. fixed an issue in `fingerprint_from_parts` where `.filter_map(...).transpose()` was used incorrectly.
2. now `children_decorator_roots` are correctly collected with proper handling of `Option` and `Result`, and the code compiles successfully in Rust.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'