### PR TITLE
fix: macOS `sed` issue + small echo tweak

### DIFF
--- a/scripts/check-msrv.sh
+++ b/scripts/check-msrv.sh
@@ -28,7 +28,9 @@ sed_i() {
   if sed --version >/dev/null 2>&1; then
     sed -i "$@"
   else
-    sed -i '' "$@"
+    local expr=$1
+    shift
+    sed -i '' "$expr" "$@"
   fi
 }
 
@@ -143,7 +145,7 @@ done < <(
 if [[ -n "$failed_packages" ]]; then
   echo "MSRV CHECK FAILED"
   echo ""
-  echo "The following packages have incorrect MSRV settings:$failed_packages"
+  echo "The following packages have incorrect MSRV settings: $failed_packages"
   echo ""
   echo "Please fix the rust-version fields in the affected Cargo.toml files as shown above."
   exit 1


### PR DESCRIPTION
## Describe your changes

fixed `sed_i` so it works on macOS too (BSD `sed` needs that empty `''` arg).
also added a space in the echo message so package names don’t stick to the text.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'