### PR TITLE
fix: exclude private procedures from MASM documentation generation

### DIFF
--- a/stdlib/build.rs
+++ b/stdlib/build.rs
@@ -170,9 +170,12 @@ fn parse_module_with_ast(label: &str, file_path: &Path) -> io::Result<DocPayload
     // Extract procedures and their documentation
     let mut procedures = Vec::new();
     for export in module.procedures() {
-        let name = export.name().to_string();
-        let docs = export.docs().map(|d| d.to_string());
-        procedures.push((name, docs));
+        // Only include exported procedures (skip private procedures)
+        if export.visibility().is_exported() {
+            let name = export.name().to_string();
+            let docs = export.docs().map(|d| d.to_string());
+            procedures.push((name, docs));
+        }
     }
 
     Ok((module_docs, procedures))


### PR DESCRIPTION
## Describe your changes

### Problem:
Documentation was being generated for private procedures (defined with proc) when it should only be generated for exported procedures (defined with export).

### Solution:
Added visibility check in parse_module_with_ast function to only include exported procedures in documentation.

### Testing:
- Verified that smt.masm module now only shows set and get procedures in docs
- Confirmed that private procedures like set_empty_leaf, insert_single_leaf, etc. are excluded
- Documentation generation works correctly with the fix
### Fixes: #2307