### PR TITLE
feat(precompiles): implement sealed trait pattern for PrecompileVerifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,6 +1653,7 @@ version = "0.19.0"
 dependencies = [
  "miden-air",
  "miden-core",
+ "miden-stdlib",
  "thiserror",
  "tracing",
  "winter-verifier",

--- a/core/src/precompile.rs
+++ b/core/src/precompile.rs
@@ -1,7 +1,7 @@
-use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use core::error::Error;
 
-use miden_crypto::{Felt, Word, hash::rpo::Rpo256};
+use miden_crypto::{Felt, Word};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -90,181 +90,6 @@ impl PrecompileCommitment {
     }
 }
 
-// PRECOMPILE VERIFIERS REGISTRY
-// ================================================================================================
-
-/// Registry of precompile verifiers.
-///
-/// This struct maintains a map of event IDs to their corresponding verifiers.
-/// It is used to verify precompile requests during proof verification.
-#[derive(Default, Clone)]
-pub struct PrecompileVerifierRegistry {
-    /// Map of event IDs to their corresponding verifiers
-    verifiers: BTreeMap<EventId, Arc<dyn PrecompileVerifier>>,
-}
-
-impl PrecompileVerifierRegistry {
-    /// Creates a new empty precompile verifiers registry.
-    pub fn new() -> Self {
-        Self { verifiers: BTreeMap::new() }
-    }
-
-    /// Registers a verifier for the specified event ID.
-    pub fn register(&mut self, event_id: EventId, verifier: Arc<dyn PrecompileVerifier>) {
-        self.verifiers.insert(event_id, verifier);
-    }
-
-    /// Gets a verifier for the specified event ID.
-    pub fn get(&self, event_id: EventId) -> Option<&dyn PrecompileVerifier> {
-        self.verifiers.get(&event_id).map(|v| v.as_ref())
-    }
-
-    /// Returns true if a verifier is registered for the specified event ID.
-    pub fn contains(&self, event_id: EventId) -> bool {
-        self.verifiers.contains_key(&event_id)
-    }
-
-    /// Returns the number of registered verifiers.
-    pub fn len(&self) -> usize {
-        self.verifiers.len()
-    }
-
-    /// Returns true if no verifiers are registered.
-    pub fn is_empty(&self) -> bool {
-        self.verifiers.is_empty()
-    }
-
-    /// Verifies all precompile requests and returns an aggregated commitment for deferred
-    /// verification.
-    ///
-    /// This method iterates through all requests and verifies each one using the
-    /// corresponding verifier from the registry. The commitments are then absorbed into a sponge,
-    /// from which we can squeeze a digest.
-    ///
-    /// # Arguments
-    /// * `requests` - Slice of precompile requests to verify
-    ///
-    /// # Errors
-    /// Returns a [`PrecompileVerificationError`] if:
-    /// - No verifier is registered for a request's event ID
-    /// - A verifier fails to verify its request
-    pub fn deferred_requests_commitment(
-        &self,
-        requests: &[PrecompileRequest],
-    ) -> Result<Word, PrecompileVerificationError> {
-        let mut state = PrecompileVerificationState::new();
-        for (index, PrecompileRequest { event_id, calldata: data }) in requests.iter().enumerate() {
-            let event_id = *event_id;
-            let verifier = self
-                .get(event_id)
-                .ok_or(PrecompileVerificationError::VerifierNotFound { index, event_id })?;
-
-            let precompile_commitment = verifier.verify(data).map_err(|error| {
-                PrecompileVerificationError::PrecompileError { index, event_id, error }
-            })?;
-            state.absorb(precompile_commitment);
-        }
-        Ok(state.finalize())
-    }
-}
-
-// PRECOMPILE VERIFIER TRAIT
-// ================================================================================================
-
-/// Trait for verifying precompile computations.
-///
-/// Each precompile type must implement this trait to enable verification of its
-/// computations during proof verification. The verifier validates that the
-/// computation was performed correctly and returns a precompile commitment.
-pub trait PrecompileVerifier: Send + Sync {
-    /// Verifies a precompile computation from the given call data.
-    ///
-    /// # Arguments
-    /// * `calldata` - The byte data containing the inputs to evaluate the precompile.
-    ///
-    /// # Returns
-    /// Returns a precompile commitment containing both tag and commitment word on success.
-    ///
-    /// # Errors
-    /// Returns an error if the verification fails.
-    fn verify(&self, calldata: &[u8]) -> Result<PrecompileCommitment, PrecompileError>;
-}
-
-/// Default implementation for both free functions and closures with signature
-/// `fn(&[u8]) -> Result<PrecompileCommitment, PrecompileError>`
-///
-/// # Example
-/// ```ignore
-/// let verifier = |data: &[u8]| -> Result<PrecompileCommitment, PrecompileError> {
-///     // Custom verification logic
-///     Ok(PrecompileCommitment { tag: [0; 4].into(), commitment: [0; 4].into() })
-/// };
-/// ```
-impl<F> PrecompileVerifier for F
-where
-    F: Fn(&[u8]) -> Result<PrecompileCommitment, PrecompileError> + Send + Sync + 'static,
-{
-    fn verify(&self, calldata: &[u8]) -> Result<PrecompileCommitment, PrecompileError> {
-        self(calldata)
-    }
-}
-
-// PRECOMPILE VERIFICATION STATE
-// ================================================================================================
-
-/// Tracks the RPO256 sponge capacity for aggregating [`PrecompileCommitment`]s.
-///
-/// This structure mirrors the VM's implementation of precompile commitment tracking. During
-/// execution, the VM maintains only the capacity portion of an RPO256 sponge, absorbing each
-/// precompile commitment as it's produced. At the end of execution, the verifier recomputes
-/// this same aggregation and compares the final digest.
-///
-/// The exact shape of the commitment is described in TODO(adr1anh)
-///
-/// # Details:
-/// This struct is a specialization of an RPO based sponge for aggregating precompile commitment.
-/// - `new()`: Initialize a sponge with capacity set to `ZERO`.
-/// - `absorb(comm)`: Permute the state `[self.capacity, comm.tag, comm.commitment]`, absorbing the
-///   `PrecompileCommitment` into the sponge and saving the resulting capacity.
-/// - `finalize()`: Permute the state `[self.capacity, ZERO, ZERO]` and extract the resulting
-///   digest.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
-struct PrecompileVerificationState {
-    /// RPO256 sponge capacity, updated with each absorbed commitment.
-    capacity: Word,
-}
-
-impl PrecompileVerificationState {
-    /// Creates a new verification state with zero-initialized capacity.
-    fn new() -> Self {
-        Self::default()
-    }
-
-    /// Absorbs a precompile commitment by applying RPO256 to `[capacity, tag, commitment]`
-    /// and saving the resulting capacity word.
-    fn absorb(&mut self, commitment: PrecompileCommitment) {
-        let mut state =
-            Word::words_as_elements(&[self.capacity, commitment.tag, commitment.commitment])
-                .try_into()
-                .unwrap();
-        Rpo256::apply_permutation(&mut state);
-        self.capacity = Word::new(state[0..4].try_into().unwrap());
-    }
-
-    /// Finalizes by applying RPO256 to `[capacity, ZERO, ZERO]` and extracting elements the first
-    /// rate word.
-    ///
-    /// This matches the VM's finalization where the rate portion is set to zeros for the final
-    /// permutation. The zero-padded rate could be used for auxiliary metadata in future versions.
-    fn finalize(self) -> Word {
-        let mut state = Word::words_as_elements(&[self.capacity, Word::empty(), Word::empty()])
-            .try_into()
-            .unwrap();
-        Rpo256::apply_permutation(&mut state);
-        Word::new(state[4..8].try_into().unwrap())
-    }
-}
-
 // PRECOMPILE ERROR
 // ================================================================================================
 
