### PR TITLE
fix(assembly-syntax): restore non-overlapping ranges in IntValue Arbitrary impl

### DIFF
--- a/crates/assembly-syntax/src/parser/token.rs
+++ b/crates/assembly-syntax/src/parser/token.rs
@@ -407,8 +407,8 @@ impl proptest::arbitrary::Arbitrary for IntValue {
             num::u8::ANY.prop_map(IntValue::U8),
             // U16 values that don't overlap with U8 to preserve variant during serialization
             (u8::MAX as u16 + 1..=u16::MAX).prop_map(IntValue::U16),
-            // U32 values - full range
-            num::u32::ANY.prop_map(IntValue::U32),
+            // U32 values that don't overlap with U8/U16 to preserve variant during serialization
+            (u16::MAX as u32 + 1..=u32::MAX).prop_map(IntValue::U32),
             // Felt values - values that don't fit in u32 but are within field modulus
             (num::u64::ANY)
                 .prop_filter_map("valid felt value", |n| {


### PR DESCRIPTION
The IntValue binary serialization loses variant information: it writes the numeric value as u64, then deserializes by inferring the variant from magnitude via shrink_u64_hex:
  - 0-255 → U8
  - 256-65535 → U16
  - 65536-4294967295 → U32
  - larger than 4294967295 → Felt

Commit 441bb4f4c (#2335) changed U32 generation from the correct `(u16::MAX + 1..=u32::MAX)` to `num::u32::ANY`, which includes values 0-65535. These serialize fine but deserialize to U8/U16, breaking roundtrip equality (e.g., U32(0) != U8(0)). This has led to some [flaky test failures](https://github.com/0xMiden/miden-vm/actions/runs/20794173327/job/59723296150).

This restores the original non-overlapping range constraint.

