### PR TITLE
refactor: move and rename byte conversion utilities to miden-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add MastForest validation ([#2412](https://github.com/0xMiden/miden-vm/pull/2412)).
 - Fixed memory chiplet constraint documentation: corrected `f_i` variable definitions, first row flag, and `f_mem_nl` constraint expression ([#2423](https://github.com/0xMiden/miden-vm/pull/2423)).
 - Removed undocumented `err_code` field from `ExecutionError::NotU32Values` ([#2419](https://github.com/0xMiden/miden-vm/pull/2419)).
+- Moved `bytes_to_packed_u32_elements` to `miden-core::utils` and added `packed_u32_elements_to_bytes` inverse function ([#2458](https://github.com/0xMiden/miden-vm/pull/2458)).
 
 ## 0.20.0 (2025-12-05)
 

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -217,3 +217,25 @@ pub fn packed_u32_elements_to_bytes(elements: &[Felt]) -> Vec<u8> {
 // ================================================================================================
 
 pub use miden_formatting::hex::{DisplayHex, ToHex, to_hex};
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn proptest_packed_u32_elements_roundtrip(values in prop::collection::vec(any::<u32>(), 0..100)) {
+            // Convert u32 values to Felts
+            let felts: Vec<Felt> = values.iter().map(|&v| Felt::from(v)).collect();
+
+            // Roundtrip: Felts -> bytes -> Felts
+            let bytes = packed_u32_elements_to_bytes(&felts);
+            let roundtrip_felts = bytes_to_packed_u32_elements(&bytes);
+
+            // Should be equal
+            prop_assert_eq!(felts, roundtrip_felts);
+        }
+    }
+}

--- a/crates/lib/core/src/dsa.rs
+++ b/crates/lib/core/src/dsa.rs
@@ -20,10 +20,11 @@ pub mod ecdsa_k256_keccak {
 
     use alloc::vec::Vec;
 
-    use miden_core::{Felt, Word, utils::Serializable};
+    use miden_core::{
+        Felt, Word,
+        utils::{Serializable, bytes_to_packed_u32_elements},
+    };
     use miden_crypto::dsa::ecdsa_k256_keccak::{PublicKey, SecretKey, Signature};
-
-    use crate::handlers::bytes_to_packed_u32_elements;
 
     /// Signs the provided message with the supplied secret key and encodes this signature and the
     /// associated public key into a vector of field elements in the format expected by
@@ -66,10 +67,11 @@ pub mod eddsa_ed25519 {
 
     use alloc::vec::Vec;
 
-    use miden_core::{Felt, Word, utils::Serializable};
+    use miden_core::{
+        Felt, Word,
+        utils::{Serializable, bytes_to_packed_u32_elements},
+    };
     use miden_crypto::dsa::eddsa_25519_sha512::{PublicKey, SecretKey, Signature};
-
-    use crate::handlers::bytes_to_packed_u32_elements;
 
     /// Signs the provided message with the supplied secret key and encodes this signature and the
     /// associated public key into a vector of field elements in the format expected by

--- a/crates/lib/core/src/handlers/ecdsa.rs
+++ b/crates/lib/core/src/handlers/ecdsa.rs
@@ -35,7 +35,10 @@ use alloc::{vec, vec::Vec};
 use miden_core::{
     EventName,
     precompile::{PrecompileCommitment, PrecompileError, PrecompileRequest, PrecompileVerifier},
-    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    utils::{
+        ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+        bytes_to_packed_u32_elements,
+    },
 };
 use miden_crypto::{
     ZERO,
@@ -44,7 +47,7 @@ use miden_crypto::{
 };
 use miden_processor::{AdviceMutation, EventError, EventHandler, ProcessState};
 
-use crate::handlers::{bytes_to_packed_u32_elements, read_memory_packed_u32};
+use crate::handlers::read_memory_packed_u32;
 
 /// Qualified event name for the ECDSA signature verification event.
 pub const ECDSA_VERIFY_EVENT_NAME: EventName =

--- a/crates/lib/core/src/handlers/eddsa_ed25519.rs
+++ b/crates/lib/core/src/handlers/eddsa_ed25519.rs
@@ -13,7 +13,10 @@ use core::convert::TryInto;
 use miden_core::{
     EventName,
     precompile::{PrecompileCommitment, PrecompileError, PrecompileRequest, PrecompileVerifier},
-    utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    utils::{
+        ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+        bytes_to_packed_u32_elements,
+    },
 };
 use miden_crypto::{
     ZERO,
@@ -22,7 +25,7 @@ use miden_crypto::{
 };
 use miden_processor::{AdviceMutation, EventError, EventHandler, ProcessState};
 
-use crate::handlers::{MemoryReadError, bytes_to_packed_u32_elements, read_memory_packed_u32};
+use crate::handlers::{MemoryReadError, read_memory_packed_u32};
 
 // CONSTANTS
 // ================================================================================================

--- a/crates/lib/core/src/handlers/keccak256.rs
+++ b/crates/lib/core/src/handlers/keccak256.rs
@@ -29,11 +29,12 @@ use core::array;
 use miden_core::{
     EventName, Felt, Word, ZERO,
     precompile::{PrecompileCommitment, PrecompileError, PrecompileRequest, PrecompileVerifier},
+    utils::bytes_to_packed_u32_elements,
 };
 use miden_crypto::hash::{keccak::Keccak256, rpo::Rpo256};
 use miden_processor::{AdviceMutation, EventError, EventHandler, ProcessState};
 
-use crate::handlers::{BYTES_PER_U32, bytes_to_packed_u32_elements, read_memory_packed_u32};
+use crate::handlers::{BYTES_PER_U32, read_memory_packed_u32};
 
 /// Event name for the keccak256 hash_bytes operation.
 pub const KECCAK_HASH_BYTES_EVENT_NAME: EventName =

--- a/crates/lib/core/src/handlers/mod.rs
+++ b/crates/lib/core/src/handlers/mod.rs
@@ -168,9 +168,6 @@ pub(crate) fn read_memory_packed_u32(
     Ok(out)
 }
 
-// Re-export bytes_to_packed_u32_elements from miden-core for backwards compatibility
-pub use miden_core::utils::bytes_to_packed_u32_elements;
-
 // ERROR TYPES
 // ================================================================================================
 

--- a/crates/lib/core/src/handlers/sha512.rs
+++ b/crates/lib/core/src/handlers/sha512.rs
@@ -11,12 +11,13 @@ use core::array;
 use miden_core::{
     EventName, Felt, Word, ZERO,
     precompile::{PrecompileCommitment, PrecompileError, PrecompileRequest, PrecompileVerifier},
+    utils::bytes_to_packed_u32_elements,
 };
 use miden_crypto::hash::rpo::Rpo256;
 use miden_processor::{AdviceMutation, EventError, EventHandler, ProcessState};
 use sha2::{Digest, Sha512};
 
-use crate::handlers::{BYTES_PER_U32, bytes_to_packed_u32_elements, read_memory_packed_u32};
+use crate::handlers::{BYTES_PER_U32, read_memory_packed_u32};
 
 /// Event name for the SHA512 hash_bytes operation.
 pub const SHA512_HASH_BYTES_EVENT_NAME: EventName =

--- a/crates/lib/core/tests/crypto/ecdsa_k256_keccak.rs
+++ b/crates/lib/core/tests/crypto/ecdsa_k256_keccak.rs
@@ -8,14 +8,11 @@
 use miden_core::{
     EventName, Felt, FieldElement, Word,
     precompile::{PrecompileCommitment, PrecompileVerifier},
-    utils::{Deserializable, Serializable},
+    utils::{Deserializable, Serializable, bytes_to_packed_u32_elements},
 };
 use miden_core_lib::{
     dsa::ecdsa_k256_keccak::sign as ecdsa_sign,
-    handlers::{
-        bytes_to_packed_u32_elements,
-        ecdsa::{EcdsaPrecompile, EcdsaRequest},
-    },
+    handlers::ecdsa::{EcdsaPrecompile, EcdsaRequest},
 };
 use miden_crypto::{dsa::ecdsa_k256_keccak::SecretKey, hash::rpo::Rpo256};
 use miden_processor::{AdviceMutation, EventError, EventHandler, ProcessState};

--- a/crates/lib/core/tests/crypto/eddsa_ed25519.rs
+++ b/crates/lib/core/tests/crypto/eddsa_ed25519.rs
@@ -11,14 +11,11 @@ use core::convert::TryFrom;
 use miden_core::{
     EventName, Felt, FieldElement, Word,
     precompile::{PrecompileCommitment, PrecompileVerifier},
-    utils::{Deserializable, Serializable},
+    utils::{Deserializable, Serializable, bytes_to_packed_u32_elements},
 };
 use miden_core_lib::{
     dsa::eddsa_ed25519::sign as eddsa_sign,
-    handlers::{
-        bytes_to_packed_u32_elements,
-        eddsa_ed25519::{EddsaPrecompile, EddsaRequest},
-    },
+    handlers::eddsa_ed25519::{EddsaPrecompile, EddsaRequest},
 };
 use miden_crypto::{
     dsa::eddsa_25519_sha512::{PublicKey, SecretKey, Signature},


### PR DESCRIPTION
## Describe your changes

- Rename `bytes_to_packed_u32_felts` to `bytes_to_packed_u32_elements`
- Add inverse function `packed_u32_elements_to_bytes`
- Move functions from `miden-core-lib` handlers to `miden-core` utils
- Re-export from handlers for backwards compatibility

Closes #2452

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
- [ ] Updated `CHANGELOG.md`