### PR TITLE
fix(assembly-syntax): implement Hash for QualifiedProcedureName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 #### Fixes
 
+- Implemented custom `Hash` for `QualifiedProcedureName`, ensuring consistency with its `PartialEq` implementation.
 - Fixed `Constant::PartialEq` to include `visibility` field in equality comparison, making it consistent with other exportable items (`Procedure`, `TypeAlias`, `EnumType`).
 
 ## 0.21.1 (2026-02-24)

--- a/crates/assembly-syntax/src/ast/procedure/name.rs
+++ b/crates/assembly-syntax/src/ast/procedure/name.rs
@@ -163,6 +163,12 @@ impl PartialEq for QualifiedProcedureName {
     }
 }
 
+impl Hash for QualifiedProcedureName {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.path.hash(state);
+    }
+}
+
 impl Ord for QualifiedProcedureName {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         self.path.cmp(&other.path)


### PR DESCRIPTION
Implement custom Hash for QualifiedProcedureName to enforce the PartialEq contract, preventing silent bugs when used as a hash map key.
