### PR TITLE
chore: replace hardcoded stack depth with MIN_STACK_DEPTH constant

### DIFF
--- a/processor/src/operations/ext2_ops.rs
+++ b/processor/src/operations/ext2_ops.rs
@@ -68,8 +68,8 @@ mod tests {
     // HELPER FUNCTIONS
     // --------------------------------------------------------------------------------------------
 
-    fn build_expected(values: &[Felt]) -> [Felt; 16] {
-        let mut expected = [ZERO; 16];
+    fn build_expected(values: &[Felt]) -> [Felt; MIN_STACK_DEPTH] {
+        let mut expected = [ZERO; MIN_STACK_DEPTH];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = value;
         }

--- a/processor/src/operations/field_ops.rs
+++ b/processor/src/operations/field_ops.rs
@@ -646,8 +646,8 @@ mod tests {
         (Felt::new(a), Felt::new(b), Felt::new(c))
     }
 
-    fn build_expected(values: &[Felt]) -> [Felt; 16] {
-        let mut expected = [ZERO; 16];
+    fn build_expected(values: &[Felt]) -> [Felt; MIN_STACK_DEPTH] {
+        let mut expected = [ZERO; MIN_STACK_DEPTH];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = value;
         }

--- a/processor/src/operations/io_ops.rs
+++ b/processor/src/operations/io_ops.rs
@@ -760,8 +760,8 @@ mod tests {
         process.execute_op(Operation::MStore, program, host).unwrap();
     }
 
-    fn build_expected_stack(values: &[u64]) -> [Felt; 16] {
-        let mut expected = [ZERO; 16];
+    fn build_expected_stack(values: &[u64]) -> [Felt; MIN_STACK_DEPTH] {
+        let mut expected = [ZERO; MIN_STACK_DEPTH];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = Felt::new(value);
         }

--- a/processor/src/operations/stack_ops.rs
+++ b/processor/src/operations/stack_ops.rs
@@ -616,8 +616,8 @@ mod tests {
     // HELPER FUNCTIONS
     // --------------------------------------------------------------------------------------------
 
-    fn build_expected(values: &[u64]) -> [Felt; 16] {
-        let mut expected = [ZERO; 16];
+    fn build_expected(values: &[u64]) -> [Felt; MIN_STACK_DEPTH] {
+        let mut expected = [ZERO; MIN_STACK_DEPTH];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = Felt::new(value);
         }

--- a/processor/src/operations/sys_ops/mod.rs
+++ b/processor/src/operations/sys_ops/mod.rs
@@ -202,8 +202,8 @@ mod tests {
     // HELPER FUNCTIONS
     // --------------------------------------------------------------------------------------------
 
-    fn build_expected_stack(values: &[u64]) -> [Felt; 16] {
-        let mut expected = [ZERO; 16];
+    fn build_expected_stack(values: &[u64]) -> [Felt; MIN_STACK_DEPTH] {
+        let mut expected = [ZERO; MIN_STACK_DEPTH];
         for (&value, result) in values.iter().zip(expected.iter_mut()) {
             *result = Felt::new(value);
         }


### PR DESCRIPTION
Replaces magic number `16` with `MIN_STACK_DEPTH` constant in test helper functions.