### PR TITLE
Remove tests that check for multiple writes in same clock cycle

### DIFF
--- a/processor/src/execution/operations/io_ops/tests.rs
+++ b/processor/src/execution/operations/io_ops/tests.rs
@@ -384,50 +384,6 @@ fn test_op_pipe() {
     assert_eq!(expected, processor.stack_top());
 }
 
-// CLOCK CYCLE CONFLICT TESTS
-// --------------------------------------------------------------------------------------------
-
-/// Ensures that reading and writing in the same clock cycle results in an error.
-#[test]
-#[ignore = "Re-enable when addressing issue 2276"]
-fn test_read_and_write_in_same_clock_cycle() {
-    let mut processor = FastProcessor::new(StackInputs::default());
-    let mut tracer = NoopTracer;
-
-    assert_eq!(0, processor.memory().num_accessed_words());
-
-    // emulate reading and writing in the same clock cycle (no increment_clk between operations)
-    op_mload(&mut processor, &mut tracer).unwrap();
-    assert!(op_mstore(&mut processor, &mut tracer).is_err());
-}
-
-/// Ensures that writing twice in the same clock cycle results in an error.
-#[test]
-#[ignore = "Re-enable when addressing issue 2276"]
-fn test_write_twice_in_same_clock_cycle() {
-    let mut processor = FastProcessor::new(StackInputs::default());
-    let mut tracer = NoopTracer;
-
-    assert_eq!(0, processor.memory().num_accessed_words());
-
-    // emulate writing twice in the same clock cycle (no increment_clk between operations)
-    op_mstore(&mut processor, &mut tracer).unwrap();
-    assert!(op_mstore(&mut processor, &mut tracer).is_err());
-}
-
-/// Ensures that reading twice in the same clock cycle does NOT result in an error.
-#[test]
-fn test_read_twice_in_same_clock_cycle() {
-    let mut processor = FastProcessor::new(StackInputs::default());
-    let mut tracer = NoopTracer;
-
-    assert_eq!(0, processor.memory().num_accessed_words());
-
-    // emulate reading twice in the same clock cycle (no increment_clk between operations)
-    op_mload(&mut processor, &mut tracer).unwrap();
-    op_mload(&mut processor, &mut tracer).unwrap();
-}
-
 // HELPER METHODS
 // --------------------------------------------------------------------------------------------
 

--- a/processor/src/fast/memory.rs
+++ b/processor/src/fast/memory.rs
@@ -9,6 +9,16 @@ use crate::{ContextId, MemoryAddress, MemoryError, PrimeField64, processor::Memo
 ///
 /// Allows to read/write elements or words to memory. Internally, it is implemented as a map from
 ///(context_id, word_address) to the word stored starting at that memory location.
+///
+/// # Invariants
+/// The memory submodule assumes that the following invariants hold:
+/// - Multiple reads in the same clock cycle to the same address are allowed, but
+/// - Multiple writes in the same clock cycle to the same address are *not* allowed
+///
+/// These invariants are not enforced by [`Memory`] explicitly, but are expected to be upheld by all
+/// processor operations (i.e. all variants of the [`miden_core::operations::Operation`] enum). This
+/// is a consequence of the design of the memory chiplet constraints, which allow for multiple reads
+/// but not multiple writes in the same clock cycle to the same address.
 #[derive(Debug, Default)]
 pub struct Memory {
     memory: BTreeMap<(ContextId, u32), Word>,


### PR DESCRIPTION
Closes #2276

Closing this one as a non-issue (and removing the tests related to that functionality). The tests were quite artificial - no one can write a program that executes `op_mstore()` twice in the same clock cycle. Instead, whether the same memory location was written multiple times in the same clock cycle is a property of our operations, and does *not* need to be checked explicitly by the processor every time. That is, we should check each operation individually and ensure that this property is maintained (and add checks if there's a risk that it's not), rather than checking "generally" on each memory write in the processor.

I've only identified the `crypto_stream` operation as having inputs that could result in 2 writes to the same location in the same clock cycle - and in the processor we [already check for this condition](https://github.com/0xMiden/miden-vm/blob/a8a291726270ea70f9befaedb63663680993d210/processor/src/execution/operations/crypto_ops/mod.rs#L617-L628). However, @Al-Kindi-0 is this something that is also handled by our constraints/buses (i.e. if someone uses a malicious prover, will proof verification fail?) - I didn't find the `CryptoStream` operation in our docs (we probably need an issue for that).