### PR TITLE
chore: fix typos in comment

### DIFF
--- a/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/channel.rs
@@ -395,7 +395,7 @@ impl ConstraintQueries {
 // ================================================================================================
 
 /// Takes a set of positions, query values of a trace at these positions and a Merkle batch proof
-/// against a committment to this trace, and outputs a partial Merkle tree with individual Merkle
+/// against a commitment to this trace, and outputs a partial Merkle tree with individual Merkle
 /// paths for each position as well as a key-value map mapping the digests of the query values
 /// (i.e. Merkle tree leaves) to their corresponding query values.
 pub fn unbatch_to_partial_mt(

--- a/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
+++ b/stdlib/tests/crypto/stark/verifier_recursive/mod.rs
@@ -137,7 +137,7 @@ pub fn generate_advice_inputs(
 
     // 5 ----- FRI  -------------------------------------------------------------------------------
 
-    // read the FRI layer committments as well as remainder polynomial
+    // read the FRI layer commitments as well as remainder polynomial
     let fri_commitments_digests = channel.read_fri_layer_commitments();
     let poly = channel.read_remainder().unwrap();
 

--- a/stdlib/tests/math/ecgfp5/scalar_field.rs
+++ b/stdlib/tests/math/ecgfp5/scalar_field.rs
@@ -55,7 +55,7 @@ impl Scalar {
 
     /// Raw subtraction of a Scalar element from another one, without reduction
     ///
-    /// Second return value, = 0xffff_ffff, if oveflow has occurred
+    /// Second return value, = 0xffff_ffff, if overflow has occurred
     ///                else  = 0, if no overflow during subtraction
     ///
     /// Adapted from https://github.com/pornin/ecgfp5/blob/82325b9/rust/src/scalar.rs#L80-L92


### PR DESCRIPTION
## Description

Corrected misspellings:

- `committment` → `commitment`
- `oveflow` → `overflow`
