### PR TITLE
doc: escape brackets in rustdoc

### DIFF
--- a/air/src/constraints/stack/field_ops/mod.rs
+++ b/air/src/constraints/stack/field_ops/mod.rs
@@ -382,7 +382,7 @@ pub fn enforce_expacc_constraints<E: FieldElement>(
 /// Enforces constraints of the EXT2MUL operation.
 ///
 /// The EXT2MUL operation computes the product of two elements in the extension
-/// field 𝔽ₚ[x]/(x² - x + 2):
+/// field 𝔽ₚ\[x\]/(x² - x + 2):
 ///
 /// Let $a = a1 \cdot x + a0$ and $b = b1 \cdot x + b0$. Then:
 ///
@@ -390,7 +390,7 @@ pub fn enforce_expacc_constraints<E: FieldElement>(
 /// a \cdot b = (a1 \cdot b1)x^2 + (a1 \cdot b0 + a0 \cdot b1)x + (a0 \cdot b0)
 /// ```
 ///
-/// Since $x^2 \equiv x - 2$ in $\mathbb{F}_p[x]/(x^2 - x + 2)$, this reduces to:
+/// Since $x^2 \equiv x - 2$ in $\mathbb{F}_p\[x\]/(x^2 - x + 2)$, this reduces to:
 ///
 /// ```math
 /// a \cdot b = (a1 \cdot b0 + a0 \cdot b1 + a1 \cdot b1)x + (a0 \cdot b0 - 2 \cdot a1 \cdot b1)

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -284,7 +284,7 @@ pub enum Operation {
     /// result back onto the stack as the third and fourth elements. Pushes 0 onto the stack as
     /// the first and second elements.
     ///
-    /// The extension field is defined as 𝔽ₚ[x]/(x² - x + 2), i.e. using the
+    /// The extension field is defined as 𝔽ₚ\[x\]/(x² - x + 2), i.e. using the
     /// irreducible quadratic polynomial x² - x + 2 over the base field.
     Ext2Mul = OPCODE_EXT2MUL,
 


### PR DESCRIPTION
Fixes a rust doc typo from #2217.
