### PR TITLE
test: Arbitrary + {winter,serde} serialization, up to Program (+ small bugfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added `proptest`'s `Arbitrary` instances for `BasicBlockNode` and `MastForest` ([#2200](https://github.com/0xMiden/miden-vm/pull/2200)).
 - Fixed mismatched Push expectations in decoder syscall_block test ([#2207](https://github.com/0xMiden/miden-vm/pull/2207))
 - [BREAKING] `Memory::read_element()` now requires `&self` instead of `&mut self` ([#2237](https://github.com/0xMiden/miden-vm/issues/2237))
+- Added `proptest`'s `Arbitrary` instances for `Program`, fixed `Attribute` serialization ([#2224](https://github.com/0xMiden/miden-vm/pull/2224)).
 
 ## 0.18.0 (2025-09-21)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,10 +1454,12 @@ dependencies = [
  "derive_more",
  "miden-assembly-syntax",
  "miden-core",
+ "miden-serde-test-macros",
  "proptest",
  "proptest-derive",
  "serde",
  "serde-untagged",
+ "serde_json",
  "thiserror",
 ]
 

--- a/core/src/advice/map.rs
+++ b/core/src/advice/map.rs
@@ -26,6 +26,10 @@ use crate::{
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(
+    all(feature = "serde", feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test
+)]
 pub struct AdviceMap(BTreeMap<Word, Arc<[Felt]>>);
 
 /// Pair representing a key-value entry in an [`AdviceMap`]

--- a/core/src/advice/map.rs
+++ b/core/src/advice/map.rs
@@ -27,8 +27,8 @@ use crate::{
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
 )]
 pub struct AdviceMap(BTreeMap<Word, Arc<[Felt]>>);
 

--- a/core/src/kernel.rs
+++ b/core/src/kernel.rs
@@ -20,8 +20,8 @@ use crate::{
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
 )]
 pub struct Kernel(Vec<Word>);
 

--- a/core/src/kernel.rs
+++ b/core/src/kernel.rs
@@ -19,6 +19,10 @@ use crate::{
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(
+    all(feature = "serde", feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test
+)]
 pub struct Kernel(Vec<Word>);
 
 impl Kernel {

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -50,10 +50,7 @@ mod tests;
 /// can be built from a [`MastForest`] to specify an entrypoint.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
-)]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
 pub struct MastForest {
     /// All of the nodes local to the trees comprising the MAST forest.
     nodes: Vec<MastNode>,
@@ -72,7 +69,6 @@ pub struct MastForest {
     /// code is triggered.
     error_codes: BTreeMap<u64, Arc<str>>,
 }
-
 // ------------------------------------------------------------------------------------------------
 /// Constructors
 impl MastForest {
@@ -578,10 +574,7 @@ impl IndexMut<DecoratorId> for MastForest {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
-)]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
 pub struct MastNodeId(u32);
 
 /// Operations that mutate a MAST often produce this mapping between old and new NodeIds.

--- a/core/src/mast/node/basic_block_node/arbitrary.rs
+++ b/core/src/mast/node/basic_block_node/arbitrary.rs
@@ -1,9 +1,12 @@
+use alloc::{collections::BTreeMap, sync::Arc};
 use core::ops::RangeInclusive;
 
 use proptest::{arbitrary::Arbitrary, prelude::*};
 
 use super::*;
-use crate::{Decorator, Operation, mast::DecoratorId};
+use crate::{
+    AdviceMap, AssemblyOp, DebugOptions, Decorator, Felt, Operation, Word, mast::DecoratorId,
+};
 
 // Strategy for operations without immediate values (non-control flow)
 pub fn op_no_imm_strategy() -> impl Strategy<Value = Operation> {
@@ -203,16 +206,19 @@ pub fn mast_forest_strategy(params: MastForestParams) -> impl Strategy<Value = M
     };
 
     // 1) Generate a Vec<BasicBlockNode> with length in `params.blocks`
-    prop::collection::vec(any_with::<BasicBlockNode>(bb_params), params.blocks.clone())
+    (
+        prop::collection::vec(any_with::<BasicBlockNode>(bb_params), params.blocks.clone()),
+        prop::collection::vec(any::<Decorator>(), params.decorators as usize..=params.decorators as usize)
+    )
         // 2) Map concrete blocks -> build a concrete MastForest
-        .prop_map(move |blocks| {
+        .prop_map(move |(blocks, decorators)| {
             let mut forest = MastForest::new();
 
             // Pre-populate the decorator ID space so referenced IDs are valid.
-            // TODO: Replace Decorator::Trace(i) with Arbitrary for Decorator
-            for i in 0..params.decorators {
+            // Generate all decorator types for more comprehensive testing
+            for decorator in decorators {
                 forest
-                    .add_decorator(Decorator::Trace(i))
+                    .add_decorator(decorator)
                     .expect("Failed to add decorator");
             }
 
@@ -231,5 +237,181 @@ impl Arbitrary for MastForest {
 
     fn arbitrary_with(p: Self::Parameters) -> Self::Strategy {
         mast_forest_strategy(p).boxed()
+    }
+}
+
+// ---------- Decorator strategies ----------
+
+/// Strategy for generating DebugOptions values
+pub fn debug_options_strategy() -> impl Strategy<Value = DebugOptions> {
+    prop_oneof![
+        Just(DebugOptions::StackAll),
+        any::<u8>().prop_map(DebugOptions::StackTop),
+        Just(DebugOptions::MemAll),
+        (any::<u32>(), any::<u32>()).prop_map(|(start, end)| DebugOptions::MemInterval(start, end)),
+        (any::<u16>(), any::<u16>(), any::<u16>()).prop_map(|(start, end, num_locals)| {
+            DebugOptions::LocalInterval(start, end, num_locals)
+        }),
+        any::<u16>().prop_map(DebugOptions::AdvStackTop),
+    ]
+}
+
+/// Strategy for generating AssemblyOp values
+pub fn assembly_op_strategy() -> impl Strategy<Value = AssemblyOp> {
+    (
+        any::<bool>(),
+        prop::collection::vec(any::<char>(), 1..=20).prop_map(|chars| chars.into_iter().collect()),
+        prop::collection::vec(any::<char>(), 1..=20).prop_map(|chars| chars.into_iter().collect()),
+        any::<u8>(),
+        any::<bool>(),
+    )
+        .prop_map(|(has_location, context_name, op, num_cycles, should_break)| {
+            use miden_debug_types::{ByteIndex, Location, Uri};
+
+            let location = if has_location {
+                Some(Location::new(Uri::new("dummy.rs"), ByteIndex(0), ByteIndex(0)))
+            } else {
+                None
+            };
+
+            AssemblyOp::new(location, context_name, num_cycles, op, should_break)
+        })
+}
+
+// ---------- Arbitrary implementations for missing types ----------
+
+impl Arbitrary for DebugOptions {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        debug_options_strategy().boxed()
+    }
+}
+
+impl Arbitrary for AssemblyOp {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        assembly_op_strategy().boxed()
+    }
+}
+
+impl Arbitrary for Decorator {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        prop_oneof![
+            any_with::<AssemblyOp>(()).prop_map(Decorator::AsmOp),
+            any_with::<DebugOptions>(()).prop_map(Decorator::Debug),
+            any::<u32>().prop_map(Decorator::Trace),
+        ]
+        .boxed()
+    }
+}
+
+impl Arbitrary for crate::advice::map::AdviceMap {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        // Strategy for generating Word keys
+        let word_strategy = prop_oneof![
+            Just(Word::default()),
+            any::<[u64; 4]>().prop_map(|[a, b, c, d]| Word::new([
+                Felt::new(a),
+                Felt::new(b),
+                Felt::new(c),
+                Felt::new(d)
+            ])),
+        ];
+
+        // Strategy for generating Arc<[Felt]> values
+        let felt_array_strategy = prop::collection::vec(any::<u64>(), 1..=4).prop_map(|vals| {
+            let felts: Arc<[Felt]> = vals.into_iter().map(Felt::new).collect();
+            felts
+        });
+
+        // Strategy for generating map entries
+        let entry_strategy = (word_strategy, felt_array_strategy);
+
+        // Strategy for generating the map itself (0 to 10 entries)
+        prop::collection::vec(entry_strategy, 0..=10)
+            .prop_map(|entries| {
+                let mut map = BTreeMap::new();
+                for (key, value) in entries {
+                    map.insert(key, value);
+                }
+                AdviceMap::from(map)
+            })
+            .boxed()
+    }
+}
+
+impl Arbitrary for crate::Program {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        // Generate a mast forest with at least one procedure root
+        let forest_strategy = prop::collection::vec(
+            any_with::<BasicBlockNode>(BasicBlockNodeParams {
+                max_ops_len: 5,
+                max_pairs: 2,
+                max_decorator_id_u32: 5,
+            }),
+            1..=3,
+        )
+        .prop_map(|blocks| {
+            let mut forest = MastForest::new();
+
+            // Add all blocks and make them roots
+            for block in blocks {
+                let node_id = forest.add_node(block).expect("Failed to add block");
+                forest.make_root(node_id);
+            }
+
+            forest
+        });
+
+        forest_strategy
+            .prop_map(|forest| {
+                use alloc::sync::Arc;
+
+                use crate::Program;
+
+                // Pick the first valid procedure root as entrypoint
+                let entrypoint = if forest.num_procedures() > 0 {
+                    forest.procedure_roots()[0]
+                } else {
+                    // Fallback to node 0 if no procedures (shouldn't happen due to our forest
+                    // generation)
+                    crate::mast::MastNodeId::new_unchecked(0)
+                };
+
+                Program::new(Arc::new(forest), entrypoint)
+            })
+            .boxed()
+    }
+}
+
+impl Arbitrary for crate::Kernel {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        // Strategy for generating Word vectors
+        let word_strategy = any::<[u64; 4]>().prop_map(|[a, b, c, d]| {
+            Word::new([Felt::new(a), Felt::new(b), Felt::new(c), Felt::new(d)])
+        });
+
+        // Strategy for generating kernel (0 to 3 words to avoid hitting MAX_NUM_PROCEDURES limit)
+        prop::collection::vec(word_strategy, 0..=3)
+            .prop_map(|words: Vec<Word>| {
+                crate::Kernel::new(&words).expect("Generated kernel should be valid")
+            })
+            .boxed()
     }
 }

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -67,10 +67,7 @@ pub const BATCH_SIZE: usize = 8;
 /// field elements (512 bits).
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
-)]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
 pub struct BasicBlockNode {
     /// The primitive operations contained in this basic block.
     ///

--- a/core/src/mast/serialization/decorator.rs
+++ b/core/src/mast/serialization/decorator.rs
@@ -3,6 +3,8 @@ use alloc::vec::Vec;
 use miden_debug_types::{Location, Uri};
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
+#[cfg(all(feature = "arbitrary", feature = "std"))]
+use proptest_derive::Arbitrary;
 
 use super::{
     DecoratorDataOffset,
@@ -20,7 +22,12 @@ use crate::{
 /// The serialized representation of [`DecoratorInfo`] is guaranteed to be fixed width, so that the
 /// decorators stored in the `decorators` table of the serialized [`MastForest`] can be accessed
 /// quickly by index.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
+#[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true), serde_test(false))
+)]
 pub struct DecoratorInfo {
     variant: EncodedDecoratorVariant,
     decorator_data_offset: DecoratorDataOffset,
@@ -145,7 +152,12 @@ impl Deserializable for DecoratorInfo {
 ///
 /// This is effectively equivalent to a set of constants, and designed to convert between variant
 /// discriminant and enum variant conveniently.
-#[derive(Debug, FromPrimitive, ToPrimitive)]
+#[derive(Debug, FromPrimitive, ToPrimitive, PartialEq, Eq)]
+#[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(Arbitrary))]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true), serde_test(false))
+)]
 #[repr(u8)]
 pub enum EncodedDecoratorVariant {
     AssemblyOp,

--- a/core/src/mast/serialization/string_table.rs
+++ b/core/src/mast/serialization/string_table.rs
@@ -8,6 +8,7 @@ use crate::utils::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
 };
 
+#[derive(Debug)]
 pub struct StringTable {
     data: Vec<u8>,
 

--- a/core/src/operations/decorators/assembly_op.rs
+++ b/core/src/operations/decorators/assembly_op.rs
@@ -11,6 +11,10 @@ use serde::{Deserialize, Serialize};
 /// Contains information corresponding to an assembly instruction (only applicable in debug mode).
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test
+)]
 pub struct AssemblyOp {
     #[cfg_attr(feature = "serde", serde(default))]
     location: Option<Location>,

--- a/core/src/operations/decorators/assembly_op.rs
+++ b/core/src/operations/decorators/assembly_op.rs
@@ -11,10 +11,7 @@ use serde::{Deserialize, Serialize};
 /// Contains information corresponding to an assembly instruction (only applicable in debug mode).
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
-)]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
 pub struct AssemblyOp {
     #[cfg_attr(feature = "serde", serde(default))]
     location: Option<Location>,

--- a/core/src/operations/decorators/debug.rs
+++ b/core/src/operations/decorators/debug.rs
@@ -12,6 +12,10 @@ use serde::{Deserialize, Serialize};
 /// executed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test
+)]
 pub enum DebugOptions {
     /// Print out the entire contents of the stack for the current execution context.
     StackAll,

--- a/core/src/operations/decorators/debug.rs
+++ b/core/src/operations/decorators/debug.rs
@@ -12,10 +12,7 @@ use serde::{Deserialize, Serialize};
 /// executed.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
-)]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
 pub enum DebugOptions {
     /// Print out the entire contents of the stack for the current execution context.
     StackAll,

--- a/core/src/operations/decorators/mod.rs
+++ b/core/src/operations/decorators/mod.rs
@@ -26,10 +26,7 @@ use crate::mast::{DecoratedOpLink, DecoratorFingerprint};
 /// a single VM cycle.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
-)]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
 pub enum Decorator {
     /// Adds information about the assembly instruction at a particular index (only applicable in
     /// debug mode).

--- a/core/src/operations/decorators/mod.rs
+++ b/core/src/operations/decorators/mod.rs
@@ -26,6 +26,10 @@ use crate::mast::{DecoratedOpLink, DecoratorFingerprint};
 /// a single VM cycle.
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test
+)]
 pub enum Decorator {
     /// Adds information about the assembly instruction at a particular index (only applicable in
     /// debug mode).

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -25,8 +25,8 @@ use crate::{
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
 )]
 pub struct Program {
     mast_forest: Arc<MastForest>,

--- a/core/src/program.rs
+++ b/core/src/program.rs
@@ -24,6 +24,10 @@ use crate::{
 /// (the kernel can be an empty kernel).
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "serde", feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test
+)]
 pub struct Program {
     mast_forest: Arc<MastForest>,
     /// The "entrypoint" is the node where execution of the program begins.

--- a/crates/assembly-syntax/src/ast/attribute/meta/expr.rs
+++ b/crates/assembly-syntax/src/ast/attribute/meta/expr.rs
@@ -18,6 +18,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test(winter_serde(true)))]
 pub enum MetaExpr {
     /// An identifier/keyword, e.g. `inline`
     Ident(Ident),

--- a/crates/assembly-syntax/src/ast/attribute/meta/expr.rs
+++ b/crates/assembly-syntax/src/ast/attribute/meta/expr.rs
@@ -18,7 +18,10 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
-#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test(winter_serde(true)))]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
+)]
 pub enum MetaExpr {
     /// An identifier/keyword, e.g. `inline`
     Ident(Ident),

--- a/crates/assembly-syntax/src/ast/attribute/meta/kv.rs
+++ b/crates/assembly-syntax/src/ast/attribute/meta/kv.rs
@@ -14,6 +14,10 @@ use crate::ast::Ident;
 /// Represents the metadata of a key-value [crate::ast::Attribute], i.e. `@props(key = value)`
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
+)]
 pub struct MetaKeyValue {
     #[cfg_attr(feature = "serde", serde(skip, default))]
     pub span: SourceSpan,

--- a/crates/assembly-syntax/src/ast/attribute/meta/list.rs
+++ b/crates/assembly-syntax/src/ast/attribute/meta/list.rs
@@ -13,6 +13,10 @@ use crate::ast::Ident;
 /// Represents the metadata of a named list [crate::ast::Attribute], i.e. `@name(item0, .., itemN)`
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
+)]
 pub struct MetaList {
     #[cfg_attr(feature = "serde", serde(skip, default))]
     pub span: SourceSpan,

--- a/crates/assembly-syntax/src/ast/attribute/mod.rs
+++ b/crates/assembly-syntax/src/ast/attribute/mod.rs
@@ -40,12 +40,10 @@ use crate::{ast::Ident, prettier};
 /// metadata attached to the procedures in the MAST output by the assembler.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-// TODO(huitseeker): figure out why the round-trip here fails
-// #[cfg_attr(
-//     all(feature = "arbitrary", test),
-//     miden_serde_test_macros::serde_test(winter_serde(true))
-// )]
-#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
+)]
 pub enum Attribute {
     /// A named behavior, trait or action; e.g. `@inline`
     Marker(Ident),
@@ -289,7 +287,7 @@ impl Serializable for Attribute {
                 list.write_into(target);
             },
             Self::KeyValue(kv) => {
-                target.write_u8(1);
+                target.write_u8(2);
                 kv.write_into(target);
             },
         }

