### PR TITLE
fix: prevent integer underflow in OpBatchAccumulator::finalize_indptr

### DIFF
--- a/core/src/mast/node/basic_block_node/op_batch.rs
+++ b/core/src/mast/node/basic_block_node/op_batch.rs
@@ -347,6 +347,10 @@ impl OpBatchAccumulator {
         {
             // This guarantees the range (within ops) spanned by an immediate value is 0
             self.indptr[uninit_group_idx] = self.ops.len();
+            // Prevent underflow: if we've reached group_idx, stop before decrementing
+            if uninit_group_idx == self.group_idx {
+                break;
+            }
             uninit_group_idx -= 1;
         }
     }


### PR DESCRIPTION
Fixes a potential panic in `finalize_indptr()` where `uninit_group_idx` could underflow to `usize::MAX` when decrementing past zero.