### PR TITLE
fix: resolve testing feature gating issue in miden-assembly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,7 @@ dependencies = [
  "env_logger",
  "insta",
  "log",
+ "miden-assembly",
  "miden-assembly-syntax",
  "miden-core",
  "miden-mast-package",

--- a/crates/assembly/Cargo.toml
+++ b/crates/assembly/Cargo.toml
@@ -36,6 +36,11 @@ smallvec.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+# NOTE: We add miden-assembly as a dev-dependency with the "testing" feature to ensure that
+# testing-specific functionality is available during test runs. This is a workaround since
+# cargo doesn't currently support enabling test-related features automatically.
+# See: https://github.com/rust-lang/cargo/issues/2911#issuecomment-1483256987
+miden-assembly = { path = ".", default-features = false, features = ["testing"] }
 miden-mast-package = { workspace = true, features = ["arbitrary"] }
 miden-stdlib = { path = "../../stdlib", default-features = false }
 insta.workspace = true

--- a/crates/assembly/src/testing.rs
+++ b/crates/assembly/src/testing.rs
@@ -1,18 +1,21 @@
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 
+#[cfg(any(test, feature = "testing"))]
+pub use miden_assembly_syntax::parser;
 use miden_assembly_syntax::{
     Library, LibraryPath, Parse, ParseOptions, Word,
-    ast::{Form, Module, ModuleKind},
-    debuginfo::{DefaultSourceManager, SourceFile, SourceManager},
+    ast::{Module, ModuleKind},
+    debuginfo::{DefaultSourceManager, SourceManager},
     diagnostics::{
         Report,
         reporting::{ReportHandlerOpts, set_hook},
     },
 };
 pub use miden_assembly_syntax::{
-    assert_diagnostic, assert_diagnostic_lines, parse_module, parser, regex, source_file,
-    testing::Pattern,
+    assert_diagnostic, assert_diagnostic_lines, parse_module, regex, source_file, testing::Pattern,
 };
+#[cfg(feature = "testing")]
+use miden_assembly_syntax::{ast::Form, debuginfo::SourceFile};
 use miden_core::Program;
 
 use crate::assembler::Assembler;
@@ -79,6 +82,7 @@ impl TestContext {
     ///
     /// This does not run semantic analysis, or construct a [Module] from the parsed
     /// forms, and is largely intended for low-level testing of the parser.
+    #[cfg(feature = "testing")]
     #[track_caller]
     pub fn parse_forms(&self, source: Arc<SourceFile>) -> Result<Vec<Form>, Report> {
         parser::parse_forms(source.clone()).map_err(|err| Report::new(err).with_source_code(source))


### PR DESCRIPTION
- Add miden-assembly as dev-dependency with testing feature to ensure testing functionality is available during test runs
- Fix feature gating for parse_forms method to only require testing feature

This resolves a compilation error when running tests without explicit testing feature: `cargo test -p miden-assembly`
