### PR TITLE
Make cli use the fast processor for trace generation (1/3)

### DIFF
--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -576,10 +576,10 @@ impl Test {
         let stack_inputs: Vec<Felt> = self.stack_inputs.clone().into_iter().rev().collect();
         let advice_inputs = self.advice_inputs.clone();
         let fast_process = FastProcessor::new_with_advice_inputs(&stack_inputs, advice_inputs);
-        let fast_stack_outputs = fast_process.execute_sync(&program, &mut host).unwrap();
+        let fast_execution_output = fast_process.execute_sync(&program, &mut host).unwrap();
 
         assert_eq!(
-            slow_stack_outputs, fast_stack_outputs,
+            slow_stack_outputs, fast_execution_output.stack,
             "stack outputs do not match between slow and fast processors"
         );
     }
@@ -637,7 +637,9 @@ impl Test {
             let stack_inputs: Vec<Felt> = self.stack_inputs.clone().into_iter().rev().collect();
             let advice_inputs: AdviceInputs = self.advice_inputs.clone();
             let fast_process = FastProcessor::new_with_advice_inputs(&stack_inputs, advice_inputs);
-            fast_process.execute_sync(&program, &mut host)
+            fast_process
+                .execute_sync(&program, &mut host)
+                .map(|execution_output| execution_output.stack)
         };
 
         let fast_result_by_step = {

--- a/miden-vm/src/cli/run.rs
+++ b/miden-vm/src/cli/run.rs
@@ -3,7 +3,9 @@ use std::{path::PathBuf, time::Instant};
 use clap::Parser;
 use miden_assembly::diagnostics::{IntoDiagnostic, Report, WrapErr};
 use miden_core_lib::CoreLibrary;
-use miden_processor::{DefaultHost, ExecutionOptions, ExecutionTrace};
+use miden_processor::{
+    DefaultHost, ExecutionOptions, ExecutionTrace, fast::FastProcessor, parallel::build_trace,
+};
 use miden_vm::internal::InputFile;
 use tracing::instrument;
 
@@ -11,6 +13,9 @@ use super::{
     data::{Libraries, OutputFile},
     utils::{get_masm_program, get_masp_program},
 };
+
+/// Default fragment size for trace generation.
+const DEFAULT_FRAGMENT_SIZE: usize = 1 << 16;
 
 #[derive(Debug, Clone, Parser)]
 #[command(about = "Run a Miden program")]
@@ -138,25 +143,29 @@ fn run_masp_program(params: &RunCmd) -> Result<(ExecutionTrace, [u8; 32]), Repor
     let advice_inputs = input_data.parse_advice_inputs().map_err(Report::msg)?;
     let mut host = DefaultHost::default().with_library(&CoreLibrary::default())?;
 
-    let execution_options = ExecutionOptions::new(
-        Some(params.max_cycles),
-        params.expected_cycles,
-        params.trace,
-        !params.release,
-    )
-    .into_diagnostic()?;
-
     let program_hash: [u8; 32] = program.hash().into();
 
-    // execute program and generate outputs
-    let trace = miden_processor::execute(
-        &program,
-        stack_inputs,
-        advice_inputs,
-        &mut host,
-        execution_options,
-    )
-    .wrap_err("Failed to generate execution trace")?;
+    // Reverse stack inputs since FastProcessor expects them in reverse order
+    // (first element = bottom of stack, last element = top)
+    let stack_inputs_reversed: Vec<_> = stack_inputs.iter().copied().rev().collect();
+
+    // execute program using FastProcessor and generate trace
+    let processor = if params.release {
+        FastProcessor::new_with_advice_inputs(&stack_inputs_reversed, advice_inputs)
+    } else {
+        FastProcessor::new_debug(&stack_inputs_reversed, advice_inputs)
+    };
+
+    let (execution_output, trace_generation_context) = processor
+        .execute_for_trace_sync(&program, &mut host, DEFAULT_FRAGMENT_SIZE)
+        .wrap_err("Failed to execute program")?;
+
+    let trace = build_trace(
+        execution_output,
+        trace_generation_context,
+        program.hash(),
+        program.kernel().clone(),
+    );
 
     Ok((trace, program_hash))
 }
