### PR TITLE
processor: Remove on_assert_failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [BREAKING] Renamed `u32overflowing_mul` to `u32widening_mul`, `u32overflowing_madd` to `u32widening_madd`, and `math::u64::overflowing_mul` to `math::u64::widening_mul` ([#2584](https://github.com/0xMiden/miden-vm/pull/2584)).
 - [BREAKING] Removed `SyncHost` and `BaseHost`, and renamed `AsyncHost` to `Host` ([#2595](https://github.com/0xMiden/miden-vm/pull/2595)).
 - [BREAKING] Moved `ExecutionOptions` to `miden-processor`, `ProvingOptions` to `miden-prove`, and `ExecutionProof` to `miden-core` (all out of `miden-air`) ([#2597](https://github.com/0xMiden/miden-vm/pull/2597)).
+- [BREAKING] Removed `on_assert_failed` method from `Host` trait ([#2600](https://github.com/0xMiden/miden-vm/pull/2600)).
 
 ## 0.20.2 (TBD)
 

--- a/processor/src/fast/operation.rs
+++ b/processor/src/fast/operation.rs
@@ -10,7 +10,7 @@ use miden_core::{
 };
 
 use crate::{
-    AdviceProvider, ContextId, ExecutionError, ProcessState,
+    AdviceProvider, ContextId, ExecutionError,
     chiplets::{CircuitEvaluation, MAX_NUM_ACE_WIRES, PTR_OFFSET_ELEM, PTR_OFFSET_WORD},
     errors::{AceError, AceEvalError, OperationError},
     fast::{FastProcessor, STACK_BUFFER_SIZE, Tracer, memory::Memory},
@@ -31,11 +31,6 @@ impl Processor for FastProcessor {
     #[inline(always)]
     fn stack(&mut self) -> &mut Self::Stack {
         self
-    }
-
-    #[inline(always)]
-    fn state(&mut self) -> ProcessState<'_> {
-        self.state()
     }
 
     #[inline(always)]

--- a/processor/src/host/handlers.rs
+++ b/processor/src/host/handlers.rs
@@ -85,12 +85,6 @@ pub type DebugError = Box<dyn Error + Send + Sync + 'static>;
 /// into this type since it is a [`Box`].
 pub type TraceError = Box<dyn Error + Send + Sync + 'static>;
 
-/// A generic [`Error`] wrapper for assertion handler errors.
-///
-/// Assertion handlers can define their own [`Error`] type which can be seamlessly converted
-/// into this type since it is a [`Box`].
-pub type AssertError = Box<dyn Error + Send + Sync + 'static>;
-
 // EVENT HANDLER REGISTRY
 // ================================================================================================
 

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -7,7 +7,7 @@ use miden_core::{
 };
 use miden_debug_types::{Location, SourceFile, SourceSpan};
 
-use crate::{AssertError, DebugError, EventError, ProcessState, TraceError};
+use crate::{DebugError, EventError, ProcessState, TraceError};
 
 pub(super) mod advice;
 
@@ -110,15 +110,6 @@ pub trait Host {
     fn on_trace(&mut self, process: &mut ProcessState, trace_id: u32) -> Result<(), TraceError> {
         let mut handler = debug::DefaultDebugHandler::default();
         handler.on_trace(process, trace_id)
-    }
-
-    /// Handles the failure of the assertion instruction.
-    fn on_assert_failed(
-        &mut self,
-        _process: &ProcessState,
-        _err_code: Felt,
-    ) -> Option<AssertError> {
-        None
     }
 
     /// Returns the [`EventName`] registered for the provided [`EventId`], if any.

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -60,8 +60,8 @@ pub use host::{
     debug::DefaultDebugHandler,
     default::{DefaultHost, HostLibrary},
     handlers::{
-        AssertError, DebugError, DebugHandler, EventError, EventHandler, EventHandlerRegistry,
-        NoopEventHandler, TraceError,
+        DebugError, DebugHandler, EventError, EventHandler, EventHandlerRegistry, NoopEventHandler,
+        TraceError,
     },
 };
 

--- a/processor/src/parallel/core_trace_fragment/mod.rs
+++ b/processor/src/parallel/core_trace_fragment/mod.rs
@@ -17,7 +17,7 @@ use miden_core::{
 };
 
 use crate::{
-    ContextId, ExecutionError, ProcessState,
+    ContextId, ExecutionError,
     chiplets::CircuitEvaluation,
     continuation_stack::Continuation,
     decoder::block_stack::ExecutionContextInfo,
@@ -625,10 +625,6 @@ impl<'a> Processor for CoreTraceFragmentFiller<'a> {
 
     fn system(&mut self) -> &mut Self::System {
         self
-    }
-
-    fn state(&mut self) -> ProcessState<'_> {
-        ProcessState::Noop(())
     }
 
     fn advice_provider(&mut self) -> &mut Self::AdviceProvider {

--- a/processor/src/processor/mod.rs
+++ b/processor/src/processor/mod.rs
@@ -8,7 +8,7 @@ use miden_core::{
 };
 
 use crate::{
-    AdviceError, ContextId, ExecutionError, Host, MemoryError, ProcessState,
+    AdviceError, ContextId, ExecutionError, Host, MemoryError,
     errors::{AceEvalError, OperationError},
     fast::Tracer,
     processor::operations::execute_sync_op,
@@ -34,9 +34,6 @@ pub trait Processor: Sized {
 
     /// Returns a mutable reference to the internal system.
     fn system(&mut self) -> &mut Self::System;
-
-    /// Returns a [ProcessState] referring to the current process state.
-    fn state(&mut self) -> ProcessState<'_>;
 
     /// Returns a mutable reference to the internal advice provider.
     fn advice_provider(&mut self) -> &mut Self::AdviceProvider;

--- a/processor/src/processor/operations/mod.rs
+++ b/processor/src/processor/operations/mod.rs
@@ -50,7 +50,7 @@ pub(super) fn execute_sync_op(
             // do nothing
         },
         Operation::Assert(err_code) => {
-            sys_ops::op_assert(processor, *err_code, host, current_forest, tracer)
+            sys_ops::op_assert(processor, *err_code, current_forest, tracer)
                 .map_exec_err_with_op_idx(current_forest, node_id, host, op_idx)?
         },
         Operation::SDepth => sys_ops::op_sdepth(processor, tracer)?,

--- a/processor/src/processor/operations/sys_ops.rs
+++ b/processor/src/processor/operations/sys_ops.rs
@@ -1,7 +1,7 @@
 use miden_core::{Felt, ONE, field::PrimeCharacteristicRing, mast::MastForest};
 
 use crate::{
-    ExecutionError, Host,
+    ExecutionError,
     errors::OperationError,
     fast::Tracer,
     processor::{Processor, StackInterface, SystemInterface},
@@ -18,16 +18,10 @@ mod tests;
 pub(super) fn op_assert<P: Processor>(
     processor: &mut P,
     err_code: Felt,
-    host: &mut impl Host,
     program: &MastForest,
     tracer: &mut impl Tracer,
 ) -> Result<(), OperationError> {
     if processor.stack().get(0) != ONE {
-        let process = &mut processor.state();
-        // Notify host of assertion failure for side effects only (logging, debugging, telemetry).
-        // The return value is intentionally ignored because the host callback is for observation,
-        // not for modifying the error. The error message comes from the program's error table.
-        let _ = host.on_assert_failed(process, err_code);
         let err_msg = program.resolve_error_message(err_code);
         return Err(OperationError::FailedAssertion { err_code, err_msg });
     }

--- a/processor/src/processor/operations/sys_ops/tests.rs
+++ b/processor/src/processor/operations/sys_ops/tests.rs
@@ -4,7 +4,6 @@ use miden_core::{Felt, ONE, ZERO, mast::MastForest, stack::MIN_STACK_DEPTH};
 
 use super::{op_assert, op_clk, op_sdepth};
 use crate::{
-    DefaultHost,
     fast::{FastProcessor, NoopTracer, step::NeverStopper},
     processor::{Processor, StackInterface, operations::stack_ops::op_push},
 };
@@ -14,14 +13,13 @@ use crate::{
 
 #[test]
 fn test_op_assert() {
-    let mut host = DefaultHost::default();
     let program = MastForest::default();
     let mut tracer = NoopTracer;
 
     // Calling assert with a minimum stack should be ok, as long as the top value is ONE.
     let mut processor = FastProcessor::new(&[ONE]);
 
-    assert!(op_assert(&mut processor, ZERO, &mut host, &program, &mut tracer).is_ok());
+    assert!(op_assert(&mut processor, ZERO, &program, &mut tracer).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Resolves https://github.com/0xMiden/miden-vm/issues/2540.

It is a first step through solving the https://github.com/0xMiden/compiler/issues/806 -- enabling source location being printed when `assert!` is triggered.
