### PR TITLE
fix: resolve composite action checkout circular dependency

### DIFF
--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -10,20 +10,10 @@ inputs:
     description: "If true, ensure the triggering SHA matches main's HEAD"
     required: false
     default: "false"
-  ref:
-    description: "Git ref to check out (optional)"
-    required: false
-    default: ""
 
 runs:
   using: "composite"
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ inputs.ref }}
-
     # Optional: guard that release happens from latest main
     - name: Verify tag matches main HEAD
       if: ${{ inputs.verify-main-head == 'true' }}

--- a/.github/workflows/workspace-dry-run.yml
+++ b/.github/workflows/workspace-dry-run.yml
@@ -20,6 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Dry-run workspace release
         uses: ./.github/actions/workspace-release
         with:

--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -15,6 +15,12 @@ jobs:
     environment: release  # Optional: for enhanced security
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
       - name: Authenticate with crates.io
         uses: rust-lang/crates-io-auth-action@v1
         id: auth
@@ -24,6 +30,5 @@ jobs:
         with:
           mode: "publish"
           verify-main-head: "true"
-          ref: "main"
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
Move repository checkout to workflow level before using local composite action. GitHub Actions cannot read local action.yml files before the repository is checked out, causing "Can't find 'action.yml'" errors.

Followup of #2441 