### PR TITLE
fix: resolve doctest failure in assembly README

### DIFF
--- a/crates/assembly/README.md
+++ b/crates/assembly/README.md
@@ -193,30 +193,31 @@ use miden_assembly_syntax::debuginfo::DefaultSourceManager;
 use miden_libcore::CoreLibrary;
 use std::sync::Arc;
 
-// Source code of the kernel module
-let kernel = "pub proc foo add end";
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Source code of the kernel module
+    let kernel = "pub proc foo add end";
 
-// Create a source manager
-let source_manager = Arc::new(DefaultSourceManager::default());
+    // Create a source manager
+    let source_manager = Arc::new(DefaultSourceManager::default());
 
-// First, assemble the kernel library
-let kernel_lib = Assembler::new(source_manager.clone())
-    .assemble_kernel(kernel)
-    .unwrap();
+    // First, assemble the kernel library
+    let kernel_lib = Assembler::new(source_manager.clone())
+        .assemble_kernel(kernel)?;
 
-// Instantiate the assembler with multiple options at once
-let assembler = Assembler::with_kernel(source_manager, kernel_lib)
-    .with_dynamic_library(&CoreLibrary::default())    .with_dynamic_library(&StdLibrary::default())
->>>>>>> 1d3ff0866 (Improve tests for always-enabled debug mode after issue #1821)
-    .unwrap();
+    // Instantiate the assembler with multiple options at once
+    let assembler = Assembler::with_kernel(source_manager, kernel_lib)
+        .with_dynamic_library(&CoreLibrary::default())?;
 
-// Assemble our program
-let program = assembler.assemble_program("
+    // Assemble our program
+    let program = assembler.assemble_program("
 begin
     push.1.2
     syscall.foo
 end
-").unwrap();
+")?;
+
+    Ok(())
+}
 ```
 
 ## License


### PR DESCRIPTION
- Remove merge conflict marker and non-existent StdLibrary reference
- Wrap doctest code in proper main() function with error handling
- Replace unwrap() calls with proper error propagation using ?

Fixes the doctest failure that was preventing make test-docs from passing.
