### PR TITLE
chore: Memory::read_element takes &self instead of &mut self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## 0.19.0 (TBD)
 
-#### Changes
-
-- Fixed mismatched Push expectations in decoder syscall_block test ([#2207](https://github.com/0xMiden/miden-vm/pull/2207))
-
 #### Enhancements
 
 - Added support for leaves with multiple pairs in `std::collections::smt::get` ([#2048](https://github.com/0xMiden/miden-vm/pull/2048)).
@@ -18,6 +14,8 @@
 - Fix ability to parse odd-length hex strings ([#2196](https://github.com/0xMiden/miden-vm/pull/2196)).
 - Added `before_enter` and `after_exit` decorator lists to `BasicBlockNode`.([#2167](https://github.com/0xMiden/miden-vm/pull/2167)).
 - Added `proptest`'s `Arbitrary` instances for `BasicBlockNode` and `MastForest` ([#2200](https://github.com/0xMiden/miden-vm/pull/2200)).
+- Fixed mismatched Push expectations in decoder syscall_block test ([#2207](https://github.com/0xMiden/miden-vm/pull/2207))
+- [BREAKING] `Memory::read_element()` now requires `&self` instead of `&mut self` ([#2237](https://github.com/0xMiden/miden-vm/issues/2237))
 
 ## 0.18.0 (2025-09-21)
 

--- a/processor/src/fast/memory.rs
+++ b/processor/src/fast/memory.rs
@@ -26,7 +26,7 @@ impl Memory {
     /// - Returns an error if the provided address is out-of-bounds.
     #[inline(always)]
     pub fn read_element(
-        &mut self,
+        &self,
         ctx: ContextId,
         addr: Felt,
         err_ctx: &impl ErrorContext,
@@ -216,7 +216,7 @@ impl MemoryInterface for Memory {
         addr: Felt,
         err_ctx: &impl ErrorContext,
     ) -> Result<Felt, MemoryError> {
-        self.read_element(ctx, addr, err_ctx)
+        Self::read_element(self, ctx, addr, err_ctx)
     }
 
     fn read_word(


### PR DESCRIPTION
Closes #2237