### PR TITLE
[DO NOT MERGE] experiment: only use start/finalize_clock_cycle methods in ExecutionTracer

### DIFF
--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -134,7 +134,7 @@ pub struct FastProcessor {
     memory: Memory,
 
     /// A map storing metadata per call to the ACE chiplet.
-    ace: Ace,
+    pub(crate) ace: Ace,
 
     /// The call stack is used when starting a new execution context (from a `call`, `syscall` or
     /// `dyncall`) to keep track of the information needed to return to the previous context upon

--- a/processor/src/trace/chiplets/ace/mod.rs
+++ b/processor/src/trace/chiplets/ace/mod.rs
@@ -28,7 +28,7 @@ pub const MAX_NUM_ACE_WIRES: u32 = instruction::MAX_ID;
 /// [`CircuitEvaluation`] per call. This is then used to generate the full trace of the ACE chiplet.
 #[derive(Debug, Default)]
 pub struct Ace {
-    circuit_evaluations: BTreeMap<RowIndex, CircuitEvaluation>,
+    pub(crate) circuit_evaluations: BTreeMap<RowIndex, CircuitEvaluation>,
 }
 
 impl Ace {


### PR DESCRIPTION
Work towards #2636

While conceptually cleaner, this affects the performance considerably of the `program_execution_for_trace` benchmark (~60% worse). Essentially, with this approach, we end up redoing too much work in the start/finalize methods.

Next steps: figure out how to cleanup the `Tracer` API so that it's well defined and conceptually easy to understand - without affecting the performance of `ExecutionTracer`.

## Benchmark results
- `next`

```
program_execution/blake3_1to1
                        time:   [5.9561 ms 5.9679 ms 5.9814 ms]
```

- this branch

```
program_execution/blake3_1to1
                        time:   [9.6478 ms 9.6659 ms 9.6850 ms]
                        change: [+61.500% +61.965% +62.465%] (p = 0.00 < 0.05)
                        Performance has regressd.
```