### PR TITLE
ci: make contribution quality job not trigger on local branches

### DIFF
--- a/.github/workflows/contribution-quality.yml
+++ b/.github/workflows/contribution-quality.yml
@@ -23,6 +23,10 @@ permissions:
 
 jobs:
   gate:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.fork == true)
     runs-on: ubuntu-latest
     env:
       DISPATCH_PR_NUMBER: ${{ inputs.pr_number }}


### PR DESCRIPTION
PR #2333 modified the author_association trigger to make the job fire despite the "contributor" value, which is applied overly broadly — with the intent of still applying the quality check to folks having made a casual contrib to the repo in the past. However #2333 now makes the quality-check job fire on every PR from maintainers of this repo (with the exception of owners).

As a way to protect maintainers of this repo from contribution quality nagging, this skips the job on a PR opened from the repo itself, as opposed to a fork.

See https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28 for details.