--- a/crates/assembly-syntax/src/ast/attribute/mod.rs
+++ b/crates/assembly-syntax/src/ast/attribute/mod.rs
@@ -40,10 +40,12 @@ use crate::{ast::Ident, prettier};
 /// metadata attached to the procedures in the MAST output by the assembler.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
-)]
+// TODO(huitseeker): figure out why the round-trip here fails
+// #[cfg_attr(
+//     all(feature = "arbitrary", test),
+//     miden_serde_test_macros::serde_test(winter_serde(true))
+// )]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
 pub enum Attribute {
     /// A named behavior, trait or action; e.g. `@inline`
     Marker(Ident),

--- a/crates/assembly-syntax/src/ast/attribute/set.rs
+++ b/crates/assembly-syntax/src/ast/attribute/set.rs
@@ -16,6 +16,12 @@ use crate::ast::Ident;
 /// types produce an error if they are declared multiple times on the same item.
 #[derive(Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+// TODO(huitseeker)
+// #[cfg_attr(
+//     all(feature = "arbitrary", test),
+//     miden_serde_test_macros::serde_test(winter_serde(true))
+// )]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
 pub struct AttributeSet {
     /// The attributes in this set.
     ///

--- a/crates/assembly-syntax/src/ast/attribute/set.rs
+++ b/crates/assembly-syntax/src/ast/attribute/set.rs
@@ -16,12 +16,10 @@ use crate::ast::Ident;
 /// types produce an error if they are declared multiple times on the same item.
 #[derive(Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-// TODO(huitseeker)
-// #[cfg_attr(
-//     all(feature = "arbitrary", test),
-//     miden_serde_test_macros::serde_test(winter_serde(true))
-// )]
-#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
+)]
 pub struct AttributeSet {
     /// The attributes in this set.
     ///

--- a/crates/assembly-syntax/src/ast/ident.rs
+++ b/crates/assembly-syntax/src/ast/ident.rs
@@ -54,6 +54,10 @@ pub enum CaseKindError {
 /// guaranteed globally, but generally holds within a given module. In the future we may make these
 /// actually interned strings with a global interner, but for now it is simply best-effort.
 #[derive(Clone)]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
+)]
 pub struct Ident {
     /// The source span associated with this identifier.
     ///

--- a/crates/assembly-syntax/src/ast/procedure/name.rs
+++ b/crates/assembly-syntax/src/ast/procedure/name.rs
@@ -32,8 +32,8 @@ use crate::{
 #[derive(Clone)]
 #[cfg_attr(feature = "arbitrary", derive(proptest_derive::Arbitrary))]
 #[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
 )]
 pub struct QualifiedProcedureName {
     /// The source span associated with this identifier.
@@ -302,8 +302,8 @@ impl<'de> serde::Deserialize<'de> for QualifiedProcedureName {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
 )]
 pub struct ProcedureName(Ident);
 

