### PR TITLE
perf(cli): eliminate duplicate proof serialization in ProofFile::write

### DIFF
--- a/miden-vm/src/cli/data.rs
+++ b/miden-vm/src/cli/data.rs
@@ -15,7 +15,7 @@ use miden_assembly::{
 use miden_stdlib::StdLibrary;
 use miden_vm::{ExecutionProof, Program, StackOutputs, Word, utils::SliceReader};
 use serde::{Deserialize, Serialize};
-use tracing::instrument;
+use tracing::{instrument, Span};
 
 // HELPERS
 // ================================================================================================
@@ -208,7 +208,7 @@ impl ProofFile {
     #[instrument(name = "write_data_to_proof_file",
                  fields(
                     path = %proof_path.clone().unwrap_or(program_path.with_extension("proof")).display(),
-                    size = format!("{} KB", proof.to_bytes().len() / 1024)), skip_all)]
+                    size = tracing::field::Empty), skip_all)]
     pub fn write(
         proof: ExecutionProof,
         proof_path: &Option<PathBuf>,
@@ -226,6 +226,7 @@ impl ProofFile {
             .map_err(|err| format!("Failed to create proof file `{}` - {}", path.display(), err))?;
 
         let proof_bytes = proof.to_bytes();
+        Span::current().record("size", &format_args!("{} KB", proof_bytes.len() / 1024));
 
         // write proof bytes to file
         file.write_all(&proof_bytes)


### PR DESCRIPTION


The `ProofFile::write` method was calling `proof.to_bytes()` twice:
1. Once in the `#[instrument]` attribute to compute the `size` field for tracing
2. Once in the function body to write the proof to disk

This caused unnecessary CPU and memory overhead, especially for large proofs that can be several megabytes in size.

## Solution

Moved the `size` field computation to after the single `proof.to_bytes()` call using `Span::current().record()`. This ensures:
- Proof serialization happens only once
- Tracing information is still captured correctly
- Reduced memory allocation and CPU usage

