### PR TITLE
ci: adjust contribution quality workflow trigger

### DIFF
--- a/.github/workflows/contribution-quality.yml
+++ b/.github/workflows/contribution-quality.yml
@@ -71,7 +71,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           else
             case "$assoc" in
-              OWNER|CONTRIBUTOR|COLLABORATOR) echo "skip=true"  >> "$GITHUB_OUTPUT" ;;
+              OWNER|COLLABORATOR|MEMBER) echo "skip=true"  >> "$GITHUB_OUTPUT" ;;
               *)                         echo "skip=false" >> "$GITHUB_OUTPUT" ;;
             esac
             [ "$draft" = "true" ] && echo "skip=true" >> "$GITHUB_OUTPUT" || true


### PR DESCRIPTION
Replace CONTRIBUTOR with MEMBER in skip conditions to allow workflow to run for external contributors while still skipping for repository owners, collaborators, and members.
