### PR TITLE
Fix diagnostics when external node resolution fails

### DIFF
--- a/processor/src/fast/external.rs
+++ b/processor/src/fast/external.rs
@@ -5,7 +5,7 @@ use miden_core::mast::{ExternalNode, MastForest, MastNodeExt, MastNodeId};
 
 use crate::{
     AsyncHost, ExecutionError,
-    continuation_stack::ContinuationStack,
+    continuation_stack::{Continuation, ContinuationStack},
     errors::OperationError,
     fast::{BreakReason, FastProcessor, Tracer},
 };
@@ -30,7 +30,12 @@ impl FastProcessor {
             .await
         {
             Ok(result) => result,
-            Err(err) => return ControlFlow::Break(BreakReason::Err(err)),
+            Err(err) => {
+                let maybe_enriched_err =
+                    maybe_use_caller_error_context(err, current_forest, continuation_stack, host);
+
+                return ControlFlow::Break(BreakReason::Err(maybe_enriched_err));
+            },
         };
 
         tracer.record_mast_forest_resolution(resolved_node_id, &new_mast_forest);
@@ -51,11 +56,8 @@ impl FastProcessor {
         ControlFlow::Continue(())
     }
 
-    /// Analogous to [`Process::resolve_external_node`](crate::Process::resolve_external_node), but
-    /// for asynchronous execution.
-    ///
-    /// Note: External node diagnostics are not fully implemented in FastProcessor (see #2476).
-    /// We pass the external node's parent forest and node_id for basic error context.
+    /// Resolves an External node by loading the MAST forest from the host that contains the
+    /// referenced procedure, if any.
     async fn resolve_external_node(
         &mut self,
         external_node: &ExternalNode,
@@ -85,4 +87,71 @@ impl FastProcessor {
 
         Ok((root_id, mast_forest))
     }
+}
+
+// HELPERS
+// ---------------------------------------------------------------------------------------------
+
+/// If the given error is an error generated when trying to resolve an External node, and there is a
+/// caller context available in the continuation stack, use the caller node ID to build the error
+/// context.
+///
+/// In practice, `ExternalNode`s are executed via a `CallNode` or `DynNode`. Thus, if we fail to
+/// resolve an `ExternalNode`, we can look at the top of the continuation stack to find the caller
+/// node ID (that we expect to be a `CallNode` or `DynNode`), and build the diagnostic from that
+/// node.
+///
+/// For example, in MASM, the user would see an error like:
+/// ```masm
+/// x no MAST forest contains the procedure with root digest <digest>
+///     ,-[::\$exec:5:13]
+///   4 |         begin
+///   5 |             call.bar::dummy_proc
+///     :             ^^^^^^^^^^^^^^^^^^^^
+///   6 |         end
+///     `----
+/// ```
+///
+/// The carets and line numbers point to the `call` instruction that triggered the error because of
+/// the remapping we do in this function.
+fn maybe_use_caller_error_context(
+    original_err: ExecutionError,
+    current_forest: &MastForest,
+    continuation_stack: &ContinuationStack,
+    host: &mut impl AsyncHost,
+) -> ExecutionError {
+    // We only care about operation errors...
+    let ExecutionError::OperationError { label: _, source_file: _, err: inner_err } = &original_err
+    else {
+        return original_err;
+    };
+
+    // ... that are related to external node resolution.
+    let is_external_resolution_err = matches!(
+        inner_err,
+        OperationError::NoMastForestWithProcedure { .. }
+            | OperationError::MalformedMastForestInHost { .. }
+    );
+    if !is_external_resolution_err {
+        return original_err;
+    }
+
+    // Look for caller context in the continuation stack
+    let Some(top_continuation) = continuation_stack.peek_continuation() else {
+        return original_err;
+    };
+
+    // Extract parent node ID from all continuations that can lead to an external node execution.
+    //
+    // Note that the assembler current doesn't attach `AssemblyOp` decorators to Join nodes.
+    let parent_node_id = match top_continuation {
+        Continuation::FinishCall(parent_node_id)
+        | Continuation::FinishJoin(parent_node_id)
+        | Continuation::FinishSplit(parent_node_id)
+        | Continuation::FinishLoop { node_id: parent_node_id, .. } => parent_node_id,
+        _ => return original_err,
+    };
+
+    // We were able to get the parent node ID, so use that to build the error context
+    inner_err.clone().with_context(current_forest, *parent_node_id, host)
 }


### PR DESCRIPTION
Closes #2476 

Re-enables the 2 tests referenced in #2476, and fixes the expected digests (due to #2547). More specifically,

- `test_diagnostic_syscall_target_not_in_kernel()`: no solution needed, the error context set up in `start_call_node()` already correctly points to the syscall `CallNode`.
- `test_diagnostic_no_mast_forest_with_procedure()`: on error, we walk up one node in the continuation stack to find the caller of the `ExternalNode`, and wse the caller's node ID to build the error context (e.g. to get the diagnostic for the `CallNode`, no the `ExternalNode`). More information can be found in the docstring of the new `maybe_use_caller_error_context()` method.

I didn't add a changelog entry, since this bug was introduced in #2477, which will land in the same release.