### PR TITLE
ci: update Rust toolchain to 1.91

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.90"
+channel = "1.91"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
The publish and dry-run workflows have been failing because cargo-msrv v0.18.4 depends on AWS SDK crates that require Rust 1.91 or later. The repository was pinned to Rust 1.90 via rust-toolchain.toml, which caused cargo install to fail with:

    rustc 1.90.0 is not supported by the following packages:
        aws-config@1.8.14 requires rustc 1.91
        aws-credential-types@1.2.12 requires rustc 1.91
        ...
        
First failure in the daily publish dry runs (harbinger that we were going to have this issue at the next release):
https://github.com/0xMiden/miden-vm/actions/runs/21923750514
Publish failure:
https://github.com/0xMiden/miden-vm/actions/runs/22026537277
        
Updating to Rust 1.91 resolves this. Note: rust-toolchain.toml specifies the version used by CI workflows, not the package MSRV (which is set separately in Cargo.toml files).