### PR TITLE
fix: remove dead imm == 0 checks in u32rotr and prepare_bitwise

### DIFF
--- a/crates/assembly/src/instruction/u32_ops.rs
+++ b/crates/assembly/src/instruction/u32_ops.rs
@@ -334,10 +334,10 @@ pub fn u32rotr(
             span_builder.push_op(Noop);
         },
         Some(imm) => {
-            if imm == 0 || imm > MAX_U32_ROTATE_VALUE {
+            if imm > MAX_U32_ROTATE_VALUE {
                 return Err(RelatedLabel::error("invalid argument")
                     .with_labeled_span(span, "this instruction argument is out of range")
-                    .with_help(format!("value must be in the range 0..={MAX_U32_ROTATE_VALUE}"))
+                    .with_help(format!("value must be in the range 1..={MAX_U32_ROTATE_VALUE}"))
                     .with_source_file(proc_ctx.source_manager().get(span.source_id()).ok())
                     .into());
             }
@@ -517,10 +517,10 @@ fn prepare_bitwise<const MAX_VALUE: u8>(
             block_builder.push_op(Noop);
         },
         Some(imm) => {
-            if imm == 0 || imm > MAX_VALUE {
+            if imm > MAX_VALUE {
                 return Err(RelatedLabel::error("invalid argument")
                     .with_labeled_span(span, "this instruction argument is out of range")
-                    .with_help(format!("value must be in the range 0..={MAX_VALUE}"))
+                    .with_help(format!("value must be in the range 1..={MAX_VALUE}"))
                     .with_source_file(proc_ctx.source_manager().get(span.source_id()).ok())
                     .into());
             }


### PR DESCRIPTION
## Describe your changes

Both u32rotr and prepare_bitwise in u32_ops.rs match on Some(0) first and emit a Noop. So the next arm Some(imm) never gets imm = 0.

But both still have imm == 0 || in their range checks — this is dead code. The error messages also say 0..=N which is wrong since 0 is handled above as a valid no-op.

Removed the dead imm == 0 checks and fixed the error range to 1..=N.

No behavioral change, just cleanup.

## Checklist before requesting a review
- [x] Repo forked and branch created from next
- [x] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md)
- [x] Self-review completed