### PR TITLE
fix: simplify Arc<str> construction

### DIFF
--- a/crates/assembly-syntax/src/ast/attribute/meta/expr.rs
+++ b/crates/assembly-syntax/src/ast/attribute/meta/expr.rs
@@ -168,9 +168,7 @@ impl Deserializable for MetaExpr {
                 let bytes = source.read_slice(len)?;
                 let id = core::str::from_utf8(bytes)
                     .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
-                Ok(Self::String(Ident::from_raw_parts(Span::unknown(Arc::from(
-                    id.to_string().into_boxed_str(),
-                )))))
+                Ok(Self::String(Ident::from_raw_parts(Span::unknown(Arc::from(id)))))
             },
             n => Err(DeserializationError::InvalidValue(format!(
                 "unknown MetaExpr variant tag '{n}'"


### PR DESCRIPTION
## Describe your changes
Replace `Arc::from(id.to_string().into_boxed_str())` with `Arc::from(id)` in Deserializable impl for MetaExpr

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.

Fixes: #2705