@@ -192,14 +201,6 @@ fn run_masm_program(params: &RunCmd) -> Result<(ExecutionTrace, [u8; 32]), Repor
     )?;
     let input_data = InputFile::read(&params.input_file, &params.program_file)?;
 
-    let execution_options = ExecutionOptions::new(
-        Some(params.max_cycles),
-        params.expected_cycles,
-        params.trace,
-        !params.release,
-    )
-    .into_diagnostic()?;
-
     // fetch the stack and program inputs from the arguments
     let stack_inputs = input_data.parse_stack_inputs().map_err(Report::msg)?;
     let advice_inputs = input_data.parse_advice_inputs().map_err(Report::msg)?;
@@ -215,14 +216,27 @@ fn run_masm_program(params: &RunCmd) -> Result<(ExecutionTrace, [u8; 32]), Repor
 
     let program_hash: [u8; 32] = program.hash().into();
 
-    let trace = miden_processor::execute(
-        &program,
-        stack_inputs,
-        advice_inputs,
-        &mut host,
-        execution_options,
-    )
-    .wrap_err("Failed to generate execution trace")?;
+    // Reverse stack inputs since FastProcessor expects them in reverse order
+    // (first element = bottom of stack, last element = top)
+    let stack_inputs_reversed: Vec<_> = stack_inputs.iter().copied().rev().collect();
+
+    // execute program using FastProcessor and generate trace
+    let processor = if params.release {
+        FastProcessor::new_with_advice_inputs(&stack_inputs_reversed, advice_inputs)
+    } else {
+        FastProcessor::new_debug(&stack_inputs_reversed, advice_inputs)
+    };
+
+    let (execution_output, trace_generation_context) = processor
+        .execute_for_trace_sync(&program, &mut host, DEFAULT_FRAGMENT_SIZE)
+        .wrap_err("Failed to execute program")?;
+
+    let trace = build_trace(
+        execution_output,
+        trace_generation_context,
+        program.hash(),
+        program.kernel().clone(),
+    );
 
     Ok((trace, program_hash))
 }

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -845,11 +845,10 @@ impl FastProcessor {
         self.stack_top_idx = new_stack_top_idx;
     }
 
-    // TESTING
+    // SYNC WRAPPERS
     // ----------------------------------------------------------------------------------------------
 
-    /// Convenience sync wrapper to [Self::step] for testing purposes.
-    #[cfg(any(test, feature = "testing"))]
+    /// Convenience sync wrapper to [Self::step].
     pub fn step_sync(
         &mut self,
         host: &mut impl AsyncHost,
@@ -864,8 +863,7 @@ impl FastProcessor {
     }
 
     /// Executes the given program step by step (calling [`Self::step`] repeatedly) and returns the
-    /// stack outputs for testing purposes.
-    #[cfg(any(test, feature = "testing"))]
+    /// stack outputs.
     pub fn execute_by_step_sync(
         mut self,
         program: &Program,
@@ -902,23 +900,19 @@ impl FastProcessor {
         })
     }
 
-    /// Convenience sync wrapper to [Self::execute] for testing purposes.
-    #[cfg(any(test, feature = "testing"))]
+    /// Convenience sync wrapper to [Self::execute].
     pub fn execute_sync(
         self,
         program: &Program,
         host: &mut impl AsyncHost,
-    ) -> Result<StackOutputs, ExecutionError> {
+    ) -> Result<ExecutionOutput, ExecutionError> {
         // Create a new Tokio runtime and block on the async execution
         let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
 
-        let execution_output = rt.block_on(self.execute(program, host))?;
-
-        Ok(execution_output.stack)
+        rt.block_on(self.execute(program, host))
     }
 
