### PR TITLE
chore(processor): audit must-use Felt suppressions

### DIFF
--- a/processor/src/chiplets/hasher/tests.rs
+++ b/processor/src/chiplets/hasher/tests.rs
@@ -84,6 +84,9 @@ fn hasher_permute() {
 
 // MERKLE TREE TESTS
 // ================================================================================================
+//
+// These tests verify trace generation, not computed results. The Merkle roots are validated
+// through `check_merkle_path`.
 
 #[test]
 fn hasher_build_merkle_root() {

--- a/processor/src/operations/utils.rs
+++ b/processor/src/operations/utils.rs
@@ -51,10 +51,10 @@ pub(crate) fn validate_dual_word_stream_addrs(
 
 /// Asserts that the given value is a binary value (0 or 1).
 #[inline(always)]
-pub fn assert_binary(value: Felt) -> Result<Felt, crate::OperationError> {
+pub fn assert_binary(value: Felt) -> Result<(), crate::OperationError> {
     if value != ZERO && value != ONE {
         Err(crate::OperationError::NotBinaryValue { value })
     } else {
-        Ok(value)
+        Ok(())
     }
 }

--- a/processor/src/parallel/core_trace_fragment/mod.rs
+++ b/processor/src/parallel/core_trace_fragment/mod.rs
@@ -81,7 +81,7 @@ impl<'a> CoreTraceFragmentFiller<'a> {
 
     /// Fills the fragment and returns the final stack rows, system rows, and number of rows built.
     pub fn fill_fragment(mut self) -> ([Felt; STACK_TRACE_WIDTH], [Felt; SYS_TRACE_WIDTH], usize) {
-        // Execute fragment generation and always finalize at the end
+        // We extract final state from `self`, so the ControlFlow result doesn't matter.
         let _ = self.fill_fragment_impl();
 
         let num_rows_built = self.num_rows_built();

--- a/processor/src/parallel/mod.rs
+++ b/processor/src/parallel/mod.rs
@@ -423,6 +423,8 @@ fn initialize_range_checker(
     range_checker
 }
 
+/// Replays recorded operations to populate chiplet traces. Results were already used during
+/// execution; this pass only needs the trace-recording side effects.
 fn initialize_chiplets(
     kernel: Kernel,
     core_trace_contexts: &[CoreTraceFragmentContext],

--- a/processor/src/processor/operations/field_ops.rs
+++ b/processor/src/processor/operations/field_ops.rs
@@ -71,8 +71,8 @@ pub(super) fn op_and<P: Processor>(
     pop2_applyfn_push_op(
         processor,
         |a, b| {
-            let _ = assert_binary(b)?;
-            let _ = assert_binary(a)?;
+            assert_binary(b)?;
+            assert_binary(a)?;
 
             if a == ONE && b == ONE { Ok(ONE) } else { Ok(ZERO) }
         },
@@ -94,8 +94,8 @@ pub(super) fn op_or<P: Processor>(
     pop2_applyfn_push_op(
         processor,
         |a, b| {
-            let _ = assert_binary(b)?;
-            let _ = assert_binary(a)?;
+            assert_binary(b)?;
+            assert_binary(a)?;
 
             if a == ONE || b == ONE { Ok(ONE) } else { Ok(ZERO) }
         },

--- a/processor/src/stack/overflow.rs
+++ b/processor/src/stack/overflow.rs
@@ -65,7 +65,7 @@ impl OverflowStack {
 
     /// Pushes a value onto the overflow stack.
     pub fn push(&mut self, entry: OverflowStackEntry) {
-        let _ = self.overflow.push(entry);
+        let _ = self.overflow.push(entry); // discard returned index
     }
 
     /// Pops a value from the overflow stack, if any.
@@ -98,7 +98,7 @@ impl OverflowTable {
     /// table at every clock cycle. This is used for debugging purposes.
     pub fn new() -> Self {
         let mut overflow = IndexVec::new();
-        let _ = overflow.push(OverflowStack::new());
+        let _ = overflow.push(OverflowStack::new()); // discard returned index
 
         Self { overflow }
     }
@@ -178,7 +178,7 @@ impl OverflowTable {
     /// Note: It is possible to return to context 0 with a syscall; in this case, each instantiation
     /// of context 0 will get a separate overflow table.
     pub fn start_context(&mut self) {
-        let _ = self.overflow.push(OverflowStack::new());
+        let _ = self.overflow.push(OverflowStack::new()); // discard returned index
     }
 
     /// Restores the specified context.


### PR DESCRIPTION
Audit `let _ = ...` suppressions that were added when the Felt type gained a must-use annotation during the Plonky3 migration.

Changes:
- `assert_binary` returns `Result<(), OperationError>` instead of `Result<Felt, OperationError>` since returned Felt was never used. 
- Add doc comment to `initialize_chiplets` explaining why return values are discarded during replay (only side effects matter for trace gen)
- Add comment to `fill_fragment` explaining why `ControlFlow` is ignored
- Add comments to overflow stack push operations explaining `IndexVec` returns an unused index
- Add comment to hasher Merkle tree tests explaining trace verification

Closes #2514
