### PR TITLE
Stdlib: fix FALCON_DIV advice stack docs and clarify falcon_sign casting

### DIFF
--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -123,9 +123,11 @@ pub fn falcon_sign(sk: &[Felt], msg: Word) -> Option<Vec<Felt>> {
     let mut sk_bytes = Vec::with_capacity(sk.len());
     for element in sk {
         let value = element.as_int();
+        // Check for valid u8 range and ensure no data loss during conversion
         if value > u8::MAX as u64 {
             return None;
         }
+        // Safe conversion since we've verified the value is within u8 range
         sk_bytes.push(value as u8);
     }
 


### PR DESCRIPTION


### Description
- Summary:
  - Align `falcon_div` advice stack docs with implementation: output is `[r_lo, q_lo, q_hi, ...]`.
  - Add concise English comments explaining invariants and I/O in `falcon_div`.
  - Clarify in `falcon_sign` that `u64 → u8` conversion is safe post range-check.

- Rationale:
  - Prevents confusion/misuse by documenting the exact stack layout.
  - Makes cryptographic code intent explicit, reducing maintenance risk.

