### PR TITLE
fix(racy-lock): tie Send/Sync to T and F; add compile-time assertions

### DIFF
--- a/crates/utils-sync/src/racy_lock.rs
+++ b/crates/utils-sync/src/racy_lock.rs
@@ -196,10 +196,7 @@ where
     }
 }
 
-impl<T, F> Drop for RacyLock<T, F>
-where
-    F: Fn() -> T,
-{
+impl<T, F> Drop for RacyLock<T, F> {
     /// Drops the underlying pointer.
     fn drop(&mut self) {
         let ptr = *self.inner.get_mut();


### PR DESCRIPTION
Add explicit unsafe impls:
- Send for RacyLock<T, F> where T: Send, F: Send + Fn() -> T
- Sync for RacyLock<T, F> where T: Sync, F: Sync + Fn() -> T

Add positive compile-time trait assertions for Send and Sync.

Rationale: Without explicit bounds, auto-trait derivation could mark RacyLock as Send/Sync even when T is not, because AtomicPtr<T> is Send + Sync regardless of T. Since force/deref expose &T across threads and F may be invoked concurrently, we must require T: Sync for shared access, T: Send for cross-thread ownership transfer, and F: Send + Sync to safely move/share the initializer. This aligns behavior with std::sync::LazyLock and once_cell and prevents unsound cross-thread access.