### PR TITLE
ci: clear cargo registry cache before workspace publish dry-run

### DIFF
--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -66,6 +66,21 @@ runs:
         echo "Cleaning target/package directory to ensure fresh state"
         rm -rf target/package
 
+    # Clear cargo registry to ensure fresh resolution during verification.
+    # This prevents issues where cached metadata from previous runs
+    # might interfere with workspace dependency feature resolution
+    # during the verification step (related to cargo#14283, cargo#14789).
+    # Specifically, this ensures the temp registry used during workspace
+    # publish verification doesn't conflict with cached crates.io data.
+    - name: Clear cargo registry for fresh resolution
+      if: ${{ inputs.mode == 'dry-run' }}
+      shell: bash
+      run: |
+        echo "Clearing cargo registry for fresh resolution"
+        rm -rf ~/.cargo/registry/cache
+        rm -rf ~/.cargo/registry/index
+        rm -rf ~/.cargo/registry/src
+
     # Dry-run vs real publish
     - name: Dry-run workspace publish
       if: ${{ inputs.mode == 'dry-run' }}


### PR DESCRIPTION
The workspace publish dry-run fails with `unresolved import miden_utils_sync::OnceLockCompat` during verification. This happens because cached registry data from previous CI runs can interfere with cargo's temp registry used for workspace dependency resolution.

During verification, cargo should use the packaged v0.21.0 from the temp registry, but stale cache entries may cause it to resolve against crates.io data instead (where v0.20.1 lacks `OnceLockCompat`).

=> Clear `~/.cargo/registry/{cache,index,src}` before the dry-run to ensure fresh resolution without interference from cached data.

Replaces #2505