### PR TITLE
Revert toolchain to 1.90 and add CI carveout for MSRV check

### DIFF
--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -52,9 +52,15 @@ runs:
       shell: bash
       run: cargo install cargo-msrv
 
+    - name: Install Rust 1.91 for MSRV check
+      shell: bash
+      run: rustup toolchain install 1.91
+
     # Keep your existing MSRV check
     - name: Check MSRV
       shell: bash
+      env:
+        RUSTUP_TOOLCHAIN: "1.91"
       run: |
         chmod +x scripts/check-msrv.sh
         ./scripts/check-msrv.sh

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.91"
+channel = "1.90"
 components = ["rustfmt", "rust-src", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
Rust 1.91+ introduces a performance regression (~15-20% slower). Revert the default toolchain to 1.90 while keeping the MSRV check on 1.91 via RUSTUP_TOOLCHAIN env var.

Mitiates #2745. Reverts #2703.
