### PR TITLE
refactor: remove err_code field from ExecutionError::NotU32Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Adds a cached commitment to the `MastForest` ([#2447](https://github.com/0xMiden/miden-vm/pull/2447))
 - Add MastForest validation ([#2412](https://github.com/0xMiden/miden-vm/pull/2412)).
 - Fixed memory chiplet constraint documentation: corrected `f_i` variable definitions, first row flag, and `f_mem_nl` constraint expression ([#2423](https://github.com/0xMiden/miden-vm/pull/2423)).
+- Removed undocumented `err_code` field from `ExecutionError::NotU32Values` ([#2419](https://github.com/0xMiden/miden-vm/pull/2419)).
 
 ## 0.20.0 (2025-12-05)
 

--- a/crates/lib/core/tests/math/u64_mod.rs
+++ b/crates/lib/core/tests/math/u64_mod.rs
@@ -4,7 +4,7 @@ use miden_core::assert_matches;
 use miden_core_lib::handlers::u64_div::{U64_DIV_EVENT_NAME, U64DivError};
 use miden_processor::ExecutionError;
 use miden_utils_testing::{
-    Felt, TRUNCATE_STACK_PROC, U32_BOUND, ZERO, expect_exec_error_matches, proptest::prelude::*,
+    Felt, TRUNCATE_STACK_PROC, U32_BOUND, expect_exec_error_matches, proptest::prelude::*,
     rand::rand_value,
 };
 
@@ -727,11 +727,10 @@ fn checked_and_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if
             values.len() == 2 &&
             values.contains(&Felt::new(a0)) &&
-            values.contains(&Felt::new(b0)) &&
-            err_code == ZERO
+            values.contains(&Felt::new(b0))
     );
 }
 
@@ -773,11 +772,10 @@ fn checked_or_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if
             values.len() == 2 &&
             values.contains(&Felt::new(a0)) &&
-            values.contains(&Felt::new(b0)) &&
-            err_code == ZERO
+            values.contains(&Felt::new(b0))
     );
 }
 
@@ -819,11 +817,10 @@ fn checked_xor_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if
             values.len() == 2 &&
             values.contains(&Felt::new(a0)) &&
-            values.contains(&Felt::new(b0)) &&
-            err_code == ZERO
+            values.contains(&Felt::new(b0))
     );
 }
 

--- a/miden-vm/tests/integration/operations/u32_ops/bitwise_ops.rs
+++ b/miden-vm/tests/integration/operations/u32_ops/bitwise_ops.rs
@@ -1,7 +1,6 @@
 use miden_processor::{ExecutionError, math::Felt};
 use miden_utils_testing::{
-    U32_BOUND, ZERO, build_op_test, expect_exec_error_matches, proptest::prelude::*,
-    rand::rand_value,
+    U32_BOUND, build_op_test, expect_exec_error_matches, proptest::prelude::*, rand::rand_value,
 };
 
 use super::test_input_out_of_bounds;
@@ -81,14 +80,14 @@ fn u32and_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)] && err_code == ZERO
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)]
     );
 
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)] && err_code == ZERO
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)]
     );
 }
 
@@ -164,14 +163,14 @@ fn u32or_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)] && err_code == ZERO
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)]
     );
 
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)] && err_code == ZERO
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)]
     );
 }
 
@@ -246,14 +245,14 @@ fn u32xor_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)] && err_code == ZERO
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)]
     );
 
     let test = build_op_test!(asm_op, &[0, U32_BOUND]);
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)] && err_code == ZERO
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if values == vec![Felt::new(U32_BOUND)]
     );
 }
 

--- a/miden-vm/tests/integration/operations/u32_ops/conversion_ops.rs
+++ b/miden-vm/tests/integration/operations/u32_ops/conversion_ops.rs
@@ -1,6 +1,6 @@
 use miden_processor::ExecutionError;
 use miden_utils_testing::{
-    Felt, StarkField, U32_BOUND, WORD_SIZE, ZERO, build_op_test, expect_exec_error_matches,
+    Felt, StarkField, U32_BOUND, WORD_SIZE, build_op_test, expect_exec_error_matches,
     proptest::prelude::*, rand::rand_value,
 };
 
@@ -103,10 +103,9 @@ fn u32assert_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if
             values.len() == 1 &&
