### PR TITLE
ci: link checker now creates issues when broken links are found

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -43,13 +43,14 @@ jobs:
             --exclude "127.0.0.1"
             --exclude "^file://"
             --exclude "github.com/0xMiden/.*"
+            --exclude "medium.com"
             docs/src/**/*.md
             **/*.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Open issue on failure (only if fail-fast is false)
-        if: steps.lychee.outcome == 'failure' && steps.flags.outputs.fail_fast != 'true'
+        if: steps.lychee.outputs.exit_code != 0 && steps.flags.outputs.fail_fast != 'true'
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: Link Checker Report


### PR DESCRIPTION
The "Open issue on failure" step was never running because of a logic bug in the condition.

The workflow sets `fail: false` on the lychee-action for scheduled runs so the pipeline does not block on broken links. However, this means the lychee step always reports `outcome == 'success'` in GitHub Actions terms, even when broken links are detected. The condition was checking `steps.lychee.outcome == 'failure'`, which was never true.

The fix checks `steps.lychee.outputs.exit_code != 0` instead. The lychee-action exposes the actual exit code from lychee (e.g. exit code 2 means broken links were found), and this value is available regardless of the step's pass/fail status.

Also excludes medium.com URLs since Medium blocks automated requests with 403 Forbidden, causing false positives.

