### PR TITLE
fix: correct typos and replace TODO expect messages

### DIFF
--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -334,7 +334,7 @@ impl Linker {
     ///
     /// Note: it is assumed that kernel and kernel_module are consistent, but this is not checked.
     ///
-    /// TODO: consider passing `KerneLibrary` into this constructor as a parameter instead.
+    /// TODO: consider passing `KernelLibrary` into this constructor as a parameter instead.
     pub(super) fn with_kernel(
         source_manager: Arc<dyn SourceManager>,
         kernel: Kernel,

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -100,7 +100,7 @@ impl MastForestBuilder {
         // All statically-linked libraries are merged into a single MastForest.
         let forests = static_libraries.into_iter().map(|lib| lib.mast_forest().as_ref());
         let (statically_linked_mast, _remapping) = MastForest::merge(forests).into_diagnostic()?;
-        // The AdviceMap of the statically-linkeed forest is copied to the forest being built.
+        // The AdviceMap of the statically-linked forest is copied to the forest being built.
         //
         // This might include excess advice map data in the built MastForest, but we currently do
         // not do any analysis to determine what advice map data is actually required by parts of

--- a/processor/src/trace/chiplets/ace/tests/circuit.rs
+++ b/processor/src/trace/chiplets/ace/tests/circuit.rs
@@ -104,11 +104,19 @@ impl Circuit {
         nodes.extend(self.constants.iter().map(|c| QuadFelt::from(*c)));
 
         for instruction in &self.instructions {
-            let id_l = layout.node_index(&instruction.node_l).expect("TODO");
-            let v_l = *nodes.get(id_l).expect("TODO");
+            let id_l = layout
+                .node_index(&instruction.node_l)
+                .expect("left operand node not found in circuit layout");
+            let v_l = *nodes
+                .get(id_l)
+                .expect("left operand index out of bounds in evaluated nodes");
 
-            let id_r = layout.node_index(&instruction.node_r).expect("TODO");
-            let v_r = *nodes.get(id_r).expect("TODO");
+            let id_r = layout
+                .node_index(&instruction.node_r)
+                .expect("right operand node not found in circuit layout");
+            let v_r = *nodes
+                .get(id_r)
+                .expect("right operand index out of bounds in evaluated nodes");
 
             let v_out = match instruction.op {
                 Op::Sub => v_l - v_r,


### PR DESCRIPTION
found a few small issues while reading through the codebase:

- fixed "linkeed" → "linked" typo in mast_forest_builder.rs comment
- fixed "KerneLibrary" → "KernelLibrary" typo in linker/mod.rs doc comment (actual type name is KernelLibrary)
- replaced .expect("TODO") placeholders in ace circuit tests with descriptive messages so panics are actually debuggable