### PR TITLE
Merge main into next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - [BREAKING] Removed `miden debug`, `miden analyze` and `miden repl` ([#2483](https://github.com/0xMiden/miden-vm/pull/2483)).
 - [BREAKING] Change backend from winterfell to Plonky3 ([#2472](https://github.com/0xMiden/miden-vm/pull/2472)).
 
+## 0.20.2 (TBD)
+- Fix issue where decorator access was not bypassed properly in release mode ([#2529](https://github.com/0xMiden/miden-vm/pull/2529)).
+
 ## 0.20.1 (2025-12-14)
 
 - Fix issue where calling procedures from statically linked libraries did not import their decorators ([#2459](https://github.com/0xMiden/miden-vm/pull/2459)).

--- a/core/src/mast/debuginfo/mod.rs
+++ b/core/src/mast/debuginfo/mod.rs
@@ -109,6 +109,25 @@ impl DebugInfo {
         }
     }
 
+    /// Creates an empty [DebugInfo] with valid CSR structures for N nodes.
+    pub fn empty_for_nodes(num_nodes: usize) -> Self {
+        let mut node_indptr_for_op_idx = IndexVec::new();
+        for _ in 0..=num_nodes {
+            let _ = node_indptr_for_op_idx.push(0);
+        }
+
+        let op_decorator_storage =
+            OpToDecoratorIds::from_components(Vec::new(), Vec::new(), node_indptr_for_op_idx)
+                .expect("Empty CSR structure should be valid");
+
+        Self {
+            decorators: IndexVec::new(),
+            op_decorator_storage,
+            node_decorator_storage: NodeToDecoratorIds::new(),
+            error_codes: BTreeMap::new(),
+        }
+    }
+
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -167,7 +167,7 @@ impl MastForest {
     ///
     /// This method modifies the forest in-place, removing all decorator information
     /// including operation-indexed decorators, before-enter decorators, after-exit
-    /// decorators, and error codes.
+    /// decorators, and error codes while keeping the CSR structure valid.
     ///
     /// # Examples
     ///
@@ -179,8 +179,7 @@ impl MastForest {
     /// forest.strip_decorators(); // forest is now stripped
     /// ```
     pub fn strip_decorators(&mut self) {
-        // Clear all debug info (decorators and error codes)
-        self.debug_info.clear();
+        self.debug_info = DebugInfo::empty_for_nodes(self.nodes.len());
     }
 
     /// Compacts the forest by merging duplicate nodes.

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -387,8 +387,11 @@ impl Test {
         let fast_stack_result = {
             let stack_inputs: Vec<Felt> = self.stack_inputs.clone().into_iter().rev().collect();
             let advice_inputs: AdviceInputs = self.advice_inputs.clone();
-            let fast_processor =
-                FastProcessor::new_with_advice_inputs(&stack_inputs, advice_inputs);
+            let fast_processor = if self.in_debug_mode {
+                FastProcessor::new_debug(&stack_inputs, advice_inputs)
+            } else {
+                FastProcessor::new_with_advice_inputs(&stack_inputs, advice_inputs)
+            };
             fast_processor.execute_for_trace_sync(&program, &mut host, FRAGMENT_SIZE)
         };
 
@@ -575,7 +578,11 @@ impl Test {
         let fast_result_by_step = {
             let stack_inputs: Vec<Felt> = self.stack_inputs.clone().into_iter().rev().collect();
             let advice_inputs: AdviceInputs = self.advice_inputs.clone();
-            let fast_process = FastProcessor::new_with_advice_inputs(&stack_inputs, advice_inputs);
+            let fast_process = if self.in_debug_mode {
+                FastProcessor::new_debug(&stack_inputs, advice_inputs)
+            } else {
+                FastProcessor::new_with_advice_inputs(&stack_inputs, advice_inputs)
+            };
             fast_process.execute_by_step_sync(&program, &mut host)
         };
 

--- a/processor/src/fast/basic_block.rs
+++ b/processor/src/fast/basic_block.rs
@@ -223,16 +223,22 @@ impl FastProcessor {
     ) -> ControlFlow<BreakReason> {
         let batch = &basic_block.op_batches()[batch_index];
 
+        // Get the node ID once since it doesn't change within the loop
+        let node_id = basic_block
+            .linked_id()
+            .expect("basic block node should be linked when executing operations");
+
         // execute operations in the batch one by one
         for (op_idx_in_batch, op) in batch.ops().iter().enumerate().skip(start_op_idx) {
             let op_idx_in_block = batch_offset_in_block + op_idx_in_batch;
 
-            // Use the forest's decorator storage to get decorators for this operation
-            let node_id = basic_block
-                .linked_id()
-                .expect("basic block node should be linked when executing operations");
-            for decorator in current_forest.decorators_for_op(node_id, op_idx_in_block) {
-                self.execute_decorator(decorator, host)?;
+            if self.in_debug_mode {
+                #[cfg(test)]
+                self.record_decorator_retrieval();
+
+                for decorator in current_forest.decorators_for_op(node_id, op_idx_in_block) {
+                    self.execute_decorator(decorator, host)?;
+                }
             }
 
             // if in trace mode, check if we need to record a trace state before executing the
@@ -250,7 +256,8 @@ impl FastProcessor {
             // whereas all the other operations are synchronous (resulting in a significant
             // performance improvement).
             {
-                let err_ctx = err_ctx!(current_forest, node_id, host, op_idx_in_block);
+                let err_ctx =
+                    err_ctx!(current_forest, node_id, host, self.in_debug_mode, op_idx_in_block);
                 match op {
                     Operation::Emit => self.op_emit(host, &err_ctx).await?,
                     _ => {
@@ -276,40 +283,6 @@ impl FastProcessor {
             })?;
         }
 
-        ControlFlow::Continue(())
-    }
-
-    #[inline(always)]
-    async fn op_emit(
-        &mut self,
-        host: &mut impl AsyncHost,
-        err_ctx: &impl ErrorContext,
-    ) -> ControlFlow<BreakReason> {
-        let mut process = self.state();
-        let event_id = EventId::from_felt(process.get_stack_item(0));
-
-        // If it's a system event, handle it directly. Otherwise, forward it to the host.
-        if let Some(system_event) = SystemEvent::from_event_id(event_id) {
-            if let Err(err) = handle_system_event(&mut process, system_event, err_ctx) {
-                return ControlFlow::Break(BreakReason::Err(err));
-            }
-        } else {
-            let clk = process.clk();
-            let mutations = match host.on_event(&process).await {
-                Ok(m) => m,
-                Err(err) => {
-                    let event_name = host.resolve_event(event_id).cloned();
-                    return ControlFlow::Break(BreakReason::Err(ExecutionError::event_error(
-                        err, event_id, event_name, err_ctx,
-                    )));
-                },
-            };
-            if let Err(err) = self.advice.apply_mutations(mutations) {
-                return ControlFlow::Break(BreakReason::Err(ExecutionError::advice_error(
-                    err, clk, err_ctx,
-                )));
-            }
-        }
         ControlFlow::Continue(())
     }
 
@@ -354,11 +327,50 @@ impl FastProcessor {
         current_forest: &Arc<MastForest>,
         host: &mut impl AsyncHost,
     ) -> ControlFlow<BreakReason> {
-        let num_ops = basic_block_node.num_operations() as usize;
-        for decorator in current_forest.decorators_for_op(node_id, num_ops) {
-            self.execute_decorator(decorator, host)?;
+        if self.in_debug_mode {
+            #[cfg(test)]
+            self.record_decorator_retrieval();
+
+            let num_ops = basic_block_node.num_operations() as usize;
+            for decorator in current_forest.decorators_for_op(node_id, num_ops) {
+                self.execute_decorator(decorator, host)?;
+            }
         }
 
+        ControlFlow::Continue(())
+    }
+
+    #[inline(always)]
+    async fn op_emit(
+        &mut self,
+        host: &mut impl AsyncHost,
+        err_ctx: &impl ErrorContext,
+    ) -> ControlFlow<BreakReason> {
+        let mut process = self.state();
+        let event_id = EventId::from_felt(process.get_stack_item(0));
+
+        // If it's a system event, handle it directly. Otherwise, forward it to the host.
+        if let Some(system_event) = SystemEvent::from_event_id(event_id) {
+            if let Err(err) = handle_system_event(&mut process, system_event, err_ctx) {
+                return ControlFlow::Break(BreakReason::Err(err));
+            }
+        } else {
+            let clk = process.clk();
+            let mutations = match host.on_event(&process).await {
+                Ok(m) => m,
+                Err(err) => {
+                    let event_name = host.resolve_event(event_id).cloned();
+                    return ControlFlow::Break(BreakReason::Err(ExecutionError::event_error(
+                        err, event_id, event_name, err_ctx,
+                    )));
+                },
+            };
+            if let Err(err) = self.advice.apply_mutations(mutations) {
+                return ControlFlow::Break(BreakReason::Err(ExecutionError::advice_error(
+                    err, clk, err_ctx,
+                )));
+            }
+        }
         ControlFlow::Continue(())
     }
 }

--- a/processor/src/fast/call_and_dyn.rs
+++ b/processor/src/fast/call_and_dyn.rs
@@ -43,7 +43,7 @@ impl FastProcessor {
         // Execute decorators that should be executed before entering the node
         self.execute_before_enter_decorators(current_node_id, current_forest, host)?;
 
-        let err_ctx = err_ctx!(current_forest, current_node_id, host);
+        let err_ctx = err_ctx!(current_forest, current_node_id, host, self.in_debug_mode);
 
         let callee_hash = current_forest[call_node.callee()].digest();
 
@@ -107,7 +107,7 @@ impl FastProcessor {
         // so we prefix it with underscore to indicate this intentional unused state
         // and suppress warnings in feature combinations that include `no_err_ctx`.
         let _call_node = current_forest[node_id].unwrap_call();
-        let err_ctx = err_ctx!(current_forest, node_id, host);
+        let err_ctx = err_ctx!(current_forest, node_id, host, self.in_debug_mode);
         // when returning from a function call or a syscall, restore the
         // context of the
         // system registers and the operand stack to what it was prior
@@ -147,7 +147,7 @@ impl FastProcessor {
         // added to the trace.
         let dyn_node = current_forest[current_node_id].unwrap_dyn();
 
-        let err_ctx = err_ctx!(&current_forest, current_node_id, host);
+        let err_ctx = err_ctx!(&current_forest, current_node_id, host, self.in_debug_mode);
 
         // Retrieve callee hash from memory, using stack top as the memory
         // address.
@@ -248,7 +248,7 @@ impl FastProcessor {
         );
 
         let dyn_node = current_forest[node_id].unwrap_dyn();
-        let err_ctx = err_ctx!(current_forest, node_id, host);
+        let err_ctx = err_ctx!(current_forest, node_id, host, self.in_debug_mode);
         // For dyncall, restore the context.
         if dyn_node.is_dyncall() {
             self.restore_context(tracer, &err_ctx)?;

--- a/processor/src/fast/loop.rs
+++ b/processor/src/fast/loop.rs
@@ -69,7 +69,7 @@ impl FastProcessor {
                 stopper,
             )
         } else {
-            let err_ctx = err_ctx!(current_forest, current_node_id, host);
+            let err_ctx = err_ctx!(current_forest, current_node_id, host, self.in_debug_mode);
             ControlFlow::Break(BreakReason::Err(ExecutionError::not_binary_value_loop(
                 condition, &err_ctx,
             )))
@@ -126,7 +126,7 @@ impl FastProcessor {
 
             self.execute_after_exit_decorators(current_node_id, current_forest, host)
         } else {
-            let err_ctx = err_ctx!(current_forest, current_node_id, host);
+            let err_ctx = err_ctx!(current_forest, current_node_id, host, self.in_debug_mode);
             ControlFlow::Break(BreakReason::Err(ExecutionError::not_binary_value_loop(
                 condition, &err_ctx,
             )))

--- a/processor/src/fast/split.rs
+++ b/processor/src/fast/split.rs
@@ -48,7 +48,7 @@ impl FastProcessor {
         } else if condition == ZERO {
             continuation_stack.push_start_node(split_node.on_false());
         } else {
-            let err_ctx = err_ctx!(current_forest, node_id, host);
+            let err_ctx = err_ctx!(current_forest, node_id, host, self.in_debug_mode);
             return ControlFlow::Break(BreakReason::Err(ExecutionError::not_binary_value_if(
                 condition, &err_ctx,
             )));

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -12,7 +12,7 @@ use miden_utils_testing::build_test;
 use rstest::rstest;
 
 use super::*;
-use crate::DefaultHost;
+use crate::{AdviceInputs, DefaultHost};
 
 mod advice_provider;
 mod all_ops;
@@ -374,7 +374,7 @@ fn test_external_node_decorator_sequencing() {
         crate::test_utils::test_consistency_host::TestConsistencyHost::with_kernel_forest(
             Arc::new(lib_forest),
         );
-    let processor = FastProcessor::new(&alloc::vec::Vec::new());
+    let processor = FastProcessor::new_debug(&alloc::vec::Vec::new(), AdviceInputs::default());
 
     let result = processor.execute_sync(&program, &mut host);
     assert!(result.is_ok(), "Execution failed: {:?}", result);

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -22,9 +22,6 @@ use crate::fast::FastProcessor;
 
 mod debug;
 
-#[cfg(test)]
-mod debug_mode_decorator_tests;
-
 // AdviceMap inlined in the script
 // ------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR merges `main` into `next`, bringing the decorator bypass optimization from #2529 into the next development branch.

## What's Being Merged

The decorator bypass optimization that was merged to main via #2529, which includes:

1. Gate all decorator retrieval behind `in_debug_mode` checks
2. Prevent expensive decorator traversal when not in debug mode
3. Maintain proper decorator storage structure even when stripped

