### PR TITLE
chore: fix lint

### DIFF
--- a/processor/src/stack/overflow.rs
+++ b/processor/src/stack/overflow.rs
@@ -266,6 +266,7 @@ impl OverflowTable {
     /// and `restore_context` functions.
     fn save_stack_to_history(&mut self) {
         let clk = self.clk;
+        #[expect(clippy::unnecessary_unwrap)]
         if self.history.is_some() {
             let stack_after_op: Vec<Felt> = self
                 .get_current_overflow_stack()


### PR DESCRIPTION
This seems to be a bug with clippy since the suggestion triggers a borrow checker error.

Note: we use the new `#[expect(clippy::some_warning)]` syntax which will trigger a warning in the future if this lint is fixed.