### PR TITLE
chore: ensure Hash/Eq consistency for TypeAlias and EnumType

### DIFF
--- a/crates/assembly-syntax/src/ast/type.rs
+++ b/crates/assembly-syntax/src/ast/type.rs
@@ -730,7 +730,10 @@ impl Eq for TypeAlias {}
 
 impl PartialEq for TypeAlias {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.docs == other.docs && self.ty == other.ty
+        self.visibility == other.visibility
+            && self.name == other.name
+            && self.docs == other.docs
+            && self.ty == other.ty
     }
 }
 
@@ -902,7 +905,8 @@ impl Eq for EnumType {}
 
 impl PartialEq for EnumType {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name
+        self.visibility == other.visibility
+            && self.name == other.name
             && self.docs == other.docs
             && self.ty == other.ty
             && self.variants == other.variants


### PR DESCRIPTION
Add visibility field to PartialEq implementations, matching existing Hash implementations to uphold Rust's Hash/Eq contract.