### PR TITLE
Updates the kernel ROM docs

### DIFF
--- a/docs/src/design/chiplets/index.md
+++ b/docs/src/design/chiplets/index.md
@@ -25,8 +25,6 @@ Each chiplet is identified within the Chiplets module by one or more chiplet sel
 
 The result is an execution trace of 18 trace columns, which allows space for the widest chiplet component (the hash chiplet) and a column to select for it.
 
-_**Note**: The following diagram is outdated (see [issue #1829](https://github.com/0xMiden/miden-vm/issues/1829))._
-
 ![chiplets](../../img/design/chiplets/chiplets.png)
 
 During the finalization of the overall execution trace, the chiplets' traces (including internal selectors) are appended to the trace of the Chiplets module one after another, as pictured. Thus, when one chiplet's trace ends, the trace of the next chiplet starts in the subsequent row.


### PR DESCRIPTION
This PR

- Removes outdated comments
- Makes the docs concrete rather than general
    - i.e. assumes the current chiplet order rather than any order, which makes it easier to follow
- Explicitly multiplies $f_{krom}$ in so that we see the full degree
    - rather than relying on surrounding text to know which equation needs to be multiplied by it