### PR TITLE
ci: contribution quality workflow permissions for external PRs

### DIFF
--- a/.github/workflows/contribution-quality.yml
+++ b/.github/workflows/contribution-quality.yml
@@ -1,7 +1,10 @@
 name: Contribution Quality
 
+# Use pull_request_target to get write permissions for fork PRs.
+# IMPORTANT: This workflow runs in the context of the BASE branch, not the PR branch.
+# Do NOT checkout or run code from the PR itself, only inspect PR metadata via the API.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, edited, synchronize, ready_for_review]
   workflow_dispatch:
     inputs:
@@ -37,6 +40,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // pull_request_target has the same payload shape as pull_request
             const isPREvent = !!context.payload.pull_request;
             const fromDispatch = context.payload?.inputs?.pr_number || process.env.DISPATCH_PR_NUMBER || '';
             const prNumber = isPREvent ? String(context.payload.pull_request.number) : String(fromDispatch || '');


### PR DESCRIPTION
This workflow checks PR quality for external contributors. It had a problem:

It failed to post comments or add labels on fork PRs with a [403 error: "Resource not accessible by integration"](https://github.com/0xMiden/miden-vm/actions/runs/20712581575/job/59491266817?pr=2533). This happens because GitHub automatically restricts the GITHUB_TOKEN to read-only permissions when a `pull_request` event is triggered from a fork (a security measure to prevent malicious PRs from modifying the base repository).

The fix: switch from `pull_request` to [`pull_request_target`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target). This event runs in the context of the base repository, so the GITHUB_TOKEN retains the write permissions declared in the workflow. This is safe here because the workflow only reads PR metadata via the GitHub API and never checks out or executes code from the PR branch.

