### PR TITLE
feat: tighten up MastForest serialization with varints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 - Added `StackInterface::get_double_word()` method for reading 8 consecutive stack elements ([#2607](https://github.com/0xMiden/miden-vm/pull/2607)).
 - Added error messages to asserts in the standard library ([#2650](https://github.com/0xMiden/miden-vm/pull/2650))
 - Optimized `ExecutionTracer` to avoid cloning `Vec<OpBatch>` on every basic block entry. ([#2664](https://github.com/0xMiden/miden-vm/pull/2664))
+- Adds error messages to asserts in the standard library ([#2650](https://github.com/0xMiden/miden-vm/pull/2650))
+- Improved serialized size of the MastForest ([#2623](https://github.com/0xMiden/miden-vm/pull/2623))
 
 #### Fixes
 

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -5,12 +5,13 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 use super::{MastForestContributor, MastNodeExt};
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     chiplets::hasher,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNode, MastNodeFingerprint,
-        MastNodeId,
+        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
     },
     operations::OPCODE_JOIN,
     prettier::PrettyPrint,

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -5,12 +5,13 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 use super::{MastForestContributor, MastNodeExt};
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     chiplets::hasher,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNode, MastNodeFingerprint,
-        MastNodeId,
+        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
     },
     operations::OPCODE_LOOP,
     prettier::PrettyPrint,

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -5,12 +5,13 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 use super::{MastForestContributor, MastNodeExt};
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     chiplets::hasher,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNode, MastNodeFingerprint,
-        MastNodeId,
+        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
     },
     operations::OPCODE_SPLIT,
     prettier::PrettyPrint,

--- a/core/src/mast/serialization/asm_op.rs
+++ b/core/src/mast/serialization/asm_op.rs
@@ -42,8 +42,8 @@ pub type AsmOpDataOffset = u32;
 /// has_location: u8 (0 or 1)
 /// [if has_location]:
 ///     uri_idx: u32 varint (index into string table)
-///     start: u32
-///     end: u32
+///     start: u32 varint
+///     end: u32 varint
 /// context_name_idx: u32 varint (index into string table)
 /// op_idx: u32 varint (index into string table)
 /// ```
@@ -77,8 +77,8 @@ impl AsmOpInfo {
         let location = if reader.read_bool()? {
             let uri_idx = read_u32_varint(&mut reader)? as usize;
             let uri = string_table.read_arc_str(uri_idx).map(Uri::from)?;
-            let start = reader.read_u32()?;
-            let end = reader.read_u32()?;
+            let start = read_u32_varint(&mut reader)?;
+            let end = read_u32_varint(&mut reader)?;
             Some(Location::new(uri, ByteIndex::new(start), ByteIndex::new(end)))
         } else {
             None
@@ -151,8 +151,8 @@ impl AsmOpDataBuilder {
             self.asm_op_data.write_bool(true); // has_location = true
             let uri_idx = self.string_table_builder.add_string(location.uri.as_str());
             write_u32_varint(&mut self.asm_op_data, uri_idx);
-            self.asm_op_data.write_u32(location.start.to_u32());
-            self.asm_op_data.write_u32(location.end.to_u32());
+            write_u32_varint(&mut self.asm_op_data, location.start.to_u32() as usize);
+            write_u32_varint(&mut self.asm_op_data, location.end.to_u32() as usize);
         } else {
             self.asm_op_data.write_bool(false); // has_location = false
         }

--- a/core/src/mast/serialization/asm_op.rs
+++ b/core/src/mast/serialization/asm_op.rs
@@ -102,6 +102,11 @@ impl Deserializable for AsmOpInfo {
         let data_offset = read_u32_varint(source)?;
         Ok(Self { data_offset })
     }
+
+    /// Returns the minimum serialized size: 1 byte varint offset.
+    fn min_serialized_size() -> usize {
+        1
+    }
 }
 
 fn read_u32_varint<R: ByteReader>(source: &mut R) -> Result<u32, DeserializationError> {

--- a/core/src/mast/serialization/asm_op.rs
+++ b/core/src/mast/serialization/asm_op.rs
@@ -13,7 +13,10 @@ use alloc::vec::Vec;
 
 use miden_debug_types::{ByteIndex, Location, Uri};
 
-use super::string_table::{StringTable, StringTableBuilder};
+use super::{
+    read_u32_varint,
+    string_table::{StringTable, StringTableBuilder},
+};
 use crate::{
     operations::AssemblyOp,
     serde::{
@@ -107,15 +110,6 @@ impl Deserializable for AsmOpInfo {
     fn min_serialized_size() -> usize {
         1
     }
-}
-
-fn read_u32_varint<R: ByteReader>(source: &mut R) -> Result<u32, DeserializationError> {
-    let value = source.read_usize()?;
-    value.try_into().map_err(|_| {
-        DeserializationError::InvalidValue(format!(
-            "Invalid value: expected to fit in u32, but was {value}"
-        ))
-    })
 }
 
 // ASM OP DATA BUILDER

--- a/core/src/mast/serialization/decorator.rs
+++ b/core/src/mast/serialization/decorator.rs
@@ -6,7 +6,7 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use proptest_derive::Arbitrary;
 
 use super::{
-    DecoratorDataOffset,
+    DecoratorDataOffset, read_u32_varint,
     string_table::{StringTable, StringTableBuilder},
 };
 use crate::{
@@ -188,15 +188,6 @@ impl Deserializable for EncodedDecoratorVariant {
     fn min_serialized_size() -> usize {
         1
     }
-}
-
-fn read_u32_varint<R: ByteReader>(source: &mut R) -> Result<u32, DeserializationError> {
-    let value = source.read_usize()?;
-    value.try_into().map_err(|_| {
-        DeserializationError::InvalidValue(format!(
-            "Invalid value: expected to fit in u32, but was {value}"
-        ))
-    })
 }
 
 // DECORATOR DATA BUILDER

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use super::{NodeDataOffset, basic_blocks::BasicBlockDataDecoder};
+use super::{NodeDataOffset, basic_blocks::BasicBlockDataDecoder, read_u32_varint};
 use crate::{
     mast::{
         MastForestContributor, MastNode, MastNodeId, Word,
@@ -298,15 +298,6 @@ impl Deserializable for MastNodeType {
     fn min_serialized_size() -> usize {
         1
     }
-}
-
-fn read_u32_varint<R: ByteReader>(source: &mut R) -> Result<u32, DeserializationError> {
-    let value = source.read_usize()?;
-    value.try_into().map_err(|_| {
-        DeserializationError::InvalidValue(format!(
-            "Invalid value: expected to fit in u32, but was {value}"
-        ))
-    })
 }
 
 #[cfg(test)]

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -117,6 +117,18 @@ const FLAGS_RESERVED_MASK: u8 = 0xfe;
 ///   Removed `breakpoint` instruction (#2655).
 const VERSION: [u8; 3] = [0, 0, 2];
 
+// SHARED SERIALIZATION HELPERS
+// ================================================================================================
+
+fn read_u32_varint<R: ByteReader>(source: &mut R) -> Result<u32, DeserializationError> {
+    let value = source.read_usize()?;
+    value.try_into().map_err(|_| {
+        DeserializationError::InvalidValue(format!(
+            "Invalid value: expected to fit in u32, but was {value}"
+        ))
+    })
+}
+
 // MAST FOREST SERIALIZATION/DESERIALIZATION
 // ================================================================================================
 

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -558,14 +558,20 @@ fn mast_forest_deserialize_invalid_ops_offset_fails() {
     let _: [u8; 8] = reader.read_array().unwrap(); // magic (4) + flags (1) + version (3)
     let _node_count: usize = reader.read().unwrap();
     let _decorator_count: usize = reader.read().unwrap();
-    let _roots: Vec<u32> = Deserializable::read_from(&mut reader).unwrap();
+    let roots_len: usize = reader.read().unwrap();
+    for _ in 0..roots_len {
+        let _: usize = reader.read().unwrap();
+    }
     let basic_block_data: Vec<u8> = Deserializable::read_from(&mut reader).unwrap();
 
     let mut counter = CountingReader::new(&serialized);
     let _header: [u8; 8] = counter.read_array().unwrap();
     let _node_count: usize = counter.read().unwrap();
     let _decorator_count: usize = counter.read().unwrap();
-    let _roots: Vec<u32> = Deserializable::read_from(&mut counter).unwrap();
+    let roots_len: usize = counter.read().unwrap();
+    for _ in 0..roots_len {
+        let _: usize = counter.read().unwrap();
+    }
     let _bb_data: Vec<u8> = Deserializable::read_from(&mut counter).unwrap();
     let node_info_offset = counter.position();
 
@@ -1526,14 +1532,18 @@ fn test_untrusted_forest_detects_hash_mismatch() {
     let bytes = forest.to_bytes();
 
     // Corrupt the digest of the node by modifying bytes in the node info section
-    // Format: magic (4) + flags (1) + version (3) + node_count (8) + decorator_count (8) +
-    //         roots_len (8) + 1 root (4) + bb_data_len (8) + bb_data + node_info
+    // Format: magic (4) + flags (1) + version (3) + node_count (varint)
+    //         + decorator_count (varint) + roots_len (varint) + 1 root (varint)
+    //         + bb_data_len (varint) + bb_data + node_info
     //
     let mut counter = CountingReader::new(&bytes);
     let _header: [u8; 8] = counter.read_array().unwrap();
     let _node_count: usize = counter.read().unwrap();
     let _decorator_count: usize = counter.read().unwrap();
-    let _roots: Vec<u32> = Deserializable::read_from(&mut counter).unwrap();
+    let roots_len: usize = counter.read().unwrap();
+    for _ in 0..roots_len {
+        let _: usize = counter.read().unwrap();
+    }
     let _bb_data: Vec<u8> = Deserializable::read_from(&mut counter).unwrap();
     let node_info_offset = counter.position();
 

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -21,6 +21,10 @@ doctest = false
 name = "compilation"
 harness = false
 
+[[bench]]
+name = "mast_serialization_size"
+harness = false
+
 [[test]]
 name = "core-lib"
 path = "tests/main.rs"

--- a/crates/lib/core/benches/mast_serialization_size.rs
+++ b/crates/lib/core/benches/mast_serialization_size.rs
@@ -1,0 +1,36 @@
+use std::{hint::black_box, path::Path, time::Duration};
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use miden_assembly::{Assembler, PathBuf as LibraryPath, serde::Serializable};
+
+fn mast_serialization_size(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mast_serialize_core_lib");
+    group.measurement_time(Duration::from_secs(10));
+
+    // Assemble the entire core library once and reuse it across iterations.
+    let assembler = Assembler::default();
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let asm_dir = Path::new(manifest_dir).join("asm");
+    let namespace = LibraryPath::new("::miden::core").expect("invalid base namespace");
+    let library = assembler.assemble_library_from_dir(asm_dir, namespace).unwrap();
+    let mast_forest = library.mast_forest();
+
+    // Measure the serialized size once for reporting/throughput configuration.
+    let initial_bytes = mast_forest.to_bytes();
+    let initial_size = initial_bytes.len() as u64;
+    group.throughput(Throughput::Bytes(initial_size));
+
+    eprintln!("core-lib MastForest serialized size (bytes): {}", initial_size);
+
+    group.bench_function("full", |bench| {
+        bench.iter(|| {
+            let bytes = mast_forest.to_bytes();
+            black_box(bytes.len());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(mast_serialization_size_group, mast_serialization_size);
+criterion_main!(mast_serialization_size_group);

--- a/crates/lib/core/benches/mast_serialization_size.rs
+++ b/crates/lib/core/benches/mast_serialization_size.rs
@@ -15,16 +15,31 @@ fn mast_serialization_size(c: &mut Criterion) {
     let library = assembler.assemble_library_from_dir(asm_dir, namespace).unwrap();
     let mast_forest = library.mast_forest();
 
-    // Measure the serialized size once for reporting/throughput configuration.
-    let initial_bytes = mast_forest.to_bytes();
-    let initial_size = initial_bytes.len() as u64;
-    group.throughput(Throughput::Bytes(initial_size));
+    // Measure serialized size once for reporting/throughput configuration.
+    let full_bytes = mast_forest.to_bytes();
+    let full_size = full_bytes.len() as u64;
+    let mut stripped_bytes = Vec::new();
+    mast_forest.write_stripped(&mut stripped_bytes);
+    let stripped_size = stripped_bytes.len() as u64;
 
-    eprintln!("core-lib MastForest serialized size (bytes): {}", initial_size);
+    eprintln!(
+        "core-lib MastForest serialized size (bytes): full={}, stripped={}",
+        full_size, stripped_size
+    );
 
+    group.throughput(Throughput::Bytes(full_size));
     group.bench_function("full", |bench| {
         bench.iter(|| {
             let bytes = mast_forest.to_bytes();
+            black_box(bytes.len());
+        });
+    });
+
+    group.throughput(Throughput::Bytes(stripped_size));
+    group.bench_function("stripped", |bench| {
+        bench.iter(|| {
+            let mut bytes = Vec::new();
+            mast_forest.write_stripped(&mut bytes);
             black_box(bytes.len());
         });
     });


### PR DESCRIPTION
- Add a benchmark that measures the serialized size of the core library MastForest. The benchmark may be of independent interest to measure the impact of the `MastNode` hashes.
- Make MastForest serialization smaller by using compact tags and varint indices/offsets where we store node types, block batch counts, asm op payload offsets, asm op string table indices, asm op locations, decorator data offsets, and procedure roots.
- Keep byte-cost comments in sync with the wire format.

Contributes to #1873

<details><summary>Changes</summary>

- New bench for core lib MastForest serialized size.
- MastNodeType uses a compact tag plus varint payloads.
- Basic block batch count uses a varint.
- AsmOpInfo and asm op payload use varint offsets and indices, including location start/end.
- DecoratorInfo uses a varint offset for decorator data.
- Procedure roots are serialized as a length prefix plus varint u32s.
</details>

## Bench Results
Run: `cargo bench -p miden-core-lib --bench mast_serialization_size -- --nocapture`

Before (8654d7815):
- Full size: 434,065 bytes
- Full time: 2.2229–2.3210 ms
- Full throughput: 178.35–186.23 MiB/s

After (ced394e40):
- Full size: 406,088 bytes
- Full time: 2.1967–2.2708 ms
- Full throughput: 170.55–176.30 MiB/s
- Stripped size: 275,653 bytes
- Stripped time: 640.23–709.10 µs
- Stripped throughput: 370.73–410.61 MiB/s


## Notes
- No backwards compatibility is preserved for these format changes. AIming to piggy-back on the serialization version bump of #2606.
