### PR TITLE
fix(assembly-syntax): properly handle quoted path components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.20.4 (Unreleased)
+
+- Fixed issue with handling of quoted components in `PathBuf` [#2618](https://github.com/0xMiden/miden-vm/pull/2618)
+
 ## 0.20.3 (2026-01-27)
 
 - Fixed issue where exports of a Library did not have attributes serialized [#2608](https://github.com/0xMiden/miden-vm/issues/2608)

--- a/crates/assembly-syntax/src/ast/path/path.rs
+++ b/crates/assembly-syntax/src/ast/path/path.rs
@@ -142,7 +142,7 @@ impl Path {
     /// Verify that `path` meets all the requirements for a valid [Path]
     pub fn validate(path: &str) -> Result<&Path, PathError> {
         match path {
-            "" => return Err(PathError::Empty),
+            "" | "\"\"" => return Err(PathError::Empty),
             "::" => return Err(PathError::EmptyComponent),
             _ => (),
         }
@@ -202,7 +202,7 @@ impl Path {
 impl Path {
     /// Returns true if this path is empty (i.e. has no components)
     pub fn is_empty(&self) -> bool {
-        self.inner.is_empty() || &self.inner == "::"
+        matches!(&self.inner, "" | "::" | "\"\"")
     }
 
     /// Returns the number of components in the path


### PR DESCRIPTION
This is based against `main` because it is a hotfix for known issues in the current release. It is a non-breaking change, so is safe to release.

/cc @greenhat 

---


Prior to this commit, when constructing PathBufs from a string containing quoted components would improperly strip the quotes from those components, which would result in later iteration over components of that path treating that part of the path as unquoted. For example, given the following path string:

`root:root_ns@1.0.0::module::"function::with::quoted::symbol_name"`

Constructing a PathBuf from this string would succeed as expected, but would encode the path internally as if it had been passed as:

`root:root_ns@1.0.0::module::function::with::quoted::symbol_name`

If we later iterate over components of the path, the part that should have been treated as a single component, i.e.
`"function::with::quoted::symbol_name`, would instead be treated as multiple components, e.g. `function`, `with`, `quoted`, and `symbol_name`.

This commit changes how we handle quoted components in the Components iterator, so that the quotes are preserved.

Additionally, a new `PathBuf::push_component` method was added, which allows one to explicitly push a string as a quoted component, ensuring the component is quoted if not already.

A regression test was added that covers the case where this was discovered, and further ensures that constructing a PathBuf from a single string, or building it up via `push_component` produce identical results.

A related issue was also identified and fixed, namely that internally the Components iterator was not consuming trailing/leading path separators after parsing a quoted component, causing unexpected results  when using `Components::as_path`. This has been fixed, making the behavior consistent across both quoted and unquoted identifiers.