### PR TITLE
chore: fix link checker job 

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       fail-fast:
         required: false
-        default: true
+        default: false
         type: boolean
   schedule:
     # runs once a day at 01:00 UTC (adjust as needed)

--- a/lychee.toml
+++ b/lychee.toml
@@ -6,6 +6,7 @@ exclude = [
     '^file:///.*stdlib/docs/sys\.md',           # Missing stdlib docs file
     '^file:///.*\.png$',                        # Image files
     '^file:///.*\.svg$',                        # SVG files
+    '^https://www.gnu.org/software/make/manual/make\.html$',  # GNU make manual
 ]
 
 # Exclude these filesystem paths from getting checked.


### PR DESCRIPTION
- Add GNU make manual URL exclusion to lychee.toml to prevent 429 errors
- Set fail-fast=false in CI workflow to allow job to continue (and open an issue) after link failures

