### PR TITLE
fix: remove clone in air/src/constraints/range.rs

### DIFF
--- a/air/src/constraints/range.rs
+++ b/air/src/constraints/range.rs
@@ -150,9 +150,7 @@ where
     // LogUp transition constraint terms
     let b_next_term = b_next.into() * lookups.clone();
     let b_term = b_local.into() * lookups;
-    let rc_term = stack_lookups
-        * memory_lookups
-        * AB::ExprEF::from(local.range[0].clone().into());
+    let rc_term = stack_lookups * memory_lookups * AB::ExprEF::from(local.range[0].clone().into());
 
     // Stack lookup removal terms
     let s0_term = sflag_rc_mem.clone() * sv1.clone() * sv2.clone() * sv3.clone();


### PR DESCRIPTION
## Describe your changes
Removed unnecessary `.clone()` calls in `air/src/constraints/range.rs`

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.

Fixes: #2652 