### PR TITLE
chore(processor): properly allocate the fast processor stack directly on heap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Fixed hex word parsing to guard against missing 0x prefix ([#2245](https://github.com/0xMiden/miden-vm/pull/2245)).
 - Systematized u32-indexed vectors ([#2254](https://github.com/0xMiden/miden-vm/pull/2254)).
 - Introduce a new `build_trace()` which builds the trace in parallel from trace fragment contexts ([#1839](https://github.com/0xMiden/miden-vm/pull/1839)) ([#2188](https://github.com/0xMiden/miden-vm/pull/2188))
-- Place the `FastProcessor` stack on the heap instead of the (OS thread) stack (#[2270](https://github.com/0xMiden/miden-vm/pull/2270))
+- Place the `FastProcessor` stack on the heap instead of the (OS thread) stack (#[2271](https://github.com/0xMiden/miden-vm/pull/2271))
  
 ## 0.18.1 (2025-10-02)
 

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -166,7 +166,11 @@ impl FastProcessor {
 
         let stack_top_idx = INITIAL_STACK_TOP_IDX;
         let stack = {
-            let mut stack = Box::new([ZERO; STACK_BUFFER_SIZE]);
+            // Note: we use `Vec::into_boxed_slice()` here, since `Box::new([T; N])` first allocates
+            // the array on the stack, and then moves it to the heap. This might cause a
+            // stack overflow on some systems.
+            let mut stack: Box<[Felt; STACK_BUFFER_SIZE]> =
+                vec![ZERO; STACK_BUFFER_SIZE].into_boxed_slice().try_into().unwrap();
             let bottom_idx = stack_top_idx - stack_inputs.len();
 
             stack[bottom_idx..stack_top_idx].copy_from_slice(stack_inputs);


### PR DESCRIPTION
Fixes a mistake made in #2270, pointed out by @Mirko-von-Leipzig.

`Box::<[T; N]>::new()` will first allocate the array on the stack, and then move it to the heap (https://github.com/rust-lang/rust/issues/53827). In this PR, we use `Vec::into_boxed_slice()` as a workaround. I verified that this does indeed allocate directly on the heap compared to `Box::new()`.