-    /// Convenience sync wrapper to [Self::execute_for_trace] for testing purposes.
-    #[cfg(any(test, feature = "testing"))]
+    /// Convenience sync wrapper to [Self::execute_for_trace].
     pub fn execute_for_trace_sync(
         self,
         program: &Program,

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -152,7 +152,7 @@ fn test_advice_provider() {
     // fast processor
     let mut fast_host = TestConsistencyHost::with_kernel_forest(kernel_lib.mast_forest().clone());
     let processor = FastProcessor::new_debug(&stack_inputs, AdviceInputs::default());
-    let fast_stack_outputs = processor.execute_sync(&program, &mut fast_host).unwrap();
+    let fast_stack_outputs = processor.execute_sync(&program, &mut fast_host).unwrap().stack;
 
     // slow processor
     let mut slow_host = TestConsistencyHost::with_kernel_forest(kernel_lib.mast_forest().clone());

--- a/processor/src/fast/tests/all_ops.rs
+++ b/processor/src/fast/tests/all_ops.rs
@@ -113,7 +113,8 @@ fn test_basic_block(
 
     let mut host = DefaultHost::default();
     let fast_processor = FastProcessor::new(&stack_inputs);
-    let fast_stack_outputs = fast_processor.execute_sync(&program, &mut host);
+    let fast_stack_outputs =
+        fast_processor.execute_sync(&program, &mut host).map(|output| output.stack);
 
     let mut host = DefaultHost::default();
     let mut slow_processor = Process::new(

--- a/processor/src/fast/tests/masm_consistency.rs
+++ b/processor/src/fast/tests/masm_consistency.rs
@@ -257,7 +257,7 @@ fn test_masm_consistency(
 
     // fast processor
     let processor = FastProcessor::new(&stack_inputs);
-    let fast_stack_outputs = processor.execute_sync(&program, &mut host).unwrap();
+    let fast_stack_outputs = processor.execute_sync(&program, &mut host).unwrap().stack;
 
     // fast processor by step
     let stepped_stack_outputs = {
@@ -401,12 +401,12 @@ fn test_log_precompile_correctness() {
 
     let mut host = DefaultHost::default();
     let processor = FastProcessor::new(&stack_inputs);
-    let stack_outputs = processor.execute_sync(&program, &mut host).unwrap();
+    let execution_output = processor.execute_sync(&program, &mut host).unwrap();
 
     // Verify stack outputs: [R1, R0, CAP_NEXT, ...]
-    let r1 = stack_outputs.get_stack_word_be(0).unwrap();
-    let r0 = stack_outputs.get_stack_word_be(4).unwrap();
-    let cap_next = stack_outputs.get_stack_word_be(8).unwrap();
+    let r1 = execution_output.stack.get_stack_word_be(0).unwrap();
+    let r0 = execution_output.stack.get_stack_word_be(4).unwrap();
+    let cap_next = execution_output.stack.get_stack_word_be(8).unwrap();
 
     assert_eq!(&hasher_state[0..4], cap_next.as_slice(), "CAP_NEXT on stack mismatch");
     assert_eq!(&hasher_state[4..8], r0.as_slice(), "R0 on stack mismatch");

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -171,7 +171,7 @@ fn test_valid_combinations_and(#[case] stack_inputs: Vec<Felt>, #[case] expected
 
     let mut host = DefaultHost::default();
     let processor = FastProcessor::new(&stack_inputs);
-    let stack_outputs = processor.execute_sync(&program, &mut host).unwrap();
+    let stack_outputs = processor.execute_sync(&program, &mut host).unwrap().stack;
 
     assert_eq!(stack_outputs.stack_truncated(1)[0], expected_output);
 }
@@ -190,7 +190,7 @@ fn test_valid_combinations_or(#[case] stack_inputs: Vec<Felt>, #[case] expected_
 
     let mut host = DefaultHost::default();
     let processor = FastProcessor::new(&stack_inputs);
-    let stack_outputs = processor.execute_sync(&program, &mut host).unwrap();
+    let stack_outputs = processor.execute_sync(&program, &mut host).unwrap().stack;
 
     assert_eq!(stack_outputs.stack_truncated(1)[0], expected_output);
 }
@@ -227,7 +227,7 @@ fn test_frie2f4() {
 
     // fast processor
     let fast_processor = FastProcessor::new(&stack_inputs);
-    let fast_stack_outputs = fast_processor.execute_sync(&program, &mut host).unwrap();
+    let fast_stack_outputs = fast_processor.execute_sync(&program, &mut host).unwrap().stack;
 
     // slow processor
     let mut slow_processor = Process::new(


### PR DESCRIPTION
Work towards #2406

Makes the CLI use the `FastProcessor` instead of `Process`.