--- a/crates/assembly-syntax/src/library/mod.rs
+++ b/crates/assembly-syntax/src/library/mod.rs
@@ -34,10 +34,7 @@ pub use self::{
 /// Metadata about a procedure exported by the interface of a [Library]
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
-)]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
 pub struct LibraryExport {
     /// The id of the MAST root node of the exported procedure
     pub node: MastNodeId,
@@ -122,10 +119,7 @@ impl Arbitrary for LibraryExport {
 /// A library exports a set of one or more procedures. Currently, all exported procedures belong
 /// to the same top-level namespace.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
-)]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
 pub struct Library {
     /// The content hash of this library, formed by hashing the roots of all exports in
     /// lexicographical order (by digest, not procedure name)

--- a/crates/assembly-syntax/src/library/namespace.rs
+++ b/crates/assembly-syntax/src/library/namespace.rs
@@ -38,8 +38,8 @@ pub enum LibraryNamespaceError {
 #[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 #[cfg_attr(
-    all(feature = "serde", feature = "arbitrary", test),
-    miden_serde_test_macros::serde_test
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
 )]
 pub enum LibraryNamespace {
     /// A reserved namespace for kernel modules

--- a/crates/assembly-syntax/src/library/path.rs
+++ b/crates/assembly-syntax/src/library/path.rs
@@ -118,6 +118,10 @@ type Components = smallvec::SmallVec<[Ident; 1]>;
 
 /// Path to a module or a procedure.
 #[derive(Default, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
+)]
 pub struct LibraryPath {
     inner: Arc<LibraryPathInner>,
 }

