### PR TITLE
chore: place the fast processor stack on the heap instead of the stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed hex word parsing to guard against missing 0x prefix ([#2245](https://github.com/0xMiden/miden-vm/pull/2245)).
 - Systematized u32-indexed vectors ([#2254](https://github.com/0xMiden/miden-vm/pull/2254)).
 - Introduce a new `build_trace()` which builds the trace in parallel from trace fragment contexts ([#1839](https://github.com/0xMiden/miden-vm/pull/1839)) ([#2188](https://github.com/0xMiden/miden-vm/pull/2188))
+- Place the `FastProcessor` stack on the heap instead of the (OS thread) stack (#[2270](https://github.com/0xMiden/miden-vm/pull/2270))
  
 ## 0.18.1 (2025-10-02)
 

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use core::cmp::min;
 
 use memory::Memory;
@@ -87,7 +87,7 @@ const INITIAL_STACK_TOP_IDX: usize = 250;
 #[derive(Debug)]
 pub struct FastProcessor {
     /// The stack is stored in reverse order, so that the last element is at the top of the stack.
-    pub(super) stack: [Felt; STACK_BUFFER_SIZE],
+    pub(super) stack: Box<[Felt; STACK_BUFFER_SIZE]>,
     /// The index of the top of the stack.
     stack_top_idx: usize,
     /// The index of the bottom of the stack.
@@ -166,7 +166,7 @@ impl FastProcessor {
 
         let stack_top_idx = INITIAL_STACK_TOP_IDX;
         let stack = {
-            let mut stack = [ZERO; STACK_BUFFER_SIZE];
+            let mut stack = Box::new([ZERO; STACK_BUFFER_SIZE]);
             let bottom_idx = stack_top_idx - stack_inputs.len();
 
             stack[bottom_idx..stack_top_idx].copy_from_slice(stack_inputs);


### PR DESCRIPTION
Places the `FastProcessor` stack on the heap to reduce the risk of (OS thread) stack overflow, as observed in e.g. https://github.com/0xMiden/miden-base/issues/1927.

Benchmarks are unaffected by this change.

Also related: https://github.com/0xMiden/miden-base/issues/1936#issuecomment-3380244534

@bobbinth I could rebase this against `main` as well if we want to release a patch version