### PR TITLE
Profile-powered synthetic tx benchmarks (2/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added constants support as an immediate value of the repeat statement ([#2548](https://github.com/0xMiden/miden-vm/pull/2548)).
 - Add deserialization of the `MastForest` from untrusted sources. Add fuzzing for MastForest deserialization. ([#2590](https://github.com/0xMiden/miden-vm/pull/2590)).
 - Added `StackInterface::get_double_word()` method for reading 8 consecutive stack elements ([#2607](https://github.com/0xMiden/miden-vm/pull/2607)).
+- Added synthetic transaction kernel benchmarks driven by VM profile snapshots from miden-base ([#2638](https://github.com/0xMiden/miden-vm/pull/2638)).
 
 #### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +389,34 @@ dependencies = [
 
 [[package]]
 name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot 0.5.0",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
@@ -391,7 +425,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
+ "criterion-plot 0.6.0",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -403,6 +437,16 @@ dependencies = [
  "tinytemplate",
  "tokio",
  "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -936,6 +980,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -997,10 +1047,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1251,7 +1321,7 @@ dependencies = [
 name = "miden-core"
 version = "0.21.0"
 dependencies = [
- "criterion",
+ "criterion 0.7.0",
  "derive_more",
  "insta",
  "itertools 0.14.0",
@@ -1277,7 +1347,8 @@ dependencies = [
 name = "miden-core-lib"
 version = "0.21.0"
 dependencies = [
- "criterion",
+ "blake3",
+ "criterion 0.7.0",
  "env_logger",
  "fs-err",
  "miden-air",
@@ -1570,7 +1641,7 @@ dependencies = [
  "assert_cmd",
  "bincode",
  "clap",
- "criterion",
+ "criterion 0.7.0",
  "escargot",
  "hex",
  "miden-assembly",
@@ -2809,6 +2880,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synthetic-tx-kernel"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "criterion 0.5.1",
+ "miden-core",
+ "miden-core-lib",
+ "miden-processor",
+ "miden-vm",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1347,7 +1347,6 @@ dependencies = [
 name = "miden-core-lib"
 version = "0.21.0"
 dependencies = [
- "blake3",
  "criterion 0.7.0",
  "env_logger",
  "fs-err",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "air",
+    "benches/synthetic-tx-kernel",
     "core",
     "crates/assembly",
     "crates/assembly-syntax",

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ build: ## Builds with default parameters
 
 .PHONY: build-no-std
 build-no-std: ## Builds without the standard library
-	$(BUILDDOCS) cargo build --no-default-features --target wasm32-unknown-unknown --workspace
+	$(BUILDDOCS) cargo build --no-default-features --target wasm32-unknown-unknown --workspace --exclude synthetic-tx-kernel
 
 # --- executable ----------------------------------------------------------------------------------
 

--- a/benches/synthetic-tx-kernel/Cargo.toml
+++ b/benches/synthetic-tx-kernel/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 miden-vm = { path = "../../miden-vm" }
 miden-core = { path = "../../core" }
 miden-processor = { path = "../../processor" }
-miden-stdlib = { path = "../../stdlib" }
 miden-core-lib = { path = "../../crates/lib/core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/benches/synthetic-tx-kernel/Cargo.toml
+++ b/benches/synthetic-tx-kernel/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 miden-vm = { path = "../../miden-vm" }
 miden-core = { path = "../../core" }
-miden-processor = { path = "../../processor" }
+miden-processor = { path = "../../processor", default-features = false, features = ["concurrent"] }
 miden-core-lib = { path = "../../crates/lib/core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/benches/synthetic-tx-kernel/Cargo.toml
+++ b/benches/synthetic-tx-kernel/Cargo.toml
@@ -2,6 +2,7 @@
 name = "synthetic-tx-kernel"
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
 
 [dependencies]
 miden-vm = { path = "../../miden-vm" }

--- a/benches/synthetic-tx-kernel/Cargo.toml
+++ b/benches/synthetic-tx-kernel/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "synthetic-tx-kernel"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+miden-vm = { path = "../../miden-vm" }
+miden-core = { path = "../../core" }
+miden-processor = { path = "../../processor" }
+miden-stdlib = { path = "../../stdlib" }
+miden-core-lib = { path = "../../crates/lib/core" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1.0"
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["async_tokio"] }
+tokio = { version = "1.0", features = ["rt-multi-thread"] }
+
+[[bench]]
+name = "component_benchmarks"
+harness = false
+
+[[bench]]
+name = "synthetic_kernel"
+harness = false

--- a/benches/synthetic-tx-kernel/README.md
+++ b/benches/synthetic-tx-kernel/README.md
@@ -1,0 +1,84 @@
+# Synthetic Transaction Kernel Benchmarks
+
+This crate generates synthetic benchmarks that mirror the transaction kernel from miden-base,
+enabling fast feedback for VM developers without requiring the full miden-base dependency.
+
+## Overview
+
+The benchmark system works by:
+
+1. **Profile Export** (in miden-base): The transaction kernel benchmark exports a VM profile
+describing its instruction mix, operation counts, and cycle breakdown.
+
+2. **Profile Consumption** (in miden-vm): This crate reads the profile and generates Miden
+assembly code that replicates the same workload characteristics.
+
+3. **Benchmark Execution**: Criterion.rs runs the generated benchmarks for statistical rigor.
+
+## Usage
+
+### Running Benchmarks
+
+```bash
+# Run component benchmarks (isolated operations)
+cargo bench -p synthetic-tx-kernel --bench component_benchmarks
+
+# Run synthetic kernel benchmark (representative workload)
+cargo bench -p synthetic-tx-kernel --bench synthetic_kernel
+```
+
+### Updating the Profile
+
+When the transaction kernel in miden-base changes:
+
+1. Run benchmarks in miden-base:
+```bash
+cd /path/to/miden-base
+cargo run --bin bench-transaction --features concurrent
+```
+
+2. Copy the generated profile:
+```bash
+cp bench-tx-vm-profile.json /path/to/miden-vm/benches/synthetic-tx-kernel/profiles/
+```
+
+3. Update the symlink:
+```bash
+cd /path/to/miden-vm/benches/synthetic-tx-kernel/profiles
+ln -sf bench-tx-vm-profile.json latest.json
+```
+
+4. Commit the new profile in miden-vm.
+
+## Profile Format
+
+Profiles are JSON files with the following structure:
+
+```json
+{
+  "profile_version": "1.0",
+  "source": "miden-base/bin/bench-transaction",
+  "timestamp": "2025-01-31T...",
+  "miden_vm_version": "0.20.0",
+  "transaction_kernel": {
+    "total_cycles": 73123,
+    "phases": { ... },
+    "instruction_mix": {
+      "arithmetic": 0.05,
+      "hashing": 0.45,
+      "memory": 0.08,
+      "control_flow": 0.05,
+      "signature_verify": 0.37
+    }
+  }
+}
+```
+
+## Architecture
+
+- `src/profile.rs`: Profile data structures
+- `src/generator.rs`: MASM code generation from profiles
+- `src/validator.rs`: Profile validation and comparison
+- `benches/component_benchmarks.rs`: Isolated operation benchmarks
+- `benches/synthetic_kernel.rs`: Representative workload benchmark
+- `profiles/`: Checked-in VM profiles from miden-base

--- a/benches/synthetic-tx-kernel/README.md
+++ b/benches/synthetic-tx-kernel/README.md
@@ -37,18 +37,12 @@ cd /path/to/miden-base
 cargo run --bin bench-transaction --features concurrent
 ```
 
-2. Copy the generated profile:
+2. Copy the generated profile to `latest.json`:
 ```bash
-cp bench-tx-vm-profile.json /path/to/miden-vm/benches/synthetic-tx-kernel/profiles/
+cp bench-tx-vm-profile.json /path/to/miden-vm/benches/synthetic-tx-kernel/profiles/latest.json
 ```
 
-3. Update the symlink:
-```bash
-cd /path/to/miden-vm/benches/synthetic-tx-kernel/profiles
-ln -sf bench-tx-vm-profile.json latest.json
-```
-
-4. Commit the new profile in miden-vm.
+3. Commit the updated profile in miden-vm.
 
 ## Profile Format
 

--- a/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
+++ b/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
@@ -1,19 +1,32 @@
 //! Component-level benchmarks for individual operations
 
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use miden_core::{Felt, Word};
+use miden_core_lib::{CoreLibrary, dsa::falcon512_poseidon2};
 use miden_processor::fast::FastProcessor;
+use miden_processor::AdviceInputs;
 use miden_vm::{Assembler, DefaultHost, StackInputs};
 use synthetic_tx_kernel::{generator::MasmGenerator, load_profile};
 
 /// Helper function to execute a benchmark with the given program
-fn bench_program(b: &mut criterion::Bencher, program: &miden_vm::Program) {
+fn bench_program(
+    b: &mut criterion::Bencher,
+    program: &miden_vm::Program,
+    stack_inputs: StackInputs,
+    advice_inputs: AdviceInputs,
+    load_core_lib: bool,
+) {
     b.to_async(tokio::runtime::Runtime::new().expect("Failed to create tokio runtime"))
         .iter_batched(
             || {
-                let host = DefaultHost::default();
+                let mut host = DefaultHost::default();
+                if load_core_lib {
+                    host.load_library(&CoreLibrary::default())
+                        .expect("Failed to load core library");
+                }
                 let processor = FastProcessor::new_with_advice_inputs(
-                    StackInputs::default(),
-                    miden_processor::AdviceInputs::default(),
+                    stack_inputs,
+                    advice_inputs.clone(),
                 );
                 (host, processor)
             },
@@ -38,8 +51,30 @@ fn benchmark_signature_verification(c: &mut Criterion) {
             .generate_component_benchmark("falcon512_verify", 1)
             .expect("Failed to generate benchmark");
 
-        let program = Assembler::default().assemble_program(&source).expect("Failed to assemble");
-        bench_program(b, &program);
+        let program = Assembler::default()
+            .with_dynamic_library(CoreLibrary::default())
+            .expect("Failed to load core library")
+            .assemble_program(&source)
+            .expect("Failed to assemble");
+
+        let secret_key = falcon512_poseidon2::SecretKey::new();
+        let message = Word::new([
+            Felt::new(1),
+            Felt::new(2),
+            Felt::new(3),
+            Felt::new(4),
+        ]);
+        let public_key = secret_key.public_key().to_commitment();
+        let signature = falcon512_poseidon2::sign(&secret_key, message)
+            .expect("Failed to generate signature");
+
+        let mut stack = Vec::with_capacity(8);
+        stack.extend_from_slice(&public_key);
+        stack.extend_from_slice(&message);
+        let stack_inputs = StackInputs::new(&stack).expect("Failed to build stack inputs");
+        let advice_inputs = AdviceInputs::default().with_stack(signature);
+
+        bench_program(b, &program, stack_inputs, advice_inputs, true);
     });
 
     group.finish();
@@ -58,7 +93,13 @@ fn benchmark_hashing(c: &mut Criterion) {
         "#;
 
         let program = Assembler::default().assemble_program(source).expect("Failed to assemble");
-        bench_program(b, &program);
+        bench_program(
+            b,
+            &program,
+            StackInputs::default(),
+            AdviceInputs::default(),
+            false,
+        );
     });
 
     group.finish();
@@ -79,7 +120,13 @@ fn benchmark_memory_operations(c: &mut Criterion) {
         "#;
 
         let program = Assembler::default().assemble_program(source).expect("Failed to assemble");
-        bench_program(b, &program);
+        bench_program(
+            b,
+            &program,
+            StackInputs::default(),
+            AdviceInputs::default(),
+            false,
+        );
     });
 
     group.finish();

--- a/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
+++ b/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
@@ -1,42 +1,44 @@
 //! Component-level benchmarks for individual operations
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BatchSize};
-use miden_vm::{Assembler, DefaultHost, StackInputs};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use miden_processor::fast::FastProcessor;
-use miden_core_lib::CoreLibrary;
-use synthetic_tx_kernel::{load_profile, generator::MasmGenerator};
+use miden_vm::{Assembler, DefaultHost, StackInputs};
+use synthetic_tx_kernel::{generator::MasmGenerator, load_profile};
+
+/// Helper function to execute a benchmark with the given program
+fn bench_program(b: &mut criterion::Bencher, program: miden_vm::Program) {
+    b.to_async(tokio::runtime::Runtime::new().unwrap()).iter_batched(
+        || {
+            let host = DefaultHost::default();
+            let processor = FastProcessor::new_with_advice_inputs(
+                StackInputs::default(),
+                miden_processor::AdviceInputs::default(),
+            );
+            (host, processor)
+        },
+        |(mut host, processor)| async move {
+            black_box(processor.execute(&program, &mut host).await.unwrap());
+        },
+        BatchSize::SmallInput,
+    );
+}
 
 fn benchmark_signature_verification(c: &mut Criterion) {
     let mut group = c.benchmark_group("signature_verification");
 
-    // Load profile to get realistic iteration counts
-    let profile = load_profile("profiles/latest.json").expect("Failed to load profile");
+    // Load profile for signature verification benchmark
+    let profile_path = format!("{}/profiles/latest.json", env!("CARGO_MANIFEST_DIR"));
+    let profile = load_profile(&profile_path).expect("Failed to load profile");
     let generator = MasmGenerator::new(profile);
 
     // Falcon512 verification benchmark
     group.bench_function("falcon512_verify", |b| {
-        let source = generator.generate_component_benchmark("falcon512_verify", 1)
+        let source = generator
+            .generate_component_benchmark("falcon512_verify", 1)
             .expect("Failed to generate benchmark");
 
-        let program = Assembler::default()
-            .assemble_program(&source)
-            .expect("Failed to assemble");
-
-        b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter_batched(
-                || {
-                    let host = DefaultHost::default();
-                    let processor = FastProcessor::new(
-                        StackInputs::default(),
-                        miden_processor::AdviceInputs::default(),
-                    );
-                    (host, program.clone(), processor)
-                },
-                |(mut host, program, processor)| async move {
-                    black_box(processor.execute(&program, &mut host).await.unwrap());
-                },
-                BatchSize::SmallInput,
-            );
+        let program = Assembler::default().assemble_program(&source).expect("Failed to assemble");
+        bench_program(b, program);
     });
 
     group.finish();
@@ -56,25 +58,8 @@ fn benchmark_hashing(c: &mut Criterion) {
             end
         "#;
 
-        let program = Assembler::default()
-            .assemble_program(source)
-            .expect("Failed to assemble");
-
-        b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter_batched(
-                || {
-                    let host = DefaultHost::default();
-                    let processor = FastProcessor::new(
-                        StackInputs::default(),
-                        miden_processor::AdviceInputs::default(),
-                    );
-                    (host, program.clone(), processor)
-                },
-                |(mut host, program, processor)| async move {
-                    black_box(processor.execute(&program, &mut host).await.unwrap());
-                },
-                BatchSize::SmallInput,
-            );
+        let program = Assembler::default().assemble_program(source).expect("Failed to assemble");
+        bench_program(b, program);
     });
 
     group.finish();
@@ -96,25 +81,8 @@ fn benchmark_memory_operations(c: &mut Criterion) {
             end
         "#;
 
-        let program = Assembler::default()
-            .assemble_program(source)
-            .expect("Failed to assemble");
-
-        b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter_batched(
-                || {
-                    let host = DefaultHost::default();
-                    let processor = FastProcessor::new(
-                        StackInputs::default(),
-                        miden_processor::AdviceInputs::default(),
-                    );
-                    (host, program.clone(), processor)
-                },
-                |(mut host, program, processor)| async move {
-                    black_box(processor.execute(&program, &mut host).await.unwrap());
-                },
-                BatchSize::SmallInput,
-            );
+        let program = Assembler::default().assemble_program(source).expect("Failed to assemble");
+        bench_program(b, program);
     });
 
     group.finish();

--- a/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
+++ b/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
@@ -3,7 +3,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use miden_core::{Felt, Word};
 use miden_core_lib::{dsa::falcon512_poseidon2, CoreLibrary};
-use miden_processor::{fast::FastProcessor, AdviceInputs};
+use miden_processor::{advice::AdviceInputs, fast::FastProcessor};
 use miden_vm::{Assembler, DefaultHost, StackInputs};
 
 /// Helper function to execute a benchmark with the given program

--- a/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
+++ b/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
@@ -3,8 +3,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use miden_core::{Felt, Word};
 use miden_core_lib::{dsa::falcon512_poseidon2, CoreLibrary};
-use miden_processor::fast::FastProcessor;
-use miden_processor::AdviceInputs;
+use miden_processor::{fast::FastProcessor, AdviceInputs};
 use miden_vm::{Assembler, DefaultHost, StackInputs};
 
 /// Helper function to execute a benchmark with the given program

--- a/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
+++ b/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
@@ -1,0 +1,129 @@
+//! Component-level benchmarks for individual operations
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, BatchSize};
+use miden_vm::{Assembler, DefaultHost, StackInputs};
+use miden_processor::fast::FastProcessor;
+use miden_core_lib::CoreLibrary;
+use synthetic_tx_kernel::{load_profile, generator::MasmGenerator};
+
+fn benchmark_signature_verification(c: &mut Criterion) {
+    let mut group = c.benchmark_group("signature_verification");
+
+    // Load profile to get realistic iteration counts
+    let profile = load_profile("profiles/latest.json").expect("Failed to load profile");
+    let generator = MasmGenerator::new(profile);
+
+    // Falcon512 verification benchmark
+    group.bench_function("falcon512_verify", |b| {
+        let source = generator.generate_component_benchmark("falcon512_verify", 1)
+            .expect("Failed to generate benchmark");
+
+        let program = Assembler::default()
+            .assemble_program(&source)
+            .expect("Failed to assemble");
+
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || {
+                    let host = DefaultHost::default();
+                    let processor = FastProcessor::new(
+                        StackInputs::default(),
+                        miden_processor::AdviceInputs::default(),
+                    );
+                    (host, program.clone(), processor)
+                },
+                |(mut host, program, processor)| async move {
+                    black_box(processor.execute(&program, &mut host).await.unwrap());
+                },
+                BatchSize::SmallInput,
+            );
+    });
+
+    group.finish();
+}
+
+fn benchmark_hashing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hashing");
+
+    group.bench_function("hperm", |b| {
+        let source = r#"
+            use.miden::core::sys
+            begin
+                repeat.100
+                    hperm
+                end
+                exec.sys::truncate_stack
+            end
+        "#;
+
+        let program = Assembler::default()
+            .assemble_program(source)
+            .expect("Failed to assemble");
+
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || {
+                    let host = DefaultHost::default();
+                    let processor = FastProcessor::new(
+                        StackInputs::default(),
+                        miden_processor::AdviceInputs::default(),
+                    );
+                    (host, program.clone(), processor)
+                },
+                |(mut host, program, processor)| async move {
+                    black_box(processor.execute(&program, &mut host).await.unwrap());
+                },
+                BatchSize::SmallInput,
+            );
+    });
+
+    group.finish();
+}
+
+fn benchmark_memory_operations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("memory_operations");
+
+    group.bench_function("load_store", |b| {
+        let source = r#"
+            use.miden::core::sys
+            begin
+                repeat.100
+                    push.1 mem_storew
+                    push.1 mem_loadw
+                    dropw
+                end
+                exec.sys::truncate_stack
+            end
+        "#;
+
+        let program = Assembler::default()
+            .assemble_program(source)
+            .expect("Failed to assemble");
+
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || {
+                    let host = DefaultHost::default();
+                    let processor = FastProcessor::new(
+                        StackInputs::default(),
+                        miden_processor::AdviceInputs::default(),
+                    );
+                    (host, program.clone(), processor)
+                },
+                |(mut host, program, processor)| async move {
+                    black_box(processor.execute(&program, &mut host).await.unwrap());
+                },
+                BatchSize::SmallInput,
+            );
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchmark_signature_verification,
+    benchmark_hashing,
+    benchmark_memory_operations
+);
+criterion_main!(benches);

--- a/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
+++ b/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
@@ -2,7 +2,7 @@
 
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use miden_core::{Felt, Word};
-use miden_core_lib::{CoreLibrary, dsa::falcon512_poseidon2};
+use miden_core_lib::{dsa::falcon512_poseidon2, CoreLibrary};
 use miden_processor::fast::FastProcessor;
 use miden_processor::AdviceInputs;
 use miden_vm::{Assembler, DefaultHost, StackInputs};
@@ -23,10 +23,8 @@ fn bench_program(
                     host.load_library(&CoreLibrary::default())
                         .expect("Failed to load core library");
                 }
-                let processor = FastProcessor::new_with_advice_inputs(
-                    stack_inputs,
-                    advice_inputs.clone(),
-                );
+                let processor =
+                    FastProcessor::new_with_advice_inputs(stack_inputs, advice_inputs.clone());
                 (host, processor)
             },
             |(mut host, processor)| async move {
@@ -58,15 +56,10 @@ fn benchmark_signature_verification(c: &mut Criterion) {
             .expect("Failed to assemble");
 
         let secret_key = falcon512_poseidon2::SecretKey::new();
-        let message = Word::new([
-            Felt::new(1),
-            Felt::new(2),
-            Felt::new(3),
-            Felt::new(4),
-        ]);
+        let message = Word::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
         let public_key = secret_key.public_key().to_commitment();
-        let signature = falcon512_poseidon2::sign(&secret_key, message)
-            .expect("Failed to generate signature");
+        let signature =
+            falcon512_poseidon2::sign(&secret_key, message).expect("Failed to generate signature");
 
         let mut stack = Vec::with_capacity(8);
         stack.extend_from_slice(public_key.as_slice());
@@ -93,13 +86,7 @@ fn benchmark_hashing(c: &mut Criterion) {
         "#;
 
         let program = Assembler::default().assemble_program(source).expect("Failed to assemble");
-        bench_program(
-            b,
-            &program,
-            StackInputs::default(),
-            AdviceInputs::default(),
-            false,
-        );
+        bench_program(b, &program, StackInputs::default(), AdviceInputs::default(), false);
     });
 
     group.finish();
@@ -112,6 +99,7 @@ fn benchmark_memory_operations(c: &mut Criterion) {
         let source = r#"
             begin
                 repeat.100
+                    push.1 push.2 push.3 push.4
                     push.0 mem_storew_be
                     push.0 mem_loadw_be
                     dropw
@@ -120,13 +108,7 @@ fn benchmark_memory_operations(c: &mut Criterion) {
         "#;
 
         let program = Assembler::default().assemble_program(source).expect("Failed to assemble");
-        bench_program(
-            b,
-            &program,
-            StackInputs::default(),
-            AdviceInputs::default(),
-            false,
-        );
+        bench_program(b, &program, StackInputs::default(), AdviceInputs::default(), false);
     });
 
     group.finish();

--- a/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
+++ b/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
@@ -50,12 +50,10 @@ fn benchmark_hashing(c: &mut Criterion) {
 
     group.bench_function("hperm", |b| {
         let source = r#"
-            use.miden::core::sys
             begin
                 repeat.100
                     hperm
                 end
-                exec.sys::truncate_stack
             end
         "#;
 
@@ -71,14 +69,12 @@ fn benchmark_memory_operations(c: &mut Criterion) {
 
     group.bench_function("load_store", |b| {
         let source = r#"
-            use.miden::core::sys
             begin
                 repeat.100
-                    push.1 mem_storew
-                    push.1 mem_loadw
+                    push.0 mem_storew_be
+                    push.0 mem_loadw_be
                     dropw
                 end
-                exec.sys::truncate_stack
             end
         "#;
 

--- a/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
+++ b/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
@@ -14,9 +14,9 @@ fn bench_program(b: &mut criterion::Bencher, program: miden_vm::Program) {
                 StackInputs::default(),
                 miden_processor::AdviceInputs::default(),
             );
-            (host, processor)
+            (host, processor, program.clone())
         },
-        |(mut host, processor)| async move {
+        |(mut host, processor, program)| async move {
             black_box(processor.execute(&program, &mut host).await.unwrap());
         },
         BatchSize::SmallInput,

--- a/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
+++ b/benches/synthetic-tx-kernel/benches/component_benchmarks.rs
@@ -3,7 +3,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use miden_core::{Felt, Word};
 use miden_core_lib::{dsa::falcon512_poseidon2, CoreLibrary};
-use miden_processor::{advice::AdviceInputs, fast::FastProcessor};
+use miden_processor::{advice::AdviceInputs, fast::FastProcessor, ExecutionOptions};
 use miden_vm::{Assembler, DefaultHost, StackInputs};
 
 /// Helper function to execute a benchmark with the given program
@@ -22,8 +22,11 @@ fn bench_program(
                     host.load_library(&CoreLibrary::default())
                         .expect("Failed to load core library");
                 }
-                let processor =
-                    FastProcessor::new_with_advice_inputs(stack_inputs, advice_inputs.clone());
+                let processor = FastProcessor::new_with_options(
+                    stack_inputs,
+                    advice_inputs.clone(),
+                    ExecutionOptions::default(),
+                );
                 (host, processor)
             },
             |(mut host, processor)| async move {

--- a/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
+++ b/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
@@ -12,7 +12,8 @@ use std::time::Duration;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
 use miden_core_lib::CoreLibrary;
-use miden_processor::{fast::FastProcessor, parallel::build_trace, ExecutionOptions};
+use miden_processor::parallel::build_trace;
+use miden_processor::{fast::FastProcessor, ExecutionOptions};
 use miden_vm::{prove_sync, Assembler, DefaultHost, ProvingOptions, StackInputs};
 use synthetic_tx_kernel::{generator::MasmGenerator, load_profile};
 
@@ -111,9 +112,10 @@ fn synthetic_transaction_kernel(c: &mut Criterion) {
     let mut test_host = DefaultHost::default()
         .with_library(&core_lib)
         .expect("Failed to initialize test host");
-    let test_processor = FastProcessor::new_with_advice_inputs(
+    let test_processor = FastProcessor::new_with_options(
         StackInputs::default(),
         miden_processor::advice::AdviceInputs::default(),
+        ExecutionOptions::default(),
     );
     let test_result = tokio::runtime::Runtime::new()
         .expect("Failed to create runtime for smoke test")
@@ -135,9 +137,10 @@ fn synthetic_transaction_kernel(c: &mut Criterion) {
                 let host = DefaultHost::default()
                     .with_library(&core_lib)
                     .expect("Failed to initialize host with core library");
-                let processor = FastProcessor::new_with_advice_inputs(
+                let processor = FastProcessor::new_with_options(
                     StackInputs::default(),
                     miden_processor::advice::AdviceInputs::default(),
+                    ExecutionOptions::default(),
                 );
                 (host, program.clone(), processor)
             },

--- a/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
+++ b/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
@@ -12,9 +12,39 @@ use std::time::Duration;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
 use miden_core_lib::CoreLibrary;
-use miden_processor::fast::FastProcessor;
-use miden_vm::{Assembler, DefaultHost, ProvingOptions, StackInputs, prove_sync};
+use miden_processor::{fast::FastProcessor, parallel::build_trace, ExecutionOptions};
+use miden_vm::{prove_sync, Assembler, DefaultHost, ProvingOptions, StackInputs};
 use synthetic_tx_kernel::{generator::MasmGenerator, load_profile};
+
+fn measure_trace_len(program: &miden_vm::Program, core_lib: &CoreLibrary) -> (u64, u64) {
+    let mut host = DefaultHost::default()
+        .with_library(core_lib)
+        .expect("Failed to initialize trace host");
+    let processor = FastProcessor::new_with_options(
+        StackInputs::default(),
+        miden_processor::advice::AdviceInputs::default(),
+        ExecutionOptions::default(),
+    );
+    let (execution_output, trace_generation_context) = processor
+        .execute_for_trace_sync(program, &mut host)
+        .expect("Failed to execute for trace");
+    let trace = build_trace(
+        execution_output,
+        trace_generation_context,
+        program.hash(),
+        program.kernel().clone(),
+    );
+    let summary = trace.trace_len_summary();
+    (summary.main_trace_len() as u64, summary.padded_trace_len() as u64)
+}
+
+fn assemble_program(source: &str, core_lib: &CoreLibrary) -> miden_vm::Program {
+    let mut assembler = Assembler::default();
+    assembler
+        .link_dynamic_library(core_lib.clone())
+        .expect("Failed to load core library");
+    assembler.assemble_program(source).expect("Failed to assemble synthetic kernel")
+}
 
 fn synthetic_transaction_kernel(c: &mut Criterion) {
     let mut group = c.benchmark_group("synthetic_transaction_kernel");
@@ -38,26 +68,44 @@ fn synthetic_transaction_kernel(c: &mut Criterion) {
     println!("Miden VM version: {}", profile.miden_vm_version);
     println!("Total cycles in reference: {}", profile.transaction_kernel.total_cycles);
 
+    let trace_target = profile.transaction_kernel.trace_main_len;
+
     // Generate the synthetic kernel
-    let generator = MasmGenerator::new(profile);
-    let source = generator.generate_kernel().expect("Failed to generate synthetic kernel");
+    let mut generator = MasmGenerator::new(profile.clone());
+    let mut source = generator.generate_kernel().expect("Failed to generate synthetic kernel");
+
+    // Assemble with core library (create one instance and reuse it)
+    let core_lib = CoreLibrary::default();
+
+    let mut program = assemble_program(&source, &core_lib);
+
+    if let Some(target_main) = trace_target {
+        let (actual_main, actual_padded) = measure_trace_len(&program, &core_lib);
+        println!(
+            "Trace sizing: target main={} actual main={} padded={}",
+            target_main, actual_main, actual_padded
+        );
+        let trace_scale = actual_main as f64 / target_main as f64;
+
+        if (trace_scale - 1.0).abs() > 0.05 {
+            generator = generator.with_trace_scale(trace_scale);
+            source = generator.generate_kernel().expect("Failed to generate trace-sized kernel");
+            program = assemble_program(&source, &core_lib);
+            let (resized_main, resized_padded) = measure_trace_len(&program, &core_lib);
+            println!(
+                "Trace sizing result: main={} padded={} scale={:.3}",
+                resized_main, resized_padded, trace_scale
+            );
+        }
+    } else {
+        println!("Trace sizing: skipped (no trace_main_len in profile)");
+    }
 
     // Write the generated code for inspection (only if MASM_WRITE env var is set)
     if std::env::var("MASM_WRITE").is_ok() {
         std::fs::write("target/synthetic_kernel.masm", &source)
             .expect("Failed to write generated kernel");
     }
-
-    // Assemble with core library (create one instance and reuse it)
-    let core_lib = CoreLibrary::default();
-    let mut assembler = Assembler::default();
-    assembler
-        .link_dynamic_library(core_lib.clone())
-        .expect("Failed to load core library");
-
-    let program = assembler
-        .assemble_program(&source)
-        .expect("Failed to assemble synthetic kernel");
 
     // Smoke test: execute once to verify the program runs correctly
     let mut test_host = DefaultHost::default()

--- a/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
+++ b/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
@@ -2,6 +2,11 @@
 //!
 //! This benchmark generates and executes a Miden program that mirrors
 //! the instruction mix and operation profile of the real transaction kernel.
+//!
+//! # Environment Variables
+//!
+//! - `MASM_WRITE`: When set, writes the generated MASM code to `target/synthetic_kernel.masm` for
+//!   debugging purposes.
 
 use std::time::Duration;
 
@@ -34,7 +39,6 @@ fn synthetic_transaction_kernel(c: &mut Criterion) {
     println!("Total cycles in reference: {}", profile.transaction_kernel.total_cycles);
 
     // Generate the synthetic kernel
-    let _total_cycles_expected = profile.transaction_kernel.total_cycles;
     let generator = MasmGenerator::new(profile);
     let source = generator.generate_kernel().expect("Failed to generate synthetic kernel");
 
@@ -64,7 +68,7 @@ fn synthetic_transaction_kernel(c: &mut Criterion) {
         miden_processor::AdviceInputs::default(),
     );
     let test_result = tokio::runtime::Runtime::new()
-        .unwrap()
+        .expect("Failed to create runtime for smoke test")
         .block_on(async { test_processor.execute(&program, &mut test_host).await });
 
     match test_result {

--- a/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
+++ b/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
@@ -3,12 +3,13 @@
 //! This benchmark generates and executes a Miden program that mirrors
 //! the instruction mix and operation profile of the real transaction kernel.
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
-use miden_vm::{Assembler, DefaultHost, StackInputs};
-use miden_processor::fast::FastProcessor;
-use miden_core_lib::CoreLibrary;
-use synthetic_tx_kernel::{load_profile, generator::MasmGenerator};
 use std::time::Duration;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
+use miden_core_lib::CoreLibrary;
+use miden_processor::fast::FastProcessor;
+use miden_vm::{Assembler, DefaultHost, StackInputs};
+use synthetic_tx_kernel::{generator::MasmGenerator, load_profile};
 
 fn synthetic_transaction_kernel(c: &mut Criterion) {
     let mut group = c.benchmark_group("synthetic_transaction_kernel");
@@ -19,8 +20,9 @@ fn synthetic_transaction_kernel(c: &mut Criterion) {
         .warm_up_time(Duration::from_millis(500))
         .measurement_time(Duration::from_secs(10));
 
-    // Load the VM profile
-    let profile = load_profile("profiles/latest.json")
+    // Load the VM profile using CARGO_MANIFEST_DIR for crate-relative path
+    let profile_path = format!("{}/profiles/latest.json", env!("CARGO_MANIFEST_DIR"));
+    let profile = load_profile(&profile_path)
         .expect("Failed to load VM profile. Run miden-base bench-transaction first.");
 
     println!("Loaded profile from: {}", profile.source);
@@ -28,40 +30,44 @@ fn synthetic_transaction_kernel(c: &mut Criterion) {
     println!("Total cycles in reference: {}", profile.transaction_kernel.total_cycles);
 
     // Generate the synthetic kernel
+    let total_cycles_expected = profile.transaction_kernel.total_cycles;
     let generator = MasmGenerator::new(profile);
-    let source = generator.generate_kernel()
-        .expect("Failed to generate synthetic kernel");
+    let source = generator.generate_kernel().expect("Failed to generate synthetic kernel");
 
-    // Optionally write the generated code for inspection
-    std::fs::write("target/synthetic_kernel.masm", &source)
-        .expect("Failed to write generated kernel");
+    // Write the generated code for inspection (only if MASM_WRITE env var is set)
+    if std::env::var("MASM_WRITE").is_ok() {
+        std::fs::write("target/synthetic_kernel.masm", &source)
+            .expect("Failed to write generated kernel");
+    }
 
-    // Assemble with core library
+    // Assemble with core library (create one instance and reuse it)
+    let core_lib = CoreLibrary::default();
     let mut assembler = Assembler::default();
-    assembler.link_dynamic_library(CoreLibrary::default())
+    assembler
+        .link_dynamic_library(core_lib.clone())
         .expect("Failed to load core library");
 
-    let program = assembler.assemble_program(&source)
+    let program = assembler
+        .assemble_program(&source)
         .expect("Failed to assemble synthetic kernel");
 
     group.bench_function("execute", |b| {
-        b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter_batched(
-                || {
-                    let host = DefaultHost::default()
-                        .with_library(&CoreLibrary::default())
-                        .expect("Failed to initialize host with core library");
-                    let processor = FastProcessor::new(
-                        StackInputs::default(),
-                        miden_processor::AdviceInputs::default(),
-                    );
-                    (host, program.clone(), processor)
-                },
-                |(mut host, program, processor)| async move {
-                    black_box(processor.execute(&program, &mut host).await.unwrap());
-                },
-                criterion::BatchSize::SmallInput,
-            );
+        b.to_async(tokio::runtime::Runtime::new().unwrap()).iter_batched(
+            || {
+                let host = DefaultHost::default()
+                    .with_library(&core_lib)
+                    .expect("Failed to initialize host with core library");
+                let processor = FastProcessor::new_with_advice_inputs(
+                    StackInputs::default(),
+                    miden_processor::AdviceInputs::default(),
+                );
+                (host, program.clone(), processor)
+            },
+            |(mut host, program, processor)| async move {
+                black_box(processor.execute(&program, &mut host).await.unwrap());
+            },
+            criterion::BatchSize::SmallInput,
+        );
     });
 
     group.finish();

--- a/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
+++ b/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
@@ -65,7 +65,7 @@ fn synthetic_transaction_kernel(c: &mut Criterion) {
         .expect("Failed to initialize test host");
     let test_processor = FastProcessor::new_with_advice_inputs(
         StackInputs::default(),
-        miden_processor::AdviceInputs::default(),
+        miden_processor::advice::AdviceInputs::default(),
     );
     let test_result = tokio::runtime::Runtime::new()
         .expect("Failed to create runtime for smoke test")
@@ -89,7 +89,7 @@ fn synthetic_transaction_kernel(c: &mut Criterion) {
                     .expect("Failed to initialize host with core library");
                 let processor = FastProcessor::new_with_advice_inputs(
                     StackInputs::default(),
-                    miden_processor::AdviceInputs::default(),
+                    miden_processor::advice::AdviceInputs::default(),
                 );
                 (host, program.clone(), processor)
             },

--- a/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
+++ b/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
@@ -1,0 +1,71 @@
+//! Synthetic transaction kernel benchmark
+//!
+//! This benchmark generates and executes a Miden program that mirrors
+//! the instruction mix and operation profile of the real transaction kernel.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
+use miden_vm::{Assembler, DefaultHost, StackInputs};
+use miden_processor::fast::FastProcessor;
+use miden_core_lib::CoreLibrary;
+use synthetic_tx_kernel::{load_profile, generator::MasmGenerator};
+use std::time::Duration;
+
+fn synthetic_transaction_kernel(c: &mut Criterion) {
+    let mut group = c.benchmark_group("synthetic_transaction_kernel");
+
+    group
+        .sampling_mode(SamplingMode::Flat)
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(10));
+
+    // Load the VM profile
+    let profile = load_profile("profiles/latest.json")
+        .expect("Failed to load VM profile. Run miden-base bench-transaction first.");
+
+    println!("Loaded profile from: {}", profile.source);
+    println!("Miden VM version: {}", profile.miden_vm_version);
+    println!("Total cycles in reference: {}", profile.transaction_kernel.total_cycles);
+
+    // Generate the synthetic kernel
+    let generator = MasmGenerator::new(profile);
+    let source = generator.generate_kernel()
+        .expect("Failed to generate synthetic kernel");
+
+    // Optionally write the generated code for inspection
+    std::fs::write("target/synthetic_kernel.masm", &source)
+        .expect("Failed to write generated kernel");
+
+    // Assemble with core library
+    let mut assembler = Assembler::default();
+    assembler.link_dynamic_library(CoreLibrary::default())
+        .expect("Failed to load core library");
+
+    let program = assembler.assemble_program(&source)
+        .expect("Failed to assemble synthetic kernel");
+
+    group.bench_function("execute", |b| {
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || {
+                    let host = DefaultHost::default()
+                        .with_library(&CoreLibrary::default())
+                        .expect("Failed to initialize host with core library");
+                    let processor = FastProcessor::new(
+                        StackInputs::default(),
+                        miden_processor::AdviceInputs::default(),
+                    );
+                    (host, program.clone(), processor)
+                },
+                |(mut host, program, processor)| async move {
+                    black_box(processor.execute(&program, &mut host).await.unwrap());
+                },
+                criterion::BatchSize::SmallInput,
+            );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, synthetic_transaction_kernel);
+criterion_main!(benches);

--- a/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
+++ b/benches/synthetic-tx-kernel/benches/synthetic_kernel.rs
@@ -12,8 +12,7 @@ use std::time::Duration;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
 use miden_core_lib::CoreLibrary;
-use miden_processor::parallel::build_trace;
-use miden_processor::{fast::FastProcessor, ExecutionOptions};
+use miden_processor::{fast::FastProcessor, trace::build_trace, ExecutionOptions};
 use miden_vm::{prove_sync, Assembler, DefaultHost, ProvingOptions, StackInputs};
 use synthetic_tx_kernel::{generator::MasmGenerator, load_profile};
 
@@ -32,8 +31,7 @@ fn measure_trace_len(program: &miden_vm::Program, core_lib: &CoreLibrary) -> (u6
     let trace = build_trace(
         execution_output,
         trace_generation_context,
-        program.hash(),
-        program.kernel().clone(),
+        miden_processor::ProgramInfo::from(program.clone()),
     );
     let summary = trace.trace_len_summary();
     (summary.main_trace_len() as u64, summary.padded_trace_len() as u64)

--- a/benches/synthetic-tx-kernel/profiles/bench-tx-vm-profile.json
+++ b/benches/synthetic-tx-kernel/profiles/bench-tx-vm-profile.json
@@ -1,0 +1,41 @@
+{
+  "profile_version": "1.0",
+  "source": "miden-base/bin/bench-transaction",
+  "timestamp": "2026-02-02T10:13:46.584544+00:00",
+  "miden_vm_version": "0.1.0",
+  "transaction_kernel": {
+    "total_cycles": 69490,
+    "phases": {
+      "prologue": {
+        "cycles": 2995,
+        "operations": {}
+      },
+      "tx_script_processing": {
+        "cycles": 527,
+        "operations": {}
+      },
+      "epilogue": {
+        "cycles": 64243,
+        "operations": {}
+      },
+      "notes_processing": {
+        "cycles": 1725,
+        "operations": {}
+      }
+    },
+    "instruction_mix": {
+      "arithmetic": 0.009715066916103033,
+      "hashing": 0.04857533458051516,
+      "memory": 0.019430133832206067,
+      "control_flow": 0.019430133832206067,
+      "signature_verify": 0.9028493308389697
+    },
+    "key_procedures": [
+      {
+        "name": "auth_procedure",
+        "cycles": 62739,
+        "invocations": 1
+      }
+    ]
+  }
+}

--- a/benches/synthetic-tx-kernel/profiles/latest.json
+++ b/benches/synthetic-tx-kernel/profiles/latest.json
@@ -5,6 +5,8 @@
   "miden_vm_version": "0.1.0",
   "transaction_kernel": {
     "total_cycles": 69454,
+    "trace_main_len": 68897,
+    "trace_padded_len": 131072,
     "phases": {
       "epilogue": {
         "cycles": 64243,

--- a/benches/synthetic-tx-kernel/profiles/latest.json
+++ b/benches/synthetic-tx-kernel/profiles/latest.json
@@ -1,1 +1,42 @@
-miden-base-v0.20.0.json
+{
+  "_comment": "This file is a copy of miden-base-v0.20.0.json. Update this when the reference profile changes.",
+  "profile_version": "1.0",
+  "source": "miden-base/bin/bench-transaction",
+  "timestamp": "2025-01-31T12:00:00Z",
+  "miden_vm_version": "0.20.0",
+  "transaction_kernel": {
+    "total_cycles": 73123,
+    "phases": {
+      "prologue": {
+        "cycles": 3173,
+        "operations": {}
+      },
+      "notes_processing": {
+        "cycles": 1714,
+        "operations": {}
+      },
+      "tx_script_processing": {
+        "cycles": 42,
+        "operations": {}
+      },
+      "epilogue": {
+        "cycles": 63977,
+        "operations": {}
+      }
+    },
+    "instruction_mix": {
+      "arithmetic": 0.05,
+      "hashing": 0.45,
+      "memory": 0.08,
+      "control_flow": 0.05,
+      "signature_verify": 0.37
+    },
+    "key_procedures": [
+      {
+        "name": "auth_procedure",
+        "cycles": 62667,
+        "invocations": 1
+      }
+    ]
+  }
+}

--- a/benches/synthetic-tx-kernel/profiles/latest.json
+++ b/benches/synthetic-tx-kernel/profiles/latest.json
@@ -1,41 +1,90 @@
 {
-  "_comment": "This file is a copy of miden-base-v0.20.0.json. Update this when the reference profile changes.",
   "profile_version": "1.0",
   "source": "miden-base/bin/bench-transaction",
-  "timestamp": "2025-01-31T12:00:00Z",
-  "miden_vm_version": "0.20.0",
+  "timestamp": "2026-02-03T00:17:10.646329+00:00",
+  "miden_vm_version": "0.1.0",
   "transaction_kernel": {
-    "total_cycles": 73123,
+    "total_cycles": 69490,
     "phases": {
       "prologue": {
-        "cycles": 3173,
-        "operations": {}
-      },
-      "notes_processing": {
-        "cycles": 1714,
-        "operations": {}
-      },
-      "tx_script_processing": {
-        "cycles": 42,
+        "cycles": 2995,
         "operations": {}
       },
       "epilogue": {
-        "cycles": 63977,
+        "cycles": 64243,
+        "operations": {}
+      },
+      "notes_processing": {
+        "cycles": 1725,
+        "operations": {}
+      },
+      "tx_script_processing": {
+        "cycles": 527,
         "operations": {}
       }
     },
     "instruction_mix": {
-      "arithmetic": 0.05,
-      "hashing": 0.45,
-      "memory": 0.08,
-      "control_flow": 0.05,
-      "signature_verify": 0.37
+      "arithmetic": 0.009715066916103033,
+      "hashing": 0.04857533458051516,
+      "memory": 0.019430133832206067,
+      "control_flow": 0.019430133832206067,
+      "signature_verify": 0.9028493308389697
     },
     "key_procedures": [
       {
         "name": "auth_procedure",
-        "cycles": 62667,
+        "cycles": 62739,
         "invocations": 1
+      }
+    ],
+    "operation_details": [
+      {
+        "op_type": "falcon512_verify",
+        "input_sizes": [
+          64,
+          32
+        ],
+        "iterations": 1,
+        "cycle_cost": 59859
+      },
+      {
+        "op_type": "hperm",
+        "input_sizes": [
+          48
+        ],
+        "iterations": 2700,
+        "cycle_cost": 1
+      },
+      {
+        "op_type": "hmerge",
+        "input_sizes": [
+          32,
+          32
+        ],
+        "iterations": 42,
+        "cycle_cost": 16
+      },
+      {
+        "op_type": "load_store",
+        "input_sizes": [
+          32
+        ],
+        "iterations": 135,
+        "cycle_cost": 10
+      },
+      {
+        "op_type": "arithmetic",
+        "input_sizes": [
+          8
+        ],
+        "iterations": 675,
+        "cycle_cost": 1
+      },
+      {
+        "op_type": "control_flow",
+        "input_sizes": [],
+        "iterations": 270,
+        "cycle_cost": 5
       }
     ]
   }

--- a/benches/synthetic-tx-kernel/profiles/latest.json
+++ b/benches/synthetic-tx-kernel/profiles/latest.json
@@ -1,0 +1,1 @@
+miden-base-v0.20.0.json

--- a/benches/synthetic-tx-kernel/profiles/latest.json
+++ b/benches/synthetic-tx-kernel/profiles/latest.json
@@ -1,21 +1,21 @@
 {
   "profile_version": "1.0",
   "source": "miden-base/bin/bench-transaction",
-  "timestamp": "2026-02-03T00:17:10.646329+00:00",
+  "timestamp": "2026-02-03T03:40:57.648937+00:00",
   "miden_vm_version": "0.1.0",
   "transaction_kernel": {
-    "total_cycles": 69490,
+    "total_cycles": 69454,
     "phases": {
-      "prologue": {
-        "cycles": 2995,
-        "operations": {}
-      },
       "epilogue": {
         "cycles": 64243,
         "operations": {}
       },
       "notes_processing": {
-        "cycles": 1725,
+        "cycles": 1707,
+        "operations": {}
+      },
+      "prologue": {
+        "cycles": 2977,
         "operations": {}
       },
       "tx_script_processing": {
@@ -24,11 +24,11 @@
       }
     },
     "instruction_mix": {
-      "arithmetic": 0.009715066916103033,
-      "hashing": 0.04857533458051516,
-      "memory": 0.019430133832206067,
-      "control_flow": 0.019430133832206067,
-      "signature_verify": 0.9028493308389697
+      "arithmetic": 0.009668269646096695,
+      "hashing": 0.04834134823048347,
+      "memory": 0.01933653929219339,
+      "control_flow": 0.01933653929219339,
+      "signature_verify": 0.9033173035390331
     },
     "key_procedures": [
       {
@@ -52,7 +52,7 @@
         "input_sizes": [
           48
         ],
-        "iterations": 2700,
+        "iterations": 2685,
         "cycle_cost": 1
       },
       {
@@ -61,7 +61,7 @@
           32,
           32
         ],
-        "iterations": 42,
+        "iterations": 41,
         "cycle_cost": 16
       },
       {
@@ -69,7 +69,7 @@
         "input_sizes": [
           32
         ],
-        "iterations": 135,
+        "iterations": 134,
         "cycle_cost": 10
       },
       {
@@ -77,13 +77,13 @@
         "input_sizes": [
           8
         ],
-        "iterations": 675,
+        "iterations": 671,
         "cycle_cost": 1
       },
       {
         "op_type": "control_flow",
         "input_sizes": [],
-        "iterations": 270,
+        "iterations": 268,
         "cycle_cost": 5
       }
     ]

--- a/benches/synthetic-tx-kernel/profiles/miden-base-v0.20.0.json
+++ b/benches/synthetic-tx-kernel/profiles/miden-base-v0.20.0.json
@@ -1,0 +1,41 @@
+{
+  "profile_version": "1.0",
+  "source": "miden-base/bin/bench-transaction",
+  "timestamp": "2025-01-31T12:00:00Z",
+  "miden_vm_version": "0.20.0",
+  "transaction_kernel": {
+    "total_cycles": 73123,
+    "phases": {
+      "prologue": {
+        "cycles": 3173,
+        "operations": {}
+      },
+      "notes_processing": {
+        "cycles": 1714,
+        "operations": {}
+      },
+      "tx_script_processing": {
+        "cycles": 42,
+        "operations": {}
+      },
+      "epilogue": {
+        "cycles": 63977,
+        "operations": {}
+      }
+    },
+    "instruction_mix": {
+      "arithmetic": 0.05,
+      "hashing": 0.45,
+      "memory": 0.08,
+      "control_flow": 0.05,
+      "signature_verify": 0.37
+    },
+    "key_procedures": [
+      {
+        "name": "auth_procedure",
+        "cycles": 62667,
+        "invocations": 1
+      }
+    ]
+  }
+}

--- a/benches/synthetic-tx-kernel/src/data_generator.rs
+++ b/benches/synthetic-tx-kernel/src/data_generator.rs
@@ -1,0 +1,221 @@
+//! Data generators for realistic benchmark inputs
+//!
+//! This module generates fresh cryptographic data for each benchmark iteration,
+//! ensuring realistic execution patterns that match real transaction kernels.
+
+use miden_core::{Felt, Word};
+use miden_core_lib::dsa::falcon512_poseidon2;
+
+/// Generates Falcon512 signature verification data
+pub struct Falcon512Generator;
+
+impl Falcon512Generator {
+    /// Generate a fresh key pair, sign a message, and return verification inputs
+    ///
+    /// Returns the public key commitment, message, and signature for verification
+    pub fn generate_verify_data() -> anyhow::Result<Falcon512VerifyData> {
+        let secret_key = falcon512_poseidon2::SecretKey::new();
+        let public_key = secret_key.public_key();
+        let public_key_commitment = public_key.to_commitment();
+
+        // Create a realistic message (4 field elements)
+        let message = Word::new([
+            Felt::new(1),
+            Felt::new(2),
+            Felt::new(3),
+            Felt::new(4),
+        ]);
+
+        // Sign the message
+        let signature = falcon512_poseidon2::sign(&secret_key, message)
+            .ok_or_else(|| anyhow::anyhow!("Failed to sign message"))?;
+
+        Ok(Falcon512VerifyData {
+            public_key_commitment,
+            message,
+            signature,
+        })
+    }
+}
+
+/// Data for Falcon512 signature verification
+#[derive(Debug, Clone)]
+pub struct Falcon512VerifyData {
+    /// Public key commitment (4 field elements)
+    pub public_key_commitment: Word,
+    /// Message that was signed (4 field elements)
+    pub message: Word,
+    /// Signature (as a vector of field elements)
+    pub signature: Vec<Felt>,
+}
+
+impl Falcon512VerifyData {
+    /// Build stack inputs for the verification procedure
+    ///
+    /// Stack layout: [PK_COMMITMENT_0, PK_COMMITMENT_1, PK_COMMITMENT_2, PK_COMMITMENT_3,
+    ///                MSG_0, MSG_1, MSG_2, MSG_3]
+    pub fn to_stack_inputs(&self) -> anyhow::Result<miden_vm::StackInputs> {
+        let mut stack = Vec::with_capacity(8);
+        // Push public key commitment (as slice)
+        stack.extend_from_slice(self.public_key_commitment.as_slice());
+        // Push message (as slice)
+        stack.extend_from_slice(self.message.as_slice());
+        miden_vm::StackInputs::new(&stack)
+            .map_err(|e| anyhow::anyhow!("Failed to build stack inputs: {}", e))
+    }
+}
+
+/// Generates hash operation data
+pub struct HashGenerator;
+
+impl HashGenerator {
+    /// Generate realistic hash state for hperm operations
+    ///
+    /// Returns a 12-element state vector representing the hash capacity and rate
+    pub fn generate_hperm_state() -> [Felt; 12] {
+        // Realistic initial state (often zeros or context-specific in transactions)
+        [
+            Felt::new(0),
+            Felt::new(0),
+            Felt::new(0),
+            Felt::new(0),
+            Felt::new(1),
+            Felt::new(2),
+            Felt::new(3),
+            Felt::new(4),
+            Felt::new(5),
+            Felt::new(6),
+            Felt::new(7),
+            Felt::new(8),
+        ]
+    }
+
+    /// Generate input data for hash operations
+    ///
+    /// Returns two 4-element words for hmerge or absorption
+    pub fn generate_hash_inputs() -> (Word, Word) {
+        let word1 = Word::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
+        let word2 = Word::new([Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)]);
+        (word1, word2)
+    }
+}
+
+/// Generates Merkle tree operation data
+pub struct MerkleGenerator;
+
+impl MerkleGenerator {
+    /// Generate a Merkle path for verification
+    ///
+    /// Creates a simple 4-level tree with a leaf at index 0
+    /// Returns the leaf value, its index, and the sibling path
+    pub fn generate_merkle_path() -> MerklePathData {
+        // Create leaf nodes (8 leaves for a 3-level tree)
+        let leaves: Vec<Word> = (0..8)
+            .map(|i| Word::new([Felt::new(i * 4), Felt::new(i * 4 + 1), Felt::new(i * 4 + 2), Felt::new(i * 4 + 3)]))
+            .collect();
+
+        // Compute sibling path for leaf 0
+        let leaf_index = 0usize;
+        let sibling_path = Self::compute_sibling_path(&leaves, leaf_index);
+
+        MerklePathData {
+            leaf: leaves[0],
+            leaf_index,
+            sibling_path,
+        }
+    }
+
+    /// Compute sibling path for a leaf
+    fn compute_sibling_path(leaves: &[Word], leaf_index: usize) -> Vec<Word> {
+        let mut path = Vec::new();
+        let mut current_level: Vec<Word> = leaves.to_vec();
+        let mut index = leaf_index;
+
+        while current_level.len() > 1 {
+            // Find sibling
+            let sibling_index = if index % 2 == 0 { index + 1 } else { index - 1 };
+            if sibling_index < current_level.len() {
+                path.push(current_level[sibling_index]);
+            }
+
+            // Move up to parent level
+            let mut next_level = Vec::new();
+            for i in (0..current_level.len()).step_by(2) {
+                if i + 1 < current_level.len() {
+                    // Compute parent hash (simplified - just use first word for now)
+                    next_level.push(current_level[i]);
+                } else {
+                    // Odd node out - promote to next level
+                    next_level.push(current_level[i]);
+                }
+            }
+            current_level = next_level;
+            index /= 2;
+        }
+
+        path
+    }
+}
+
+/// Data for Merkle path verification
+#[derive(Debug, Clone)]
+pub struct MerklePathData {
+    /// The leaf value being proven
+    pub leaf: Word,
+    /// Index of the leaf in the tree
+    pub leaf_index: usize,
+    /// Sibling nodes from leaf to root
+    pub sibling_path: Vec<Word>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use miden_core::field::PrimeCharacteristicRing;
+
+    #[test]
+    fn falcon512_generator_produces_valid_data() {
+        let data = Falcon512Generator::generate_verify_data()
+            .expect("Failed to generate Falcon512 data");
+
+        // Verify the data has correct structure (Word is [Felt; 4])
+        assert_eq!(data.public_key_commitment.as_slice().len(), 4);
+        assert_eq!(data.message.as_slice().len(), 4);
+    }
+
+    #[test]
+    fn falcon512_stack_inputs_builds_correctly() {
+        let data = Falcon512Generator::generate_verify_data()
+            .expect("Failed to generate Falcon512 data");
+
+        let stack_inputs = data.to_stack_inputs()
+            .expect("Failed to build stack inputs");
+
+        // StackInputs always has MIN_STACK_DEPTH (16) elements
+        // First 8 should be our inputs (4 for PK commitment + 4 for message)
+        // Remaining should be zeros
+        let inputs: Vec<_> = stack_inputs.iter().copied().collect();
+        assert_eq!(inputs.len(), 16);
+
+        // Check first 8 are non-zero (our actual inputs)
+        assert!(inputs[..8].iter().all(|f| *f != Felt::ZERO));
+
+        // Check last 8 are zeros (padding)
+        assert!(inputs[8..].iter().all(|f| *f == Felt::ZERO));
+    }
+
+    #[test]
+    fn hash_generator_produces_valid_state() {
+        let state = HashGenerator::generate_hperm_state();
+        assert_eq!(state.len(), 12);
+    }
+
+    #[test]
+    fn merkle_generator_produces_valid_path() {
+        let path_data = MerkleGenerator::generate_merkle_path();
+
+        // For an 8-leaf tree, path should have 3 siblings
+        assert_eq!(path_data.sibling_path.len(), 3);
+        assert_eq!(path_data.leaf_index, 0);
+    }
+}

--- a/benches/synthetic-tx-kernel/src/data_generator.rs
+++ b/benches/synthetic-tx-kernel/src/data_generator.rs
@@ -172,8 +172,9 @@ pub struct MerklePathData {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use miden_core::field::PrimeCharacteristicRing;
+
+    use super::*;
 
     #[test]
     fn falcon512_generator_produces_valid_data() {

--- a/benches/synthetic-tx-kernel/src/data_generator.rs
+++ b/benches/synthetic-tx-kernel/src/data_generator.rs
@@ -135,7 +135,7 @@ impl MerkleGenerator {
 
         while current_level.len() > 1 {
             // Find sibling
-            let sibling_index = if index % 2 == 0 { index + 1 } else { index - 1 };
+            let sibling_index = if index.is_multiple_of(2) { index + 1 } else { index - 1 };
             if sibling_index < current_level.len() {
                 path.push(current_level[sibling_index]);
             }

--- a/benches/synthetic-tx-kernel/src/generator.rs
+++ b/benches/synthetic-tx-kernel/src/generator.rs
@@ -4,6 +4,12 @@ use anyhow::Result;
 
 use crate::profile::VmProfile;
 
+/// Cycle costs for individual operations (measured from actual execution)
+pub const CYCLES_PER_HPERM: u64 = 1;
+pub const CYCLES_PER_HMERGE: u64 = 16;
+pub const CYCLES_PER_FALCON512_VERIFY: u64 = 59859;
+pub const CYCLES_PER_LOAD_STORE: u64 = 10; // Approximate for push+store+load+drop
+
 /// Generates masm code for a synthetic transaction kernel
 pub struct MasmGenerator {
     profile: VmProfile,
@@ -23,12 +29,19 @@ impl MasmGenerator {
         code.push_str(&format!("# Generated from: {}\n", self.profile.source));
         code.push_str(&format!("# Version: {}\n\n", self.profile.miden_vm_version));
 
+        // Use core library for crypto operations
+        code.push_str("use miden::core::crypto::dsa::falcon512poseidon2\n");
+        code.push_str("use miden::core::crypto::hashes::poseidon2\n\n");
+
         // Main program
         code.push_str("begin\n");
         code.push_str("    # Synthetic transaction kernel\n");
         code.push_str("    # Total cycles: ");
         code.push_str(&self.profile.transaction_kernel.total_cycles.to_string());
-        code.push_str("\n\n");
+        code.push_str("\n");
+        code.push_str("    # Instruction mix: ");
+        code.push_str(&format!("{:?}\n", self.profile.transaction_kernel.instruction_mix));
+        code.push_str("\n");
 
         // Generate each phase
         for (phase_name, phase) in &self.profile.transaction_kernel.phases {
@@ -44,31 +57,240 @@ impl MasmGenerator {
         let mut code = String::new();
         code.push_str(&format!("    # Phase: {} ({} cycles)\n", name, phase.cycles));
 
-        // Generate operations based on the phase's operation counts
-        for (op_name, count) in &phase.operations {
-            code.push_str(&self.generate_operation(op_name, *count)?);
+        // If phase has specific operations defined, use those
+        if !phase.operations.is_empty() {
+            for (op_name, count) in &phase.operations {
+                code.push_str(&self.generate_operation(op_name, *count)?);
+            }
+        } else {
+            // Otherwise, generate operations based on instruction mix
+            code.push_str(&self.generate_phase_from_mix(name, phase.cycles)?);
         }
 
         code.push('\n');
         Ok(code)
     }
 
+    /// Generate operations for a phase based on the global instruction mix
+    ///
+    /// This generates a representative mix of operations that approximates the
+    /// instruction mix without trying to exactly match every cycle (which would
+    /// create an impractical number of operations).
+    fn generate_phase_from_mix(&self, _phase_name: &str, phase_cycles: u64) -> Result<String> {
+        let mix = &self.profile.transaction_kernel.instruction_mix;
+        let mut code = String::new();
+
+        // Scale down the operations to reasonable numbers while maintaining proportions
+        // We target ~1000-10000 cycles per phase for the synthetic benchmark
+        let scale_factor = if phase_cycles > 10000 {
+            phase_cycles as f64 / 5000.0 // Scale to ~5000 cycles
+        } else {
+            1.0
+        };
+
+        // Calculate how many of each operation to generate based on instruction mix
+        let sig_verify_count = ((phase_cycles as f64 * mix.signature_verify) / CYCLES_PER_FALCON512_VERIFY as f64 / scale_factor).max(1.0) as u64;
+        let hperm_count = ((phase_cycles as f64 * mix.hashing) / CYCLES_PER_HPERM as f64 / scale_factor).max(10.0) as u64;
+        let load_store_count = ((phase_cycles as f64 * mix.memory) / CYCLES_PER_LOAD_STORE as f64 / scale_factor).max(5.0) as u64;
+        let arithmetic_count = ((phase_cycles as f64 * mix.arithmetic) / scale_factor).max(10.0) as u64;
+        let control_count = ((phase_cycles as f64 * mix.control_flow) / 5.0 / scale_factor).max(5.0) as u64;
+
+        // Generate signature verifications (most expensive operation)
+        if mix.signature_verify > 0.0 {
+            code.push_str(&self.generate_falcon_verify_block(sig_verify_count)?);
+        }
+
+        // Generate hashing operations
+        if mix.hashing > 0.0 {
+            code.push_str(&self.generate_hperm_block(hperm_count)?);
+        }
+
+        // Generate memory operations
+        if mix.memory > 0.0 {
+            code.push_str(&self.generate_load_store_block(load_store_count)?);
+        }
+
+        // Generate arithmetic operations (simple math)
+        if mix.arithmetic > 0.0 {
+            code.push_str(&self.generate_arithmetic_block(arithmetic_count)?);
+        }
+
+        // Generate control flow (loops, conditionals)
+        if mix.control_flow > 0.0 {
+            code.push_str(&self.generate_control_flow_block(control_count)?);
+        }
+
+        Ok(code)
+    }
+
     fn generate_operation(&self, op_name: &str, count: u64) -> Result<String> {
-        // Map operation names to masm code
         match op_name {
-            "hperm" => Ok(format!("    # {} hperm operations\n", count)),
-            "hmerge" => Ok(format!("    # {} hmerge operations\n", count)),
-            "mtree_get" => Ok(format!("    # {} mtree_get operations\n", count)),
-            "sig_verify_falcon512" => self.generate_falcon_verify(count),
+            "hperm" => self.generate_hperm_block(count),
+            "hmerge" => self.generate_hmerge_block(count),
+            "mtree_get" => self.generate_mtree_get_block(count),
+            "sig_verify_falcon512" => self.generate_falcon_verify_block(count),
             _ => Ok(format!("    # {} {} operations (unimplemented)\n", count, op_name)),
         }
     }
 
-    fn generate_falcon_verify(&self, count: u64) -> Result<String> {
+    fn generate_hperm_block(&self, count: u64) -> Result<String> {
+        let mut code = String::new();
+        code.push_str(&format!("    # {} hperm operations\n", count));
+
+        // Set up initial hash state (12 elements)
+        code.push_str("    # Initialize hash state\n");
+        code.push_str("    padw padw padw\n");
+
+        // Generate hperm operations in a loop
+        if count > 100 {
+            code.push_str(&format!("    repeat.{}\n", count));
+            code.push_str("        hperm\n");
+            code.push_str("    end\n");
+        } else {
+            for _ in 0..count {
+                code.push_str("    hperm\n");
+            }
+        }
+
+        // Clean up stack
+        code.push_str("    dropw dropw dropw\n");
+        Ok(code)
+    }
+
+    fn generate_hmerge_block(&self, count: u64) -> Result<String> {
+        let mut code = String::new();
+        code.push_str(&format!("    # {} hmerge operations\n", count));
+
+        // Set up two words to merge
+        code.push_str("    # Initialize words for merging\n");
+        code.push_str("    push.1 push.2 push.3 push.4\n");
+        code.push_str("    push.5 push.6 push.7 push.8\n");
+
+        // Generate hmerge operations
+        if count > 100 {
+            code.push_str(&format!("    repeat.{}\n", count));
+            code.push_str("        hmerge\n");
+            code.push_str("        # Set up next word\n");
+            code.push_str("        movup.4 drop push.1\n");
+            code.push_str("    end\n");
+        } else {
+            for _ in 0..count {
+                code.push_str("    hmerge\n");
+            }
+        }
+
+        // Clean up
+        code.push_str("    dropw\n");
+        Ok(code)
+    }
+
+    fn generate_mtree_get_block(&self, count: u64) -> Result<String> {
+        let mut code = String::new();
+        code.push_str(&format!("    # {} mtree_get operations\n", count));
+        code.push_str("    # Note: mtree_get requires Merkle store setup\n");
+
+        // Placeholder - mtree_get requires proper Merkle store initialization
+        for _ in 0..count.min(10) {
+            code.push_str("    # mtree_get (requires store setup)\n");
+        }
+
+        Ok(code)
+    }
+
+    fn generate_falcon_verify_block(&self, count: u64) -> Result<String> {
         let mut code = String::new();
         code.push_str(&format!("    # {} Falcon512 signature verifications\n", count));
-        // Placeholder - actual implementation would call falcon512 verify
-        code.push_str("    # exec.falcon512::verify\n");
+        code.push_str(&format!("    # Each verification is ~{} cycles\n", CYCLES_PER_FALCON512_VERIFY));
+
+        // For synthetic benchmarks, we simulate the cycle cost without actually
+        // executing the verification (which requires advice inputs).
+        // We use a loop of nop operations that approximates the cycle count.
+        // Each loop iteration costs ~1 cycle (the nop itself + loop overhead).
+
+        for _ in 0..count {
+            // Simulate ~59859 cycles
+            // Using a single loop with nop - each iteration is ~1 cycle
+            code.push_str("    # Simulating falcon512_verify cycle count (~60000 cycles)\n");
+            // Note: We can't use repeat.60000 directly as it would exceed max loop iterations
+            // Use nested loops: 60 * 1000 = 60000
+            code.push_str("    repeat.60\n");
+            code.push_str("        repeat.1000\n");
+            code.push_str("            nop\n");
+            code.push_str("        end\n");
+            code.push_str("    end\n");
+        }
+
+        Ok(code)
+    }
+
+    fn generate_load_store_block(&self, count: u64) -> Result<String> {
+        let mut code = String::new();
+        code.push_str(&format!("    # {} load/store operations\n", count));
+
+        if count > 100 {
+            code.push_str(&format!("    repeat.{}\n", count));
+            code.push_str("        push.0 mem_storew_be\n");
+            code.push_str("        push.0 mem_loadw_be\n");
+            code.push_str("        dropw\n");
+            code.push_str("    end\n");
+        } else {
+            for _ in 0..count {
+                code.push_str("    push.0 mem_storew_be\n");
+                code.push_str("    push.0 mem_loadw_be\n");
+                code.push_str("    dropw\n");
+            }
+        }
+
+        Ok(code)
+    }
+
+    fn generate_arithmetic_block(&self, count: u64) -> Result<String> {
+        let mut code = String::new();
+        code.push_str(&format!("    # {} arithmetic operations\n", count));
+
+        // Use balanced operations that don't accumulate on the stack
+        // Each iteration: push two values, add them, drop the result
+        if count > 100 {
+            code.push_str(&format!("    repeat.{}\n", count));
+            code.push_str("        push.1 push.2 add drop\n");
+            code.push_str("    end\n");
+        } else {
+            for _ in 0..count {
+                code.push_str("    push.1 push.2 add drop\n");
+            }
+        }
+
+        Ok(code)
+    }
+
+    fn generate_control_flow_block(&self, count: u64) -> Result<String> {
+        let mut code = String::new();
+        code.push_str(&format!("    # {} control flow operations\n", count));
+
+        // Simple control flow with if/else
+        let iterations = count / 5; // Each iteration ~5 cycles
+        if iterations > 10 {
+            code.push_str(&format!("    repeat.{}\n", iterations.min(100)));
+            code.push_str("        push.1\n");
+            code.push_str("        if.true\n");
+            code.push_str("            push.2\n");
+            code.push_str("        else\n");
+            code.push_str("            push.3\n");
+            code.push_str("        end\n");
+            code.push_str("        drop\n");
+            code.push_str("    end\n");
+        } else {
+            for _ in 0..iterations {
+                code.push_str("    push.1\n");
+                code.push_str("    if.true\n");
+                code.push_str("        push.2\n");
+                code.push_str("    else\n");
+                code.push_str("        push.3\n");
+                code.push_str("    end\n");
+                code.push_str("    drop\n");
+            }
+        }
+
         Ok(code)
     }
 
@@ -81,36 +303,89 @@ impl MasmGenerator {
         let mut code = String::new();
 
         code.push_str(&format!("# Component Benchmark: {}\n", operation));
-        if operation == "falcon512_verify" {
-            code.push_str("use miden::core::crypto::dsa::falcon512poseidon2\n\n");
-        }
-        code.push_str("begin\n");
-        code.push_str(&format!("    repeat.{}\n", iterations));
 
-        // Generate actual operations based on the operation type
         match operation {
             "falcon512_verify" => {
+                code.push_str("use miden::core::crypto::dsa::falcon512poseidon2\n\n");
+                code.push_str("begin\n");
+                code.push_str("    # Set up public key commitment and message on stack\n");
+                code.push_str("    # Stack: [PK_COMMITMENT (4 elements), MSG (4 elements)]\n");
+                code.push_str(&format!("    repeat.{}\n", iterations));
+                code.push_str("        # Push public key commitment (4 field elements)\n");
+                code.push_str("        push.0 push.0 push.0 push.0\n");
+                code.push_str("        # Push message (4 field elements)\n");
+                code.push_str("        push.1 push.2 push.3 push.4\n");
+                code.push_str("        # Execute verification\n");
                 code.push_str("        exec.falcon512poseidon2::verify\n");
+                code.push_str("    end\n");
+                code.push_str("end\n");
             }
             "hperm" => {
+                code.push_str("begin\n");
+                code.push_str("    # Initialize hash state (12 elements)\n");
+                code.push_str("    padw padw padw\n");
+                code.push_str(&format!("    repeat.{}\n", iterations));
                 code.push_str("        hperm\n");
+                code.push_str("    end\n");
+                code.push_str("    # Clean up\n");
+                code.push_str("    dropw dropw dropw\n");
+                code.push_str("end\n");
             }
             "hmerge" => {
+                code.push_str("begin\n");
+                code.push_str("    # Initialize two words for merging\n");
+                code.push_str("    push.1 push.2 push.3 push.4\n");
+                code.push_str("    push.5 push.6 push.7 push.8\n");
+                code.push_str(&format!("    repeat.{}\n", iterations));
                 code.push_str("        hmerge\n");
+                code.push_str("        # Set up next word\n");
+                code.push_str("        movup.4 drop push.1\n");
+                code.push_str("    end\n");
+                code.push_str("    dropw\n");
+                code.push_str("end\n");
             }
             "load_store" => {
+                code.push_str("begin\n");
+                code.push_str(&format!("    repeat.{}\n", iterations));
                 code.push_str("        push.0 mem_storew_be\n");
                 code.push_str("        push.0 mem_loadw_be\n");
                 code.push_str("        dropw\n");
+                code.push_str("    end\n");
+                code.push_str("end\n");
+            }
+            "arithmetic" => {
+                code.push_str("begin\n");
+                code.push_str("    push.1 push.2\n");
+                code.push_str(&format!("    repeat.{}\n", iterations));
+                code.push_str("        add\n");
+                code.push_str("        dup\n");
+                code.push_str("        push.1\n");
+                code.push_str("    end\n");
+                code.push_str("    drop drop\n");
+                code.push_str("end\n");
+            }
+            "control_flow" => {
+                code.push_str("begin\n");
+                code.push_str(&format!("    repeat.{}\n", iterations));
+                code.push_str("        push.1\n");
+                code.push_str("        if.true\n");
+                code.push_str("            push.2\n");
+                code.push_str("        else\n");
+                code.push_str("            push.3\n");
+                code.push_str("        end\n");
+                code.push_str("        drop\n");
+                code.push_str("    end\n");
+                code.push_str("end\n");
             }
             _ => {
-                code.push_str(&format!("        # {} operation (unimplemented)\n", operation));
+                code.push_str(&format!("# {} operation (unimplemented)\n", operation));
+                code.push_str("begin\n");
+                code.push_str(&format!("    repeat.{}\n", iterations));
                 code.push_str("        nop\n");
+                code.push_str("    end\n");
+                code.push_str("end\n");
             }
         }
-
-        code.push_str("    end\n");
-        code.push_str("end\n");
 
         Ok(code)
     }
@@ -153,6 +428,7 @@ mod tests {
                     cycles: 0,
                     invocations: 0,
                 }],
+                operation_details: Vec::new(),
             },
         };
 

--- a/benches/synthetic-tx-kernel/src/generator.rs
+++ b/benches/synthetic-tx-kernel/src/generator.rs
@@ -1,6 +1,6 @@
 //! Generates Miden assembly from VM profiles
 
-use crate::profile::{VmProfile, InstructionMix, ProcedureProfile};
+use crate::profile::VmProfile;
 use anyhow::Result;
 
 /// Generates masm code for a synthetic transaction kernel
@@ -61,7 +61,7 @@ impl MasmGenerator {
 
     fn generate_operation(&self, op_name: &str, count: u64) -> Result<String> {
         // Map operation names to masm code
-        match op_name.as_str() {
+        match op_name {
             "hperm" => Ok(format!("    # {} hperm operations\n", count)),
             "hmerge" => Ok(format!("    # {} hmerge operations\n", count)),
             "mtree_get" => Ok(format!("    # {} mtree_get operations\n", count)),

--- a/benches/synthetic-tx-kernel/src/generator.rs
+++ b/benches/synthetic-tx-kernel/src/generator.rs
@@ -440,7 +440,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use miden_core_lib::CoreLibrary;
-    use miden_processor::{advice::AdviceInputs, fast::FastProcessor};
+    use miden_processor::{advice::AdviceInputs, fast::FastProcessor, ExecutionOptions};
     use miden_vm::{Assembler, DefaultHost, StackInputs};
 
     use super::*;
@@ -528,9 +528,10 @@ mod tests {
                 .expect("failed to assemble benchmark");
 
             let mut host = DefaultHost::default();
-            let processor = FastProcessor::new_with_advice_inputs(
+            let processor = FastProcessor::new_with_options(
                 StackInputs::default(),
                 AdviceInputs::default(),
+                ExecutionOptions::default(),
             );
             let runtime = tokio::runtime::Runtime::new().expect("failed to create runtime");
 
@@ -559,7 +560,11 @@ mod tests {
 
         let mut host = DefaultHost::default();
         host.load_library(&CoreLibrary::default()).expect("failed to load core library");
-        let processor = FastProcessor::new_with_advice_inputs(stack_inputs, advice_inputs);
+        let processor = FastProcessor::new_with_options(
+            stack_inputs,
+            advice_inputs,
+            ExecutionOptions::default(),
+        );
         let runtime = tokio::runtime::Runtime::new().expect("failed to create runtime");
 
         runtime

--- a/benches/synthetic-tx-kernel/src/generator.rs
+++ b/benches/synthetic-tx-kernel/src/generator.rs
@@ -1,7 +1,8 @@
 //! Generates Miden assembly from VM profiles
 
-use crate::profile::VmProfile;
 use anyhow::Result;
+
+use crate::profile::VmProfile;
 
 /// Generates masm code for a synthetic transaction kernel
 pub struct MasmGenerator {
@@ -79,7 +80,11 @@ impl MasmGenerator {
     }
 
     /// Generate a component benchmark for a specific operation type
-    pub fn generate_component_benchmark(&self, operation: &str, iterations: usize) -> Result<String> {
+    pub fn generate_component_benchmark(
+        &self,
+        operation: &str,
+        iterations: usize,
+    ) -> Result<String> {
         let mut code = String::new();
 
         code.push_str(&format!("# Component Benchmark: {}\n", operation));

--- a/benches/synthetic-tx-kernel/src/generator.rs
+++ b/benches/synthetic-tx-kernel/src/generator.rs
@@ -427,7 +427,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use miden_core_lib::CoreLibrary;
-    use miden_processor::{fast::FastProcessor, AdviceInputs};
+    use miden_processor::{advice::AdviceInputs, fast::FastProcessor};
     use miden_vm::{Assembler, DefaultHost, StackInputs};
 
     use super::*;

--- a/benches/synthetic-tx-kernel/src/generator.rs
+++ b/benches/synthetic-tx-kernel/src/generator.rs
@@ -23,11 +23,6 @@ impl MasmGenerator {
         code.push_str(&format!("# Generated from: {}\n", self.profile.source));
         code.push_str(&format!("# Version: {}\n\n", self.profile.miden_vm_version));
 
-        // Imports
-        code.push_str("use.miden::core::sys\n");
-        code.push_str("use.miden::core::mem\n");
-        code.push_str("use.miden::std::crypto::falcon::falcon512\n\n");
-
         // Main program
         code.push_str("begin\n");
         code.push_str("    # Synthetic transaction kernel\n");
@@ -40,8 +35,6 @@ impl MasmGenerator {
             code.push_str(&self.generate_phase(phase_name, phase)?);
         }
 
-        code.push_str("\n    # Clean up stack\n");
-        code.push_str("    exec.sys::truncate_stack\n");
         code.push_str("end\n");
 
         Ok(code)
@@ -88,13 +81,34 @@ impl MasmGenerator {
         let mut code = String::new();
 
         code.push_str(&format!("# Component Benchmark: {}\n", operation));
-        code.push_str("use.miden::core::sys\n\n");
         code.push_str("begin\n");
         code.push_str(&format!("    repeat.{}\n", iterations));
-        code.push_str("        # Perform operation\n");
-        code.push_str(&format!("        # {} operation here\n", operation));
+
+        // Generate actual operations based on the operation type
+        match operation {
+            "falcon512_verify" => {
+                // Placeholder: push dummy values for falcon512 verification
+                code.push_str("        push.1 push.2 push.3 push.4\n");
+                code.push_str("        drop drop drop drop\n");
+            }
+            "hperm" => {
+                code.push_str("        hperm\n");
+            }
+            "hmerge" => {
+                code.push_str("        hmerge\n");
+            }
+            "load_store" => {
+                code.push_str("        push.0 mem_storew_be\n");
+                code.push_str("        push.0 mem_loadw_be\n");
+                code.push_str("        dropw\n");
+            }
+            _ => {
+                code.push_str(&format!("        # {} operation (unimplemented)\n", operation));
+                code.push_str("        nop\n");
+            }
+        }
+
         code.push_str("    end\n");
-        code.push_str("    exec.sys::truncate_stack\n");
         code.push_str("end\n");
 
         Ok(code)

--- a/benches/synthetic-tx-kernel/src/generator.rs
+++ b/benches/synthetic-tx-kernel/src/generator.rs
@@ -1,0 +1,97 @@
+//! Generates Miden assembly from VM profiles
+
+use crate::profile::{VmProfile, InstructionMix, ProcedureProfile};
+use anyhow::Result;
+
+/// Generates masm code for a synthetic transaction kernel
+pub struct MasmGenerator {
+    profile: VmProfile,
+}
+
+impl MasmGenerator {
+    pub fn new(profile: VmProfile) -> Self {
+        Self { profile }
+    }
+
+    /// Generate the complete synthetic kernel program
+    pub fn generate_kernel(&self) -> Result<String> {
+        let mut code = String::new();
+
+        // Header
+        code.push_str("# Synthetic Transaction Kernel\n");
+        code.push_str(&format!("# Generated from: {}\n", self.profile.source));
+        code.push_str(&format!("# Version: {}\n\n", self.profile.miden_vm_version));
+
+        // Imports
+        code.push_str("use.miden::core::sys\n");
+        code.push_str("use.miden::core::mem\n");
+        code.push_str("use.miden::std::crypto::falcon::falcon512\n\n");
+
+        // Main program
+        code.push_str("begin\n");
+        code.push_str("    # Synthetic transaction kernel\n");
+        code.push_str("    # Total cycles: ");
+        code.push_str(&self.profile.transaction_kernel.total_cycles.to_string());
+        code.push_str("\n\n");
+
+        // Generate each phase
+        for (phase_name, phase) in &self.profile.transaction_kernel.phases {
+            code.push_str(&self.generate_phase(phase_name, phase)?);
+        }
+
+        code.push_str("\n    # Clean up stack\n");
+        code.push_str("    exec.sys::truncate_stack\n");
+        code.push_str("end\n");
+
+        Ok(code)
+    }
+
+    fn generate_phase(&self, name: &str, phase: &crate::profile::PhaseProfile) -> Result<String> {
+        let mut code = String::new();
+        code.push_str(&format!("    # Phase: {} ({} cycles)\n", name, phase.cycles));
+
+        // Generate operations based on the phase's operation counts
+        for (op_name, count) in &phase.operations {
+            code.push_str(&self.generate_operation(op_name, *count)?);
+        }
+
+        code.push('\n');
+        Ok(code)
+    }
+
+    fn generate_operation(&self, op_name: &str, count: u64) -> Result<String> {
+        // Map operation names to masm code
+        match op_name.as_str() {
+            "hperm" => Ok(format!("    # {} hperm operations\n", count)),
+            "hmerge" => Ok(format!("    # {} hmerge operations\n", count)),
+            "mtree_get" => Ok(format!("    # {} mtree_get operations\n", count)),
+            "sig_verify_falcon512" => self.generate_falcon_verify(count),
+            _ => Ok(format!("    # {} {} operations (unimplemented)\n", count, op_name)),
+        }
+    }
+
+    fn generate_falcon_verify(&self, count: u64) -> Result<String> {
+        let mut code = String::new();
+        code.push_str(&format!("    # {} Falcon512 signature verifications\n", count));
+        // Placeholder - actual implementation would call falcon512 verify
+        code.push_str("    # exec.falcon512::verify\n");
+        Ok(code)
+    }
+
+    /// Generate a component benchmark for a specific operation type
+    pub fn generate_component_benchmark(&self, operation: &str, iterations: usize) -> Result<String> {
+        let mut code = String::new();
+
+        code.push_str(&format!("# Component Benchmark: {}\n", operation));
+        code.push_str("use.miden::core::sys\n\n");
+        code.push_str("begin\n");
+        code.push_str(&format!("    repeat.{}\n", iterations));
+        code.push_str("        # Perform operation\n");
+        code.push_str(&format!("        # {} operation here\n", operation));
+        code.push_str("    end\n");
+        code.push_str("    exec.sys::truncate_stack\n");
+        code.push_str("end\n");
+
+        Ok(code)
+    }
+}

--- a/benches/synthetic-tx-kernel/src/lib.rs
+++ b/benches/synthetic-tx-kernel/src/lib.rs
@@ -1,0 +1,23 @@
+//! Synthetic transaction kernel benchmark generator
+//!
+//! This crate generates Miden assembly benchmarks based on VM profiles
+//! exported from miden-base's transaction kernel.
+
+pub mod profile;
+pub mod generator;
+pub mod validator;
+
+use anyhow::Result;
+use std::path::Path;
+
+/// Load a VM profile from a JSON file
+pub fn load_profile<P: AsRef<Path>>(path: P) -> Result<profile::VmProfile> {
+    let content = std::fs::read_to_string(path)?;
+    let profile = serde_json::from_str(&content)?;
+    Ok(profile)
+}
+
+/// Get the latest profile from the profiles directory
+pub fn latest_profile() -> Result<profile::VmProfile> {
+    load_profile("profiles/latest.json")
+}

--- a/benches/synthetic-tx-kernel/src/lib.rs
+++ b/benches/synthetic-tx-kernel/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate generates Miden assembly benchmarks based on VM profiles
 //! exported from miden-base's transaction kernel.
 
+pub mod data_generator;
 pub mod generator;
 pub mod profile;
 pub mod validator;

--- a/benches/synthetic-tx-kernel/src/lib.rs
+++ b/benches/synthetic-tx-kernel/src/lib.rs
@@ -29,6 +29,5 @@ pub fn latest_profile() -> Result<profile::VmProfile> {
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
 
-    let profile_path = manifest_dir.join("profiles/latest.json");
-    load_profile(profile_path)
+    load_profile(manifest_dir.join("profiles/latest.json"))
 }

--- a/benches/synthetic-tx-kernel/src/lib.rs
+++ b/benches/synthetic-tx-kernel/src/lib.rs
@@ -25,9 +25,11 @@ pub fn load_profile<P: AsRef<Path>>(path: P) -> Result<profile::VmProfile> {
 /// For workspace-relative paths, use `load_profile` with an explicit path.
 pub fn latest_profile() -> Result<profile::VmProfile> {
     // Try to find the workspace root by looking for Cargo.toml with workspace definition
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").map(std::path::PathBuf::from).or_else(|_| {
+            std::env::current_dir()
+                .map_err(|e| anyhow::anyhow!("Failed to determine current directory: {}", e))
+        })?;
 
     load_profile(manifest_dir.join("profiles/latest.json"))
 }

--- a/benches/synthetic-tx-kernel/src/lib.rs
+++ b/benches/synthetic-tx-kernel/src/lib.rs
@@ -3,12 +3,13 @@
 //! This crate generates Miden assembly benchmarks based on VM profiles
 //! exported from miden-base's transaction kernel.
 
-pub mod profile;
 pub mod generator;
+pub mod profile;
 pub mod validator;
 
-use anyhow::Result;
 use std::path::Path;
+
+use anyhow::Result;
 
 /// Load a VM profile from a JSON file
 pub fn load_profile<P: AsRef<Path>>(path: P) -> Result<profile::VmProfile> {
@@ -18,6 +19,16 @@ pub fn load_profile<P: AsRef<Path>>(path: P) -> Result<profile::VmProfile> {
 }
 
 /// Get the latest profile from the profiles directory
+///
+/// # Note
+/// This function looks for the profile relative to the current working directory.
+/// For workspace-relative paths, use `load_profile` with an explicit path.
 pub fn latest_profile() -> Result<profile::VmProfile> {
-    load_profile("profiles/latest.json")
+    // Try to find the workspace root by looking for Cargo.toml with workspace definition
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default());
+
+    let profile_path = manifest_dir.join("profiles/latest.json");
+    load_profile(profile_path)
 }

--- a/benches/synthetic-tx-kernel/src/profile.rs
+++ b/benches/synthetic-tx-kernel/src/profile.rs
@@ -26,6 +26,9 @@ pub struct TransactionKernelProfile {
     pub phases: BTreeMap<String, PhaseProfile>,
     pub instruction_mix: InstructionMix,
     pub key_procedures: Vec<ProcedureProfile>,
+    /// Detailed operation information for generating realistic benchmarks
+    #[serde(default)]
+    pub operation_details: Vec<OperationDetails>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -50,6 +53,20 @@ pub struct ProcedureProfile {
     pub name: String,
     pub cycles: u64,
     pub invocations: u64,
+}
+
+/// Detailed information about a specific operation type
+/// Used by synthetic benchmark generators to create realistic workloads
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationDetails {
+    /// Operation type identifier (e.g., "falcon512_verify", "hperm", "hmerge")
+    pub op_type: String,
+    /// Size of each input in bytes (for operations with variable input sizes)
+    pub input_sizes: Vec<usize>,
+    /// Number of times this operation is executed
+    pub iterations: u64,
+    /// Estimated cycle cost per operation (for validation)
+    pub cycle_cost: u64,
 }
 
 impl InstructionMix {
@@ -137,6 +154,7 @@ mod tests {
                     cycles: 62667,
                     invocations: 1,
                 }],
+                operation_details: Vec::new(),
             },
         }
     }
@@ -295,6 +313,7 @@ mod tests {
                     signature_verify: 0.2,
                 },
                 key_procedures: vec![],
+                operation_details: Vec::new(),
             },
         };
 
@@ -329,6 +348,7 @@ mod tests {
                     signature_verify: 0.2,
                 },
                 key_procedures: vec![],
+                operation_details: Vec::new(),
             },
         };
 

--- a/benches/synthetic-tx-kernel/src/profile.rs
+++ b/benches/synthetic-tx-kernel/src/profile.rs
@@ -21,6 +21,10 @@ pub struct VmProfile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionKernelProfile {
     pub total_cycles: u64,
+    #[serde(default)]
+    pub trace_main_len: Option<u64>,
+    #[serde(default)]
+    pub trace_padded_len: Option<u64>,
     /// Phase names are expected to be from a fixed set:
     /// "prologue", "notes_processing", "tx_script_processing", "epilogue"
     pub phases: BTreeMap<String, PhaseProfile>,
@@ -147,6 +151,8 @@ mod tests {
             miden_vm_version: "0.20.0".to_string(),
             transaction_kernel: TransactionKernelProfile {
                 total_cycles: 73123,
+                trace_main_len: None,
+                trace_padded_len: None,
                 phases,
                 instruction_mix: create_valid_instruction_mix(),
                 key_procedures: vec![ProcedureProfile {
@@ -304,6 +310,8 @@ mod tests {
             miden_vm_version: "0.20.0".to_string(),
             transaction_kernel: TransactionKernelProfile {
                 total_cycles: 0,
+                trace_main_len: None,
+                trace_padded_len: None,
                 phases: BTreeMap::new(),
                 instruction_mix: InstructionMix {
                     arithmetic: 0.2,
@@ -339,6 +347,8 @@ mod tests {
             miden_vm_version: "0.20.0".to_string(),
             transaction_kernel: TransactionKernelProfile {
                 total_cycles: 0,
+                trace_main_len: None,
+                trace_padded_len: None,
                 phases,
                 instruction_mix: InstructionMix {
                     arithmetic: 0.2,

--- a/benches/synthetic-tx-kernel/src/profile.rs
+++ b/benches/synthetic-tx-kernel/src/profile.rs
@@ -50,6 +50,9 @@ pub struct ProcedureProfile {
     pub invocations: u64,
 }
 
+/// Tolerance for floating point comparisons (1%)
+const INSTRUCTION_MIX_TOLERANCE: f64 = 0.01;
+
 impl InstructionMix {
     /// Validates that:
     /// - All individual values are between 0.0 and 1.0 (inclusive)
@@ -80,7 +83,7 @@ impl InstructionMix {
             + self.memory
             + self.control_flow
             + self.signature_verify;
-        if (total - 1.0).abs() > 0.01 {
+        if (total - 1.0).abs() > INSTRUCTION_MIX_TOLERANCE {
             anyhow::bail!("Instruction mix percentages sum to {}, expected ~1.0", total);
         }
 

--- a/benches/synthetic-tx-kernel/src/profile.rs
+++ b/benches/synthetic-tx-kernel/src/profile.rs
@@ -1,13 +1,17 @@
 //! VM profile types (mirrors miden-base profile format)
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct VmProfile {
+    /// Profile format version (expected format: "major.minor.patch", e.g., "1.0.0")
     pub profile_version: String,
     pub source: String,
+    /// ISO 8601 formatted timestamp (e.g., "2024-01-15T10:30:00Z")
     pub timestamp: String,
+    /// Miden VM version (expected format: "major.minor.patch", e.g., "0.20.0")
     pub miden_vm_version: String,
     pub transaction_kernel: TransactionKernelProfile,
 }
@@ -15,7 +19,9 @@ pub struct VmProfile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionKernelProfile {
     pub total_cycles: u64,
-    pub phases: HashMap<String, PhaseProfile>,
+    /// Phase names are expected to be from a fixed set:
+    /// "prologue", "notes_processing", "tx_script_processing", "epilogue"
+    pub phases: BTreeMap<String, PhaseProfile>,
     pub instruction_mix: InstructionMix,
     pub key_procedures: Vec<ProcedureProfile>,
 }
@@ -23,7 +29,9 @@ pub struct TransactionKernelProfile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PhaseProfile {
     pub cycles: u64,
-    pub operations: HashMap<String, u64>,
+    /// Operation types are expected to be from a fixed set:
+    /// "hperm", "hmerge", "mtree_get", "sig_verify_falcon512"
+    pub operations: BTreeMap<String, u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,12 +51,236 @@ pub struct ProcedureProfile {
 }
 
 impl InstructionMix {
-    /// Validate that mix percentages sum to approximately 1.0
+    /// Validates that:
+    /// - All individual values are between 0.0 and 1.0 (inclusive)
+    /// - Values sum to approximately 1.0 (within 1% tolerance)
     pub fn validate(&self) -> anyhow::Result<()> {
-        let total = self.arithmetic + self.hashing + self.memory + self.control_flow + self.signature_verify;
+        // Check each field is in valid range [0.0, 1.0]
+        let fields = [
+            ("arithmetic", self.arithmetic),
+            ("hashing", self.hashing),
+            ("memory", self.memory),
+            ("control_flow", self.control_flow),
+            ("signature_verify", self.signature_verify),
+        ];
+
+        for (name, value) in fields {
+            if !(0.0..=1.0).contains(&value) {
+                anyhow::bail!(
+                    "Instruction mix field '{}' must be between 0.0 and 1.0, got {}",
+                    name,
+                    value
+                );
+            }
+        }
+
+        // Check sum is approximately 1.0
+        let total = self.arithmetic
+            + self.hashing
+            + self.memory
+            + self.control_flow
+            + self.signature_verify;
         if (total - 1.0).abs() > 0.01 {
             anyhow::bail!("Instruction mix percentages sum to {}, expected ~1.0", total);
         }
+
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_valid_instruction_mix() -> InstructionMix {
+        InstructionMix {
+            arithmetic: 0.05,
+            hashing: 0.45,
+            memory: 0.08,
+            control_flow: 0.05,
+            signature_verify: 0.37,
+        }
+    }
+
+    fn create_valid_vm_profile() -> VmProfile {
+        let mut phases = BTreeMap::new();
+        phases.insert(
+            "prologue".to_string(),
+            PhaseProfile {
+                cycles: 3173,
+                operations: BTreeMap::new(),
+            },
+        );
+        phases.insert(
+            "epilogue".to_string(),
+            PhaseProfile {
+                cycles: 63977,
+                operations: BTreeMap::new(),
+            },
+        );
+
+        VmProfile {
+            profile_version: "1.0.0".to_string(),
+            source: "test".to_string(),
+            timestamp: "2024-01-15T10:30:00Z".to_string(),
+            miden_vm_version: "0.20.0".to_string(),
+            transaction_kernel: TransactionKernelProfile {
+                total_cycles: 73123,
+                phases,
+                instruction_mix: create_valid_instruction_mix(),
+                key_procedures: vec![ProcedureProfile {
+                    name: "auth_procedure".to_string(),
+                    cycles: 62667,
+                    invocations: 1,
+                }],
+            },
+        }
+    }
+
+    #[test]
+    fn instruction_mix_valid_passes() {
+        let mix = create_valid_instruction_mix();
+        assert!(mix.validate().is_ok());
+    }
+
+    #[test]
+    fn instruction_mix_negative_value_fails() {
+        let mix = InstructionMix {
+            arithmetic: -0.1,
+            hashing: 0.5,
+            memory: 0.2,
+            control_flow: 0.2,
+            signature_verify: 0.2,
+        };
+        assert!(mix.validate().is_err());
+    }
+
+    #[test]
+    fn instruction_mix_value_over_one_fails() {
+        let mix = InstructionMix {
+            arithmetic: 1.5,
+            hashing: 0.5,
+            memory: 0.2,
+            control_flow: 0.2,
+            signature_verify: 0.2,
+        };
+        assert!(mix.validate().is_err());
+    }
+
+    #[test]
+    fn instruction_mix_sum_not_one_fails() {
+        let mix = InstructionMix {
+            arithmetic: 0.3,
+            hashing: 0.3,
+            memory: 0.2,
+            control_flow: 0.2,
+            signature_verify: 0.2,
+        };
+        let result = mix.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("sum to"));
+    }
+
+    #[test]
+    fn instruction_mix_sum_within_tolerance_passes() {
+        let mix = InstructionMix {
+            arithmetic: 0.2001,
+            hashing: 0.1999,
+            memory: 0.2,
+            control_flow: 0.2,
+            signature_verify: 0.2,
+        };
+        assert!(mix.validate().is_ok());
+    }
+
+    #[test]
+    fn serde_roundtrip_vm_profile() {
+        let original = create_valid_vm_profile();
+        let json = serde_json::to_string(&original).expect("serialize failed");
+        let deserialized: VmProfile = serde_json::from_str(&json).expect("deserialize failed");
+
+        assert_eq!(original.profile_version, deserialized.profile_version);
+        assert_eq!(original.source, deserialized.source);
+        assert_eq!(original.timestamp, deserialized.timestamp);
+        assert_eq!(original.miden_vm_version, deserialized.miden_vm_version);
+        assert_eq!(
+            original.transaction_kernel.total_cycles,
+            deserialized.transaction_kernel.total_cycles
+        );
+        assert_eq!(
+            original.transaction_kernel.phases.len(),
+            deserialized.transaction_kernel.phases.len()
+        );
+        assert_eq!(
+            original.transaction_kernel.key_procedures.len(),
+            deserialized.transaction_kernel.key_procedures.len()
+        );
+    }
+
+    #[test]
+    fn serde_empty_hashmaps() {
+        let profile = VmProfile {
+            profile_version: "1.0.0".to_string(),
+            source: "test".to_string(),
+            timestamp: "2024-01-15T10:30:00Z".to_string(),
+            miden_vm_version: "0.20.0".to_string(),
+            transaction_kernel: TransactionKernelProfile {
+                total_cycles: 0,
+                phases: BTreeMap::new(),
+                instruction_mix: InstructionMix {
+                    arithmetic: 0.2,
+                    hashing: 0.2,
+                    memory: 0.2,
+                    control_flow: 0.2,
+                    signature_verify: 0.2,
+                },
+                key_procedures: vec![],
+            },
+        };
+
+        let json = serde_json::to_string(&profile).expect("serialize failed");
+        let deserialized: VmProfile = serde_json::from_str(&json).expect("deserialize failed");
+
+        assert!(deserialized.transaction_kernel.phases.is_empty());
+        assert!(deserialized.transaction_kernel.key_procedures.is_empty());
+    }
+
+    #[test]
+    fn serde_zero_cycles() {
+        let mut phases = BTreeMap::new();
+        phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 0, operations: BTreeMap::new() },
+        );
+
+        let profile = VmProfile {
+            profile_version: "1.0.0".to_string(),
+            source: "test".to_string(),
+            timestamp: "2024-01-15T10:30:00Z".to_string(),
+            miden_vm_version: "0.20.0".to_string(),
+            transaction_kernel: TransactionKernelProfile {
+                total_cycles: 0,
+                phases,
+                instruction_mix: InstructionMix {
+                    arithmetic: 0.2,
+                    hashing: 0.2,
+                    memory: 0.2,
+                    control_flow: 0.2,
+                    signature_verify: 0.2,
+                },
+                key_procedures: vec![],
+            },
+        };
+
+        let json = serde_json::to_string(&profile).expect("serialize failed");
+        let deserialized: VmProfile = serde_json::from_str(&json).expect("deserialize failed");
+
+        assert_eq!(deserialized.transaction_kernel.total_cycles, 0);
+        let prologue = deserialized
+            .transaction_kernel
+            .phases
+            .get("prologue")
+            .expect("prologue phase missing");
+        assert_eq!(prologue.cycles, 0);
     }
 }

--- a/benches/synthetic-tx-kernel/src/profile.rs
+++ b/benches/synthetic-tx-kernel/src/profile.rs
@@ -1,0 +1,54 @@
+//! VM profile types (mirrors miden-base profile format)
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VmProfile {
+    pub profile_version: String,
+    pub source: String,
+    pub timestamp: String,
+    pub miden_vm_version: String,
+    pub transaction_kernel: TransactionKernelProfile,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionKernelProfile {
+    pub total_cycles: u64,
+    pub phases: HashMap<String, PhaseProfile>,
+    pub instruction_mix: InstructionMix,
+    pub key_procedures: Vec<ProcedureProfile>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PhaseProfile {
+    pub cycles: u64,
+    pub operations: HashMap<String, u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstructionMix {
+    pub arithmetic: f64,
+    pub hashing: f64,
+    pub memory: f64,
+    pub control_flow: f64,
+    pub signature_verify: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcedureProfile {
+    pub name: String,
+    pub cycles: u64,
+    pub invocations: u64,
+}
+
+impl InstructionMix {
+    /// Validate that mix percentages sum to approximately 1.0
+    pub fn validate(&self) -> anyhow::Result<()> {
+        let total = self.arithmetic + self.hashing + self.memory + self.control_flow + self.signature_verify;
+        if (total - 1.0).abs() > 0.01 {
+            anyhow::bail!("Instruction mix percentages sum to {}, expected ~1.0", total);
+        }
+        Ok(())
+    }
+}

--- a/benches/synthetic-tx-kernel/src/validator.rs
+++ b/benches/synthetic-tx-kernel/src/validator.rs
@@ -5,14 +5,14 @@ use anyhow::{bail, Result};
 use crate::profile::VmProfile;
 
 /// Validates a VM profile for correctness
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct ProfileValidator;
 
 impl ProfileValidator {
     /// Validate a profile
     pub fn validate(&self, profile: &VmProfile) -> Result<()> {
-        // Check version
-        if profile.profile_version != "1.0" {
+        // Check version - supports "1.0" or "1.0.x" format
+        if !profile.profile_version.starts_with("1.0") {
             bail!("Unsupported profile version: {}", profile.profile_version);
         }
 
@@ -165,7 +165,22 @@ mod tests {
             PhaseProfile { cycles: 50, operations: BTreeMap::new() },
         );
 
-        let profile = create_test_profile("1.0", 100, phases);
+        // Test with "1.0.0" format (major.minor.patch)
+        let profile = create_test_profile("1.0.0", 100, phases);
+
+        assert!(ProfileValidator.validate(&profile).is_ok());
+    }
+
+    #[test]
+    fn validate_valid_profile_short_version_passes() {
+        let mut phases = BTreeMap::new();
+        phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 50, operations: BTreeMap::new() },
+        );
+
+        // Test with "1.0" format (major.minor)
+        let profile = create_test_profile("1.0", 50, phases);
 
         assert!(ProfileValidator.validate(&profile).is_ok());
     }

--- a/benches/synthetic-tx-kernel/src/validator.rs
+++ b/benches/synthetic-tx-kernel/src/validator.rs
@@ -5,19 +5,10 @@ use anyhow::{bail, Result};
 use crate::profile::VmProfile;
 
 /// Validates a VM profile for correctness
+#[derive(Debug, Clone, Copy)]
 pub struct ProfileValidator;
 
-impl Default for ProfileValidator {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl ProfileValidator {
-    pub fn new() -> Self {
-        Self
-    }
-
     /// Validate a profile
     pub fn validate(&self, profile: &VmProfile) -> Result<()> {
         // Check version
@@ -175,9 +166,8 @@ mod tests {
         );
 
         let profile = create_test_profile("1.0", 100, phases);
-        let validator = ProfileValidator::new();
 
-        assert!(validator.validate(&profile).is_ok());
+        assert!(ProfileValidator.validate(&profile).is_ok());
     }
 
     #[test]
@@ -189,9 +179,8 @@ mod tests {
         );
 
         let profile = create_test_profile("2.0", 100, phases);
-        let validator = ProfileValidator::new();
 
-        let result = validator.validate(&profile);
+        let result = ProfileValidator.validate(&profile);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Unsupported profile version"));
     }
@@ -200,9 +189,8 @@ mod tests {
     fn validate_zero_cycles_fails() {
         let phases = BTreeMap::new();
         let profile = create_test_profile("1.0", 0, phases);
-        let validator = ProfileValidator::new();
 
-        let result = validator.validate(&profile);
+        let result = ProfileValidator.validate(&profile);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Total cycles is zero"));
     }
@@ -216,9 +204,8 @@ mod tests {
         );
         // total_cycles is 1000 but phases only sum to 50
         let profile = create_test_profile("1.0", 1000, phases);
-        let validator = ProfileValidator::new();
 
-        let result = validator.validate(&profile);
+        let result = ProfileValidator.validate(&profile);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("differs from total"));
     }
@@ -234,9 +221,8 @@ mod tests {
 
         // total_cycles = 10, phases sum to 10, diff = 0, tolerance = max(10/100, 1) = 1
         let profile = create_test_profile("1.0", 10, phases);
-        let validator = ProfileValidator::new();
 
-        assert!(validator.validate(&profile).is_ok());
+        assert!(ProfileValidator.validate(&profile).is_ok());
     }
 
     #[test]
@@ -256,8 +242,7 @@ mod tests {
         let baseline = create_test_profile("1.0", 100, baseline_phases);
         let current = create_test_profile("1.0", 150, current_phases);
 
-        let validator = ProfileValidator::new();
-        let diff = validator.compare_profiles(&baseline, &current);
+        let diff = ProfileValidator.compare_profiles(&baseline, &current);
 
         assert_eq!(diff.total_cycles_delta, 50);
         assert_eq!(diff.phase_deltas.len(), 1);
@@ -283,8 +268,7 @@ mod tests {
         let baseline = create_test_profile("1.0", 0, baseline_phases);
         let current = create_test_profile("1.0", 50, current_phases);
 
-        let validator = ProfileValidator::new();
-        let diff = validator.compare_profiles(&baseline, &current);
+        let diff = ProfileValidator.compare_profiles(&baseline, &current);
 
         assert_eq!(diff.phase_deltas.len(), 1);
         assert_eq!(diff.phase_deltas[0].percent_change, f64::INFINITY);
@@ -307,8 +291,7 @@ mod tests {
         let baseline = create_test_profile("1.0", 0, baseline_phases);
         let current = create_test_profile("1.0", 0, current_phases);
 
-        let validator = ProfileValidator::new();
-        let diff = validator.compare_profiles(&baseline, &current);
+        let diff = ProfileValidator.compare_profiles(&baseline, &current);
 
         assert_eq!(diff.phase_deltas.len(), 1);
         assert_eq!(diff.phase_deltas[0].percent_change, 0.0);
@@ -336,8 +319,7 @@ mod tests {
         let baseline = create_test_profile("1.0", 200, baseline_phases);
         let current = create_test_profile("1.0", 100, current_phases);
 
-        let validator = ProfileValidator::new();
-        let diff = validator.compare_profiles(&baseline, &current);
+        let diff = ProfileValidator.compare_profiles(&baseline, &current);
 
         assert_eq!(diff.missing_phases.len(), 1);
         assert_eq!(diff.missing_phases[0], "epilogue");
@@ -364,23 +346,9 @@ mod tests {
         let baseline = create_test_profile("1.0", 100, baseline_phases);
         let current = create_test_profile("1.0", 150, current_phases);
 
-        let validator = ProfileValidator::new();
-        let diff = validator.compare_profiles(&baseline, &current);
+        let diff = ProfileValidator.compare_profiles(&baseline, &current);
 
         assert_eq!(diff.new_phases.len(), 1);
         assert_eq!(diff.new_phases[0], "new_phase");
-    }
-
-    #[test]
-    fn default_validator_works() {
-        let validator = ProfileValidator;
-        let mut phases = BTreeMap::new();
-        phases.insert(
-            "prologue".to_string(),
-            PhaseProfile { cycles: 100, operations: BTreeMap::new() },
-        );
-
-        let profile = create_test_profile("1.0", 100, phases);
-        assert!(validator.validate(&profile).is_ok());
     }
 }

--- a/benches/synthetic-tx-kernel/src/validator.rs
+++ b/benches/synthetic-tx-kernel/src/validator.rs
@@ -126,11 +126,18 @@ pub struct PhaseDelta {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::profile::{InstructionMix, PhaseProfile, ProcedureProfile, TransactionKernelProfile};
     use std::collections::BTreeMap;
 
-    fn create_test_profile(version: &str, total_cycles: u64, phases: BTreeMap<String, PhaseProfile>) -> VmProfile {
+    use super::*;
+    use crate::profile::{
+        InstructionMix, PhaseProfile, ProcedureProfile, TransactionKernelProfile,
+    };
+
+    fn create_test_profile(
+        version: &str,
+        total_cycles: u64,
+        phases: BTreeMap<String, PhaseProfile>,
+    ) -> VmProfile {
         VmProfile {
             profile_version: version.to_string(),
             source: "test".to_string(),
@@ -158,8 +165,14 @@ mod tests {
     #[test]
     fn validate_valid_profile_passes() {
         let mut phases = BTreeMap::new();
-        phases.insert("prologue".to_string(), PhaseProfile { cycles: 50, operations: BTreeMap::new() });
-        phases.insert("epilogue".to_string(), PhaseProfile { cycles: 50, operations: BTreeMap::new() });
+        phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 50, operations: BTreeMap::new() },
+        );
+        phases.insert(
+            "epilogue".to_string(),
+            PhaseProfile { cycles: 50, operations: BTreeMap::new() },
+        );
 
         let profile = create_test_profile("1.0", 100, phases);
         let validator = ProfileValidator::new();
@@ -170,7 +183,10 @@ mod tests {
     #[test]
     fn validate_unsupported_version_fails() {
         let mut phases = BTreeMap::new();
-        phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+        phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 100, operations: BTreeMap::new() },
+        );
 
         let profile = create_test_profile("2.0", 100, phases);
         let validator = ProfileValidator::new();
@@ -194,7 +210,10 @@ mod tests {
     #[test]
     fn validate_mismatched_totals_fails() {
         let mut phases = BTreeMap::new();
-        phases.insert("prologue".to_string(), PhaseProfile { cycles: 50, operations: BTreeMap::new() });
+        phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 50, operations: BTreeMap::new() },
+        );
         // total_cycles is 1000 but phases only sum to 50
         let profile = create_test_profile("1.0", 1000, phases);
         let validator = ProfileValidator::new();
@@ -208,7 +227,10 @@ mod tests {
     fn validate_small_profile_with_min_tolerance() {
         // Profile with total_cycles < 100 should still work with max(1) tolerance
         let mut phases = BTreeMap::new();
-        phases.insert("prologue".to_string(), PhaseProfile { cycles: 10, operations: BTreeMap::new() });
+        phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 10, operations: BTreeMap::new() },
+        );
 
         // total_cycles = 10, phases sum to 10, diff = 0, tolerance = max(10/100, 1) = 1
         let profile = create_test_profile("1.0", 10, phases);
@@ -220,10 +242,16 @@ mod tests {
     #[test]
     fn compare_profiles_detects_deltas() {
         let mut baseline_phases = BTreeMap::new();
-        baseline_phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+        baseline_phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 100, operations: BTreeMap::new() },
+        );
 
         let mut current_phases = BTreeMap::new();
-        current_phases.insert("prologue".to_string(), PhaseProfile { cycles: 150, operations: BTreeMap::new() });
+        current_phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 150, operations: BTreeMap::new() },
+        );
 
         let baseline = create_test_profile("1.0", 100, baseline_phases);
         let current = create_test_profile("1.0", 150, current_phases);
@@ -241,10 +269,16 @@ mod tests {
     #[test]
     fn compare_profiles_zero_baseline_cycles() {
         let mut baseline_phases = BTreeMap::new();
-        baseline_phases.insert("prologue".to_string(), PhaseProfile { cycles: 0, operations: BTreeMap::new() });
+        baseline_phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 0, operations: BTreeMap::new() },
+        );
 
         let mut current_phases = BTreeMap::new();
-        current_phases.insert("prologue".to_string(), PhaseProfile { cycles: 50, operations: BTreeMap::new() });
+        current_phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 50, operations: BTreeMap::new() },
+        );
 
         let baseline = create_test_profile("1.0", 0, baseline_phases);
         let current = create_test_profile("1.0", 50, current_phases);
@@ -259,10 +293,16 @@ mod tests {
     #[test]
     fn compare_profiles_both_zero_cycles() {
         let mut baseline_phases = BTreeMap::new();
-        baseline_phases.insert("prologue".to_string(), PhaseProfile { cycles: 0, operations: BTreeMap::new() });
+        baseline_phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 0, operations: BTreeMap::new() },
+        );
 
         let mut current_phases = BTreeMap::new();
-        current_phases.insert("prologue".to_string(), PhaseProfile { cycles: 0, operations: BTreeMap::new() });
+        current_phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 0, operations: BTreeMap::new() },
+        );
 
         let baseline = create_test_profile("1.0", 0, baseline_phases);
         let current = create_test_profile("1.0", 0, current_phases);
@@ -277,11 +317,20 @@ mod tests {
     #[test]
     fn compare_profiles_detects_missing_phases() {
         let mut baseline_phases = BTreeMap::new();
-        baseline_phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
-        baseline_phases.insert("epilogue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+        baseline_phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 100, operations: BTreeMap::new() },
+        );
+        baseline_phases.insert(
+            "epilogue".to_string(),
+            PhaseProfile { cycles: 100, operations: BTreeMap::new() },
+        );
 
         let mut current_phases = BTreeMap::new();
-        current_phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+        current_phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 100, operations: BTreeMap::new() },
+        );
         // epilogue is missing
 
         let baseline = create_test_profile("1.0", 200, baseline_phases);
@@ -297,11 +346,20 @@ mod tests {
     #[test]
     fn compare_profiles_detects_new_phases() {
         let mut baseline_phases = BTreeMap::new();
-        baseline_phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+        baseline_phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 100, operations: BTreeMap::new() },
+        );
 
         let mut current_phases = BTreeMap::new();
-        current_phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
-        current_phases.insert("new_phase".to_string(), PhaseProfile { cycles: 50, operations: BTreeMap::new() });
+        current_phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 100, operations: BTreeMap::new() },
+        );
+        current_phases.insert(
+            "new_phase".to_string(),
+            PhaseProfile { cycles: 50, operations: BTreeMap::new() },
+        );
 
         let baseline = create_test_profile("1.0", 100, baseline_phases);
         let current = create_test_profile("1.0", 150, current_phases);
@@ -315,9 +373,12 @@ mod tests {
 
     #[test]
     fn default_validator_works() {
-        let validator = ProfileValidator::default();
+        let validator = ProfileValidator;
         let mut phases = BTreeMap::new();
-        phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+        phases.insert(
+            "prologue".to_string(),
+            PhaseProfile { cycles: 100, operations: BTreeMap::new() },
+        );
 
         let profile = create_test_profile("1.0", 100, phases);
         assert!(validator.validate(&profile).is_ok());

--- a/benches/synthetic-tx-kernel/src/validator.rs
+++ b/benches/synthetic-tx-kernel/src/validator.rs
@@ -148,6 +148,7 @@ mod tests {
                     cycles: 100,
                     invocations: 1,
                 }],
+                operation_details: Vec::new(),
             },
         }
     }

--- a/benches/synthetic-tx-kernel/src/validator.rs
+++ b/benches/synthetic-tx-kernel/src/validator.rs
@@ -1,0 +1,92 @@
+//! Validates that synthetic benchmarks match their source profiles
+
+use crate::profile::VmProfile;
+use anyhow::{Result, bail};
+
+/// Validates a VM profile for correctness
+pub struct ProfileValidator;
+
+impl ProfileValidator {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Validate a profile
+    pub fn validate(&self, profile: &VmProfile) -> Result<()> {
+        // Check version
+        if profile.profile_version != "1.0" {
+            bail!("Unsupported profile version: {}", profile.profile_version);
+        }
+
+        // Validate instruction mix sums to ~1.0
+        profile.transaction_kernel.instruction_mix.validate()?;
+
+        // Check that total cycles matches sum of phases
+        let phase_total: u64 = profile.transaction_kernel.phases.values()
+            .map(|p| p.cycles)
+            .sum();
+
+        if phase_total == 0 {
+            bail!("Total cycles is zero");
+        }
+
+        // Allow 1% tolerance
+        let diff = if phase_total > profile.transaction_kernel.total_cycles {
+            phase_total - profile.transaction_kernel.total_cycles
+        } else {
+            profile.transaction_kernel.total_cycles - phase_total
+        };
+
+        let tolerance = profile.transaction_kernel.total_cycles / 100;
+        if diff > tolerance {
+            bail!(
+                "Phase cycle sum ({}) differs from total ({}) by more than 1%",
+                phase_total,
+                profile.transaction_kernel.total_cycles
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Compare two profiles and report differences
+    pub fn compare_profiles(&self, baseline: &VmProfile, current: &VmProfile) -> ProfileDiff {
+        ProfileDiff {
+            total_cycles_delta: current.transaction_kernel.total_cycles as i64
+                - baseline.transaction_kernel.total_cycles as i64,
+            phase_deltas: self.compare_phases(baseline, current),
+        }
+    }
+
+    fn compare_phases(&self, baseline: &VmProfile, current: &VmProfile) -> Vec<PhaseDelta> {
+        let mut deltas = Vec::new();
+
+        for (name, current_phase) in &current.transaction_kernel.phases {
+            if let Some(baseline_phase) = baseline.transaction_kernel.phases.get(name) {
+                let delta = current_phase.cycles as i64 - baseline_phase.cycles as i64;
+                let pct_change = (delta as f64 / baseline_phase.cycles as f64) * 100.0;
+
+                deltas.push(PhaseDelta {
+                    name: name.clone(),
+                    cycles_delta: delta,
+                    percent_change: pct_change,
+                });
+            }
+        }
+
+        deltas
+    }
+}
+
+#[derive(Debug)]
+pub struct ProfileDiff {
+    pub total_cycles_delta: i64,
+    pub phase_deltas: Vec<PhaseDelta>,
+}
+
+#[derive(Debug)]
+pub struct PhaseDelta {
+    pub name: String,
+    pub cycles_delta: i64,
+    pub percent_change: f64,
+}

--- a/benches/synthetic-tx-kernel/src/validator.rs
+++ b/benches/synthetic-tx-kernel/src/validator.rs
@@ -1,10 +1,17 @@
 //! Validates that synthetic benchmarks match their source profiles
 
+use anyhow::{bail, Result};
+
 use crate::profile::VmProfile;
-use anyhow::{Result, bail};
 
 /// Validates a VM profile for correctness
 pub struct ProfileValidator;
+
+impl Default for ProfileValidator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl ProfileValidator {
     pub fn new() -> Self {
@@ -22,22 +29,16 @@ impl ProfileValidator {
         profile.transaction_kernel.instruction_mix.validate()?;
 
         // Check that total cycles matches sum of phases
-        let phase_total: u64 = profile.transaction_kernel.phases.values()
-            .map(|p| p.cycles)
-            .sum();
+        let phase_total: u64 = profile.transaction_kernel.phases.values().map(|p| p.cycles).sum();
 
         if phase_total == 0 {
             bail!("Total cycles is zero");
         }
 
-        // Allow 1% tolerance
-        let diff = if phase_total > profile.transaction_kernel.total_cycles {
-            phase_total - profile.transaction_kernel.total_cycles
-        } else {
-            profile.transaction_kernel.total_cycles - phase_total
-        };
+        // Allow 1% tolerance, with minimum of 1 to avoid zero tolerance for small profiles
+        let diff = phase_total.abs_diff(profile.transaction_kernel.total_cycles);
 
-        let tolerance = profile.transaction_kernel.total_cycles / 100;
+        let tolerance = (profile.transaction_kernel.total_cycles / 100).max(1);
         if diff > tolerance {
             bail!(
                 "Phase cycle sum ({}) differs from total ({}) by more than 1%",
@@ -51,30 +52,58 @@ impl ProfileValidator {
 
     /// Compare two profiles and report differences
     pub fn compare_profiles(&self, baseline: &VmProfile, current: &VmProfile) -> ProfileDiff {
+        let (phase_deltas, missing_phases, new_phases) = self.compare_phases(baseline, current);
+
         ProfileDiff {
             total_cycles_delta: current.transaction_kernel.total_cycles as i64
                 - baseline.transaction_kernel.total_cycles as i64,
-            phase_deltas: self.compare_phases(baseline, current),
+            phase_deltas,
+            missing_phases,
+            new_phases,
         }
     }
 
-    fn compare_phases(&self, baseline: &VmProfile, current: &VmProfile) -> Vec<PhaseDelta> {
+    fn compare_phases(
+        &self,
+        baseline: &VmProfile,
+        current: &VmProfile,
+    ) -> (Vec<PhaseDelta>, Vec<String>, Vec<String>) {
         let mut deltas = Vec::new();
+        let mut missing_phases = Vec::new();
+        let mut new_phases = Vec::new();
 
+        // Find phases in current that differ from or are missing in baseline
         for (name, current_phase) in &current.transaction_kernel.phases {
             if let Some(baseline_phase) = baseline.transaction_kernel.phases.get(name) {
                 let delta = current_phase.cycles as i64 - baseline_phase.cycles as i64;
-                let pct_change = (delta as f64 / baseline_phase.cycles as f64) * 100.0;
+                let pct_change = if baseline_phase.cycles == 0 {
+                    if current_phase.cycles == 0 {
+                        0.0
+                    } else {
+                        f64::INFINITY
+                    }
+                } else {
+                    (delta as f64 / baseline_phase.cycles as f64) * 100.0
+                };
 
                 deltas.push(PhaseDelta {
                     name: name.clone(),
                     cycles_delta: delta,
                     percent_change: pct_change,
                 });
+            } else {
+                new_phases.push(name.clone());
             }
         }
 
-        deltas
+        // Find phases in baseline that are missing in current
+        for name in baseline.transaction_kernel.phases.keys() {
+            if !current.transaction_kernel.phases.contains_key(name) {
+                missing_phases.push(name.clone());
+            }
+        }
+
+        (deltas, missing_phases, new_phases)
     }
 }
 
@@ -82,6 +111,10 @@ impl ProfileValidator {
 pub struct ProfileDiff {
     pub total_cycles_delta: i64,
     pub phase_deltas: Vec<PhaseDelta>,
+    /// Phases present in baseline but missing in current
+    pub missing_phases: Vec<String>,
+    /// Phases present in current but not in baseline
+    pub new_phases: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -89,4 +122,204 @@ pub struct PhaseDelta {
     pub name: String,
     pub cycles_delta: i64,
     pub percent_change: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profile::{InstructionMix, PhaseProfile, ProcedureProfile, TransactionKernelProfile};
+    use std::collections::BTreeMap;
+
+    fn create_test_profile(version: &str, total_cycles: u64, phases: BTreeMap<String, PhaseProfile>) -> VmProfile {
+        VmProfile {
+            profile_version: version.to_string(),
+            source: "test".to_string(),
+            timestamp: "2024-01-15T10:30:00Z".to_string(),
+            miden_vm_version: "0.20.0".to_string(),
+            transaction_kernel: TransactionKernelProfile {
+                total_cycles,
+                phases,
+                instruction_mix: InstructionMix {
+                    arithmetic: 0.2,
+                    hashing: 0.2,
+                    memory: 0.2,
+                    control_flow: 0.2,
+                    signature_verify: 0.2,
+                },
+                key_procedures: vec![ProcedureProfile {
+                    name: "test".to_string(),
+                    cycles: 100,
+                    invocations: 1,
+                }],
+            },
+        }
+    }
+
+    #[test]
+    fn validate_valid_profile_passes() {
+        let mut phases = BTreeMap::new();
+        phases.insert("prologue".to_string(), PhaseProfile { cycles: 50, operations: BTreeMap::new() });
+        phases.insert("epilogue".to_string(), PhaseProfile { cycles: 50, operations: BTreeMap::new() });
+
+        let profile = create_test_profile("1.0", 100, phases);
+        let validator = ProfileValidator::new();
+
+        assert!(validator.validate(&profile).is_ok());
+    }
+
+    #[test]
+    fn validate_unsupported_version_fails() {
+        let mut phases = BTreeMap::new();
+        phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+
+        let profile = create_test_profile("2.0", 100, phases);
+        let validator = ProfileValidator::new();
+
+        let result = validator.validate(&profile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unsupported profile version"));
+    }
+
+    #[test]
+    fn validate_zero_cycles_fails() {
+        let phases = BTreeMap::new();
+        let profile = create_test_profile("1.0", 0, phases);
+        let validator = ProfileValidator::new();
+
+        let result = validator.validate(&profile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Total cycles is zero"));
+    }
+
+    #[test]
+    fn validate_mismatched_totals_fails() {
+        let mut phases = BTreeMap::new();
+        phases.insert("prologue".to_string(), PhaseProfile { cycles: 50, operations: BTreeMap::new() });
+        // total_cycles is 1000 but phases only sum to 50
+        let profile = create_test_profile("1.0", 1000, phases);
+        let validator = ProfileValidator::new();
+
+        let result = validator.validate(&profile);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("differs from total"));
+    }
+
+    #[test]
+    fn validate_small_profile_with_min_tolerance() {
+        // Profile with total_cycles < 100 should still work with max(1) tolerance
+        let mut phases = BTreeMap::new();
+        phases.insert("prologue".to_string(), PhaseProfile { cycles: 10, operations: BTreeMap::new() });
+
+        // total_cycles = 10, phases sum to 10, diff = 0, tolerance = max(10/100, 1) = 1
+        let profile = create_test_profile("1.0", 10, phases);
+        let validator = ProfileValidator::new();
+
+        assert!(validator.validate(&profile).is_ok());
+    }
+
+    #[test]
+    fn compare_profiles_detects_deltas() {
+        let mut baseline_phases = BTreeMap::new();
+        baseline_phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+
+        let mut current_phases = BTreeMap::new();
+        current_phases.insert("prologue".to_string(), PhaseProfile { cycles: 150, operations: BTreeMap::new() });
+
+        let baseline = create_test_profile("1.0", 100, baseline_phases);
+        let current = create_test_profile("1.0", 150, current_phases);
+
+        let validator = ProfileValidator::new();
+        let diff = validator.compare_profiles(&baseline, &current);
+
+        assert_eq!(diff.total_cycles_delta, 50);
+        assert_eq!(diff.phase_deltas.len(), 1);
+        assert_eq!(diff.phase_deltas[0].name, "prologue");
+        assert_eq!(diff.phase_deltas[0].cycles_delta, 50);
+        assert_eq!(diff.phase_deltas[0].percent_change, 50.0);
+    }
+
+    #[test]
+    fn compare_profiles_zero_baseline_cycles() {
+        let mut baseline_phases = BTreeMap::new();
+        baseline_phases.insert("prologue".to_string(), PhaseProfile { cycles: 0, operations: BTreeMap::new() });
+
+        let mut current_phases = BTreeMap::new();
+        current_phases.insert("prologue".to_string(), PhaseProfile { cycles: 50, operations: BTreeMap::new() });
+
+        let baseline = create_test_profile("1.0", 0, baseline_phases);
+        let current = create_test_profile("1.0", 50, current_phases);
+
+        let validator = ProfileValidator::new();
+        let diff = validator.compare_profiles(&baseline, &current);
+
+        assert_eq!(diff.phase_deltas.len(), 1);
+        assert_eq!(diff.phase_deltas[0].percent_change, f64::INFINITY);
+    }
+
+    #[test]
+    fn compare_profiles_both_zero_cycles() {
+        let mut baseline_phases = BTreeMap::new();
+        baseline_phases.insert("prologue".to_string(), PhaseProfile { cycles: 0, operations: BTreeMap::new() });
+
+        let mut current_phases = BTreeMap::new();
+        current_phases.insert("prologue".to_string(), PhaseProfile { cycles: 0, operations: BTreeMap::new() });
+
+        let baseline = create_test_profile("1.0", 0, baseline_phases);
+        let current = create_test_profile("1.0", 0, current_phases);
+
+        let validator = ProfileValidator::new();
+        let diff = validator.compare_profiles(&baseline, &current);
+
+        assert_eq!(diff.phase_deltas.len(), 1);
+        assert_eq!(diff.phase_deltas[0].percent_change, 0.0);
+    }
+
+    #[test]
+    fn compare_profiles_detects_missing_phases() {
+        let mut baseline_phases = BTreeMap::new();
+        baseline_phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+        baseline_phases.insert("epilogue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+
+        let mut current_phases = BTreeMap::new();
+        current_phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+        // epilogue is missing
+
+        let baseline = create_test_profile("1.0", 200, baseline_phases);
+        let current = create_test_profile("1.0", 100, current_phases);
+
+        let validator = ProfileValidator::new();
+        let diff = validator.compare_profiles(&baseline, &current);
+
+        assert_eq!(diff.missing_phases.len(), 1);
+        assert_eq!(diff.missing_phases[0], "epilogue");
+    }
+
+    #[test]
+    fn compare_profiles_detects_new_phases() {
+        let mut baseline_phases = BTreeMap::new();
+        baseline_phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+
+        let mut current_phases = BTreeMap::new();
+        current_phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+        current_phases.insert("new_phase".to_string(), PhaseProfile { cycles: 50, operations: BTreeMap::new() });
+
+        let baseline = create_test_profile("1.0", 100, baseline_phases);
+        let current = create_test_profile("1.0", 150, current_phases);
+
+        let validator = ProfileValidator::new();
+        let diff = validator.compare_profiles(&baseline, &current);
+
+        assert_eq!(diff.new_phases.len(), 1);
+        assert_eq!(diff.new_phases[0], "new_phase");
+    }
+
+    #[test]
+    fn default_validator_works() {
+        let validator = ProfileValidator::default();
+        let mut phases = BTreeMap::new();
+        phases.insert("prologue".to_string(), PhaseProfile { cycles: 100, operations: BTreeMap::new() });
+
+        let profile = create_test_profile("1.0", 100, phases);
+        assert!(validator.validate(&profile).is_ok());
+    }
 }

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -9,6 +9,8 @@ use miden_formatting::{
 use serde::{Deserialize, Serialize};
 
 use super::{MastForestContributor, MastNodeExt};
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     chiplets::hasher,
@@ -18,8 +20,6 @@ use crate::{
     operations::{OPCODE_CALL, OPCODE_SYSCALL},
     utils::{Idx, LookupByIdx},
 };
-#[cfg(debug_assertions)]
-use crate::mast::MastNode;
 
 // CALL NODE
 // ================================================================================================

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -13,8 +13,7 @@ use crate::{
     Felt, Word,
     chiplets::hasher,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNode, MastNodeFingerprint,
-        MastNodeId,
+        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
     },
     operations::{OPCODE_CALL, OPCODE_SYSCALL},
     utils::{Idx, LookupByIdx},

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -18,6 +18,8 @@ use crate::{
     operations::{OPCODE_CALL, OPCODE_SYSCALL},
     utils::{Idx, LookupByIdx},
 };
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 
 // CALL NODE
 // ================================================================================================

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -5,6 +5,8 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 use super::{MastForestContributor, MastNodeExt};
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     mast::{
@@ -14,8 +16,6 @@ use crate::{
     prettier::{Document, PrettyPrint, const_text, nl},
     utils::LookupByIdx,
 };
-#[cfg(debug_assertions)]
-use crate::mast::MastNode;
 
 // DYN NODE
 // ================================================================================================

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -8,8 +8,7 @@ use super::{MastForestContributor, MastNodeExt};
 use crate::{
     Felt, Word,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNode, MastNodeFingerprint,
-        MastNodeId,
+        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
     },
     operations::{OPCODE_DYN, OPCODE_DYNCALL},
     prettier::{Document, PrettyPrint, const_text, nl},

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -14,6 +14,8 @@ use crate::{
     prettier::{Document, PrettyPrint, const_text, nl},
     utils::LookupByIdx,
 };
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 
 // DYN NODE
 // ================================================================================================

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -15,6 +15,8 @@ use crate::{
     prettier::PrettyPrint,
     utils::{Idx, LookupByIdx},
 };
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 
 // JOIN NODE
 // ================================================================================================

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -9,8 +9,7 @@ use crate::{
     Felt, Word,
     chiplets::hasher,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNode, MastNodeFingerprint,
-        MastNodeId,
+        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
     },
     operations::OPCODE_JOIN,
     prettier::PrettyPrint,

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -5,6 +5,8 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 use super::{MastForestContributor, MastNodeExt};
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     chiplets::hasher,
@@ -15,8 +17,6 @@ use crate::{
     prettier::PrettyPrint,
     utils::{Idx, LookupByIdx},
 };
-#[cfg(debug_assertions)]
-use crate::mast::MastNode;
 
 // JOIN NODE
 // ================================================================================================

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -15,6 +15,8 @@ use crate::{
     prettier::PrettyPrint,
     utils::{Idx, LookupByIdx},
 };
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 
 // LOOP NODE
 // ================================================================================================

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -9,8 +9,7 @@ use crate::{
     Felt, Word,
     chiplets::hasher,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNode, MastNodeFingerprint,
-        MastNodeId,
+        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
     },
     operations::OPCODE_LOOP,
     prettier::PrettyPrint,

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -5,6 +5,8 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 use super::{MastForestContributor, MastNodeExt};
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     chiplets::hasher,
@@ -15,8 +17,6 @@ use crate::{
     prettier::PrettyPrint,
     utils::{Idx, LookupByIdx},
 };
-#[cfg(debug_assertions)]
-use crate::mast::MastNode;
 
 // LOOP NODE
 // ================================================================================================

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -15,6 +15,8 @@ use crate::{
     prettier::PrettyPrint,
     utils::{Idx, LookupByIdx},
 };
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 
 // SPLIT NODE
 // ================================================================================================

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -5,6 +5,8 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 
 use super::{MastForestContributor, MastNodeExt};
+#[cfg(debug_assertions)]
+use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     chiplets::hasher,
@@ -15,8 +17,6 @@ use crate::{
     prettier::PrettyPrint,
     utils::{Idx, LookupByIdx},
 };
-#[cfg(debug_assertions)]
-use crate::mast::MastNode;
 
 // SPLIT NODE
 // ================================================================================================

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -9,8 +9,7 @@ use crate::{
     Felt, Word,
     chiplets::hasher,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNode, MastNodeFingerprint,
-        MastNodeId,
+        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
     },
     operations::OPCODE_SPLIT,
     prettier::PrettyPrint,


### PR DESCRIPTION
Companion PR of https://github.com/0xMiden/miden-base/pull/2391
----
This branch adds a synthetic transaction kernel benchmark so miden-vm can be tested without pulling in the full protocol, as discussed in issue #2256. It introduces a new benchmark crate with generators, validators, and bench targets that consume the VM profile snapshot exported by miden-base, which is treated as the only real workload benchmark. This keeps miden-vm performance testing representative while staying decoupled from protocol dependencies. 

Workflow across repos:
- Run the transaction kernel bench in miden-base and export the VM profile JSON.
- Copy that profile into `benches/synthetic-tx-kernel/profiles` in miden-vm.
- Run the synthetic benchmarks in miden-vm against that snapshot.
