### PR TITLE
refactor: deduplicate struct construction in BlockHashTableRow::from_split

### DIFF
--- a/processor/src/trace/decoder/aux_trace/block_hash_table.rs
+++ b/processor/src/trace/decoder/aux_trace/block_hash_table.rs
@@ -182,23 +182,17 @@ impl BlockHashTableRow {
         let is_first_child = false;
         let is_loop_body = false;
 
-        if stack_top == ONE {
-            let left_child_block_hash = main_trace.decoder_hasher_state_first_half(row);
-            Self {
-                parent_block_id,
-                child_block_hash: left_child_block_hash,
-                is_first_child,
-                is_loop_body,
-            }
+        let child_block_hash = if stack_top == ONE {
+            main_trace.decoder_hasher_state_first_half(row)
         } else {
-            let right_child_block_hash = main_trace.decoder_hasher_state_second_half(row);
+            main_trace.decoder_hasher_state_second_half(row)
+        };
 
-            Self {
-                parent_block_id,
-                child_block_hash: right_child_block_hash,
-                is_first_child,
-                is_loop_body,
-            }
+        Self {
+            parent_block_id,
+            child_block_hash,
+            is_first_child,
+            is_loop_body,
         }
     }
 


### PR DESCRIPTION
## Describe your changes

Removed duplicated Self { ... } construction in from_split by extracting child_block_hash into a variable, matching the pattern already used in from_join

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.

Fixes: #2708 