--- a/crates/assembly-syntax/src/parser/token.rs
+++ b/crates/assembly-syntax/src/parser/token.rs
@@ -106,6 +106,10 @@ impl crate::prettier::PrettyPrint for PushValue {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
+)]
 pub struct WordValue(pub [Felt; 4]);
 
 impl fmt::Display for WordValue {
@@ -165,8 +169,10 @@ impl proptest::arbitrary::Arbitrary for WordValue {
     type Parameters = ();
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        use proptest::{array::uniform4, num, strategy::Strategy};
-        uniform4(num::u64::ANY.prop_map(Felt::new)).prop_map(WordValue).boxed()
+        use proptest::{array::uniform4, strategy::Strategy};
+        uniform4((0..=crate::FIELD_MODULUS).prop_map(Felt::new))
+            .prop_map(WordValue)
+            .boxed()
     }
 
     type Strategy = proptest::prelude::BoxedStrategy<Self>;
@@ -199,6 +205,10 @@ impl Deserializable for WordValue {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
+)]
 pub enum IntValue {
     /// A tiny value
     U8(u8),

--- a/package/Cargo.toml
+++ b/package/Cargo.toml
@@ -35,3 +35,7 @@ proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde-untagged = { workspace = true, optional = true }
 thiserror.workspace = true
+
+[dev-dependencies]
+miden-serde-test-macros.workspace = true
+serde_json = { workspace = true }

--- a/package/src/dependency/mod.rs
+++ b/package/src/dependency/mod.rs
@@ -14,6 +14,10 @@ pub(crate) mod resolver;
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::From)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
+)]
 pub struct DependencyName(String);
 
 #[cfg(feature = "arbitrary")]