-            values[0] == Felt::new(equal) &&
-            err_code == ZERO
+            values[0] == Felt::new(equal)
     );
 
     // --- test when a > 2^32 ---------------------------------------------------------------------
@@ -114,10 +113,9 @@ fn u32assert_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if
             values.len() == 1 &&
-            values[0] == Felt::new(larger) &&
-            err_code == ZERO
+            values[0] == Felt::new(larger)
     );
 }
 
@@ -148,11 +146,10 @@ fn u32assert2_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if
             values.len() == 2 &&
             values[0] == Felt::new(value_b) &&
-            values[1] == Felt::new(value_a) &&
-            err_code == ZERO
+            values[1] == Felt::new(value_a)
     );
 
     // -------- Case 2: a > 2^32 and b < 2^32 ---------------------------------------------------
@@ -162,10 +159,9 @@ fn u32assert2_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if
             values.len() == 1 &&
-            values[0] == Felt::new(value_a) &&
-            err_code == ZERO
+            values[0] == Felt::new(value_a)
     );
 
     // --------- Case 3: a < 2^32 and b > 2^32 --------------------------------------------------
@@ -175,10 +171,9 @@ fn u32assert2_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if
             values.len() == 1 &&
-            values[0] == Felt::new(value_b) &&
-            err_code == ZERO
+            values[0] == Felt::new(value_b)
     );
 }
 
@@ -206,10 +201,9 @@ fn u32assertw_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if
             values.len() == 2 &&
-            values.iter().all(|v| *v == Felt::new(U32_BOUND)) &&
-            err_code == ZERO
+            values.iter().all(|v| *v == Felt::new(U32_BOUND))
     );
 }
 

--- a/miden-vm/tests/integration/operations/u32_ops/mod.rs
+++ b/miden-vm/tests/integration/operations/u32_ops/mod.rs
@@ -1,7 +1,5 @@
 use miden_processor::ExecutionError;
-use miden_utils_testing::{
-    Felt, U32_BOUND, ZERO, build_op_test, expect_exec_error_matches, prop_randw,
-};
+use miden_utils_testing::{Felt, U32_BOUND, build_op_test, expect_exec_error_matches, prop_randw};
 
 mod arithmetic_ops;
 mod bitwise_ops;
@@ -18,10 +16,9 @@ pub fn test_input_out_of_bounds(asm_op: &str) {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if
+        ExecutionError::NotU32Values{ values, label: _, source_file: _ } if
             values.len() == 1 &&
-            values[0] == Felt::new(U32_BOUND) &&
-            err_code == ZERO
+            values[0] == Felt::new(U32_BOUND)
     );
 }
 
@@ -39,10 +36,9 @@ pub fn test_inputs_out_of_bounds(asm_op: &str, input_count: usize) {
 
         expect_exec_error_matches!(
             test,
-            ExecutionError::NotU32Values{ values, err_code, label: _, source_file: _ } if
+            ExecutionError::NotU32Values{ values, label: _, source_file: _ } if
                 values.len() == 1 &&
-                values[0] == Felt::new(U32_BOUND) &&
-                err_code == ZERO
+                values[0] == Felt::new(U32_BOUND)
         );
     }
 }

--- a/processor/src/chiplets/bitwise/mod.rs
+++ b/processor/src/chiplets/bitwise/mod.rs
@@ -5,7 +5,7 @@ use miden_air::trace::chiplets::bitwise::{
     PREV_OUTPUT_COL_IDX, TRACE_WIDTH,
 };
 
-use super::{ExecutionError, Felt, TraceFragment, ZERO};
+use super::{ExecutionError, Felt, TraceFragment};
 use crate::ErrorContext;
 
 #[cfg(test)]
