### PR TITLE
fix: Add #[allow(unused_assignments)] surrounding the miette Diagnostic macros

### DIFF
--- a/crates/assembly-syntax/src/library/error.rs
+++ b/crates/assembly-syntax/src/library/error.rs
@@ -1,3 +1,6 @@
+// Allow unused assignments - required by miette::Diagnostic derive macro
+#![allow(unused_assignments)]
+
 use miden_core::errors::KernelError;
 
 use crate::{

--- a/crates/assembly-syntax/src/library/namespace.rs
+++ b/crates/assembly-syntax/src/library/namespace.rs
@@ -1,3 +1,6 @@
+// Allow unused assignments - required by miette::Diagnostic derive macro
+#![allow(unused_assignments)]
+
 use alloc::{string::ToString, sync::Arc};
 use core::{
     fmt,

--- a/crates/assembly-syntax/src/parser/error.rs
+++ b/crates/assembly-syntax/src/parser/error.rs
@@ -1,3 +1,6 @@
+// Allow unused assignments - required by miette::Diagnostic derive macro
+#![allow(unused_assignments)]
+
 use alloc::{
     string::{String, ToString},
     vec::Vec,

--- a/crates/assembly-syntax/src/sema/errors.rs
+++ b/crates/assembly-syntax/src/sema/errors.rs
@@ -1,3 +1,6 @@
+// Allow unused assignments - required by miette::Diagnostic derive macro
+#![allow(unused_assignments)]
+
 use alloc::{sync::Arc, vec::Vec};
 use core::fmt;
 

--- a/crates/assembly/src/linker/errors.rs
+++ b/crates/assembly/src/linker/errors.rs
@@ -1,3 +1,6 @@
+// Allow unused assignments - required by miette::Diagnostic derive macro
+#![allow(unused_assignments)]
+
 use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 
 use miden_assembly_syntax::{

--- a/processor/src/chiplets/memory/errors.rs
+++ b/processor/src/chiplets/memory/errors.rs
@@ -1,3 +1,6 @@
+// Allow unused assignments - required by miette::Diagnostic derive macro
+#![allow(unused_assignments)]
+
 use alloc::sync::Arc;
 
 use miden_core::Felt;

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -1,3 +1,6 @@
+// Allow unused assignments - required by miette::Diagnostic derive macro
+#![allow(unused_assignments)]
+
 use alloc::{sync::Arc, vec::Vec};
 
 use miden_air::RowIndex;

--- a/processor/src/host/advice/errors.rs
+++ b/processor/src/host/advice/errors.rs
@@ -1,3 +1,6 @@
+// Allow unused assignments - required by miette::Diagnostic derive macro
+#![allow(unused_assignments)]
+
 use alloc::vec::Vec;
 
 use miden_utils_diagnostics::{Diagnostic, miette};


### PR DESCRIPTION
This is a stopgap to CI failing post nightly update.

The long-term fixes would be to fix this in https://github.com/0xmiden/miette, or contribute the `no_std` support upstream and update.