@@ -47,6 +51,10 @@ impl Deserializable for DependencyName {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(proptest_derive::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    all(feature = "arbitrary", test),
+    miden_serde_test_macros::serde_test(winter_serde(true))
+)]
 pub struct Dependency {
     /// The name of the dependency.
     /// Serves as a human-readable identifier for the dependency and a search hint for the resolver

--- a/package/src/package/manifest.rs
+++ b/package/src/package/manifest.rs
@@ -83,6 +83,7 @@ impl PackageManifest {
 #[derive(Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(proptest_derive::Arbitrary))]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(all(feature = "arbitrary", test), miden_serde_test_macros::serde_test)]
 pub struct PackageExport {
     /// The fully-qualified name of the procedure exported by this package.
     pub name: QualifiedProcedureName,


### PR DESCRIPTION
**This PR:**
- is stacked on #2200,
- extends the round-trip macros started in #2132 to also generate winterfell round-trip tests,
- adds a few instances of Arbitrary for types that were missing one (up to and including `Program`), fixing an issue in the instance for `WordValue` 
- adds ~35 roundtrip serialization tests,
- fixes an enum-tagging bug in the serialization of `Attribute`

**Also (unrelated)**:
- adds a rust-toolchain because CI (based on rustup atm) isn't picking up the latest stable.

**Why?** I am working on a feature which is blocked by a (winter) serialization issue in the space *between* `MastForest` (ok) and `Program` (not so). This lets me rule out a range of issues.