### PR TITLE
fix: replace unsafe expect("TODO") with proper error handling in ACE circuit tests

### DIFF
--- a/processor/src/chiplets/ace/tests/circuit.rs
+++ b/processor/src/chiplets/ace/tests/circuit.rs
@@ -44,6 +44,8 @@ pub enum CircuitError {
     LayoutInvalid,
     InstructionMalformed,
     InputsWrongNumber,
+    NodeIndexOutOfBounds,
+    NodeNotFound,
 }
 
 /// Layout of a circuit representing the number of different `Node`s of each type.
@@ -105,11 +107,15 @@ impl Circuit {
         nodes.extend(self.constants.iter().map(|c| QuadFelt::from(*c)));
 
         for instruction in &self.instructions {
-            let id_l = layout.node_index(&instruction.node_l).expect("TODO");
-            let v_l = *nodes.get(id_l).expect("TODO");
+            let id_l = layout.node_index(&instruction.node_l)
+                .ok_or(CircuitError::NodeIndexOutOfBounds)?;
+            let v_l = *nodes.get(id_l)
+                .ok_or(CircuitError::NodeNotFound)?;
 
-            let id_r = layout.node_index(&instruction.node_r).expect("TODO");
-            let v_r = *nodes.get(id_r).expect("TODO");
+            let id_r = layout.node_index(&instruction.node_r)
+                .ok_or(CircuitError::NodeIndexOutOfBounds)?;
+            let v_r = *nodes.get(id_r)
+                .ok_or(CircuitError::NodeNotFound)?;
 
             let v_out = match instruction.op {
                 Op::Sub => v_l - v_r,

--- a/processor/src/chiplets/ace/tests/circuit.rs
+++ b/processor/src/chiplets/ace/tests/circuit.rs
@@ -107,15 +107,15 @@ impl Circuit {
         nodes.extend(self.constants.iter().map(|c| QuadFelt::from(*c)));
 
         for instruction in &self.instructions {
-            let id_l = layout.node_index(&instruction.node_l)
+            let id_l = layout
+                .node_index(&instruction.node_l)
                 .ok_or(CircuitError::NodeIndexOutOfBounds)?;
-            let v_l = *nodes.get(id_l)
-                .ok_or(CircuitError::NodeNotFound)?;
+            let v_l = *nodes.get(id_l).ok_or(CircuitError::NodeNotFound)?;
 
-            let id_r = layout.node_index(&instruction.node_r)
+            let id_r = layout
+                .node_index(&instruction.node_r)
                 .ok_or(CircuitError::NodeIndexOutOfBounds)?;
-            let v_r = *nodes.get(id_r)
-                .ok_or(CircuitError::NodeNotFound)?;
+            let v_r = *nodes.get(id_r).ok_or(CircuitError::NodeNotFound)?;
 
             let v_out = match instruction.op {
                 Op::Sub => v_l - v_r,


### PR DESCRIPTION
Replace expect("TODO") calls with proper error handling in Circuit::evaluate method

These changes are necessary because:
1. expect("TODO") with placeholder messages is dangerous in production code
2. Panics from expect() calls can cause DoS attacks or system crashes
3. Proper error handling provides better debugging information and graceful failure modes
4. The existing validation in Circuit::new() ensures these errors should never occur, but 
   defensive programming requires proper error handling