@@ -275,18 +100,24 @@ impl PrecompileVerificationState {
 /// different precompile implementations to define their own specific error types.
 pub type PrecompileError = Box<dyn Error + Send + Sync + 'static>;
 
-#[derive(Debug, thiserror::Error)]
-pub enum PrecompileVerificationError {
-    #[error("no verifier found for request at index {index} with event ID {event_id}")]
-    VerifierNotFound { index: usize, event_id: EventId },
+// PRECOMPILE VERIFIER REGISTRY (PLACEHOLDER)
+// ================================================================================================
 
-    #[error("verification error when verifying request at index {index}, with event ID {event_id}")]
-    PrecompileError {
-        index: usize,
-        event_id: EventId,
-        #[source]
-        error: PrecompileError,
-    },
+/// Placeholder for precompile verifier registry.
+///
+/// NOTE: The actual registry is defined in stdlib.
+/// This is kept for backward compatibility during the transition.
+#[derive(Default)]
+pub struct PrecompileVerifierRegistry {
+    /// Placeholder implementation
+    _placeholder: (),
+}
+
+impl PrecompileVerifierRegistry {
+    /// Creates a new empty precompile verifiers registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 // TESTS

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -1,19 +1,22 @@
 #![no_std]
 
 pub mod handlers;
+pub mod precompile;
 
 extern crate alloc;
 
 use alloc::{sync::Arc, vec, vec::Vec};
 
 use miden_assembly::{Library, mast::MastForest, utils::Deserializable};
-use miden_core::{EventId, Felt, Word, precompile::PrecompileVerifier};
+use miden_core::{EventId, Felt, Word};
 use miden_processor::{EventHandler, HostLibrary};
 use miden_utils_sync::LazyLock;
+// Export the sealed trait and registry
+pub use precompile::{PrecompileVerificationError, PrecompileVerifier, PrecompileVerifierRegistry};
 
 use crate::handlers::{
     falcon_div::{FALCON_DIV_EVENT_ID, handle_falcon_div},
-    keccak256::{KECCAK_HASH_MEMORY_EVENT_ID, handle_keccak_hash_memory, keccak_verifier},
+    keccak256::{KECCAK_HASH_MEMORY_EVENT_ID, KeccakVerifier, handle_keccak_hash_memory},
     smt_peek::{SMT_PEEK_EVENT_ID, handle_smt_peek},
     sorted_array::{
         LOWERBOUND_ARRAY_EVENT_ID, LOWERBOUND_KEY_VALUE_EVENT_ID, handle_lowerbound_array,
@@ -79,7 +82,7 @@ impl StdLibrary {
 
     /// List of all `PrecompileVerifier` required to verify precompile requests.
     pub fn verifiers(&self) -> Vec<(EventId, Arc<dyn PrecompileVerifier>)> {
-        vec![(KECCAK_HASH_MEMORY_EVENT_ID, Arc::new(keccak_verifier))]
+        vec![(KECCAK_HASH_MEMORY_EVENT_ID, Arc::new(KeccakVerifier::new()))]
     }
 }
 

--- a/stdlib/src/precompile.rs
+++ b/stdlib/src/precompile.rs
@@ -1,0 +1,195 @@
+//! Precompile verifier trait and sealed pattern implementation.
+
+use alloc::{boxed::Box, collections::BTreeMap, sync::Arc};
+use core::error::Error;
+
+use miden_core::EventId;
+// Import core types
+pub use miden_core::precompile::{PrecompileCommitment, PrecompileRequest};
+use miden_crypto::{Word, hash::rpo::Rpo256};
+
+/// This trait is sealed and cannot be implemented for types outside this crate.
+///
+/// This pattern restricts implementations of PrecompileVerifier to specific types
+/// within the stdlib crate, ensuring that only approved verifiers can be used.
+///
+/// The trait provides a common interface for verifying precompile computations
+/// and generating cryptographic commitments.
+pub trait PrecompileVerifier: private::Sealed {
+    /// Verifies a precompile computation from the given call data.
+    ///
+    /// # Arguments
+    /// * `calldata` - The byte data containing the inputs to evaluate the precompile.
+    ///
+    /// # Returns
+    /// Returns a precompile commitment containing both tag and commitment word on success.
+    ///
+    /// # Errors
+    /// Returns an error if the verification fails.
+    fn verify(&self, calldata: &[u8]) -> Result<PrecompileCommitment, PrecompileError>;
+}
+
+// Move PrecompileVerificationError and related types to stdlib
+/// Type alias for precompile errors.
+///
+/// This allows custom error types to be used by precompile verifiers while maintaining
+/// a consistent interface. Similar to EventError, this provides flexibility for
+/// different precompile implementations to define their own specific error types.
+pub type PrecompileError = Box<dyn Error + Send + Sync + 'static>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum PrecompileVerificationError {
+    #[error("no verifier found for request at index {index} with event ID {event_id}")]
+    VerifierNotFound { index: usize, event_id: EventId },
+
+    #[error("verification error when verifying request at index {index}, with event ID {event_id}")]
+    PrecompileError {
+        index: usize,
+        event_id: EventId,
+        #[source]
+        error: PrecompileError,
+    },
+}
+
+/// Registry of precompile verifiers.
+///
+/// This struct maintains a map of event IDs to their corresponding verifiers.
+/// It is used to verify precompile requests during proof verification.
+#[derive(Default, Clone)]
+pub struct PrecompileVerifierRegistry {
+    /// Map of event IDs to their corresponding verifiers
+    verifiers: BTreeMap<EventId, Arc<dyn PrecompileVerifier>>,
+}
+
+impl PrecompileVerifierRegistry {
+    /// Creates a new empty precompile verifiers registry.
+    pub fn new() -> Self {
+        Self { verifiers: BTreeMap::new() }
+    }
+
+    /// Registers a verifier for the specified event ID.
+    pub fn register(&mut self, event_id: EventId, verifier: Arc<dyn PrecompileVerifier>) {
+        self.verifiers.insert(event_id, verifier);
+    }
+
+    /// Gets a verifier for the specified event ID.
+    pub fn get(&self, event_id: EventId) -> Option<&dyn PrecompileVerifier> {
+        self.verifiers.get(&event_id).map(|v| v.as_ref())
+    }
+
+    /// Returns true if a verifier is registered for the specified event ID.
+    pub fn contains(&self, event_id: EventId) -> bool {
+        self.verifiers.contains_key(&event_id)
+    }
+
+    /// Returns the number of registered verifiers.
+    pub fn len(&self) -> usize {
+        self.verifiers.len()
+    }
+
+    /// Returns true if no verifiers are registered.
+    pub fn is_empty(&self) -> bool {
+        self.verifiers.is_empty()
+    }
+
+    /// Verifies all precompile requests and returns an aggregated commitment for deferred
+    /// verification.
+    ///
+    /// This method iterates through all requests and verifies each one using the
+    /// corresponding verifier from the registry. The commitments are then absorbed into a sponge,
+    /// from which we can squeeze a digest.
+    ///
+    /// # Arguments
+    /// * `requests` - Slice of precompile requests to verify
+    ///
+    /// # Errors
+    /// Returns a [`PrecompileVerificationError`] if:
+    /// - No verifier is registered for a request's event ID
+    /// - A verifier fails to verify its request
+    pub fn deferred_requests_commitment(
+        &self,
+        requests: &[PrecompileRequest],
+    ) -> Result<Word, PrecompileVerificationError> {
+        let mut state = PrecompileVerificationState::new();
+        for (index, request) in requests.iter().enumerate() {
+            let event_id = request.event_id();
+            let verifier = self
+                .get(event_id)
+                .ok_or(PrecompileVerificationError::VerifierNotFound { index, event_id })?;
+
+            let precompile_commitment = verifier.verify(request.calldata()).map_err(|error| {
+                PrecompileVerificationError::PrecompileError { index, event_id, error }
+            })?;
+            state.absorb(precompile_commitment);
+        }
+        Ok(state.finalize())
+    }
+}
+
+/// Tracks the RPO256 sponge capacity for aggregating [`PrecompileCommitment`]s.
+///
+/// This structure mirrors the VM's implementation of precompile commitment tracking. During
+/// execution, the VM maintains only the capacity portion of an RPO256 sponge, absorbing each
+/// precompile commitment as it's produced. At the end of execution, the verifier recomputes
+/// this same aggregation and compares the final digest.
+///
+/// The exact shape of the commitment is described in TODO(adr1anh)
+///
+/// # Details:
+/// This struct is a specialization of an RPO based sponge for aggregating precompile commitment.
+/// - `new()`: Initialize a sponge with capacity set to `ZERO`.
+/// - `absorb(comm)`: Permute the state `[self.capacity, comm.tag, comm.commitment]`, absorbing the
+///   `PrecompileCommitment` into the sponge and saving the resulting capacity.
+/// - `finalize()`: Permute the state `[self.capacity, ZERO, ZERO]` and extract the resulting
+///   digest.
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+struct PrecompileVerificationState {
+    /// RPO256 sponge capacity, updated with each absorbed commitment.
+    capacity: Word,
+}
+
+impl PrecompileVerificationState {
+    /// Creates a new verification state with zero-initialized capacity.
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// Absorbs a precompile commitment by applying RPO256 to `[capacity, tag, commitment]`
+    /// and saving the resulting capacity word.
+    fn absorb(&mut self, commitment: PrecompileCommitment) {
+        let mut state =
+            Word::words_as_elements(&[self.capacity, commitment.tag, commitment.commitment])
+                .try_into()
+                .unwrap();
+        Rpo256::apply_permutation(&mut state);
+        self.capacity = Word::new(state[0..4].try_into().unwrap());
+    }
+
+    /// Finalizes by applying RPO256 to `[capacity, ZERO, ZERO]` and extracting elements the first
+    /// rate word.
+    ///
+    /// This matches the VM's finalization where the rate portion is set to zeros for the final
+    /// permutation. The zero-padded rate could be used for auxiliary metadata in future versions.
+    fn finalize(self) -> Word {
+        let mut state = Word::words_as_elements(&[self.capacity, Word::empty(), Word::empty()])
+            .try_into()
+            .unwrap();
+        Rpo256::apply_permutation(&mut state);
+        Word::new(state[4..8].try_into().unwrap())
+    }
+}
+
+// MARKER TRAIT FOR SEALING
+// ================================================================================================
+
+// Private module to contain the sealed trait
+mod private {
+    /// This trait is sealed and cannot be implemented for types outside this crate.
+    pub trait Sealed {}
+
+    /// Implement Sealed for specific types that are allowed to implement PrecompileVerifier.
+    ///
+    /// Currently, only types defined within the stdlib crate are allowed to implement
+    /// the PrecompileVerifier trait.
+    impl Sealed for crate::handlers::keccak256::KeccakVerifier {}
+}

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -25,6 +25,7 @@ std = ["miden-air/std", "miden-core/std", "thiserror/std", "winter-verifier/std"
 # Miden dependencies
 miden-air.workspace = true
 miden-core.workspace = true
+miden-stdlib.workspace = true
 
 # External dependencies
 tracing.workspace = true

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -19,13 +19,16 @@ use winter_verifier::{crypto::MerkleTree, verify as verify_proof};
 mod exports {
     pub use miden_core::{
         Kernel, ProgramInfo, StackInputs, StackOutputs, Word,
-        precompile::{PrecompileError, PrecompileVerificationError, PrecompileVerifierRegistry},
+        precompile::{PrecompileError, PrecompileRequest},
     };
     pub use winter_verifier::{AcceptableOptions, VerifierError};
     pub mod math {
         pub use miden_core::{Felt, FieldElement, StarkField};
     }
     pub use miden_air::ExecutionProof;
+    pub use miden_stdlib::{
+        PrecompileVerificationError, PrecompileVerifier, PrecompileVerifierRegistry,
+    };
 }
 pub use exports::*;
 


### PR DESCRIPTION
- Removes blanket implementation of PrecompileVerifier for function types in core
- Move PrecompileVerifier trait and associated types to stdlib with sealed pattern
- Create private Sealed marker trait to restrict implementations to stdlib
- Implement KeccakVerifier struct to replace function-based verifier
- Add Sealed bound to PrecompileVerifier trait

 Not really meant to be merged, meant as a PoC of the sealed trait pattern for #2183.