### PR TITLE
fix: after_exit executed incorrectly in External nodes

### DIFF
--- a/processor/src/continuation_stack.rs
+++ b/processor/src/continuation_stack.rs
@@ -26,6 +26,8 @@ pub enum Continuation {
     FinishCall(MastNodeId),
     /// Process the finish phase of a Dyn node.
     FinishDyn(MastNodeId),
+    /// Process the finish phase of an External node (execute after_exit decorators).
+    FinishExternal((MastNodeId, Arc<MastForest>)),
     /// Enter a new MAST forest, where all subsequent `MastNodeId`s will be relative to this forest.
     ///
     /// When we encounter an `ExternalNode`, we enter the corresponding MAST forest directly, and
@@ -87,6 +89,11 @@ impl ContinuationStack {
     /// Pushes a dyn finish continuation onto the stack.
     pub fn push_finish_dyn(&mut self, node_id: MastNodeId) {
         self.stack.push(Continuation::FinishDyn(node_id));
+    }
+
+    /// Pushes an external finish continuation onto the stack.
+    pub fn push_finish_external(&mut self, node_id: MastNodeId, forest: Arc<MastForest>) {
+        self.stack.push(Continuation::FinishExternal((node_id, forest)));
     }
 
     /// Pushes a continuation to start processing the given node.

--- a/processor/src/fast/external.rs
+++ b/processor/src/fast/external.rs
@@ -34,7 +34,9 @@ impl FastProcessor {
         // Push the root node of the external MAST forest onto the continuation stack.
         continuation_stack.push_start_node(resolved_node_id);
 
-        self.execute_after_exit_decorators(external_node_id, current_forest, host)?;
+        // Push a continuation to execute after_exit decorators when we return from the external
+        // forest
+        continuation_stack.push_finish_external(external_node_id, current_forest.clone());
 
         // Update the current forest to the new MAST forest.
         *current_forest = new_mast_forest;

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -465,6 +465,10 @@ impl FastProcessor {
                     host,
                     tracer,
                 )?,
+                Continuation::FinishExternal((node_id, external_forest)) => {
+                    // Execute after_exit decorators when returning from an external node
+                    self.execute_after_exit_decorators(node_id, &external_forest, host)?;
+                },
                 Continuation::EnterForest(previous_forest) => {
                     // Restore the previous forest
                     current_forest = previous_forest;

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -2,7 +2,10 @@ use alloc::{string::ToString, sync::Arc};
 
 use miden_air::ExecutionOptions;
 use miden_assembly::{Assembler, DefaultSourceManager};
-use miden_core::{Kernel, ONE, Operation, StackInputs, assert_matches};
+use miden_core::{
+    Decorator, Kernel, ONE, Operation, StackInputs, assert_matches,
+    mast::{BasicBlockNode, ExternalNode, MastForest},
+};
 use miden_utils_testing::build_test;
 use rstest::rstest;
 
@@ -400,6 +403,56 @@ fn test_call_node_preserves_stack_overflow_table() {
             15_u32.into(),
             16_u32.into(),
         ]
+    );
+}
+
+// EXTERNAL NODE TESTS
+// -----------------------------------------------------------------------------------------------
+
+#[test]
+fn test_external_node_decorator_sequencing() {
+    let mut lib_forest = MastForest::new();
+    let lib_operations = [Operation::Push(1_u32.into()), Operation::Add];
+    let lib_block = BasicBlockNode::new(lib_operations.to_vec(), alloc::vec::Vec::new()).unwrap();
+    let lib_block_id = lib_forest.add_node(lib_block).unwrap();
+    lib_forest.make_root(lib_block_id);
+
+    let mut main_forest = MastForest::new();
+    let before_decorator = Decorator::Trace(1);
+    let after_decorator = Decorator::Trace(3);
+    let before_id = main_forest.add_decorator(before_decorator.clone()).unwrap();
+    let after_id = main_forest.add_decorator(after_decorator.clone()).unwrap();
+
+    let mut external_node = ExternalNode::new(lib_forest[lib_block_id].digest());
+    external_node.append_before_enter(&[before_id]);
+    external_node.append_after_exit(&[after_id]);
+    let external_id = main_forest.add_node(external_node).unwrap();
+    main_forest.make_root(external_id);
+
+    let program = Program::new(main_forest.into(), external_id);
+    let mut host =
+        crate::test_utils::test_consistency_host::TestConsistencyHost::with_kernel_forest(
+            Arc::new(lib_forest),
+        );
+    let processor = FastProcessor::new(&alloc::vec::Vec::new());
+
+    let result = processor.execute_sync(&program, &mut host);
+    assert!(result.is_ok(), "Execution failed: {:?}", result);
+
+    // Verify both decorators executed
+    assert_eq!(host.get_trace_count(1), 1, "before_enter decorator should execute exactly once");
+    assert_eq!(host.get_trace_count(3), 1, "after_exit decorator should execute exactly once");
+
+    // More importantly, verify the execution order by checking trace order
+    let execution_order = host.get_execution_order();
+    assert_eq!(execution_order.len(), 2, "Should have exactly 2 trace events");
+    assert_eq!(execution_order[0].0, 1, "before_enter should execute first");
+    assert_eq!(execution_order[1].0, 3, "after_exit should execute after external operations");
+
+    // Verify that after_exit executes at a later clock cycle than before_enter
+    assert!(
+        execution_order[1].1 >= execution_order[0].1,
+        "after_exit should execute at a later clock cycle"
     );
 }
 


### PR DESCRIPTION
Modified continuation_stack.rs: Added FinishExternal((MastNodeId, Arc<MastForest>)) continuation type to store both node ID and forest reference for after_exit decorator execution.

Fixes #2005 