### PR TITLE
hotfix 0.18.2: place the fast processor stack on the heap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.18.2 (2025-10-10)
+
+- Place the `FastProcessor` stack on the heap instead of the (OS thread) stack (#[2275](https://github.com/0xMiden/miden-vm/pull/2275))
+
 ## 0.18.1 (2025-10-02)
 
 - Gate stdlib doc generation in build.rs on `MIDEN_BUILD_STDLIB_DOCS` environmnent variable ([#2239](https://github.com/0xMiden/miden-vm/pull/2239/))


### PR DESCRIPTION
Cherry-pick (and squash) of #2270 and #2271 onto `main`