### PR TITLE
fix: add miden-utils-indexing to pulish script

### DIFF
--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -12,6 +12,7 @@
 cargo publish -p miden-utils-sync
 cargo publish -p miden-debug-types
 cargo publish -p miden-utils-diagnostics
+cargo publish -p miden-utils-indexing
 cargo publish -p miden-core
 cargo publish -p miden-air
 cargo publish -p miden-assembly-syntax


### PR DESCRIPTION
Add missing miden-utils-indexing crate to publish-release.sh script.

Fixes https://github.com/0xMiden/miden-vm/issues/2272