### PR TITLE
Update proof.rs

### DIFF
--- a/air/src/proof.rs
+++ b/air/src/proof.rs
@@ -70,12 +70,7 @@ impl ExecutionProof {
     // SERIALIZATION / DESERIALIZATION
     // --------------------------------------------------------------------------------------------
 
-    /// Serializes this proof into a vector of bytes.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        self.write_into(&mut bytes);
-        bytes
-    }
+    // NOTE: Removed manual to_bytes() in favor of Serializable::to_bytes() to avoid duplication.
 
     /// Reads the source bytes, parsing a new proof instance.
     pub fn from_bytes(source: &[u8]) -> Result<Self, DeserializationError> {


### PR DESCRIPTION

**Description:**


Removed the redundant `ExecutionProof::to_bytes()` method that duplicated the functionality already provided by the `Serializable` trait implementation.

## Changes

- **Removed**: Manual `to_bytes()` implementation in `air/src/proof.rs`
- **Kept**: Existing `Serializable` trait implementation for consistent serialization behavior

## Rationale

The manual implementation was unnecessary since `ExecutionProof` already implements the `Serializable` trait, which provides the same `to_bytes()` functionality. This change:

- Eliminates code duplication
- Reduces maintenance burden  
- Prevents potential synchronization issues between implementations
- Maintains existing API compatibility