@@ -215,7 +215,7 @@ impl Default for Bitwise {
 pub fn assert_u32(value: Felt, err_ctx: &impl ErrorContext) -> Result<Felt, ExecutionError> {
     let val_u64 = value.as_int();
     if val_u64 > u32::MAX.into() {
-        Err(ExecutionError::not_u32_value(value, ZERO, err_ctx))
+        Err(ExecutionError::not_u32_value(value, err_ctx))
     } else {
         Ok(value)
     }

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -222,14 +222,13 @@ pub enum ExecutionError {
         source_file: Option<Arc<SourceFile>>,
         value: Felt,
     },
-    #[error("operation expected u32 values, but got values: {values:?} (error code: {err_code})")]
+    #[error("operation expected u32 values, but got values: {values:?}")]
     NotU32Values {
         #[label]
         label: SourceSpan,
         #[source_code]
         source_file: Option<Arc<SourceFile>>,
         values: Vec<Felt>,
-        err_code: Felt,
     },
     #[error(
         "Operand stack input is {input} but it is expected to fit in a u32 at clock cycle {clk}"
@@ -427,19 +426,14 @@ impl ExecutionError {
         Self::NotBinaryValueLoop { label, source_file, value }
     }
 
-    pub fn not_u32_value(value: Felt, err_code: Felt, err_ctx: &impl ErrorContext) -> Self {
+    pub fn not_u32_value(value: Felt, err_ctx: &impl ErrorContext) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
-        Self::NotU32Values {
-            label,
-            source_file,
-            values: vec![value],
-            err_code,
-        }
+        Self::NotU32Values { label, source_file, values: vec![value] }
     }
 
-    pub fn not_u32_values(values: Vec<Felt>, err_code: Felt, err_ctx: &impl ErrorContext) -> Self {
+    pub fn not_u32_values(values: Vec<Felt>, err_ctx: &impl ErrorContext) -> Self {
         let (label, source_file) = err_ctx.label_and_source_file();
-        Self::NotU32Values { label, source_file, values, err_code }
+        Self::NotU32Values { label, source_file, values }
     }
 
     pub fn smt_node_not_found(node: Word, err_ctx: &impl ErrorContext) -> Self {

--- a/processor/src/fast/basic_block.rs
+++ b/processor/src/fast/basic_block.rs
@@ -255,14 +255,9 @@ impl FastProcessor {
                     Operation::Emit => self.op_emit(host, &err_ctx).await?,
                     _ => {
                         // if the operation is not an Emit, we execute it normally
-                        if let Err(err) = self.execute_sync_op(
-                            op,
-                            op_idx_in_block,
-                            current_forest,
-                            host,
-                            &err_ctx,
-                            tracer,
-                        ) {
+                        if let Err(err) =
+                            self.execute_sync_op(op, current_forest, host, &err_ctx, tracer)
+                        {
                             return ControlFlow::Break(BreakReason::Err(err));
                         }
                     },

--- a/processor/src/operations/sys_ops/sys_event_handlers.rs
+++ b/processor/src/operations/sys_ops/sys_event_handlers.rs
@@ -521,7 +521,7 @@ fn push_transformed_stack_top(
     let stack_top: u32 = stack_top
         .as_int()
         .try_into()
-        .map_err(|_| ExecutionError::not_u32_value(stack_top, ZERO, err_ctx))?;
+        .map_err(|_| ExecutionError::not_u32_value(stack_top, err_ctx))?;
     let transformed_stack_top = f(stack_top);
     process.advice_provider_mut().push_stack(transformed_stack_top);
     Ok(())

--- a/processor/src/parallel/core_trace_fragment/mod.rs
+++ b/processor/src/parallel/core_trace_fragment/mod.rs
@@ -445,11 +445,8 @@ impl<'a> CoreTraceFragmentFiller<'a> {
                 let user_op_helpers = if let Operation::Emit = op {
                     None
                 } else {
-                    // Note that the `op_idx_in_block` is only used in case of error, so we set it
-                    // to 0.
                     self.execute_sync_op(
                         op,
-                        0,
                         current_forest,
                         &mut NoopHost,
                         &(),

--- a/processor/src/processor/mod.rs
+++ b/processor/src/processor/mod.rs
@@ -97,13 +97,12 @@ pub trait Processor: Sized {
     fn execute_sync_op(
         &mut self,
         op: &Operation,
-        op_idx_in_block: usize,
         current_forest: &MastForest,
         host: &mut impl BaseHost,
         err_ctx: &impl ErrorContext,
         tracer: &mut impl Tracer,
     ) -> Result<Option<[Felt; NUM_USER_OP_HELPERS]>, ExecutionError> {
-        execute_sync_op(self, op, op_idx_in_block, current_forest, host, err_ctx, tracer)
+        execute_sync_op(self, op, current_forest, host, err_ctx, tracer)
     }
 }
 

--- a/processor/src/processor/operations/mod.rs
+++ b/processor/src/processor/operations/mod.rs
@@ -31,7 +31,6 @@ const DOUBLE_WORD_SIZE: Felt = Felt::new(8);
 pub(super) fn execute_sync_op(
     processor: &mut impl Processor,
     op: &Operation,
-    op_idx_in_block: usize,
     current_forest: &MastForest,
     host: &mut impl BaseHost,
     err_ctx: &impl ErrorContext,
@@ -108,7 +107,7 @@ pub(super) fn execute_sync_op(
             user_op_helpers = Some(u32add3_helpers);
         },
         Operation::U32sub => {
-            let u32sub_helpers = u32_ops::op_u32sub(processor, op_idx_in_block, err_ctx, tracer)?;
+            let u32sub_helpers = u32_ops::op_u32sub(processor, err_ctx, tracer)?;
             user_op_helpers = Some(u32sub_helpers);
         },
         Operation::U32mul => {

--- a/processor/src/processor/operations/u32_ops.rs
+++ b/processor/src/processor/operations/u32_ops.rs
@@ -14,10 +14,7 @@ use crate::{
 const U32_MAX: u64 = u32::MAX as u64;
 
 macro_rules! require_u32_operands {
-    ($processor:expr, [$($idx:expr),*], $err_ctx:expr) => {
-        require_u32_operands!($processor, [$($idx),*], miden_core::ZERO, $err_ctx)
-    };
-    ($processor:expr, [$($idx:expr),*], $errno:expr, $err_ctx:expr) => {{
+    ($processor:expr, [$($idx:expr),*], $err_ctx:expr) => {{
         let mut invalid_values = Vec::new();
 
         paste!{
@@ -29,7 +26,7 @@ macro_rules! require_u32_operands {
             )*
 
             if !invalid_values.is_empty() {
-                return Err(ExecutionError::not_u32_values(invalid_values, $errno, $err_ctx));
+                return Err(ExecutionError::not_u32_values(invalid_values, $err_ctx));
             }
             // Return tuple of operands based on indices
             ($([<operand_ $idx>]),*)
@@ -110,12 +107,10 @@ pub(super) fn op_u32add3<P: Processor>(
 #[inline(always)]
 pub(super) fn op_u32sub<P: Processor>(
     processor: &mut P,
-    op_idx: usize,
     err_ctx: &impl ErrorContext,
     tracer: &mut impl Tracer,
 ) -> Result<[Felt; NUM_USER_OP_HELPERS], ExecutionError> {
-    let (first_old, second_old) =
-        require_u32_operands!(processor, [0, 1], Felt::from(op_idx as u32), err_ctx);
+    let (first_old, second_old) = require_u32_operands!(processor, [0, 1], err_ctx);
 
     let result = second_old.as_int().wrapping_sub(first_old.as_int());
     let first_new = Felt::new(result >> 63);
@@ -254,11 +249,11 @@ pub(super) fn op_u32xor<P: Processor>(
 #[inline(always)]
 pub(super) fn op_u32assert2<P: Processor>(
     processor: &mut P,
-    err_code: Felt,
+    _err_code: Felt,
     err_ctx: &impl ErrorContext,
     tracer: &mut impl Tracer,
 ) -> Result<[Felt; NUM_USER_OP_HELPERS], ExecutionError> {
-    let (first, second) = require_u32_operands!(processor, [0, 1], err_code, err_ctx);
+    let (first, second) = require_u32_operands!(processor, [0, 1], err_ctx);
 
     tracer.record_u32_range_checks(processor.system().clk(), first, second);
 


### PR DESCRIPTION
  Removes the undocumented `err_code` field from `NotU32Values` error variant and the `op_idx` parameter from `op_u32sub` and `execute_sync_op` functions.

  With rich diagnostics now available, outputting an operation index is no longer needed for debugging purposes.

  Closes #2386

  ## Checklist before requesting a review
  - [x] Repo forked and branch created from `next` according to naming convention.
  - [x] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
  - [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
  - [x] Relevant issues are linked in the PR description.
  - [x] Tests added for new functionality.
  - [x] Documentation/comments updated according to changes.
  - [x] Updated `CHANGELOG.md`