### PR TITLE
Remove redundant clone in exec test to avoid unnecessary copy

### DIFF
--- a/miden-vm/tests/integration/exec.rs
+++ b/miden-vm/tests/integration/exec.rs
@@ -42,12 +42,11 @@ fn advice_map_loaded_before_execution() {
     }
 
     // Test `miden_processor::execute` works if advice map provided with the program
-    let mast_forest: MastForest = (**program_without_advice_map.mast_forest()).clone();
+    let mut mast_forest: MastForest = (**program_without_advice_map.mast_forest()).clone();
 
     let key = Word::new([ONE, ONE, ONE, ONE]);
     let value = vec![ONE, ONE];
 
-    let mut mast_forest = mast_forest.clone();
     mast_forest.advice_map_mut().insert(key, value);
     let program_with_advice_map =
         Program::new(mast_forest.into(), program_without_advice_map.entrypoint());


### PR DESCRIPTION


### PR Description
- **What**: Replace a double-clone pattern by making the initial `mast_forest` binding mutable and removing the subsequent `clone`.
- **Where**: `miden-vm/tests/integration/exec.rs`
- **Why**: The second `clone` created an unnecessary allocation/copy with no behavioral impact. Using a single mutable owner is clearer and cheaper.

#### Change Summary
- Made the first `mast_forest` binding mutable.
- Removed the redundant `mast_forest.clone()` before `advice_map_mut().insert(...)`.

