### PR TITLE
Refactor MAST forest serialization around fixed-layout hashless sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 #### Changes
 
+- [BREAKING] Refactored MAST forest serialization around fixed-layout full, stripped, and hashless sections, and bumped the MAST wire format to `0.0.3` ([#2765](https://github.com/0xMiden/miden-vm/pull/2765)).
 - Documented sortedness precondition more prominently for sorted array operations ([#2832](https://github.com/0xMiden/miden-vm/pull/2832)).
 - [BREAKING] Updated the Miden crypto stack to `miden-crypto` and `miden-lifted-stark` v0.24, and switched digest-ordering code to `Word`'s native lexicographic ordering ([#3039](https://github.com/0xMiden/miden-vm/pull/3039)).
 - Borrowed operation slices in basic-block batching helpers to avoid cloning in the fingerprinting path ([#2994](https://github.com/0xMiden/miden-vm/pull/2994)).
@@ -50,7 +51,6 @@
 #### Fixes
 
 - Fixed stale `ReplayProcessor` doc comment links to `ExecutionTracer` after module-structure refactors.
-- [BREAKING] Refactored MAST forest serialization around fixed-layout full, stripped, and hashless sections, and bumped the MAST wire format to `0.0.3` ([#2765](https://github.com/0xMiden/miden-vm/pull/2765)).
 
 ## 0.22.1 (2026-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 #### Fixes
 
 - Fixed stale `ReplayProcessor` doc comment links to `ExecutionTracer` after module-structure refactors.
+- [BREAKING] Refactored MAST forest serialization around fixed-layout full, stripped, and hashless sections, and bumped the MAST wire format to `0.0.3` ([#2765](https://github.com/0xMiden/miden-vm/pull/2765)).
 
 ## 0.22.1 (2026-04-07)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,7 @@ dependencies = [
  "criterion",
  "derive_more",
  "insta",
+ "log",
  "miden-crypto",
  "miden-debug-types",
  "miden-formatting",

--- a/Makefile
+++ b/Makefile
@@ -279,11 +279,23 @@ fuzz-mast-forest: fuzz-seeds ## Run fuzzing for MastForest deserialization
 fuzz-mast-validate: fuzz-seeds ## Run fuzzing for UntrustedMastForest validation
 	-@cargo +nightly fuzz run mast_forest_validate --release --fuzz-dir miden-core-fuzz
 
+.PHONY: fuzz-mast-node-info
+fuzz-mast-node-info: fuzz-seeds ## Run fuzzing for SerializedMastForest node metadata access
+	-@cargo +nightly fuzz run mast_node_info --release --fuzz-dir miden-core-fuzz
+
+.PHONY: fuzz-serialized-mast-forest
+fuzz-serialized-mast-forest: fuzz-seeds ## Run fuzzing for SerializedMastForest structural inspection
+	-@cargo +nightly fuzz run serialized_mast_forest_new --release --fuzz-dir miden-core-fuzz
+
 .PHONY: fuzz-all
 fuzz-all: fuzz-seeds ## Run all fuzz targets (in sequence)
 	-@cargo +nightly fuzz run mast_forest_deserialize --release --fuzz-dir miden-core-fuzz -- -max_total_time=300
 	-@cargo +nightly fuzz run mast_forest_serde_deserialize --release --fuzz-dir miden-core-fuzz -- -max_total_time=300
 	-@cargo +nightly fuzz run mast_forest_validate --release --fuzz-dir miden-core-fuzz -- -max_total_time=300
+	-@cargo +nightly fuzz run mast_node_info --release --fuzz-dir miden-core-fuzz -- -max_total_time=300
+	-@cargo +nightly fuzz run serialized_mast_forest_new --release --fuzz-dir miden-core-fuzz -- -max_total_time=300
+	-@cargo +nightly fuzz run basic_block_data --release --fuzz-dir miden-core-fuzz -- -max_total_time=300
+	-@cargo +nightly fuzz run debug_info --release --fuzz-dir miden-core-fuzz -- -max_total_time=300
 	-@cargo +nightly fuzz run program_deserialize --release --fuzz-dir miden-core-fuzz -- -max_total_time=300
 	-@cargo +nightly fuzz run program_serde_deserialize --release --fuzz-dir miden-core-fuzz -- -max_total_time=300
 	-@cargo +nightly fuzz run kernel_deserialize --release --fuzz-dir miden-core-fuzz -- -max_total_time=300

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,6 +23,11 @@ name = "mast_forest_merge"
 required-features = ["arbitrary"]
 harness = false
 
+[[bench]]
+name = "mast_serialization_size"
+required-features = ["arbitrary"]
+harness = false
+
 [features]
 default = ["std"]
 std = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -59,6 +59,7 @@ miden-utils-sync.workspace = true
 
 # External dependencies
 derive_more.workspace = true
+log.workspace = true
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 proptest = { workspace = true, optional = true }

--- a/core/benches/mast_serialization_size.rs
+++ b/core/benches/mast_serialization_size.rs
@@ -1,0 +1,101 @@
+//! Benchmark MastForest serialization and report byte sizes for full/stripped/hashless.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use miden_core::{
+    mast::{MastForest, arbitrary::MastForestParams},
+    serde::Serializable,
+};
+use proptest::{
+    arbitrary::any_with,
+    strategy::Strategy,
+    test_runner::{Config, RngAlgorithm, TestRng, TestRunner},
+};
+
+/// Draw one MastForest sample from proptest's strategy space using the Arbitrary impl.
+fn sample_forest(params: MastForestParams, runner: &mut TestRunner) -> MastForest {
+    let strat = any_with::<MastForest>(params);
+    strat.new_tree(runner).expect("strategy should be valid").current()
+}
+
+fn serialize_sizes(forest: &MastForest) -> (usize, usize, usize) {
+    let full_bytes = forest.to_bytes();
+
+    let mut stripped_bytes = Vec::new();
+    forest.write_stripped(&mut stripped_bytes);
+
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+
+    (full_bytes.len(), stripped_bytes.len(), hashless_bytes.len())
+}
+
+fn bench_serialization_sizes(c: &mut Criterion) {
+    let sizes: &[usize] = &[8, 16, 32, 64, 128, 256];
+    let mut group = c.benchmark_group("mast_serialization");
+
+    let seed = [0u8; 32];
+    let mut runner = TestRunner::new_with_rng(
+        Config::default(),
+        TestRng::from_seed(RngAlgorithm::ChaCha, &seed),
+    );
+
+    for &blocks_per_forest in sizes {
+        let gen_params = MastForestParams {
+            decorators: 32,
+            blocks: blocks_per_forest..=blocks_per_forest,
+            max_joins: blocks_per_forest.min(8),
+            max_splits: blocks_per_forest.min(8),
+            max_loops: blocks_per_forest.min(4),
+            max_calls: blocks_per_forest.min(4),
+            max_syscalls: 0,
+            max_externals: blocks_per_forest.min(2),
+            max_dyns: blocks_per_forest.min(2),
+        };
+
+        let forest = sample_forest(gen_params, &mut runner);
+        let (full, stripped, hashless) = serialize_sizes(&forest);
+        eprintln!("blocks={blocks_per_forest} full={full} stripped={stripped} hashless={hashless}");
+
+        group.throughput(Throughput::Bytes(full as u64));
+        group.bench_with_input(
+            BenchmarkId::new("full", blocks_per_forest),
+            &forest,
+            |b, forest| {
+                b.iter(|| black_box(forest.to_bytes()));
+            },
+        );
+
+        group.throughput(Throughput::Bytes(stripped as u64));
+        group.bench_with_input(
+            BenchmarkId::new("stripped", blocks_per_forest),
+            &forest,
+            |b, forest| {
+                b.iter(|| {
+                    let mut bytes = Vec::new();
+                    forest.write_stripped(&mut bytes);
+                    black_box(bytes);
+                });
+            },
+        );
+
+        group.throughput(Throughput::Bytes(hashless as u64));
+        group.bench_with_input(
+            BenchmarkId::new("hashless", blocks_per_forest),
+            &forest,
+            |b, forest| {
+                b.iter(|| {
+                    let mut bytes = Vec::new();
+                    forest.write_hashless(&mut bytes);
+                    black_box(bytes);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_serialization_sizes);
+criterion_main!(benches);

--- a/core/src/advice/map.rs
+++ b/core/src/advice/map.rs
@@ -71,6 +71,19 @@ impl AdviceMap {
         self.0.is_empty()
     }
 
+    /// Returns the exact serialized size of this AdviceMap in bytes.
+    pub(crate) fn serialized_size_hint(&self) -> usize {
+        let mut size = self.0.len().get_size_hint();
+        for (key, values) in self.0.iter() {
+            size += key.get_size_hint();
+            size += values.len().get_size_hint();
+            for value in values.iter() {
+                size += value.get_size_hint();
+            }
+        }
+        size
+    }
+
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
     pub fn entry(&mut self, key: Word) -> Entry<'_, Word, Arc<[Felt]>> {
         self.0.entry(key)

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -727,34 +727,6 @@ impl MastForest {
         Ok(())
     }
 
-    fn procedure_name_bindings(&self) -> Vec<(Word, Arc<str>, Option<MastNodeId>)> {
-        self.debug_info
-            .procedure_names()
-            .map(|(digest, name)| (digest, Arc::clone(name), self.find_procedure_root(digest)))
-            .collect()
-    }
-
-    fn remap_procedure_name_bindings(
-        &mut self,
-        bindings: &[(Word, Arc<str>, Option<MastNodeId>)],
-    ) -> Result<(), MastForestError> {
-        self.debug_info.clear_procedure_names();
-        for (digest, name, incoming_root_id) in bindings {
-            let resolved_digest = if let Some(root_id) = incoming_root_id {
-                self.get_node_by_id(*root_id)
-                    .ok_or(MastForestError::NodeIdOverflow(*root_id, self.nodes.len()))?
-                    .digest()
-            } else if self.find_procedure_root(*digest).is_some() {
-                *digest
-            } else {
-                return Err(MastForestError::InvalidProcedureNameDigest(*digest));
-            };
-            self.debug_info.insert_procedure_name(resolved_digest, Arc::clone(name));
-        }
-
-        Ok(())
-    }
-
     /// Validates that all BasicBlockNodes in this forest satisfy the core invariants:
     /// 1. Power-of-two number of groups in each batch
     /// 2. No operation group ends with an operation requiring an immediate value
@@ -770,36 +742,36 @@ impl MastForest {
         self.validate_procedure_name_digests()
     }
 
-    /// Recomputes node hashes in topological order and overwrites node digests.
+    /// Validates that stored node digests match the hashes implied by local structure.
     ///
-    /// For `External` nodes the digest is kept as-is because it is externally provided and cannot
-    /// be reconstructed from local structure alone.
-    fn recompute_node_hashes_in_place(&mut self) -> Result<(), MastForestError> {
-        let procedure_name_bindings = self.procedure_name_bindings();
+    /// For `External` nodes the digest is accepted as-is because it is externally provided and
+    /// cannot be reconstructed from local structure alone.
+    fn validate_node_hashes(&self) -> Result<(), MastForestError> {
         let computed_hashes = self.compute_node_hashes()?;
-        let source_forest = self.clone();
-
-        let mut rebuilt_forest = MastForest::new();
-        rebuilt_forest.debug_info = source_forest.debug_info.clone();
-        rebuilt_forest.advice_map = source_forest.advice_map.clone();
-
-        for (idx, node) in source_forest.nodes.iter().cloned().enumerate() {
-            node.to_builder(&source_forest)
-                .with_digest(computed_hashes[idx])
-                .add_to_forest_relaxed(&mut rebuilt_forest)?;
+        for (node_idx, (node, computed_digest)) in
+            self.nodes.iter().zip(computed_hashes).enumerate()
+        {
+            let expected_digest = node.digest();
+            if expected_digest != computed_digest {
+                return Err(MastForestError::HashMismatch {
+                    node_id: MastNodeId::new_unchecked(node_idx as u32),
+                    expected: expected_digest,
+                    computed: computed_digest,
+                });
+            }
         }
-
-        rebuilt_forest.roots = source_forest.roots.clone();
-        rebuilt_forest.remap_procedure_name_bindings(&procedure_name_bindings)?;
-        rebuilt_forest.commitment_cache = OnceLockCompat::new();
-        *self = rebuilt_forest;
 
         Ok(())
     }
 
     /// Computes node hashes in topological order.
     ///
+    /// The returned vector is aligned with node indices, so `digests[node_id as usize]` is the
+    /// digest of that node.
+    ///
     /// For `External` nodes, the existing digest is returned unchanged.
+    ///
+    /// Returns [`MastForestError::ForwardReference`] if nodes are not in topological order.
     fn compute_node_hashes(&self) -> Result<Vec<Word>, MastForestError> {
         use crate::chiplets::hasher;
 
@@ -1430,10 +1402,10 @@ impl UntrustedMastForest {
     ///
     /// This method performs a complete validation of the deserialized forest:
     ///
-    /// 1. Resolves procedure-name bindings against the incoming root set.
-    /// 2. Recomputes all non-external node hashes and overwrites stored digests.
-    /// 3. Rebinds procedure names to the recomputed root digests.
-    /// 4. Validates structural invariants and topological ordering against the recomputed forest.
+    /// 1. If wire node hashes are present, recomputes all non-external node hashes and requires
+    ///    them to match the serialized digests.
+    /// 2. If the payload is hashless, uses the digests rebuilt during materialization.
+    /// 3. Validates structural invariants, topological ordering, and procedure-name roots.
     ///
     /// # Returns
     ///
@@ -1449,21 +1421,22 @@ impl UntrustedMastForest {
     ///   ([`MastForestError::InvalidProcedureNameDigest`])
     /// - Any node references a child that appears later in the forest
     ///   ([`MastForestError::ForwardReference`])
+    /// - Any non-external wire digest does not match the recomputed digest
+    ///   ([`MastForestError::HashMismatch`])
     /// - Any node's digest cannot be recomputed because structural validation fails first
     ///
     /// Security convention:
-    /// - This validator never trusts serialized digest bytes for non-external nodes.
+    /// - Hashless payloads rebuild non-external digests from structure during materialization.
+    /// - If wire node hashes are present, validation recomputes them and requires them to match.
     /// - External node digests are marshaled as opaque values and are not semantically resolved
     ///   here.
     pub fn validate(self) -> Result<MastForest, MastForestError> {
         let is_hashless = self.layout.is_hashless();
-        let mut forest = self.into_materialized().map_err(MastForestError::Deserialization)?;
+        let forest = self.into_materialized().map_err(MastForestError::Deserialization)?;
 
-        // Step 1: Ensure every non-external digest comes from local structure rather than wire
-        // input. Hashless materialization already rebuilt the digest table, while full/stripped
-        // payloads still need this trust-boundary recomputation here.
+        // Step 1: Validate over-specified wire hashes instead of silently rewriting them.
         if !is_hashless {
-            forest.recompute_node_hashes_in_place()?;
+            forest.validate_node_hashes()?;
         }
 
         // Step 2: Validate the recomputed forest.

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -15,6 +15,9 @@
 //! [`UntrustedMastForest::read_from_bytes`] applies default parsing and validation budgets derived
 //! from the input size. Use [`UntrustedMastForest::read_from_bytes_with_budget`] to tune only the
 //! wire-parsing budget, or [`UntrustedMastForest::read_from_bytes_with_budgets`] to tune both:
+//! the parsing budget limits allocations driven directly by wire counts while reading the payload,
+//! and the validation budget limits later helper allocations needed to materialize and check
+//! stripped or hashless payloads.
 //!
 //! ```ignore
 //! use miden_core::mast::UntrustedMastForest;
@@ -696,6 +699,9 @@ impl MastForest {
     /// 3. The last operation group in a batch cannot contain operations requiring immediate values
     /// 4. OpBatch structural consistency (num_groups <= BATCH_SIZE, group size <= GROUP_SIZE,
     ///    indptr integrity, bounds checking)
+    ///
+    /// This also validates that each stored procedure-name digest resolves to a procedure root in
+    /// the forest.
     ///
     /// This addresses the gap created by PR 2094, where padding NOOPs are now inserted
     /// at assembly time rather than dynamically during execution, and adds comprehensive

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -86,10 +86,7 @@ pub use debuginfo::{
 };
 
 mod serialization;
-pub use serialization::{MastNodeEntry, MastNodeInfo, SerializedMastForest};
-
-mod view;
-pub use view::MastForestView;
+pub use serialization::{MastForestView, MastNodeEntry, MastNodeInfo, SerializedMastForest};
 
 mod merger;
 pub(crate) use merger::MastForestMerger;

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -74,6 +74,9 @@ pub use debuginfo::{
 mod serialization;
 pub use serialization::{MastNodeEntry, MastNodeInfo, SerializedMastForest};
 
+mod view;
+pub use view::MastForestView;
+
 mod merger;
 pub(crate) use merger::MastForestMerger;
 pub use merger::MastForestRootMap;
@@ -517,58 +520,6 @@ impl MastForest {
     /// Returns the exact size of stripped serialization in bytes.
     pub fn stripped_size_hint(&self) -> usize {
         serialization::stripped_size_hint(self)
-    }
-}
-
-/// Read-only view over MAST node metadata.
-///
-/// This trait is implemented by both in-memory [`MastForest`] and serialized
-/// [`SerializedMastForest`] representations, enabling callers to consume a shared random-access
-/// API independent of backing storage.
-pub trait MastForestView {
-    /// Returns the number of nodes in the forest.
-    fn node_count(&self) -> usize;
-
-    /// Returns fixed-width structural metadata for a node at the specified index.
-    fn node_entry_at(&self, index: usize) -> Result<MastNodeEntry, DeserializationError>;
-
-    /// Returns the digest of the node at the specified index.
-    fn node_digest_at(&self, index: usize) -> Result<Word, DeserializationError>;
-
-    /// Returns serialized-equivalent metadata for a node at the specified index.
-    fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError> {
-        Ok(MastNodeInfo::from_entry(
-            self.node_entry_at(index)?,
-            self.node_digest_at(index)?,
-        ))
-    }
-
-    /// Returns the number of procedure roots in the forest.
-    fn procedure_root_count(&self) -> usize;
-
-    /// Returns the procedure root id at the specified index.
-    fn procedure_root_at(&self, index: usize) -> Result<MastNodeId, DeserializationError>;
-
-    /// Returns true when the forest contains no nodes.
-    fn is_empty(&self) -> bool {
-        self.node_count() == 0
-    }
-
-    /// Returns true when `index` is a valid node index.
-    fn has_node(&self, index: usize) -> bool {
-        index < self.node_count()
-    }
-
-    /// Returns all node infos in index order.
-    fn all_node_infos(&self) -> Result<Vec<MastNodeInfo>, DeserializationError> {
-        (0..self.node_count()).map(|index| self.node_info_at(index)).collect()
-    }
-
-    /// Returns all procedure roots in index order.
-    fn procedure_roots(&self) -> Result<Vec<MastNodeId>, DeserializationError> {
-        (0..self.procedure_root_count())
-            .map(|index| self.procedure_root_at(index))
-            .collect()
     }
 }
 

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -12,20 +12,34 @@
 //!     .validate()?;
 //! ```
 //!
-//! For maximum protection against denial-of-service attacks from malicious input, use
-//! [`UntrustedMastForest::read_from_bytes_with_budget`] which limits memory consumption:
+//! [`UntrustedMastForest::read_from_bytes`] applies default parsing and validation budgets derived
+//! from the input size. Use [`UntrustedMastForest::read_from_bytes_with_budget`] to tune only the
+//! wire-parsing budget, or [`UntrustedMastForest::read_from_bytes_with_budgets`] to tune both:
 //!
 //! ```ignore
 //! use miden_core::mast::UntrustedMastForest;
 //!
-//! // Budget limits pre-allocation sizes and total bytes consumed
+//! // Parsing budget only
 //! let forest = UntrustedMastForest::read_from_bytes_with_budget(&bytes, bytes.len())?
+//!     .validate()?;
+//!
+//! // Parsing budget plus explicit validation-allocation budget
+//! let forest = UntrustedMastForest::read_from_bytes_with_budgets(&bytes, bytes.len(), bytes.len() * 7)?
 //!     .validate()?;
 //! ```
 //!
 //! This recomputes all node hashes and checks structural invariants before returning a usable
 //! `MastForest`. Direct deserialization via `MastForest::read_from_bytes` trusts the serialized
 //! hashes and should only be used for data from trusted sources (e.g. compiled locally).
+//!
+//! In practice, the public entry points split into three policies:
+//! - [`MastForest::read_from_bytes`]: trusted full deserialization; rejects hashless payloads and
+//!   trusts serialized non-external digests.
+//! - [`SerializedMastForest::new`]: trusted inspection path; scans only the structural layout
+//!   needed for random access and may accept full, stripped, or hashless payloads.
+//! - [`UntrustedMastForest::read_from_bytes`] and
+//!   [`UntrustedMastForest::read_from_bytes_with_budgets`]: untrusted paths; parse with bounded
+//!   readers and require [`UntrustedMastForest::validate`] before use.
 
 use alloc::{
     collections::{BTreeMap, BTreeSet},
@@ -1346,6 +1360,7 @@ pub struct UntrustedMastForest {
     layout: serialization::ForestLayout,
     advice_map: AdviceMap,
     debug_info: DebugInfo,
+    remaining_allocation_budget: Option<usize>,
 }
 
 impl UntrustedMastForest {
@@ -1398,11 +1413,15 @@ impl UntrustedMastForest {
 
     /// Deserializes an [`UntrustedMastForest`] from bytes.
     ///
-    /// This method uses a [`BudgetedReader`] with a budget equal to the input size to protect
-    /// against denial-of-service attacks from malicious input.
+    /// This method uses a [`BudgetedReader`] plus a bounded validation-allocation budget derived
+    /// from the input size to protect against denial-of-service attacks from malicious input.
+    /// The default validation budget includes room for the retained serialized copy used by the
+    /// deferred-validation path, in addition to stripped/hashless helper allocations. Concretely,
+    /// the default is `bytes.len()` for parsing and `bytes.len() * 7` for validation allocations.
+    /// That `* 7` factor is a coarse convenience bound, not an exact peak-memory formula.
     ///
-    /// For stricter limits, use
-    /// [`read_from_bytes_with_budget`](Self::read_from_bytes_with_budget) with a custom budget.
+    /// For explicit parsing and validation limits, use
+    /// [`read_from_bytes_with_budgets`](Self::read_from_bytes_with_budgets).
     ///
     /// # Example
     ///
@@ -1414,7 +1433,11 @@ impl UntrustedMastForest {
     /// let forest = untrusted.validate()?;
     /// ```
     pub fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
-        Self::read_from_bytes_with_budget(bytes, bytes.len())
+        Self::read_from_bytes_with_budgets(
+            bytes,
+            bytes.len(),
+            serialization::default_untrusted_allocation_budget(bytes.len()),
+        )
     }
 
     /// Deserializes an [`UntrustedMastForest`] from bytes and returns the raw wire flags.
@@ -1422,7 +1445,11 @@ impl UntrustedMastForest {
     /// This enables callers to inspect serializer intent flags (e.g., HASHLESS) without affecting
     /// the untrusted deserialization path.
     pub fn read_from_bytes_with_flags(bytes: &[u8]) -> Result<(Self, u8), DeserializationError> {
-        Self::read_from_bytes_with_budget_and_flags(bytes, bytes.len())
+        Self::read_from_bytes_with_budgets_and_flags(
+            bytes,
+            bytes.len(),
+            serialization::default_untrusted_allocation_budget(bytes.len()),
+        )
     }
 
     /// Deserializes an [`UntrustedMastForest`] from bytes with a byte budget.
@@ -1434,13 +1461,13 @@ impl UntrustedMastForest {
     /// # Arguments
     ///
     /// * `bytes` - The serialized forest bytes
-    /// * `budget` - Maximum bytes to consume during deserialization. Set this to `bytes.len()` for
-    ///   typical use cases, or lower to enforce stricter limits.
+    /// * `budget` - Maximum bytes to consume while parsing the wire payload and pre-sizing
+    ///   wire-driven collections via [`BudgetedReader`]
     ///
     /// # Example
     ///
     /// ```ignore
-    /// // Read from untrusted source with budget equal to input size
+    /// // Read from untrusted source with an explicit parsing budget
     /// let untrusted = UntrustedMastForest::read_from_bytes_with_budget(&bytes, bytes.len())?;
     ///
     /// // Validate before use
@@ -1455,12 +1482,15 @@ impl UntrustedMastForest {
     ///
     /// This prevents attacks where malicious input claims an unrealistic number of elements
     /// (e.g., `len = 2^60`), causing excessive memory allocation before any data is read.
+    ///
+    /// To also cap stripped/hashless validation helper allocations, use
+    /// [`read_from_bytes_with_budgets`](Self::read_from_bytes_with_budgets).
     pub fn read_from_bytes_with_budget(
         bytes: &[u8],
         budget: usize,
     ) -> Result<Self, DeserializationError> {
         let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
-        Self::read_from(&mut reader)
+        serialization::read_untrusted_with_flags(&mut reader).map(|(forest, _flags)| forest)
     }
 
     /// Deserializes an [`UntrustedMastForest`] from bytes with a byte budget and returns flags.
@@ -1470,5 +1500,38 @@ impl UntrustedMastForest {
     ) -> Result<(Self, u8), DeserializationError> {
         let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
         serialization::read_untrusted_with_flags(&mut reader)
+    }
+
+    /// Deserializes an [`UntrustedMastForest`] from bytes with separate parsing and validation
+    /// budgets.
+    ///
+    /// `parsing_budget` limits wire-driven parsing and collection pre-sizing. `validation_budget`
+    /// additionally caps tracked stripped/hashless helper allocations such as empty debug-info
+    /// scaffolding, digest slot tables, and rebuilt digest tables.
+    pub fn read_from_bytes_with_budgets(
+        bytes: &[u8],
+        parsing_budget: usize,
+        validation_budget: usize,
+    ) -> Result<Self, DeserializationError> {
+        let mut reader = BudgetedReader::new(SliceReader::new(bytes), parsing_budget);
+        serialization::read_untrusted_with_flags_and_allocation_budget(
+            &mut reader,
+            validation_budget,
+        )
+        .map(|(forest, _flags)| forest)
+    }
+
+    /// Deserializes an [`UntrustedMastForest`] from bytes with separate parsing and validation
+    /// budgets and returns flags.
+    pub fn read_from_bytes_with_budgets_and_flags(
+        bytes: &[u8],
+        parsing_budget: usize,
+        validation_budget: usize,
+    ) -> Result<(Self, u8), DeserializationError> {
+        let mut reader = BudgetedReader::new(SliceReader::new(bytes), parsing_budget);
+        serialization::read_untrusted_with_flags_and_allocation_budget(
+            &mut reader,
+            validation_budget,
+        )
     }
 }

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -72,7 +72,7 @@ pub use debuginfo::{
 };
 
 mod serialization;
-pub use serialization::{MastNodeInfo, SerializedMastForest};
+pub use serialization::{MastNodeEntry, MastNodeInfo, SerializedMastForest};
 
 mod merger;
 pub(crate) use merger::MastForestMerger;
@@ -517,8 +517,6 @@ impl MastForest {
     }
 
     /// Returns the exact size of stripped serialization in bytes.
-    ///
-    /// Hashless serialization has the same size as stripped serialization.
     pub fn stripped_size_hint(&self) -> usize {
         serialization::stripped_size_hint(self)
     }
@@ -533,8 +531,19 @@ pub trait MastForestView {
     /// Returns the number of nodes in the forest.
     fn node_count(&self) -> usize;
 
+    /// Returns fixed-width structural metadata for a node at the specified index.
+    fn node_entry_at(&self, index: usize) -> Result<MastNodeEntry, DeserializationError>;
+
+    /// Returns the digest of the node at the specified index.
+    fn node_digest_at(&self, index: usize) -> Result<Word, DeserializationError>;
+
     /// Returns serialized-equivalent metadata for a node at the specified index.
-    fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError>;
+    fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError> {
+        Ok(MastNodeInfo::from_entry(
+            self.node_entry_at(index)?,
+            self.node_digest_at(index)?,
+        ))
+    }
 
     /// Returns the number of procedure roots in the forest.
     fn procedure_root_count(&self) -> usize;
@@ -550,11 +559,6 @@ pub trait MastForestView {
     /// Returns true when `index` is a valid node index.
     fn has_node(&self, index: usize) -> bool {
         index < self.node_count()
-    }
-
-    /// Returns the digest of the node at the specified index.
-    fn node_digest_at(&self, index: usize) -> Result<Word, DeserializationError> {
-        Ok(self.node_info_at(index)?.digest())
     }
 
     /// Returns all node infos in index order.
@@ -701,6 +705,58 @@ impl MastForest {
 // ------------------------------------------------------------------------------------------------
 /// Validation methods
 impl MastForest {
+    fn validate_basic_block_invariants(&self) -> Result<(), MastForestError> {
+        for (node_id_idx, node) in self.nodes.iter().enumerate() {
+            let node_id =
+                MastNodeId::new_unchecked(node_id_idx.try_into().expect("too many nodes"));
+            if let MastNode::Block(basic_block) = node {
+                basic_block.validate_batch_invariants().map_err(|error_msg| {
+                    MastForestError::InvalidBatchPadding(node_id, error_msg)
+                })?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_procedure_name_digests(&self) -> Result<(), MastForestError> {
+        for (digest, _) in self.debug_info.procedure_names() {
+            if self.find_procedure_root(digest).is_none() {
+                return Err(MastForestError::InvalidProcedureNameDigest(digest));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn procedure_name_bindings(&self) -> Vec<(Word, Arc<str>, Option<MastNodeId>)> {
+        self.debug_info
+            .procedure_names()
+            .map(|(digest, name)| (digest, Arc::clone(name), self.find_procedure_root(digest)))
+            .collect()
+    }
+
+    fn remap_procedure_name_bindings(
+        &mut self,
+        bindings: &[(Word, Arc<str>, Option<MastNodeId>)],
+    ) -> Result<(), MastForestError> {
+        self.debug_info.clear_procedure_names();
+        for (digest, name, incoming_root_id) in bindings {
+            let resolved_digest = if let Some(root_id) = incoming_root_id {
+                self.get_node_by_id(*root_id)
+                    .ok_or(MastForestError::NodeIdOverflow(*root_id, self.nodes.len()))?
+                    .digest()
+            } else if self.find_procedure_root(*digest).is_some() {
+                *digest
+            } else {
+                return Err(MastForestError::InvalidProcedureNameDigest(*digest));
+            };
+            self.debug_info.insert_procedure_name(resolved_digest, Arc::clone(name));
+        }
+
+        Ok(())
+    }
+
     /// Validates that all BasicBlockNodes in this forest satisfy the core invariants:
     /// 1. Power-of-two number of groups in each batch
     /// 2. No operation group ends with an operation requiring an immediate value
@@ -712,60 +768,8 @@ impl MastForest {
     /// at assembly time rather than dynamically during execution, and adds comprehensive
     /// structural validation to prevent deserialization-time panics.
     pub fn validate(&self) -> Result<(), MastForestError> {
-        // Validate basic block batch invariants
-        for (node_id_idx, node) in self.nodes.iter().enumerate() {
-            let node_id =
-                MastNodeId::new_unchecked(node_id_idx.try_into().expect("too many nodes"));
-            if let MastNode::Block(basic_block) = node {
-                basic_block.validate_batch_invariants().map_err(|error_msg| {
-                    MastForestError::InvalidBatchPadding(node_id, error_msg)
-                })?;
-            }
-        }
-
-        // Validate that all procedure name digests correspond to procedure roots in the forest
-        for (digest, _) in self.debug_info.procedure_names() {
-            if self.find_procedure_root(digest).is_none() {
-                return Err(MastForestError::InvalidProcedureNameDigest(digest));
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Validates topological ordering of nodes and checks all node hashes.
-    ///
-    /// This method iterates through all nodes in index order, verifying:
-    /// 1. All child references point to nodes with smaller indices (topological order)
-    /// 2. Each node's recomputed digest matches its stored digest
-    ///
-    /// # Errors
-    ///
-    /// Returns `MastForestError::ForwardReference` if any node references a child that
-    /// appears later in the forest.
-    ///
-    /// Returns `MastForestError::HashMismatch` if any node's recomputed digest doesn't
-    /// match its stored digest.
-    fn validate_node_hashes(&self) -> Result<(), MastForestError> {
-        let computed_hashes = self.compute_node_hashes()?;
-        for (node_idx, node) in self.nodes.iter().enumerate() {
-            if node.is_external() {
-                continue;
-            }
-
-            let node_id = MastNodeId::new_unchecked(node_idx as u32);
-            let stored_digest = node.digest();
-            let computed_digest = computed_hashes[node_idx];
-            if computed_digest != stored_digest {
-                return Err(MastForestError::HashMismatch {
-                    node_id,
-                    expected: stored_digest,
-                    computed: computed_digest,
-                });
-            }
-        }
-
-        Ok(())
+        self.validate_basic_block_invariants()?;
+        self.validate_procedure_name_digests()
     }
 
     /// Recomputes node hashes in topological order and overwrites node digests.
@@ -773,20 +777,24 @@ impl MastForest {
     /// For `External` nodes the digest is kept as-is because it is externally provided and cannot
     /// be reconstructed from local structure alone.
     fn recompute_node_hashes_in_place(&mut self) -> Result<(), MastForestError> {
+        let procedure_name_bindings = self.procedure_name_bindings();
         let computed_hashes = self.compute_node_hashes()?;
         let source_forest = self.clone();
 
-        let mut rebuilt_nodes = IndexVec::new();
+        let mut rebuilt_forest = MastForest::new();
+        rebuilt_forest.debug_info = source_forest.debug_info.clone();
+        rebuilt_forest.advice_map = source_forest.advice_map.clone();
+
         for (idx, node) in source_forest.nodes.iter().cloned().enumerate() {
-            let rebuilt_node = node
-                .to_builder(&source_forest)
+            node.to_builder(&source_forest)
                 .with_digest(computed_hashes[idx])
-                .build(&source_forest)?;
-            let _ = rebuilt_nodes.push(rebuilt_node);
+                .add_to_forest_relaxed(&mut rebuilt_forest)?;
         }
 
-        self.nodes = rebuilt_nodes;
-        self.commitment_cache = OnceLockCompat::new();
+        rebuilt_forest.roots = source_forest.roots.clone();
+        rebuilt_forest.remap_procedure_name_bindings(&procedure_name_bindings)?;
+        rebuilt_forest.commitment_cache = OnceLockCompat::new();
+        *self = rebuilt_forest;
 
         Ok(())
     }
@@ -1421,10 +1429,10 @@ impl UntrustedMastForest {
     ///
     /// This method performs a complete validation of the deserialized forest:
     ///
-    /// 1. Validates structural invariants (batch padding, procedure names)
-    /// 2. Validates topological ordering (no forward references)
-    /// 3. If `HASHLESS` is set, recomputes all non-external node hashes and overwrites stored
-    ///    digests. Otherwise recomputes and verifies against stored digests.
+    /// 1. Resolves procedure-name bindings against the incoming root set.
+    /// 2. Recomputes all non-external node hashes and overwrites stored digests.
+    /// 3. Rebinds procedure names to the recomputed root digests.
+    /// 4. Validates structural invariants and topological ordering against the recomputed forest.
     ///
     /// # Returns
     ///
@@ -1440,28 +1448,22 @@ impl UntrustedMastForest {
     ///   ([`MastForestError::InvalidProcedureNameDigest`])
     /// - Any node references a child that appears later in the forest
     ///   ([`MastForestError::ForwardReference`])
-    /// - Any node's recomputed hash doesn't match its stored digest
-    ///   ([`MastForestError::HashMismatch`])
+    /// - Any node's digest cannot be recomputed because structural validation fails first
     ///
     /// Security convention:
-    /// - In hashless mode, this validator does not trust serialized digest bytes for non-external
-    ///   nodes.
+    /// - This validator never trusts serialized digest bytes for non-external nodes.
     /// - External node digests are marshaled as opaque values and are not semantically resolved
     ///   here.
     pub fn validate(self) -> Result<MastForest, MastForestError> {
-        let hashless = self.decoded.is_hashless();
         let mut forest =
             self.decoded.into_mast_forest().map_err(MastForestError::Deserialization)?;
 
-        // Step 1: Validate structural invariants.
-        forest.validate()?;
+        // Step 1: Recompute all non-external hashes. Untrusted validation never trusts
+        // serialized digests; overspecified trusted payload is accepted but ignored.
+        forest.recompute_node_hashes_in_place()?;
 
-        // Step 2: Hash handling policy.
-        if hashless {
-            forest.recompute_node_hashes_in_place()?;
-        } else {
-            forest.validate_node_hashes()?;
-        }
+        // Step 2: Validate the recomputed forest.
+        forest.validate()?;
 
         Ok(forest)
     }

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -72,6 +72,7 @@ pub use debuginfo::{
 };
 
 mod serialization;
+pub use serialization::{MastNodeInfo, SerializedMastForest};
 
 mod merger;
 pub(crate) use merger::MastForestMerger;
@@ -503,6 +504,70 @@ impl MastForest {
         use serialization::StrippedMastForest;
         StrippedMastForest(self).write_into(target);
     }
+
+    /// Serializes this MastForest with the HASHLESS flag set.
+    ///
+    /// Hashless implies stripped: debug info is omitted, and digests must be recomputed during
+    /// validation. Trusted deserialization rejects this flag.
+    ///
+    /// Use this when producing data for untrusted validation.
+    pub fn write_hashless<W: ByteWriter>(&self, target: &mut W) {
+        use serialization::HashlessMastForest;
+        HashlessMastForest(self).write_into(target);
+    }
+
+    /// Returns the exact size of stripped serialization in bytes.
+    ///
+    /// Hashless serialization has the same size as stripped serialization.
+    pub fn stripped_size_hint(&self) -> usize {
+        serialization::stripped_size_hint(self)
+    }
+}
+
+/// Read-only view over MAST node metadata.
+///
+/// This trait is implemented by both in-memory [`MastForest`] and serialized
+/// [`SerializedMastForest`] representations, enabling callers to consume a shared random-access
+/// API independent of backing storage.
+pub trait MastForestView {
+    /// Returns the number of nodes in the forest.
+    fn node_count(&self) -> usize;
+
+    /// Returns serialized-equivalent metadata for a node at the specified index.
+    fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError>;
+
+    /// Returns the number of procedure roots in the forest.
+    fn procedure_root_count(&self) -> usize;
+
+    /// Returns the procedure root id at the specified index.
+    fn procedure_root_at(&self, index: usize) -> Result<MastNodeId, DeserializationError>;
+
+    /// Returns true when the forest contains no nodes.
+    fn is_empty(&self) -> bool {
+        self.node_count() == 0
+    }
+
+    /// Returns true when `index` is a valid node index.
+    fn has_node(&self, index: usize) -> bool {
+        index < self.node_count()
+    }
+
+    /// Returns the digest of the node at the specified index.
+    fn node_digest_at(&self, index: usize) -> Result<Word, DeserializationError> {
+        Ok(self.node_info_at(index)?.digest())
+    }
+
+    /// Returns all node infos in index order.
+    fn all_node_infos(&self) -> Result<Vec<MastNodeInfo>, DeserializationError> {
+        (0..self.node_count()).map(|index| self.node_info_at(index)).collect()
+    }
+
+    /// Returns all procedure roots in index order.
+    fn procedure_roots(&self) -> Result<Vec<MastNodeId>, DeserializationError> {
+        (0..self.procedure_root_count())
+            .map(|index| self.procedure_root_at(index))
+            .collect()
+    }
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -668,7 +733,7 @@ impl MastForest {
         Ok(())
     }
 
-    /// Validates topological ordering of nodes and recomputes all node hashes.
+    /// Validates topological ordering of nodes and checks all node hashes.
     ///
     /// This method iterates through all nodes in index order, verifying:
     /// 1. All child references point to nodes with smaller indices (topological order)
@@ -682,6 +747,54 @@ impl MastForest {
     /// Returns `MastForestError::HashMismatch` if any node's recomputed digest doesn't
     /// match its stored digest.
     fn validate_node_hashes(&self) -> Result<(), MastForestError> {
+        let computed_hashes = self.compute_node_hashes()?;
+        for (node_idx, node) in self.nodes.iter().enumerate() {
+            if node.is_external() {
+                continue;
+            }
+
+            let node_id = MastNodeId::new_unchecked(node_idx as u32);
+            let stored_digest = node.digest();
+            let computed_digest = computed_hashes[node_idx];
+            if computed_digest != stored_digest {
+                return Err(MastForestError::HashMismatch {
+                    node_id,
+                    expected: stored_digest,
+                    computed: computed_digest,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Recomputes node hashes in topological order and overwrites node digests.
+    ///
+    /// For `External` nodes the digest is kept as-is because it is externally provided and cannot
+    /// be reconstructed from local structure alone.
+    fn recompute_node_hashes_in_place(&mut self) -> Result<(), MastForestError> {
+        let computed_hashes = self.compute_node_hashes()?;
+        let source_forest = self.clone();
+
+        let mut rebuilt_nodes = IndexVec::new();
+        for (idx, node) in source_forest.nodes.iter().cloned().enumerate() {
+            let rebuilt_node = node
+                .to_builder(&source_forest)
+                .with_digest(computed_hashes[idx])
+                .build(&source_forest)?;
+            let _ = rebuilt_nodes.push(rebuilt_node);
+        }
+
+        self.nodes = rebuilt_nodes;
+        self.commitment_cache = OnceLockCompat::new();
+
+        Ok(())
+    }
+
+    /// Computes node hashes in topological order.
+    ///
+    /// For `External` nodes, the existing digest is returned unchanged.
+    fn compute_node_hashes(&self) -> Result<Vec<Word>, MastForestError> {
         use crate::chiplets::hasher;
 
         /// Checks that child_id references a node that appears before node_id in topological order.
@@ -695,10 +808,11 @@ impl MastForest {
             Ok(())
         }
 
+        let mut computed_hashes = Vec::with_capacity(self.nodes.len());
         for (node_idx, node) in self.nodes.iter().enumerate() {
             let node_id = MastNodeId::new_unchecked(node_idx as u32);
 
-            // Check topological ordering and compute expected digest
+            // Check topological ordering and compute digest.
             let computed_digest = match node {
                 MastNode::Block(block) => {
                     let op_groups: Vec<Felt> =
@@ -711,8 +825,8 @@ impl MastForest {
                     check_no_forward_ref(node_id, left_id)?;
                     check_no_forward_ref(node_id, right_id)?;
 
-                    let left_digest = self.nodes[left_id].digest();
-                    let right_digest = self.nodes[right_id].digest();
+                    let left_digest = computed_hashes[left_id.0 as usize];
+                    let right_digest = computed_hashes[right_id.0 as usize];
                     hasher::merge_in_domain(&[left_digest, right_digest], JoinNode::DOMAIN)
                 },
                 MastNode::Split(split) => {
@@ -721,22 +835,22 @@ impl MastForest {
                     check_no_forward_ref(node_id, true_id)?;
                     check_no_forward_ref(node_id, false_id)?;
 
-                    let true_digest = self.nodes[true_id].digest();
-                    let false_digest = self.nodes[false_id].digest();
+                    let true_digest = computed_hashes[true_id.0 as usize];
+                    let false_digest = computed_hashes[false_id.0 as usize];
                     hasher::merge_in_domain(&[true_digest, false_digest], SplitNode::DOMAIN)
                 },
                 MastNode::Loop(loop_node) => {
                     let body_id = loop_node.body();
                     check_no_forward_ref(node_id, body_id)?;
 
-                    let body_digest = self.nodes[body_id].digest();
+                    let body_digest = computed_hashes[body_id.0 as usize];
                     hasher::merge_in_domain(&[body_digest, Word::default()], LoopNode::DOMAIN)
                 },
                 MastNode::Call(call) => {
                     let callee_id = call.callee();
                     check_no_forward_ref(node_id, callee_id)?;
 
-                    let callee_digest = self.nodes[callee_id].digest();
+                    let callee_digest = computed_hashes[callee_id.0 as usize];
                     let domain = if call.is_syscall() {
                         CallNode::SYSCALL_DOMAIN
                     } else {
@@ -752,22 +866,15 @@ impl MastForest {
                     }
                 },
                 MastNode::External(_) => {
-                    // External nodes have externally-provided digests that cannot be recomputed
-                    continue;
+                    // External nodes have externally-provided digests that cannot be recomputed.
+                    node.digest()
                 },
             };
 
-            let stored_digest = node.digest();
-            if computed_digest != stored_digest {
-                return Err(MastForestError::HashMismatch {
-                    node_id,
-                    expected: stored_digest,
-                    computed: computed_digest,
-                });
-            }
+            computed_hashes.push(computed_digest);
         }
 
-        Ok(())
+        Ok(computed_hashes)
     }
 }
 
@@ -1239,6 +1346,8 @@ pub enum MastForestError {
         expected: Word,
         computed: Word,
     },
+    #[error("deserialization failed: {0}")]
+    Deserialization(DeserializationError),
 }
 
 // Custom serde implementations for MastForest that handle linked decorators properly
@@ -1274,9 +1383,9 @@ impl<'de> Deserialize<'de> for MastForest {
 
 /// A [`MastForest`] deserialized from untrusted input that has not yet been validated.
 ///
-/// This type wraps a `MastForest` that was deserialized from bytes but has not had its
-/// node hashes verified. Before using the forest, callers must call [`validate()`](Self::validate)
-/// to verify structural integrity and recompute all node hashes.
+/// This type wraps a serialized-backed, decoded MAST representation that has not had its node
+/// hashes verified. Before using the forest, callers must call [`validate()`](Self::validate) to
+/// materialize and verify structural integrity and node hashes.
 ///
 /// # Usage
 ///
@@ -1303,7 +1412,9 @@ impl<'de> Deserialize<'de> for MastForest {
 /// 3. **Hash recomputation**: Recomputes the digest for every node and verifies it matches the
 ///    stored digest.
 #[derive(Debug, Clone)]
-pub struct UntrustedMastForest(MastForest);
+pub struct UntrustedMastForest {
+    decoded: serialization::DecodedSerializedForest,
+}
 
 impl UntrustedMastForest {
     /// Validates the forest by checking structural invariants and recomputing all node hashes.
@@ -1312,7 +1423,8 @@ impl UntrustedMastForest {
     ///
     /// 1. Validates structural invariants (batch padding, procedure names)
     /// 2. Validates topological ordering (no forward references)
-    /// 3. Recomputes all node hashes and compares against stored digests
+    /// 3. If `HASHLESS` is set, recomputes all non-external node hashes and overwrites stored
+    ///    digests. Otherwise recomputes and verifies against stored digests.
     ///
     /// # Returns
     ///
@@ -1322,6 +1434,7 @@ impl UntrustedMastForest {
     /// # Errors
     ///
     /// Returns an error if:
+    /// - Deferred materialization from serialized form fails ([`MastForestError::Deserialization`])
     /// - Any basic block has invalid batch structure ([`MastForestError::InvalidBatchPadding`])
     /// - Any procedure name references a non-root digest
     ///   ([`MastForestError::InvalidProcedureNameDigest`])
@@ -1329,14 +1442,26 @@ impl UntrustedMastForest {
     ///   ([`MastForestError::ForwardReference`])
     /// - Any node's recomputed hash doesn't match its stored digest
     ///   ([`MastForestError::HashMismatch`])
+    ///
+    /// Security convention:
+    /// - In hashless mode, this validator does not trust serialized digest bytes for non-external
+    ///   nodes.
+    /// - External node digests are marshaled as opaque values and are not semantically resolved
+    ///   here.
     pub fn validate(self) -> Result<MastForest, MastForestError> {
-        let forest = self.0;
+        let hashless = self.decoded.is_hashless();
+        let mut forest =
+            self.decoded.into_mast_forest().map_err(MastForestError::Deserialization)?;
 
-        // Step 1: Validate structural invariants (existing validate() checks)
+        // Step 1: Validate structural invariants.
         forest.validate()?;
 
-        // Step 2: Validate topological ordering and recompute hashes
-        forest.validate_node_hashes()?;
+        // Step 2: Hash handling policy.
+        if hashless {
+            forest.recompute_node_hashes_in_place()?;
+        } else {
+            forest.validate_node_hashes()?;
+        }
 
         Ok(forest)
     }
@@ -1360,6 +1485,14 @@ impl UntrustedMastForest {
     /// ```
     pub fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
         Self::read_from_bytes_with_budget(bytes, bytes.len())
+    }
+
+    /// Deserializes an [`UntrustedMastForest`] from bytes and returns the header flags.
+    ///
+    /// This enables callers to inspect intent flags (e.g., HASHLESS) without affecting the
+    /// deserialization path.
+    pub fn read_from_bytes_with_flags(bytes: &[u8]) -> Result<(Self, u8), DeserializationError> {
+        Self::read_from_bytes_with_budget_and_flags(bytes, bytes.len())
     }
 
     /// Deserializes an [`UntrustedMastForest`] from bytes with a byte budget.
@@ -1398,5 +1531,14 @@ impl UntrustedMastForest {
     ) -> Result<Self, DeserializationError> {
         let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
         Self::read_from(&mut reader)
+    }
+
+    /// Deserializes an [`UntrustedMastForest`] from bytes with a byte budget and returns flags.
+    pub fn read_from_bytes_with_budget_and_flags(
+        bytes: &[u8],
+        budget: usize,
+    ) -> Result<(Self, u8), DeserializationError> {
+        let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
+        serialization::read_untrusted_with_flags(&mut reader)
     }
 }

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -1421,7 +1421,10 @@ impl<'de> Deserialize<'de> for MastForest {
 ///    stored digest.
 #[derive(Debug, Clone)]
 pub struct UntrustedMastForest {
-    decoded: serialization::DecodedSerializedForest,
+    bytes: Vec<u8>,
+    layout: serialization::ForestLayout,
+    advice_map: AdviceMap,
+    debug_info: DebugInfo,
 }
 
 impl UntrustedMastForest {
@@ -1455,12 +1458,15 @@ impl UntrustedMastForest {
     /// - External node digests are marshaled as opaque values and are not semantically resolved
     ///   here.
     pub fn validate(self) -> Result<MastForest, MastForestError> {
-        let mut forest =
-            self.decoded.into_mast_forest().map_err(MastForestError::Deserialization)?;
+        let is_hashless = self.layout.is_hashless();
+        let mut forest = self.into_materialized().map_err(MastForestError::Deserialization)?;
 
-        // Step 1: Recompute all non-external hashes. Untrusted validation never trusts
-        // serialized digests; overspecified trusted payload is accepted but ignored.
-        forest.recompute_node_hashes_in_place()?;
+        // Step 1: Recompute all non-external hashes when wire hashes were supplied. Hashless
+        // materialization already rebuilt digests from structure, so running the rebuild a second
+        // time only duplicates work.
+        if !is_hashless {
+            forest.recompute_node_hashes_in_place()?;
+        }
 
         // Step 2: Validate the recomputed forest.
         forest.validate()?;

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -35,8 +35,9 @@
 //! In practice, the public entry points split into three policies:
 //! - [`MastForest::read_from_bytes`]: trusted full deserialization; rejects hashless payloads and
 //!   trusts serialized non-external digests.
-//! - [`SerializedMastForest::new`]: trusted inspection path; scans only the structural layout
-//!   needed for random access and may accept full, stripped, or hashless payloads.
+//! - [`SerializedMastForest::new`]: structural inspection path for local tooling; scans only the
+//!   layout needed for random access and may accept full, stripped, or hashless payloads, but it is
+//!   not an untrusted-validation entry point.
 //! - [`UntrustedMastForest::read_from_bytes`] and
 //!   [`UntrustedMastForest::read_from_bytes_with_budgets`]: untrusted paths; parse with bounded
 //!   readers and require [`UntrustedMastForest::validate`] before use.

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -501,8 +501,7 @@ impl MastForest {
     /// // let restored = MastForest::read_from_bytes(&stripped_bytes).unwrap();
     /// ```
     pub fn write_stripped<W: ByteWriter>(&self, target: &mut W) {
-        use serialization::StrippedMastForest;
-        StrippedMastForest(self).write_into(target);
+        serialization::write_stripped_into(self, target);
     }
 
     /// Serializes this MastForest with the HASHLESS flag set.
@@ -512,8 +511,7 @@ impl MastForest {
     ///
     /// Use this when producing data for untrusted validation.
     pub fn write_hashless<W: ByteWriter>(&self, target: &mut W) {
-        use serialization::HashlessMastForest;
-        HashlessMastForest(self).write_into(target);
+        serialization::write_hashless_into(self, target);
     }
 
     /// Returns the exact size of stripped serialization in bytes.
@@ -1461,9 +1459,9 @@ impl UntrustedMastForest {
         let is_hashless = self.layout.is_hashless();
         let mut forest = self.into_materialized().map_err(MastForestError::Deserialization)?;
 
-        // Step 1: Recompute all non-external hashes when wire hashes were supplied. Hashless
-        // materialization already rebuilt digests from structure, so running the rebuild a second
-        // time only duplicates work.
+        // Step 1: Ensure every non-external digest comes from local structure rather than wire
+        // input. Hashless materialization already rebuilt the digest table, while full/stripped
+        // payloads still need this trust-boundary recomputation here.
         if !is_hashless {
             forest.recompute_node_hashes_in_place()?;
         }
@@ -1495,10 +1493,10 @@ impl UntrustedMastForest {
         Self::read_from_bytes_with_budget(bytes, bytes.len())
     }
 
-    /// Deserializes an [`UntrustedMastForest`] from bytes and returns the header flags.
+    /// Deserializes an [`UntrustedMastForest`] from bytes and returns the raw wire flags.
     ///
-    /// This enables callers to inspect intent flags (e.g., HASHLESS) without affecting the
-    /// deserialization path.
+    /// This enables callers to inspect serializer intent flags (e.g., HASHLESS) without affecting
+    /// the untrusted deserialization path.
     pub fn read_from_bytes_with_flags(bytes: &[u8]) -> Result<(Self, u8), DeserializationError> {
         Self::read_from_bytes_with_budget_and_flags(bytes, bytes.len())
     }

--- a/core/src/mast/serialization/basic_blocks.rs
+++ b/core/src/mast/serialization/basic_blocks.rs
@@ -1,13 +1,19 @@
-//! Basic block serialization format.
+//! Basic block serialization for the MAST wire format.
 //!
-//! ## Wire Format
+//! Basic blocks are the variable-size part of the format. Node entries only store an offset into
+//! this section.
 //!
-//! - Padded operations (variable size)
-//! - Batch count (4 bytes)
-//! - Delta-encoded indptr per batch (4 bytes each: 8 deltas × 4 bits, packed)
-//! - Padding flags per batch (1 byte each, bit-packed)
+//! The wire layout for one basic block is:
+//! - Encoded operations vector (`Vec<Operation>`)
+//! - Batch count (`u32`)
+//! - Delta-encoded `indptr` arrays for each batch (`4 * num_batches` bytes)
+//! - Padding flags for each batch (`1 * num_batches` bytes)
 //!
-//! **Total**: `ops_size + 4 + (5 * num_batches)` bytes
+//! The total encoded size is:
+//! `encoded_operations_len + size_of::<u32>() + (5 * num_batches)`.
+//!
+//! This matches [`basic_block_data_len`], which is used for size accounting in stripped and
+//! hashless serialization.
 
 use alloc::vec::Vec;
 

--- a/core/src/mast/serialization/basic_blocks.rs
+++ b/core/src/mast/serialization/basic_blocks.rs
@@ -34,6 +34,22 @@ impl BasicBlockDataBuilder {
     }
 }
 
+/// Returns the serialized size of a basic block in the node data section.
+pub(super) fn basic_block_data_len(basic_block: &BasicBlockNode) -> usize {
+    let mut op_count = 0usize;
+    let mut ops_size = 0usize;
+    for op in basic_block.operations() {
+        op_count += 1;
+        ops_size += op.encoded_size();
+    }
+
+    let num_batches = basic_block.num_op_batches();
+    let mut size = op_count.get_size_hint() + ops_size;
+    size += core::mem::size_of::<u32>();
+    size += 5 * num_batches;
+    size
+}
+
 /// Mutators
 impl BasicBlockDataBuilder {
     /// Encodes a [`BasicBlockNode`]'s operations into the serialized [`crate::mast::MastForest`]

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -12,11 +12,11 @@ use crate::{
 // MAST NODE INFO
 // ================================================================================================
 
-/// Represents a serialized [`MastNode`], with some data inlined in its [`MastNodeType`].
+/// Represents a serialized [`MastNode`], with some data inlined in its node type metadata.
 ///
 /// The serialized representation of [`MastNodeInfo`] is guaranteed to be fixed width, so that the
-/// nodes stored in the `nodes` table of the serialized [`MastForest`] can be accessed quickly by
-/// index.
+/// nodes stored in the `nodes` table of the serialized [`crate::mast::MastForest`] can be
+/// accessed quickly by index.
 #[derive(Debug)]
 pub struct MastNodeInfo {
     ty: MastNodeType,
@@ -39,8 +39,8 @@ impl MastNodeInfo {
 
     /// Attempts to convert this [`MastNodeInfo`] into a [`MastNodeBuilder`].
     ///
-    /// The `node_count` is the total expected number of nodes in the [`MastForest`] **after
-    /// deserialization**.
+    /// The `node_count` is the total expected number of nodes in the
+    /// [`crate::mast::MastForest`] **after deserialization**.
     pub fn try_into_mast_node_builder(
         self,
         node_count: usize,
@@ -102,6 +102,21 @@ impl MastNodeInfo {
                 Ok(MastNodeBuilder::External(builder))
             },
         }
+    }
+
+    /// Returns the serialized node type metadata.
+    pub fn node_type(&self) -> MastNodeType {
+        self.ty
+    }
+
+    /// Returns the stored node digest.
+    pub fn digest(&self) -> Word {
+        self.digest
+    }
+
+    /// Builds node metadata directly from serialized components.
+    pub(super) fn from_parts(ty: MastNodeType, digest: Word) -> Self {
+        Self { ty, digest }
     }
 }
 

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -12,19 +12,17 @@ use crate::{
 // MAST NODE INFO
 // ================================================================================================
 
-/// Represents a serialized [`MastNode`], with some data inlined in its node type metadata.
+/// Fixed-width structural metadata for a serialized [`MastNode`].
 ///
-/// The serialized representation of [`MastNodeInfo`] is guaranteed to be fixed width, so that the
-/// nodes stored in the `nodes` table of the serialized [`crate::mast::MastForest`] can be
-/// accessed quickly by index.
-#[derive(Debug)]
-pub struct MastNodeInfo {
+/// This is the random-access portion of the node table. Digests are intentionally modeled
+/// separately so the wire format can move them into dedicated sections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MastNodeEntry {
     ty: MastNodeType,
-    digest: Word,
 }
 
-impl MastNodeInfo {
-    /// Constructs a new [`MastNodeInfo`] from a [`MastNode`], along with an `ops_offset`
+impl MastNodeEntry {
+    /// Constructs a new [`MastNodeEntry`] from a [`MastNode`], along with an `ops_offset`
     ///
     /// For non-basic block nodes, `ops_offset` is ignored, and should be set to 0.
     pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
@@ -33,11 +31,10 @@ impl MastNodeInfo {
         }
 
         let ty = MastNodeType::new(mast_node, ops_offset);
-
-        Self { ty, digest: mast_node.digest() }
+        Self { ty }
     }
 
-    /// Attempts to convert this [`MastNodeInfo`] into a [`MastNodeBuilder`].
+    /// Attempts to convert this [`MastNodeEntry`] into a [`MastNodeBuilder`].
     ///
     /// The `node_count` is the total expected number of nodes in the
     /// [`crate::mast::MastForest`] **after deserialization**.
@@ -45,6 +42,7 @@ impl MastNodeInfo {
         self,
         node_count: usize,
         basic_block_data_decoder: &BasicBlockDataDecoder,
+        digest: Word,
     ) -> Result<MastNodeBuilder, DeserializationError> {
         match self.ty {
             MastNodeType::Block { ops_offset } => {
@@ -52,7 +50,7 @@ impl MastNodeInfo {
                 let builder = crate::mast::node::BasicBlockNodeBuilder::from_op_batches(
                     op_batches,
                     Vec::new(), // decorators set later
-                    self.digest,
+                    digest,
                 );
                 Ok(MastNodeBuilder::BasicBlock(builder))
             },
@@ -60,46 +58,41 @@ impl MastNodeInfo {
                 let left_child = MastNodeId::from_u32_with_node_count(left_child_id, node_count)?;
                 let right_child = MastNodeId::from_u32_with_node_count(right_child_id, node_count)?;
                 let builder = crate::mast::node::JoinNodeBuilder::new([left_child, right_child])
-                    .with_digest(self.digest);
+                    .with_digest(digest);
                 Ok(MastNodeBuilder::Join(builder))
             },
             MastNodeType::Split { if_branch_id, else_branch_id } => {
                 let if_branch = MastNodeId::from_u32_with_node_count(if_branch_id, node_count)?;
                 let else_branch = MastNodeId::from_u32_with_node_count(else_branch_id, node_count)?;
                 let builder = crate::mast::node::SplitNodeBuilder::new([if_branch, else_branch])
-                    .with_digest(self.digest);
+                    .with_digest(digest);
                 Ok(MastNodeBuilder::Split(builder))
             },
             MastNodeType::Loop { body_id } => {
                 let body_id = MastNodeId::from_u32_with_node_count(body_id, node_count)?;
-                let builder =
-                    crate::mast::node::LoopNodeBuilder::new(body_id).with_digest(self.digest);
+                let builder = crate::mast::node::LoopNodeBuilder::new(body_id).with_digest(digest);
                 Ok(MastNodeBuilder::Loop(builder))
             },
             MastNodeType::Call { callee_id } => {
                 let callee_id = MastNodeId::from_u32_with_node_count(callee_id, node_count)?;
                 let builder =
-                    crate::mast::node::CallNodeBuilder::new(callee_id).with_digest(self.digest);
+                    crate::mast::node::CallNodeBuilder::new(callee_id).with_digest(digest);
                 Ok(MastNodeBuilder::Call(builder))
             },
             MastNodeType::SysCall { callee_id } => {
                 let callee_id = MastNodeId::from_u32_with_node_count(callee_id, node_count)?;
-                let builder = crate::mast::node::CallNodeBuilder::new_syscall(callee_id)
-                    .with_digest(self.digest);
+                let builder =
+                    crate::mast::node::CallNodeBuilder::new_syscall(callee_id).with_digest(digest);
                 Ok(MastNodeBuilder::Call(builder))
             },
-            MastNodeType::Dyn => {
-                let builder = crate::mast::node::DynNodeBuilder::new_dyn().with_digest(self.digest);
-                Ok(MastNodeBuilder::Dyn(builder))
-            },
-            MastNodeType::Dyncall => {
-                let builder =
-                    crate::mast::node::DynNodeBuilder::new_dyncall().with_digest(self.digest);
-                Ok(MastNodeBuilder::Dyn(builder))
-            },
+            MastNodeType::Dyn => Ok(MastNodeBuilder::Dyn(
+                crate::mast::node::DynNodeBuilder::new_dyn().with_digest(digest),
+            )),
+            MastNodeType::Dyncall => Ok(MastNodeBuilder::Dyn(
+                crate::mast::node::DynNodeBuilder::new_dyncall().with_digest(digest),
+            )),
             MastNodeType::External => {
-                let builder = crate::mast::node::ExternalNodeBuilder::new(self.digest);
-                Ok(MastNodeBuilder::External(builder))
+                Ok(MastNodeBuilder::External(crate::mast::node::ExternalNodeBuilder::new(digest)))
             },
         }
     }
@@ -108,6 +101,62 @@ impl MastNodeInfo {
     pub fn node_type(&self) -> MastNodeType {
         self.ty
     }
+}
+
+impl Serializable for MastNodeEntry {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.ty.write_into(target);
+    }
+}
+
+impl Deserializable for MastNodeEntry {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let ty = Deserializable::read_from(source)?;
+        Ok(Self { ty })
+    }
+
+    fn min_serialized_size() -> usize {
+        MastNodeType::min_serialized_size()
+    }
+}
+
+/// Logical node metadata combining fixed-width structure and the node digest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MastNodeInfo {
+    entry: MastNodeEntry,
+    digest: Word,
+}
+
+impl MastNodeInfo {
+    /// Constructs a new [`MastNodeInfo`] from a [`MastNode`], along with an `ops_offset`
+    ///
+    /// For non-basic block nodes, `ops_offset` is ignored, and should be set to 0.
+    pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
+        Self {
+            entry: MastNodeEntry::new(mast_node, ops_offset),
+            digest: mast_node.digest(),
+        }
+    }
+
+    /// Attempts to convert this [`MastNodeInfo`] into a [`MastNodeBuilder`].
+    pub fn try_into_mast_node_builder(
+        self,
+        node_count: usize,
+        basic_block_data_decoder: &BasicBlockDataDecoder,
+    ) -> Result<MastNodeBuilder, DeserializationError> {
+        self.entry
+            .try_into_mast_node_builder(node_count, basic_block_data_decoder, self.digest)
+    }
+
+    /// Returns the fixed-width structural node entry.
+    pub fn node_entry(&self) -> MastNodeEntry {
+        self.entry
+    }
+
+    /// Returns the serialized node type metadata.
+    pub fn node_type(&self) -> MastNodeType {
+        self.entry.node_type()
+    }
 
     /// Returns the stored node digest.
     pub fn digest(&self) -> Word {
@@ -115,31 +164,28 @@ impl MastNodeInfo {
     }
 
     /// Builds node metadata directly from serialized components.
-    pub(super) fn from_parts(ty: MastNodeType, digest: Word) -> Self {
-        Self { ty, digest }
+    pub(crate) fn from_entry(entry: MastNodeEntry, digest: Word) -> Self {
+        Self { entry, digest }
     }
 }
 
 impl Serializable for MastNodeInfo {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let Self { ty, digest } = self;
-
-        ty.write_into(target);
-        digest.write_into(target);
+        self.entry.write_into(target);
+        self.digest.write_into(target);
     }
 }
 
 impl Deserializable for MastNodeInfo {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let ty = Deserializable::read_from(source)?;
+        let entry = MastNodeEntry::read_from(source)?;
         let digest = Word::read_from(source)?;
-
-        Ok(Self { ty, digest })
+        Ok(Self { entry, digest })
     }
 
     /// Returns the minimum serialized size: 8 bytes for MastNodeType + 32 bytes for Word digest.
     fn min_serialized_size() -> usize {
-        40
+        MastNodeEntry::min_serialized_size() + Word::min_serialized_size()
     }
 }
 

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -1,13 +1,25 @@
 use alloc::vec::Vec;
 
 use super::{NodeDataOffset, basic_blocks::BasicBlockDataDecoder};
+#[cfg(test)]
+use crate::mast::node::MastNodeExt;
 use crate::{
-    mast::{
-        MastForestContributor, MastNode, MastNodeId, Word,
-        node::{MastNodeBuilder, MastNodeExt},
-    },
+    mast::{MastForestContributor, MastNode, MastNodeId, Word, node::MastNodeBuilder},
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
+
+// CONSTANTS
+// ================================================================================================
+
+const JOIN: u8 = 0;
+const SPLIT: u8 = 1;
+const LOOP: u8 = 2;
+const BLOCK: u8 = 3;
+const CALL: u8 = 4;
+const SYSCALL: u8 = 5;
+const DYN: u8 = 6;
+const DYNCALL: u8 = 7;
+const EXTERNAL: u8 = 8;
 
 // MAST NODE ENTRIES
 // ================================================================================================
@@ -53,6 +65,9 @@ pub enum MastNodeEntry {
 
 /// Constructors
 impl MastNodeEntry {
+    /// Serialized byte size of one fixed-width MAST node entry.
+    pub const SERIALIZED_SIZE: usize = 8;
+
     /// Constructs a new [`MastNodeEntry`] from a [`MastNode`].
     pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
         use MastNode::*;
@@ -227,7 +242,7 @@ impl Deserializable for MastNodeEntry {
 
     /// Returns the fixed serialized size: always 8 bytes (u64).
     fn min_serialized_size() -> usize {
-        8
+        Self::SERIALIZED_SIZE
     }
 }
 
@@ -286,6 +301,9 @@ impl MastNodeEntry {
     }
 }
 
+// MAST NODE INFO
+// ================================================================================================
+
 /// Logical node metadata combining fixed-width structure and a digest value.
 ///
 /// This is a convenience type for APIs that want both pieces together. The wire format does not
@@ -300,6 +318,7 @@ impl MastNodeInfo {
     /// Constructs a new [`MastNodeInfo`] from a [`MastNode`], along with an `ops_offset`
     ///
     /// For non-basic block nodes, `ops_offset` is ignored, and should be set to 0.
+    #[cfg(test)]
     pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
         Self {
             entry: MastNodeEntry::new(mast_node, ops_offset),
@@ -308,6 +327,7 @@ impl MastNodeInfo {
     }
 
     /// Attempts to convert this [`MastNodeInfo`] into a [`MastNodeBuilder`].
+    #[cfg(test)]
     pub fn try_into_mast_node_builder(
         self,
         node_count: usize,
@@ -333,6 +353,7 @@ impl MastNodeInfo {
     }
 }
 
+#[cfg(test)]
 impl Serializable for MastNodeInfo {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.entry.write_into(target);
@@ -340,6 +361,7 @@ impl Serializable for MastNodeInfo {
     }
 }
 
+#[cfg(test)]
 impl Deserializable for MastNodeInfo {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let entry = MastNodeEntry::read_from(source)?;
@@ -353,15 +375,8 @@ impl Deserializable for MastNodeInfo {
     }
 }
 
-const JOIN: u8 = 0;
-const SPLIT: u8 = 1;
-const LOOP: u8 = 2;
-const BLOCK: u8 = 3;
-const CALL: u8 = 4;
-const SYSCALL: u8 = 5;
-const DYN: u8 = 6;
-const DYNCALL: u8 = 7;
-const EXTERNAL: u8 = 8;
+// TESTS
+// ================================================================================================
 
 #[cfg(test)]
 mod tests {

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -9,212 +9,22 @@ use crate::{
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 
-// MAST NODE INFO
+// MAST NODE ENTRIES
 // ================================================================================================
 
 /// Fixed-width structural metadata for a serialized [`MastNode`].
 ///
 /// This is the random-access portion of the node table. Digests are intentionally modeled
 /// separately so the wire format can move them into dedicated sections.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MastNodeEntry {
-    ty: MastNodeType,
-}
-
-impl MastNodeEntry {
-    /// Constructs a new [`MastNodeEntry`] from a [`MastNode`], along with an `ops_offset`
-    ///
-    /// For non-basic block nodes, `ops_offset` is ignored, and should be set to 0.
-    pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
-        if !matches!(mast_node, &MastNode::Block(_)) {
-            debug_assert_eq!(ops_offset, 0);
-        }
-
-        let ty = MastNodeType::new(mast_node, ops_offset);
-        Self { ty }
-    }
-
-    /// Attempts to convert this [`MastNodeEntry`] into a [`MastNodeBuilder`].
-    ///
-    /// The `node_count` is the total expected number of nodes in the
-    /// [`crate::mast::MastForest`] **after deserialization**.
-    pub fn try_into_mast_node_builder(
-        self,
-        node_count: usize,
-        basic_block_data_decoder: &BasicBlockDataDecoder,
-        digest: Word,
-    ) -> Result<MastNodeBuilder, DeserializationError> {
-        match self.ty {
-            MastNodeType::Block { ops_offset } => {
-                let op_batches = basic_block_data_decoder.decode_operations(ops_offset)?;
-                let builder = crate::mast::node::BasicBlockNodeBuilder::from_op_batches(
-                    op_batches,
-                    Vec::new(), // decorators set later
-                    digest,
-                );
-                Ok(MastNodeBuilder::BasicBlock(builder))
-            },
-            MastNodeType::Join { left_child_id, right_child_id } => {
-                let left_child = MastNodeId::from_u32_with_node_count(left_child_id, node_count)?;
-                let right_child = MastNodeId::from_u32_with_node_count(right_child_id, node_count)?;
-                let builder = crate::mast::node::JoinNodeBuilder::new([left_child, right_child])
-                    .with_digest(digest);
-                Ok(MastNodeBuilder::Join(builder))
-            },
-            MastNodeType::Split { if_branch_id, else_branch_id } => {
-                let if_branch = MastNodeId::from_u32_with_node_count(if_branch_id, node_count)?;
-                let else_branch = MastNodeId::from_u32_with_node_count(else_branch_id, node_count)?;
-                let builder = crate::mast::node::SplitNodeBuilder::new([if_branch, else_branch])
-                    .with_digest(digest);
-                Ok(MastNodeBuilder::Split(builder))
-            },
-            MastNodeType::Loop { body_id } => {
-                let body_id = MastNodeId::from_u32_with_node_count(body_id, node_count)?;
-                let builder = crate::mast::node::LoopNodeBuilder::new(body_id).with_digest(digest);
-                Ok(MastNodeBuilder::Loop(builder))
-            },
-            MastNodeType::Call { callee_id } => {
-                let callee_id = MastNodeId::from_u32_with_node_count(callee_id, node_count)?;
-                let builder =
-                    crate::mast::node::CallNodeBuilder::new(callee_id).with_digest(digest);
-                Ok(MastNodeBuilder::Call(builder))
-            },
-            MastNodeType::SysCall { callee_id } => {
-                let callee_id = MastNodeId::from_u32_with_node_count(callee_id, node_count)?;
-                let builder =
-                    crate::mast::node::CallNodeBuilder::new_syscall(callee_id).with_digest(digest);
-                Ok(MastNodeBuilder::Call(builder))
-            },
-            MastNodeType::Dyn => Ok(MastNodeBuilder::Dyn(
-                crate::mast::node::DynNodeBuilder::new_dyn().with_digest(digest),
-            )),
-            MastNodeType::Dyncall => Ok(MastNodeBuilder::Dyn(
-                crate::mast::node::DynNodeBuilder::new_dyncall().with_digest(digest),
-            )),
-            MastNodeType::External => {
-                Ok(MastNodeBuilder::External(crate::mast::node::ExternalNodeBuilder::new(digest)))
-            },
-        }
-    }
-
-    /// Returns the serialized node type metadata.
-    pub fn node_type(&self) -> MastNodeType {
-        self.ty
-    }
-}
-
-impl Serializable for MastNodeEntry {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.ty.write_into(target);
-    }
-}
-
-impl Deserializable for MastNodeEntry {
-    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let ty = Deserializable::read_from(source)?;
-        Ok(Self { ty })
-    }
-
-    fn min_serialized_size() -> usize {
-        MastNodeType::min_serialized_size()
-    }
-}
-
-/// Logical node metadata combining fixed-width structure and a digest value.
-///
-/// This is a convenience type for APIs that want both pieces together. The wire format does not
-/// require `MastNodeInfo` to appear as one contiguous fixed-width section.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MastNodeInfo {
-    entry: MastNodeEntry,
-    digest: Word,
-}
-
-impl MastNodeInfo {
-    /// Constructs a new [`MastNodeInfo`] from a [`MastNode`], along with an `ops_offset`
-    ///
-    /// For non-basic block nodes, `ops_offset` is ignored, and should be set to 0.
-    pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
-        Self {
-            entry: MastNodeEntry::new(mast_node, ops_offset),
-            digest: mast_node.digest(),
-        }
-    }
-
-    /// Attempts to convert this [`MastNodeInfo`] into a [`MastNodeBuilder`].
-    pub fn try_into_mast_node_builder(
-        self,
-        node_count: usize,
-        basic_block_data_decoder: &BasicBlockDataDecoder,
-    ) -> Result<MastNodeBuilder, DeserializationError> {
-        self.entry
-            .try_into_mast_node_builder(node_count, basic_block_data_decoder, self.digest)
-    }
-
-    /// Returns the fixed-width structural node entry.
-    pub fn node_entry(&self) -> MastNodeEntry {
-        self.entry
-    }
-
-    /// Returns the serialized node type metadata.
-    pub fn node_type(&self) -> MastNodeType {
-        self.entry.node_type()
-    }
-
-    /// Returns the stored node digest.
-    pub fn digest(&self) -> Word {
-        self.digest
-    }
-
-    /// Builds node metadata directly from serialized components.
-    pub(crate) fn from_entry(entry: MastNodeEntry, digest: Word) -> Self {
-        Self { entry, digest }
-    }
-}
-
-impl Serializable for MastNodeInfo {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.entry.write_into(target);
-        self.digest.write_into(target);
-    }
-}
-
-impl Deserializable for MastNodeInfo {
-    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let entry = MastNodeEntry::read_from(source)?;
-        let digest = Word::read_from(source)?;
-        Ok(Self { entry, digest })
-    }
-
-    /// Returns the minimum serialized size: 8 bytes for MastNodeType + 32 bytes for Word digest.
-    fn min_serialized_size() -> usize {
-        MastNodeEntry::min_serialized_size() + Word::min_serialized_size()
-    }
-}
-
-// MAST NODE TYPE
-// ================================================================================================
-
-const JOIN: u8 = 0;
-const SPLIT: u8 = 1;
-const LOOP: u8 = 2;
-const BLOCK: u8 = 3;
-const CALL: u8 = 4;
-const SYSCALL: u8 = 5;
-const DYN: u8 = 6;
-const DYNCALL: u8 = 7;
-const EXTERNAL: u8 = 8;
-
-/// Represents the variant of a [`MastNode`], along with any inline structural payload.
 ///
 /// Child indices for `Join`, `Split`, `Loop`, `Call`, and `SysCall` are stored inline so random
 /// access does not need any extra pointer chasing.
 ///
-/// The serialized representation is always 8 bytes, which keeps [`MastNodeEntry`] fixed-width on
-/// the wire.
+/// The serialized representation is always 8 bytes, which keeps the node-entry table fixed-width
+/// on the wire.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
-pub enum MastNodeType {
+pub enum MastNodeEntry {
     Join {
         left_child_id: u32,
         right_child_id: u32,
@@ -242,13 +52,17 @@ pub enum MastNodeType {
 }
 
 /// Constructors
-impl MastNodeType {
-    /// Constructs a new [`MastNodeType`] from a [`MastNode`].
+impl MastNodeEntry {
+    /// Constructs a new [`MastNodeEntry`] from a [`MastNode`].
     pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
         use MastNode::*;
 
+        if !matches!(mast_node, &Block(_)) {
+            debug_assert_eq!(ops_offset, 0);
+        }
+
         match mast_node {
-            Block(_block_node) => Self::Block { ops_offset },
+            Block(_) => Self::Block { ops_offset },
             Join(join_node) => Self::Join {
                 left_child_id: join_node.first().0,
                 right_child_id: join_node.second().0,
@@ -275,29 +89,90 @@ impl MastNodeType {
             External(_) => Self::External,
         }
     }
+
+    /// Attempts to convert this [`MastNodeEntry`] into a [`MastNodeBuilder`].
+    ///
+    /// The `node_count` is the total expected number of nodes in the
+    /// [`crate::mast::MastForest`] **after deserialization**.
+    pub fn try_into_mast_node_builder(
+        self,
+        node_count: usize,
+        basic_block_data_decoder: &BasicBlockDataDecoder,
+        digest: Word,
+    ) -> Result<MastNodeBuilder, DeserializationError> {
+        match self {
+            Self::Block { ops_offset } => {
+                let op_batches = basic_block_data_decoder.decode_operations(ops_offset)?;
+                let builder = crate::mast::node::BasicBlockNodeBuilder::from_op_batches(
+                    op_batches,
+                    Vec::new(), // decorators set later
+                    digest,
+                );
+                Ok(MastNodeBuilder::BasicBlock(builder))
+            },
+            Self::Join { left_child_id, right_child_id } => {
+                let left_child = MastNodeId::from_u32_with_node_count(left_child_id, node_count)?;
+                let right_child = MastNodeId::from_u32_with_node_count(right_child_id, node_count)?;
+                let builder = crate::mast::node::JoinNodeBuilder::new([left_child, right_child])
+                    .with_digest(digest);
+                Ok(MastNodeBuilder::Join(builder))
+            },
+            Self::Split { if_branch_id, else_branch_id } => {
+                let if_branch = MastNodeId::from_u32_with_node_count(if_branch_id, node_count)?;
+                let else_branch = MastNodeId::from_u32_with_node_count(else_branch_id, node_count)?;
+                let builder = crate::mast::node::SplitNodeBuilder::new([if_branch, else_branch])
+                    .with_digest(digest);
+                Ok(MastNodeBuilder::Split(builder))
+            },
+            Self::Loop { body_id } => {
+                let body_id = MastNodeId::from_u32_with_node_count(body_id, node_count)?;
+                let builder = crate::mast::node::LoopNodeBuilder::new(body_id).with_digest(digest);
+                Ok(MastNodeBuilder::Loop(builder))
+            },
+            Self::Call { callee_id } => {
+                let callee_id = MastNodeId::from_u32_with_node_count(callee_id, node_count)?;
+                let builder =
+                    crate::mast::node::CallNodeBuilder::new(callee_id).with_digest(digest);
+                Ok(MastNodeBuilder::Call(builder))
+            },
+            Self::SysCall { callee_id } => {
+                let callee_id = MastNodeId::from_u32_with_node_count(callee_id, node_count)?;
+                let builder =
+                    crate::mast::node::CallNodeBuilder::new_syscall(callee_id).with_digest(digest);
+                Ok(MastNodeBuilder::Call(builder))
+            },
+            Self::Dyn => Ok(MastNodeBuilder::Dyn(
+                crate::mast::node::DynNodeBuilder::new_dyn().with_digest(digest),
+            )),
+            Self::Dyncall => Ok(MastNodeBuilder::Dyn(
+                crate::mast::node::DynNodeBuilder::new_dyncall().with_digest(digest),
+            )),
+            Self::External => {
+                Ok(MastNodeBuilder::External(crate::mast::node::ExternalNodeBuilder::new(digest)))
+            },
+        }
+    }
 }
 
-impl Serializable for MastNodeType {
+impl Serializable for MastNodeEntry {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         let discriminant = self.discriminant() as u64;
         assert!(discriminant <= 0b1111);
 
         let payload = match *self {
-            MastNodeType::Join {
+            Self::Join {
                 left_child_id: left,
                 right_child_id: right,
             } => Self::encode_u32_pair(left, right),
-            MastNodeType::Split {
+            Self::Split {
                 if_branch_id: if_branch,
                 else_branch_id: else_branch,
             } => Self::encode_u32_pair(if_branch, else_branch),
-            MastNodeType::Loop { body_id: body } => Self::encode_u32_payload(body),
-            MastNodeType::Block { ops_offset } => Self::encode_u32_payload(ops_offset),
-            MastNodeType::Call { callee_id } => Self::encode_u32_payload(callee_id),
-            MastNodeType::SysCall { callee_id } => Self::encode_u32_payload(callee_id),
-            MastNodeType::Dyn => 0,
-            MastNodeType::Dyncall => 0,
-            MastNodeType::External => 0,
+            Self::Loop { body_id: body } => Self::encode_u32_payload(body),
+            Self::Block { ops_offset } => Self::encode_u32_payload(ops_offset),
+            Self::Call { callee_id } => Self::encode_u32_payload(callee_id),
+            Self::SysCall { callee_id } => Self::encode_u32_payload(callee_id),
+            Self::Dyn | Self::Dyncall | Self::External => 0,
         };
 
         let value = (discriminant << 60) | payload;
@@ -305,47 +180,12 @@ impl Serializable for MastNodeType {
     }
 }
 
-/// Serialization helpers
-impl MastNodeType {
-    fn discriminant(&self) -> u8 {
-        // SAFETY: This is safe because we have given this enum a primitive representation with
-        // #[repr(u8)], with the first field of the underlying union-of-structs the discriminant.
-        //
-        // See the section on "accessing the numeric value of the discriminant"
-        // here: https://doc.rust-lang.org/std/mem/fn.discriminant.html
-        unsafe { *<*const _>::from(self).cast::<u8>() }
-    }
-
-    /// Encodes two u32 numbers in the first 60 bits of a `u64`.
-    ///
-    /// # Panics
-    /// - Panics if either `left_value` or `right_value` doesn't fit in 30 bits.
-    fn encode_u32_pair(left_value: u32, right_value: u32) -> u64 {
-        assert!(
-            left_value.leading_zeros() >= 2,
-            "MastNodeType::encode_u32_pair: left value doesn't fit in 30 bits: {left_value}",
-        );
-        assert!(
-            right_value.leading_zeros() >= 2,
-            "MastNodeType::encode_u32_pair: right value doesn't fit in 30 bits: {right_value}",
-        );
-
-        ((left_value as u64) << 30) | (right_value as u64)
-    }
-
-    fn encode_u32_payload(payload: u32) -> u64 {
-        payload as u64
-    }
-}
-
-impl Deserializable for MastNodeType {
+impl Deserializable for MastNodeEntry {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let (discriminant, payload) = {
             let value = source.read_u64()?;
 
-            // 4 bits
             let discriminant = (value >> 60) as u8;
-            // 60 bits
             let payload = value & 0x0f_ff_ff_ff_ff_ff_ff_ff;
 
             (discriminant, payload)
@@ -391,8 +231,41 @@ impl Deserializable for MastNodeType {
     }
 }
 
+/// Serialization helpers
+impl MastNodeEntry {
+    fn discriminant(&self) -> u8 {
+        // SAFETY: This is safe because we have given this enum a primitive representation with
+        // #[repr(u8)], with the first field of the underlying union-of-structs the discriminant.
+        //
+        // See the section on "accessing the numeric value of the discriminant"
+        // here: https://doc.rust-lang.org/std/mem/fn.discriminant.html
+        unsafe { *<*const _>::from(self).cast::<u8>() }
+    }
+
+    /// Encodes two u32 numbers in the first 60 bits of a `u64`.
+    ///
+    /// # Panics
+    /// - Panics if either `left_value` or `right_value` doesn't fit in 30 bits.
+    fn encode_u32_pair(left_value: u32, right_value: u32) -> u64 {
+        assert!(
+            left_value.leading_zeros() >= 2,
+            "MastNodeEntry::encode_u32_pair: left value doesn't fit in 30 bits: {left_value}",
+        );
+        assert!(
+            right_value.leading_zeros() >= 2,
+            "MastNodeEntry::encode_u32_pair: right value doesn't fit in 30 bits: {right_value}",
+        );
+
+        ((left_value as u64) << 30) | (right_value as u64)
+    }
+
+    fn encode_u32_payload(payload: u32) -> u64 {
+        payload as u64
+    }
+}
+
 /// Deserialization helpers
-impl MastNodeType {
+impl MastNodeEntry {
     /// Decodes two `u32` numbers from a 60-bit payload.
     fn decode_u32_pair(payload: u64) -> (u32, u32) {
         let left_value = (payload >> 30) as u32;
@@ -413,6 +286,83 @@ impl MastNodeType {
     }
 }
 
+/// Logical node metadata combining fixed-width structure and a digest value.
+///
+/// This is a convenience type for APIs that want both pieces together. The wire format does not
+/// require `MastNodeInfo` to appear as one contiguous fixed-width section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MastNodeInfo {
+    entry: MastNodeEntry,
+    digest: Word,
+}
+
+impl MastNodeInfo {
+    /// Constructs a new [`MastNodeInfo`] from a [`MastNode`], along with an `ops_offset`
+    ///
+    /// For non-basic block nodes, `ops_offset` is ignored, and should be set to 0.
+    pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
+        Self {
+            entry: MastNodeEntry::new(mast_node, ops_offset),
+            digest: mast_node.digest(),
+        }
+    }
+
+    /// Attempts to convert this [`MastNodeInfo`] into a [`MastNodeBuilder`].
+    pub fn try_into_mast_node_builder(
+        self,
+        node_count: usize,
+        basic_block_data_decoder: &BasicBlockDataDecoder,
+    ) -> Result<MastNodeBuilder, DeserializationError> {
+        self.entry
+            .try_into_mast_node_builder(node_count, basic_block_data_decoder, self.digest)
+    }
+
+    /// Returns the fixed-width structural node entry.
+    pub fn node_entry(&self) -> MastNodeEntry {
+        self.entry
+    }
+
+    /// Returns the stored node digest.
+    pub fn digest(&self) -> Word {
+        self.digest
+    }
+
+    /// Builds node metadata directly from serialized components.
+    pub(crate) fn from_entry(entry: MastNodeEntry, digest: Word) -> Self {
+        Self { entry, digest }
+    }
+}
+
+impl Serializable for MastNodeInfo {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.entry.write_into(target);
+        self.digest.write_into(target);
+    }
+}
+
+impl Deserializable for MastNodeInfo {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let entry = MastNodeEntry::read_from(source)?;
+        let digest = Word::read_from(source)?;
+        Ok(Self { entry, digest })
+    }
+
+    /// Returns the minimum serialized size: 8 bytes for `MastNodeEntry` + 32 bytes for `Word`.
+    fn min_serialized_size() -> usize {
+        MastNodeEntry::min_serialized_size() + Word::min_serialized_size()
+    }
+}
+
+const JOIN: u8 = 0;
+const SPLIT: u8 = 1;
+const LOOP: u8 = 2;
+const BLOCK: u8 = 3;
+const CALL: u8 = 4;
+const SYSCALL: u8 = 5;
+const DYN: u8 = 6;
+const DYNCALL: u8 = 7;
+const EXTERNAL: u8 = 8;
+
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
@@ -422,41 +372,41 @@ mod tests {
     #[test]
     fn serialize_deserialize_60_bit_payload() {
         // each child needs 30 bits
-        let mast_node_type = MastNodeType::Join {
+        let mast_node_entry = MastNodeEntry::Join {
             left_child_id: 0x3f_ff_ff_ff,
             right_child_id: 0x3f_ff_ff_ff,
         };
 
-        let serialized = mast_node_type.to_bytes();
-        let deserialized = MastNodeType::read_from_bytes(&serialized).unwrap();
+        let serialized = mast_node_entry.to_bytes();
+        let deserialized = MastNodeEntry::read_from_bytes(&serialized).unwrap();
 
-        assert_eq!(mast_node_type, deserialized);
+        assert_eq!(mast_node_entry, deserialized);
     }
 
     #[test]
     #[should_panic]
     fn serialize_large_payloads_fails_1() {
         // left child needs 31 bits
-        let mast_node_type = MastNodeType::Join {
+        let mast_node_entry = MastNodeEntry::Join {
             left_child_id: 0x4f_ff_ff_ff,
             right_child_id: 0x0,
         };
 
         // must panic
-        let _serialized = mast_node_type.to_bytes();
+        let _serialized = mast_node_entry.to_bytes();
     }
 
     #[test]
     #[should_panic]
     fn serialize_large_payloads_fails_2() {
         // right child needs 31 bits
-        let mast_node_type = MastNodeType::Join {
+        let mast_node_entry = MastNodeEntry::Join {
             left_child_id: 0x0,
             right_child_id: 0x4f_ff_ff_ff,
         };
 
         // must panic
-        let _serialized = mast_node_type.to_bytes();
+        let _serialized = mast_node_entry.to_bytes();
     }
 
     #[test]
@@ -471,7 +421,7 @@ mod tests {
             serialized_buffer
         };
 
-        let deserialized_result = MastNodeType::read_from_bytes(&serialized);
+        let deserialized_result = MastNodeEntry::read_from_bytes(&serialized);
 
         assert_matches!(deserialized_result, Err(DeserializationError::InvalidValue(_)));
     }

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -120,7 +120,10 @@ impl Deserializable for MastNodeEntry {
     }
 }
 
-/// Logical node metadata combining fixed-width structure and the node digest.
+/// Logical node metadata combining fixed-width structure and a digest value.
+///
+/// This is a convenience type for APIs that want both pieces together. The wire format does not
+/// require `MastNodeInfo` to appear as one contiguous fixed-width section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MastNodeInfo {
     entry: MastNodeEntry,
@@ -202,12 +205,13 @@ const DYN: u8 = 6;
 const DYNCALL: u8 = 7;
 const EXTERNAL: u8 = 8;
 
-/// Represents the variant of a [`MastNode`], as well as any additional data. For example, for more
-/// efficient decoding, and because of the frequency with which these node types appear, we directly
-/// represent the child indices for `Join`, `Split`, and `Loop`, `Call` and `SysCall` inline.
+/// Represents the variant of a [`MastNode`], along with any inline structural payload.
 ///
-/// The serialized representation of the MAST node type is guaranteed to be 8 bytes, so that
-/// [`MastNodeInfo`] (which contains it) can be of fixed width.
+/// Child indices for `Join`, `Split`, `Loop`, `Call`, and `SysCall` are stored inline so random
+/// access does not need any extra pointer chasing.
+///
+/// The serialized representation is always 8 bytes, which keeps [`MastNodeEntry`] fixed-width on
+/// the wire.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum MastNodeType {

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -8,6 +8,11 @@ use crate::{
     serde::{ByteReader, Deserializable, DeserializationError, SliceReader},
 };
 
+/// Fixed offsets and counts for the structural sections of a serialized MAST forest.
+///
+/// This is the shared substrate used by both serialized random-access views and the reader-based
+/// deserialization paths. It answers "where is this section?" but does not decide whether the
+/// bytes should be trusted.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ForestLayout {
     pub(super) node_count: usize,
@@ -25,6 +30,10 @@ pub(crate) struct ForestLayout {
     pub(super) node_hash_count: usize,
 }
 
+/// Raw wire flags from the MAST header.
+///
+/// These flags describe which optional sections are present in the payload. Trust policy lives in
+/// the caller that reads the payload, not in the flags themselves.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct WireFlags(u8);
 
@@ -33,6 +42,8 @@ impl ForestLayout {
         self.node_hash_offset.is_none()
     }
 
+    /// Converts scan-time offsets, which are relative to the post-header payload, into byte
+    /// offsets into the full serialized blob.
     pub(super) fn resolve(mut self) -> Result<Self, DeserializationError> {
         let header_len = MAGIC.len() + 1 + VERSION.len();
         self.roots_offset = header_len.checked_add(self.roots_offset).ok_or_else(|| {
@@ -165,6 +176,7 @@ pub(super) fn read_header_and_scan_layout<R: OffsetTrackingReader>(
     source: &mut R,
     allow_hashless: bool,
 ) -> Result<(WireFlags, ForestLayout), DeserializationError> {
+    // Reader trust policy is enforced here, before deeper parsing.
     let (raw_flags, _version) = read_and_validate_header(source)?;
     let flags = WireFlags::new(raw_flags)?;
     if flags.is_hashless() && !allow_hashless {

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -1,0 +1,317 @@
+use alloc::{string::ToString, vec::Vec};
+
+use super::{
+    FLAG_HASHLESS, FLAG_STRIPPED, FLAGS_RESERVED_MASK, MAGIC, MastForest, MastNodeEntry, VERSION,
+};
+use crate::{
+    mast::serialization::info::MastNodeType,
+    serde::{ByteReader, Deserializable, DeserializationError},
+};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ForestLayout {
+    pub(super) node_count: usize,
+    pub(super) roots_count: usize,
+    pub(super) roots_offset: usize,
+    pub(super) basic_block_offset: usize,
+    pub(super) basic_block_len: usize,
+    pub(super) node_entry_offset: usize,
+    pub(super) node_entry_size: usize,
+    pub(super) external_digest_offset: usize,
+    #[cfg(test)]
+    pub(super) external_digest_count: usize,
+    pub(super) node_hash_offset: Option<usize>,
+    #[cfg(test)]
+    pub(super) node_hash_count: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct WireFlags(u8);
+
+impl ForestLayout {
+    pub(crate) fn is_hashless(&self) -> bool {
+        self.node_hash_offset.is_none()
+    }
+
+    pub(super) fn resolve(mut self) -> Result<Self, DeserializationError> {
+        let header_len = MAGIC.len() + 1 + VERSION.len();
+        self.roots_offset = header_len.checked_add(self.roots_offset).ok_or_else(|| {
+            DeserializationError::InvalidValue("roots offset overflow".to_string())
+        })?;
+        self.basic_block_offset =
+            header_len.checked_add(self.basic_block_offset).ok_or_else(|| {
+                DeserializationError::InvalidValue("basic-block offset overflow".to_string())
+            })?;
+        self.node_entry_offset =
+            header_len.checked_add(self.node_entry_offset).ok_or_else(|| {
+                DeserializationError::InvalidValue("node entry offset overflow".to_string())
+            })?;
+        self.external_digest_offset =
+            header_len.checked_add(self.external_digest_offset).ok_or_else(|| {
+                DeserializationError::InvalidValue("external digest offset overflow".to_string())
+            })?;
+        self.node_hash_offset = self
+            .node_hash_offset
+            .map(|offset| {
+                header_len.checked_add(offset).ok_or_else(|| {
+                    DeserializationError::InvalidValue("node hash offset overflow".to_string())
+                })
+            })
+            .transpose()?;
+
+        Ok(self)
+    }
+}
+
+impl WireFlags {
+    pub(super) fn new(bits: u8) -> Result<Self, DeserializationError> {
+        let flags = Self(bits);
+        if flags.is_hashless() && !flags.is_stripped() {
+            return Err(DeserializationError::InvalidValue(
+                "HASHLESS flag requires STRIPPED flag to be set".to_string(),
+            ));
+        }
+
+        Ok(flags)
+    }
+
+    pub(super) fn bits(self) -> u8 {
+        self.0
+    }
+
+    pub(super) fn is_stripped(self) -> bool {
+        self.0 & FLAG_STRIPPED != 0
+    }
+
+    pub(super) fn is_hashless(self) -> bool {
+        self.0 & FLAG_HASHLESS != 0
+    }
+}
+
+pub(super) fn read_header_and_scan_layout<R: OffsetTrackingReader>(
+    source: &mut R,
+    allow_hashless: bool,
+) -> Result<(WireFlags, ForestLayout), DeserializationError> {
+    let (raw_flags, _version) = read_and_validate_header(source)?;
+    let flags = WireFlags::new(raw_flags)?;
+    if flags.is_hashless() && !allow_hashless {
+        return Err(DeserializationError::InvalidValue(
+            "HASHLESS flag is set; use UntrustedMastForest for untrusted input".to_string(),
+        ));
+    }
+    let layout = scan_layout_sections(source, flags.is_hashless())?;
+
+    Ok((flags, layout))
+}
+
+pub(super) trait OffsetTrackingReader: ByteReader {
+    fn offset(&self) -> usize;
+}
+
+pub(super) struct TrackingReader<'a, R> {
+    inner: &'a mut R,
+    offset: usize,
+    recorded: Option<Vec<u8>>,
+}
+
+impl<'a, R> TrackingReader<'a, R> {
+    pub(super) fn new(inner: &'a mut R) -> Self {
+        Self { inner, offset: 0, recorded: None }
+    }
+
+    pub(super) fn new_recording(inner: &'a mut R) -> Self {
+        Self {
+            inner,
+            offset: 0,
+            recorded: Some(Vec::new()),
+        }
+    }
+
+    pub(super) fn into_recorded(self) -> Vec<u8> {
+        self.recorded.unwrap_or_default()
+    }
+
+    fn advance_offset(&mut self, len: usize) -> Result<(), DeserializationError> {
+        self.offset = self
+            .offset
+            .checked_add(len)
+            .ok_or_else(|| DeserializationError::InvalidValue("offset overflow".to_string()))?;
+        Ok(())
+    }
+
+    fn record_slice(&mut self, slice: &[u8]) {
+        if let Some(recorded) = &mut self.recorded {
+            recorded.extend_from_slice(slice);
+        }
+    }
+}
+
+impl<R: ByteReader> ByteReader for TrackingReader<'_, R> {
+    fn read_u8(&mut self) -> Result<u8, DeserializationError> {
+        let byte = self.inner.read_u8()?;
+        self.advance_offset(1)?;
+        self.record_slice(&[byte]);
+        Ok(byte)
+    }
+
+    fn peek_u8(&self) -> Result<u8, DeserializationError> {
+        self.inner.peek_u8()
+    }
+
+    fn read_slice(&mut self, len: usize) -> Result<&[u8], DeserializationError> {
+        let slice = self.inner.read_slice(len)?;
+        self.offset = self
+            .offset
+            .checked_add(len)
+            .ok_or_else(|| DeserializationError::InvalidValue("offset overflow".to_string()))?;
+        if let Some(recorded) = &mut self.recorded {
+            recorded.extend_from_slice(slice);
+        }
+        Ok(slice)
+    }
+
+    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], DeserializationError> {
+        let array = self.inner.read_array::<N>()?;
+        self.advance_offset(N)?;
+        self.record_slice(&array);
+        Ok(array)
+    }
+
+    fn check_eor(&self, num_bytes: usize) -> Result<(), DeserializationError> {
+        self.inner.check_eor(num_bytes)
+    }
+
+    fn has_more_bytes(&self) -> bool {
+        self.inner.has_more_bytes()
+    }
+
+    fn max_alloc(&self, element_size: usize) -> usize {
+        self.inner.max_alloc(element_size)
+    }
+}
+
+impl<R: ByteReader> OffsetTrackingReader for TrackingReader<'_, R> {
+    fn offset(&self) -> usize {
+        self.offset
+    }
+}
+
+fn scan_layout_sections<R: OffsetTrackingReader>(
+    source: &mut R,
+    is_hashless: bool,
+) -> Result<ForestLayout, DeserializationError> {
+    let body_start = source.offset();
+
+    let node_count = source.read_usize()?;
+    if node_count > MastForest::MAX_NODES {
+        return Err(DeserializationError::InvalidValue(format!(
+            "node count {} exceeds maximum allowed {}",
+            node_count,
+            MastForest::MAX_NODES
+        )));
+    }
+    let _decorator_count = source.read_usize()?;
+
+    let roots_count = source.read_usize()?;
+    let roots_offset = source
+        .offset()
+        .checked_sub(body_start)
+        .ok_or_else(|| DeserializationError::InvalidValue("roots offset underflow".to_string()))?;
+    let roots_len_bytes = roots_count
+        .checked_mul(core::mem::size_of::<u32>())
+        .ok_or_else(|| DeserializationError::InvalidValue("roots length overflow".to_string()))?;
+    let _roots_data = source.read_slice(roots_len_bytes)?;
+
+    let basic_block_len = source.read_usize()?;
+    let basic_block_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
+        DeserializationError::InvalidValue("basic-block offset underflow".to_string())
+    })?;
+    let _basic_block_data = source.read_slice(basic_block_len)?;
+
+    let node_entry_size = MastNodeEntry::min_serialized_size();
+    let node_entry_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
+        DeserializationError::InvalidValue("node entry offset underflow".to_string())
+    })?;
+    let mut external_digest_count = 0usize;
+    for _ in 0..node_count {
+        let node_entry = MastNodeEntry::read_from(source)?;
+        if matches!(node_entry.node_type(), MastNodeType::External) {
+            external_digest_count = external_digest_count.checked_add(1).ok_or_else(|| {
+                DeserializationError::InvalidValue("external digest count overflow".to_string())
+            })?;
+        }
+    }
+
+    let external_digest_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
+        DeserializationError::InvalidValue("external digest offset underflow".to_string())
+    })?;
+    let external_digests_len = external_digest_count
+        .checked_mul(crate::Word::min_serialized_size())
+        .ok_or_else(|| {
+            DeserializationError::InvalidValue("external digest length overflow".to_string())
+        })?;
+    let _external_digests = source.read_slice(external_digests_len)?;
+
+    let node_hash_count = node_count.checked_sub(external_digest_count).ok_or_else(|| {
+        DeserializationError::InvalidValue("node hash count underflow".to_string())
+    })?;
+    let node_hash_offset = if is_hashless {
+        None
+    } else {
+        let offset = source.offset().checked_sub(body_start).ok_or_else(|| {
+            DeserializationError::InvalidValue("node hash offset underflow".to_string())
+        })?;
+        let node_hash_len =
+            node_hash_count.checked_mul(crate::Word::min_serialized_size()).ok_or_else(|| {
+                DeserializationError::InvalidValue("node hash length overflow".to_string())
+            })?;
+        let _node_hashes = source.read_slice(node_hash_len)?;
+        Some(offset)
+    };
+
+    Ok(ForestLayout {
+        node_count,
+        roots_count,
+        roots_offset,
+        basic_block_offset,
+        basic_block_len,
+        node_entry_offset,
+        node_entry_size,
+        external_digest_offset,
+        #[cfg(test)]
+        external_digest_count,
+        node_hash_offset,
+        #[cfg(test)]
+        node_hash_count,
+    })
+}
+
+fn read_and_validate_header<R: ByteReader>(
+    source: &mut R,
+) -> Result<(u8, [u8; 3]), DeserializationError> {
+    let magic: [u8; 4] = source.read_array()?;
+    if magic != *MAGIC {
+        return Err(DeserializationError::InvalidValue(format!(
+            "Invalid magic bytes. Expected '{:?}', got '{:?}'",
+            *MAGIC, magic
+        )));
+    }
+
+    let flags: u8 = source.read_u8()?;
+
+    let version: [u8; 3] = source.read_array()?;
+    if version != VERSION {
+        return Err(DeserializationError::InvalidValue(format!(
+            "Unsupported version. Got '{version:?}', but only '{VERSION:?}' is supported",
+        )));
+    }
+
+    if flags & FLAGS_RESERVED_MASK != 0 {
+        return Err(DeserializationError::InvalidValue(format!(
+            "Unknown flags set in MAST header: {:#04x}. Reserved bits must be zero.",
+            flags & FLAGS_RESERVED_MASK
+        )));
+    }
+
+    Ok((flags, version))
+}

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -4,7 +4,7 @@ use super::{
     FLAG_HASHLESS, FLAG_STRIPPED, FLAGS_RESERVED_MASK, MAGIC, MastForest, MastNodeEntry, VERSION,
 };
 use crate::{
-    mast::{MastNodeId, serialization::info::MastNodeType},
+    mast::MastNodeId,
     serde::{ByteReader, Deserializable, DeserializationError, SliceReader},
 };
 
@@ -318,7 +318,7 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
     let mut external_digest_count = 0usize;
     for _ in 0..node_count {
         let node_entry = MastNodeEntry::read_from(source)?;
-        if matches!(node_entry.node_type(), MastNodeType::External) {
+        if matches!(node_entry, MastNodeEntry::External) {
             external_digest_count = external_digest_count.checked_add(1).ok_or_else(|| {
                 DeserializationError::InvalidValue("external digest count overflow".to_string())
             })?;

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -8,6 +8,9 @@ use crate::{
     serde::{ByteReader, Deserializable, DeserializationError, SliceReader},
 };
 
+// FOREST LAYOUT
+// ================================================================================================
+
 /// Fixed offsets and counts for the structural sections of a serialized MAST forest.
 ///
 /// This is the shared substrate used by both serialized random-access views and the reader-based
@@ -28,7 +31,6 @@ pub(crate) struct ForestLayout {
     pub(super) basic_block_offset: usize,
     pub(super) basic_block_len: usize,
     pub(super) node_entry_offset: usize,
-    pub(super) node_entry_size: usize,
     pub(super) external_digest_offset: usize,
     #[cfg(test)]
     pub(super) external_digest_count: usize,
@@ -87,7 +89,7 @@ impl ForestLayout {
         let mut reader = SliceReader::new(read_fixed_section_entry(
             bytes,
             self.node_entry_offset,
-            self.node_entry_size,
+            MastNodeEntry::SERIALIZED_SIZE,
             index,
             "node entry",
         )?);
@@ -123,6 +125,9 @@ impl ForestLayout {
     }
 }
 
+// WIRE FLAGS
+// ================================================================================================
+
 impl WireFlags {
     pub(super) fn new(bits: u8) -> Result<Self, DeserializationError> {
         let flags = Self(bits);
@@ -147,6 +152,9 @@ impl WireFlags {
         self.0 & FLAG_HASHLESS != 0
     }
 }
+
+// LAYOUT SCANNING
+// ================================================================================================
 
 pub(super) fn read_header_and_scan_layout<R: OffsetTrackingReader>(
     source: &mut R,
@@ -271,12 +279,7 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
             MastForest::MAX_NODES
         )));
     }
-    validate_budgeted_count(
-        source,
-        node_count,
-        MastNodeEntry::min_serialized_size(),
-        "node count",
-    )?;
+    validate_budgeted_count(source, node_count, MastNodeEntry::SERIALIZED_SIZE, "node count")?;
 
     let roots_count = source.read_usize()?;
     validate_budgeted_count(source, roots_count, core::mem::size_of::<u32>(), "root count")?;
@@ -290,7 +293,6 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
     let basic_block_offset = source.offset();
     let _basic_block_data = source.read_slice(basic_block_len)?;
 
-    let node_entry_size = MastNodeEntry::min_serialized_size();
     let node_entry_offset = source.offset();
     let mut external_digest_count = 0usize;
     for _ in 0..node_count {
@@ -332,7 +334,6 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
         basic_block_offset,
         basic_block_len,
         node_entry_offset,
-        node_entry_size,
         external_digest_offset,
         #[cfg(test)]
         external_digest_count,
@@ -387,6 +388,9 @@ fn read_and_validate_header<R: ByteReader>(
 
     Ok((flags, version))
 }
+
+// HELPERS
+// ================================================================================================
 
 pub(super) fn read_fixed_section_entry<'a>(
     bytes: &'a [u8],

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -4,8 +4,8 @@ use super::{
     FLAG_HASHLESS, FLAG_STRIPPED, FLAGS_RESERVED_MASK, MAGIC, MastForest, MastNodeEntry, VERSION,
 };
 use crate::{
-    mast::serialization::info::MastNodeType,
-    serde::{ByteReader, Deserializable, DeserializationError},
+    mast::{MastNodeId, serialization::info::MastNodeType},
+    serde::{ByteReader, Deserializable, DeserializationError, SliceReader},
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -60,6 +60,79 @@ impl ForestLayout {
             .transpose()?;
 
         Ok(self)
+    }
+
+    pub(super) fn read_procedure_root_at(
+        &self,
+        bytes: &[u8],
+        index: usize,
+    ) -> Result<MastNodeId, DeserializationError> {
+        if index >= self.roots_count {
+            return Err(DeserializationError::InvalidValue(format!(
+                "root index {} out of bounds for {} roots",
+                index, self.roots_count
+            )));
+        }
+
+        let mut raw = [0u8; core::mem::size_of::<u32>()];
+        raw.copy_from_slice(read_fixed_section_entry(
+            bytes,
+            self.roots_offset,
+            core::mem::size_of::<u32>(),
+            index,
+            "root",
+        )?);
+        MastNodeId::from_u32_with_node_count(u32::from_le_bytes(raw), self.node_count)
+    }
+
+    pub(super) fn read_node_entry_at(
+        &self,
+        bytes: &[u8],
+        index: usize,
+    ) -> Result<MastNodeEntry, DeserializationError> {
+        if index >= self.node_count {
+            return Err(DeserializationError::InvalidValue(format!(
+                "node index {} out of bounds for {} nodes",
+                index, self.node_count
+            )));
+        }
+
+        let mut reader = SliceReader::new(read_fixed_section_entry(
+            bytes,
+            self.node_entry_offset,
+            self.node_entry_size,
+            index,
+            "node entry",
+        )?);
+        MastNodeEntry::read_from(&mut reader)
+    }
+
+    #[cfg(test)]
+    pub(super) fn advice_map_offset(
+        &self,
+        bytes_len: usize,
+    ) -> Result<usize, DeserializationError> {
+        let digest_section_end = if let Some(node_hash_offset) = self.node_hash_offset {
+            node_hash_offset
+                .checked_add(self.node_hash_count * crate::Word::min_serialized_size())
+                .ok_or_else(|| {
+                    DeserializationError::InvalidValue("node hash section overflow".to_string())
+                })?
+        } else {
+            self.external_digest_offset
+                .checked_add(self.external_digest_count * crate::Word::min_serialized_size())
+                .ok_or_else(|| {
+                    DeserializationError::InvalidValue(
+                        "external digest section overflow".to_string(),
+                    )
+                })?
+        };
+
+        if digest_section_end > bytes_len {
+            return Err(DeserializationError::UnexpectedEOF);
+        }
+
+        Ok(digest_section_end)
     }
 }
 
@@ -314,4 +387,27 @@ fn read_and_validate_header<R: ByteReader>(
     }
 
     Ok((flags, version))
+}
+
+pub(super) fn read_fixed_section_entry<'a>(
+    bytes: &'a [u8],
+    section_offset: usize,
+    entry_size: usize,
+    index: usize,
+    section_name: &str,
+) -> Result<&'a [u8], DeserializationError> {
+    let entry_offset = index
+        .checked_mul(entry_size)
+        .and_then(|delta| section_offset.checked_add(delta))
+        .ok_or_else(|| {
+            DeserializationError::InvalidValue(format!("{section_name} offset overflow"))
+        })?;
+    let entry_end = entry_offset.checked_add(entry_size).ok_or_else(|| {
+        DeserializationError::InvalidValue(format!("{section_name} length overflow"))
+    })?;
+    if entry_end > bytes.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+
+    Ok(&bytes[entry_offset..entry_end])
 }

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -1,4 +1,4 @@
-use alloc::{string::ToString, vec::Vec};
+use alloc::{format, string::ToString, vec::Vec};
 
 use super::{
     FLAG_HASHLESS, FLAG_STRIPPED, FLAGS_RESERVED_MASK, MAGIC, MastForest, MastNodeEntry, VERSION,
@@ -11,8 +11,15 @@ use crate::{
 /// Fixed offsets and counts for the structural sections of a serialized MAST forest.
 ///
 /// This is the shared substrate used by both serialized random-access views and the reader-based
-/// deserialization paths. It answers "where is this section?" but does not decide whether the
-/// bytes should be trusted.
+/// deserialization paths. All offsets are absolute byte offsets into the full serialized blob.
+/// `ForestLayout` itself is not a trust marker; it only says the structural sections fit within
+/// the scanned byte slice.
+///
+/// The scanner validates section sizes immediately. For budgeted readers, it also bounds wire
+/// counts via [`ByteReader::max_alloc`] before those counts are used to size fixed-width sections.
+/// Plain [`SliceReader`] leaves `max_alloc` unconstrained, so trusted inspection paths keep their
+/// previous behavior. Full untrusted validation lives above this layer in
+/// [`crate::mast::UntrustedMastForest`].
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ForestLayout {
     pub(super) node_count: usize,
@@ -40,37 +47,6 @@ pub(super) struct WireFlags(u8);
 impl ForestLayout {
     pub(crate) fn is_hashless(&self) -> bool {
         self.node_hash_offset.is_none()
-    }
-
-    /// Converts scan-time offsets, which are relative to the post-header payload, into byte
-    /// offsets into the full serialized blob.
-    pub(super) fn resolve(mut self) -> Result<Self, DeserializationError> {
-        let header_len = MAGIC.len() + 1 + VERSION.len();
-        self.roots_offset = header_len.checked_add(self.roots_offset).ok_or_else(|| {
-            DeserializationError::InvalidValue("roots offset overflow".to_string())
-        })?;
-        self.basic_block_offset =
-            header_len.checked_add(self.basic_block_offset).ok_or_else(|| {
-                DeserializationError::InvalidValue("basic-block offset overflow".to_string())
-            })?;
-        self.node_entry_offset =
-            header_len.checked_add(self.node_entry_offset).ok_or_else(|| {
-                DeserializationError::InvalidValue("node entry offset overflow".to_string())
-            })?;
-        self.external_digest_offset =
-            header_len.checked_add(self.external_digest_offset).ok_or_else(|| {
-                DeserializationError::InvalidValue("external digest offset overflow".to_string())
-            })?;
-        self.node_hash_offset = self
-            .node_hash_offset
-            .map(|offset| {
-                header_len.checked_add(offset).ok_or_else(|| {
-                    DeserializationError::InvalidValue("node hash offset overflow".to_string())
-                })
-            })
-            .transpose()?;
-
-        Ok(self)
     }
 
     pub(super) fn read_procedure_root_at(
@@ -176,7 +152,9 @@ pub(super) fn read_header_and_scan_layout<R: OffsetTrackingReader>(
     source: &mut R,
     allow_hashless: bool,
 ) -> Result<(WireFlags, ForestLayout), DeserializationError> {
-    // Reader trust policy is enforced here, before deeper parsing.
+    // This scanner always enforces syntactic layout validity. Reader choice determines the trust
+    // policy for counts: e.g. `SliceReader` for trusted inspection versus `BudgetedReader` for the
+    // untrusted deserialization path.
     let (raw_flags, _version) = read_and_validate_header(source)?;
     let flags = WireFlags::new(raw_flags)?;
     if flags.is_hashless() && !allow_hashless {
@@ -285,8 +263,6 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
     source: &mut R,
     is_hashless: bool,
 ) -> Result<ForestLayout, DeserializationError> {
-    let body_start = source.offset();
-
     let node_count = source.read_usize()?;
     if node_count > MastForest::MAX_NODES {
         return Err(DeserializationError::InvalidValue(format!(
@@ -295,26 +271,27 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
             MastForest::MAX_NODES
         )));
     }
+    validate_budgeted_count(
+        source,
+        node_count,
+        MastNodeEntry::min_serialized_size(),
+        "node count",
+    )?;
+
     let roots_count = source.read_usize()?;
-    let roots_offset = source
-        .offset()
-        .checked_sub(body_start)
-        .ok_or_else(|| DeserializationError::InvalidValue("roots offset underflow".to_string()))?;
+    validate_budgeted_count(source, roots_count, core::mem::size_of::<u32>(), "root count")?;
+    let roots_offset = source.offset();
     let roots_len_bytes = roots_count
         .checked_mul(core::mem::size_of::<u32>())
         .ok_or_else(|| DeserializationError::InvalidValue("roots length overflow".to_string()))?;
     let _roots_data = source.read_slice(roots_len_bytes)?;
 
     let basic_block_len = source.read_usize()?;
-    let basic_block_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
-        DeserializationError::InvalidValue("basic-block offset underflow".to_string())
-    })?;
+    let basic_block_offset = source.offset();
     let _basic_block_data = source.read_slice(basic_block_len)?;
 
     let node_entry_size = MastNodeEntry::min_serialized_size();
-    let node_entry_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
-        DeserializationError::InvalidValue("node entry offset underflow".to_string())
-    })?;
+    let node_entry_offset = source.offset();
     let mut external_digest_count = 0usize;
     for _ in 0..node_count {
         let node_entry = MastNodeEntry::read_from(source)?;
@@ -325,9 +302,7 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
         }
     }
 
-    let external_digest_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
-        DeserializationError::InvalidValue("external digest offset underflow".to_string())
-    })?;
+    let external_digest_offset = source.offset();
     let external_digests_len = external_digest_count
         .checked_mul(crate::Word::min_serialized_size())
         .ok_or_else(|| {
@@ -341,9 +316,7 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
     let node_hash_offset = if is_hashless {
         None
     } else {
-        let offset = source.offset().checked_sub(body_start).ok_or_else(|| {
-            DeserializationError::InvalidValue("node hash offset underflow".to_string())
-        })?;
+        let offset = source.offset();
         let node_hash_len =
             node_hash_count.checked_mul(crate::Word::min_serialized_size()).ok_or_else(|| {
                 DeserializationError::InvalidValue("node hash length overflow".to_string())
@@ -367,6 +340,22 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
         #[cfg(test)]
         node_hash_count,
     })
+}
+
+fn validate_budgeted_count<R: ByteReader>(
+    source: &R,
+    count: usize,
+    element_size: usize,
+    label: &str,
+) -> Result<(), DeserializationError> {
+    let max_count = source.max_alloc(element_size);
+    if count > max_count {
+        return Err(DeserializationError::InvalidValue(format!(
+            "{label} {count} exceeds reader allocation bound {max_count} for {element_size}-byte elements",
+        )));
+    }
+
+    Ok(())
 }
 
 fn read_and_validate_header<R: ByteReader>(

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -295,8 +295,6 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
             MastForest::MAX_NODES
         )));
     }
-    let _decorator_count = source.read_usize()?;
-
     let roots_count = source.read_usize()?;
     let roots_offset = source
         .offset()

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -8,7 +8,8 @@
 //!
 //! Wire flags describe serializer intent, not reader trust policy. Trusted [`MastForest`] reads
 //! reject hashless payloads. [`crate::mast::UntrustedMastForest`] accepts them and rebuilds
-//! non-external digests before use.
+//! non-external digests before use. If a non-hashless payload is sent down the untrusted path,
+//! validation recomputes those digests and requires them to match the serialized values.
 //!
 //! The main layers fit together like this:
 //!
@@ -32,7 +33,6 @@
 //!
 //! (Counts)
 //! - nodes count (`usize`)
-//! - decorators count (`usize`) - 0 if stripped, reserved for future use in lazy loading (#2504)
 //!
 //! (Procedure roots section)
 //! - procedure roots (`Vec<u32>` as MastNodeId values)
@@ -42,12 +42,15 @@
 //!
 //! (Node entries section)
 //! - fixed-width structural node entries (`Vec<MastNodeEntry>`)
+//! - `Block` entries store offsets into the basic-block section above
 //!
 //! (External digest section)
 //! - digests for `External` nodes only (`Vec<Word>`, ordered by node index)
+//! - lookup is dense-by-kind: the Nth external node uses slot N in this section
 //!
 //! (Node hash section - omitted if FLAGS bit 1 is set)
 //! - digests for all non-external nodes (`Vec<Word>`, ordered by node index)
+//! - lookup is also dense-by-kind: the Nth non-external node uses slot N in this section
 //!
 //! (Advice map section)
 //! - Advice map (`AdviceMap`)
@@ -67,6 +70,10 @@
 //! In hashless format, the internal node-hash section is omitted and `HASHLESS` also implies
 //! `STRIPPED`. External node digests still stay on the wire because they cannot be rebuilt from
 //! local structure.
+//!
+//! Readers recover per-node digest lookup by scanning node entries once and building a compact
+//! "slot by node index" table. This preserves random access without forcing all digests into the
+//! same contiguous array on the wire.
 
 #[cfg(test)]
 use alloc::string::ToString;
@@ -168,6 +175,8 @@ const FLAGS_RESERVED_MASK: u8 = 0xfc;
 /// - [0, 0, 3]: Added HASHLESS flag (bit 1). HASHLESS implies STRIPPED. Trusted deserialization
 ///   rejects HASHLESS. Split fixed-width node entries from digest storage. External digests moved
 ///   to a dedicated section. Hashless serialization omits the general node-hash section entirely.
+///   Dropped the serialized decorator-count field because it was not used by the wire layout or
+///   deserializers.
 const VERSION: [u8; 3] = [0, 0, 3];
 
 // MAST FOREST SERIALIZATION/DESERIALIZATION
@@ -201,9 +210,8 @@ impl MastForest {
         // version
         target.write_bytes(&VERSION);
 
-        // node & decorator counts
+        // node count
         target.write_usize(self.nodes.len());
-        target.write_usize(if stripped { 0 } else { self.debug_info.num_decorators() });
 
         // roots
         let roots: Vec<u32> = self.roots.iter().copied().map(u32::from).collect();
@@ -273,12 +281,6 @@ fn serialized_size_hint(forest: &MastForest, stripped: bool, hashless: bool) -> 
 
     let mut size = MAGIC.len() + 1 + VERSION.len();
     size += node_count.get_size_hint();
-    size += if stripped {
-        0usize
-    } else {
-        forest.debug_info.num_decorators()
-    }
-    .get_size_hint();
 
     let roots_len = forest.roots.len();
     size += roots_len.get_size_hint();
@@ -648,7 +650,7 @@ pub(super) fn read_untrusted_with_flags<R: ByteReader>(
 fn log_untrusted_overspecification(flags: WireFlags) {
     if !flags.is_hashless() {
         log::error!(
-            "UntrustedMastForest expected HASHLESS input; supplied artifact includes wire node hashes that will be ignored and recomputed during validation"
+            "UntrustedMastForest expected HASHLESS input; supplied artifact includes wire node hashes, and validation will recompute them and require them to match"
         );
     }
 

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -239,12 +239,16 @@ impl MastForest {
     }
 }
 
-pub(super) fn stripped_size_hint(forest: &MastForest) -> usize {
-    serialized_size_hint(forest, true, false)
+pub(super) fn write_stripped_into<W: ByteWriter>(forest: &MastForest, target: &mut W) {
+    forest.write_into_with_options(target, true, false);
 }
 
-fn hashless_size_hint(forest: &MastForest) -> usize {
-    serialized_size_hint(forest, true, true)
+pub(super) fn write_hashless_into<W: ByteWriter>(forest: &MastForest, target: &mut W) {
+    forest.write_into_with_options(target, true, true);
+}
+
+pub(super) fn stripped_size_hint(forest: &MastForest) -> usize {
+    serialized_size_hint(forest, true, false)
 }
 
 fn serialized_size_hint(forest: &MastForest, stripped: bool, hashless: bool) -> usize {
@@ -286,10 +290,15 @@ fn serialized_size_hint(forest: &MastForest, stripped: bool, hashless: bool) -> 
     size
 }
 
-/// A zero-copy view over a stripped, serialized MAST forest.
+/// A zero-copy structural view over serialized MAST forest bytes.
 ///
-/// This is intended for trusted inputs and supports random access to `MastNodeInfo`
-/// entries without deserializing the full forest.
+/// This view accepts full, stripped, and hashless payloads. It eagerly validates the header and
+/// fixed-width structural sections needed for random access, but leaves digest resolution lazy:
+/// digests are read from the wire when present and otherwise recomputed on first access.
+///
+/// Use this when callers need random access to roots or node metadata without deserializing the
+/// full forest. For strict trusted deserialization, use
+/// [`crate::mast::MastForest::read_from_bytes`].
 ///
 /// # Examples
 ///
@@ -323,7 +332,7 @@ pub struct SerializedMastForest<'a> {
 impl<'a> SerializedMastForest<'a> {
     /// Creates a new view from serialized bytes.
     ///
-    /// The input may be either full or stripped format.
+    /// The input may be full, stripped, or hashless format.
     /// Structural parsing is delegated to the same single-pass scanner used by reader-based
     /// deserialization paths.
     ///
@@ -334,10 +343,14 @@ impl<'a> SerializedMastForest<'a> {
     /// For strict full-payload validation, use
     /// [`crate::mast::MastForest::read_from_bytes`].
     ///
-    /// Conventions:
-    /// - If `HASHLESS` is not set, node digests are read from wire data.
-    /// - If `HASHLESS` is set, wire digests are ignored and non-external node digests are
-    ///   recomputed lazily the first time digest-backed access is requested.
+    /// Wire flags describe serializer intent, not a trust policy. This constructor accepts
+    /// hashless payloads for inspection even though trusted [`crate::mast::MastForest`]
+    /// deserialization rejects them.
+    ///
+    /// Digest conventions:
+    /// - If `HASHLESS` is not set, node digests are read from the wire hash section.
+    /// - If `HASHLESS` is set, non-external node digests are recomputed lazily the first time
+    ///   digest-backed access is requested.
     /// - For `External` nodes in `HASHLESS` mode, digests are marshaled opaquely from wire data;
     ///   this view does not attempt semantic resolution of external references.
     ///
@@ -379,12 +392,12 @@ impl<'a> SerializedMastForest<'a> {
         self.layout.node_count
     }
 
-    /// Returns `true` when this view uses hashless convention and recomputed digests.
+    /// Returns `true` when the wire header declares hashless serializer intent.
     pub fn is_hashless(&self) -> bool {
         self.flags.is_hashless()
     }
 
-    /// Returns `true` when this view represents stripped serialization.
+    /// Returns `true` when the wire header declares stripped serializer intent.
     pub fn is_stripped(&self) -> bool {
         self.flags.is_stripped()
     }
@@ -434,6 +447,9 @@ impl<'a> SerializedMastForest<'a> {
     }
 
     /// Returns the digest for the node at the specified index.
+    ///
+    /// This resolves digests lazily. Hashless views rebuild non-external node digests on first
+    /// digest-backed access and cache the result for later lookups.
     pub fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
         self.resolved()?.node_digest_at(index)
     }
@@ -681,41 +697,5 @@ impl Deserializable for super::UntrustedMastForest {
     /// the forest.
     fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
         super::UntrustedMastForest::read_from_bytes(bytes)
-    }
-}
-
-// STRIPPED SERIALIZATION
-// ================================================================================================
-
-/// Wrapper for serializing a [`MastForest`] without debug information.
-///
-/// This newtype enables an alternative serialization format that omits the DebugInfo section,
-/// producing smaller output files suitable for production deployment where debug info is not
-/// needed.
-///
-/// The resulting bytes can be deserialized with the standard [`Deserializable`] impl for
-/// [`MastForest`], which auto-detects the format via the flags byte in the header.
-pub(super) struct StrippedMastForest<'a>(pub(super) &'a MastForest);
-
-impl Serializable for StrippedMastForest<'_> {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.0.write_into_with_options(target, true, false);
-    }
-
-    fn get_size_hint(&self) -> usize {
-        stripped_size_hint(self.0)
-    }
-}
-
-/// Wrapper for serializing a [`MastForest`] with the HASHLESS flag set.
-pub(super) struct HashlessMastForest<'a>(pub(super) &'a MastForest);
-
-impl Serializable for HashlessMastForest<'_> {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.0.write_into_with_options(target, true, true);
-    }
-
-    fn get_size_hint(&self) -> usize {
-        hashless_size_hint(self.0)
     }
 }

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -1,4 +1,16 @@
-//! The serialization format of MastForest is as follows:
+//! MAST forest serialization keeps one fixed structural layout for full, stripped, and hashless
+//! payloads.
+//!
+//! The main goal is to keep random access cheap in stripped and hashless modes. Node structure
+//! stays in one fixed-width section. Variable-size data lives in separate sections. Internal node
+//! digests also live in a separate section so hashless payloads can omit them without changing the
+//! structural layout.
+//!
+//! Wire flags describe serializer intent, not reader trust policy. Trusted [`MastForest`] reads
+//! reject hashless payloads. [`crate::mast::UntrustedMastForest`] accepts them and rebuilds
+//! non-external digests before use.
+//!
+//! The format is:
 //!
 //! (Metadata)
 //! - MAGIC (4 bytes) + FLAGS (1 byte) + VERSION (3 bytes)
@@ -34,18 +46,12 @@
 //! - NodeToDecoratorIds CSR (before_enter and after_exit decorators, dense representation)
 //! - Procedure names map (`BTreeMap<Word, String>`)
 //!
-//! # Stripped Format
+//! In stripped format, the `DebugInfo` section is omitted and readers materialize an empty
+//! `DebugInfo`.
 //!
-//! When serializing with [`MastForest::write_stripped`], the FLAGS byte has bit 0 set
-//! and the entire DebugInfo section is omitted. Deserialization auto-detects the format
-//! and creates an empty `DebugInfo` with valid CSR structures when reading stripped files.
-//!
-//! # Hashless Format
-//!
-//! When serializing with [`MastForest::write_hashless`], the FLAGS byte has bit 1 set, and
-//! bit 0 is also set (hashless implies stripped). In this format, the general node-hash section
-//! is omitted entirely. Trusted deserialization rejects hashless inputs; use
-//! [`UntrustedMastForest`] instead.
+//! In hashless format, the internal node-hash section is omitted and `HASHLESS` also implies
+//! `STRIPPED`. External node digests still stay on the wire because they cannot be rebuilt from
+//! local structure.
 
 #[cfg(test)]
 use alloc::string::ToString;
@@ -107,26 +113,21 @@ type StringIndex = usize;
 
 /// Magic bytes for detecting that a file is binary-encoded MAST.
 ///
-/// The format uses 4 bytes for identification followed by a flags byte:
-/// - Bytes 0-3: `b"MAST"` - Magic identifier
-/// - Byte 4: Flags byte (see [`FLAG_STRIPPED`] and [`FLAGS_RESERVED_MASK`] constants)
+/// The header is `b"MAST"` + flags byte + version bytes.
 ///
-/// This design repurposes the original null terminator (`b"MAST\0"`) as a flags byte,
-/// maintaining backward compatibility: old files have flags=0x00 (the null byte),
-/// which means "debug info present".
+/// This repurposes the old `b"MAST\0"` terminator as the flags byte, so legacy payloads still
+/// decode as "debug info present".
 const MAGIC: &[u8; 4] = b"MAST";
 
-/// Flag indicating debug info is stripped from the serialized MastForest.
+/// Flag indicating that the `DebugInfo` section is omitted from the wire payload.
 ///
-/// When this bit is set in the flags byte, the DebugInfo section is omitted entirely.
-/// The deserializer will create an empty `DebugInfo` with valid CSR structures.
+/// Readers treat this as serializer intent about the wire layout, not as a trust decision.
 const FLAG_STRIPPED: u8 = 0x01;
 
-/// Flag indicating the serialized MastForest should be treated as hashless.
+/// Flag indicating that the internal node-hash section is omitted from the wire payload.
 ///
-/// When this bit is set, the general node-hash section is omitted. External digests remain
-/// serialized in their dedicated section because they cannot be reconstructed locally.
-/// Trusted deserialization rejects this format. This flag implies [`FLAG_STRIPPED`].
+/// External digests still remain serialized in their own section because they cannot be rebuilt
+/// from local structure. This flag implies [`FLAG_STRIPPED`].
 pub(super) const FLAG_HASHLESS: u8 = 0x02;
 
 /// Mask for reserved flag bits that must be zero.
@@ -292,9 +293,9 @@ fn serialized_size_hint(forest: &MastForest, stripped: bool, hashless: bool) -> 
 
 /// A zero-copy structural view over serialized MAST forest bytes.
 ///
-/// This view accepts full, stripped, and hashless payloads. It eagerly validates the header and
-/// fixed-width structural sections needed for random access, but leaves digest resolution lazy:
-/// digests are read from the wire when present and otherwise recomputed on first access.
+/// This view accepts full, stripped, and hashless payloads. It validates the header and the
+/// fixed-width structural sections needed for random access, but it does not fully materialize the
+/// forest.
 ///
 /// Use this when callers need random access to roots or node metadata without deserializing the
 /// full forest. For strict trusted deserialization, use
@@ -343,16 +344,15 @@ impl<'a> SerializedMastForest<'a> {
     /// For strict full-payload validation, use
     /// [`crate::mast::MastForest::read_from_bytes`].
     ///
-    /// Wire flags describe serializer intent, not a trust policy. This constructor accepts
+    /// Wire flags describe serializer intent, not trust policy. This constructor accepts
     /// hashless payloads for inspection even though trusted [`crate::mast::MastForest`]
     /// deserialization rejects them.
     ///
-    /// Digest conventions:
-    /// - If `HASHLESS` is not set, node digests are read from the wire hash section.
-    /// - If `HASHLESS` is set, non-external node digests are recomputed lazily the first time
-    ///   digest-backed access is requested.
-    /// - For `External` nodes in `HASHLESS` mode, digests are marshaled opaquely from wire data;
-    ///   this view does not attempt semantic resolution of external references.
+    /// Digest lookup follows the wire layout:
+    /// - If the internal-hash section is present, non-external node digests are read from it.
+    /// - If the internal-hash section is absent, the first digest-backed access rebuilds all
+    ///   non-external node digests from structure and caches them.
+    /// - External node digests are always read from the external-digest section.
     ///
     /// # Examples
     ///
@@ -392,12 +392,12 @@ impl<'a> SerializedMastForest<'a> {
         self.layout.node_count
     }
 
-    /// Returns `true` when the wire header declares hashless serializer intent.
+    /// Returns `true` when the wire header says that the internal-hash section is omitted.
     pub fn is_hashless(&self) -> bool {
         self.flags.is_hashless()
     }
 
-    /// Returns `true` when the wire header declares stripped serializer intent.
+    /// Returns `true` when the wire header says that the `DebugInfo` section is omitted.
     pub fn is_stripped(&self) -> bool {
         self.flags.is_stripped()
     }
@@ -448,8 +448,8 @@ impl<'a> SerializedMastForest<'a> {
 
     /// Returns the digest for the node at the specified index.
     ///
-    /// This resolves digests lazily. Hashless views rebuild non-external node digests on first
-    /// digest-backed access and cache the result for later lookups.
+    /// This resolves digests lazily. If the internal-hash section is absent, the first
+    /// digest-backed access rebuilds all non-external node digests and caches them.
     pub fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
         self.resolved()?.node_digest_at(index)
     }

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -151,10 +151,9 @@ const FLAGS_RESERVED_MASK: u8 = 0xfc;
 ///   separately in DebugInfo. Removed `should_break` field from AssemblyOp serialization (#2646).
 ///   Removed `breakpoint` instruction (#2655).
 /// - [0, 0, 3]: Added HASHLESS flag (bit 1). HASHLESS implies STRIPPED. Trusted deserialization
-///   rejects HASHLESS.
-/// - [0, 0, 4]: Split fixed-width node entries from digest storage. External digests moved to a
-///   dedicated section. Hashless serialization omits the general node-hash section entirely.
-const VERSION: [u8; 3] = [0, 0, 4];
+///   rejects HASHLESS. Split fixed-width node entries from digest storage. External digests moved
+///   to a dedicated section. Hashless serialization omits the general node-hash section entirely.
+const VERSION: [u8; 3] = [0, 0, 3];
 
 // MAST FOREST SERIALIZATION/DESERIALIZATION
 // ================================================================================================

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -51,6 +51,8 @@
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
+use miden_utils_sync::OnceLockCompat;
+
 use super::{MastForest, MastNode, MastNodeId};
 use crate::{
     advice::AdviceMap,
@@ -312,8 +314,10 @@ fn serialized_size_hint(forest: &MastForest, stripped: bool, hashless: bool) -> 
 /// ```
 #[derive(Debug)]
 pub struct SerializedMastForest<'a> {
+    bytes: &'a [u8],
     flags: WireFlags,
-    forest: ResolvedSerializedForest<'a>,
+    layout: ForestLayout,
+    resolved: OnceLockCompat<Result<ResolvedSerializedForest<'a>, DeserializationError>>,
 }
 
 impl<'a> SerializedMastForest<'a> {
@@ -332,8 +336,8 @@ impl<'a> SerializedMastForest<'a> {
     ///
     /// Conventions:
     /// - If `HASHLESS` is not set, node digests are read from wire data.
-    /// - If `HASHLESS` is set, wire digests are ignored and node digests are recomputed during
-    ///   construction whenever possible.
+    /// - If `HASHLESS` is set, wire digests are ignored and non-external node digests are
+    ///   recomputed lazily the first time digest-backed access is requested.
     /// - For `External` nodes in `HASHLESS` mode, digests are marshaled opaquely from wire data;
     ///   this view does not attempt semantic resolution of external references.
     ///
@@ -361,14 +365,18 @@ impl<'a> SerializedMastForest<'a> {
         let mut reader = SliceReader::new(bytes);
         let mut scanner = TrackingReader::new(&mut reader);
         let (flags, layout) = read_header_and_scan_layout(&mut scanner, true)?;
-        let forest = ResolvedSerializedForest::new(bytes, layout)?;
 
-        Ok(Self { flags, forest })
+        Ok(Self {
+            bytes,
+            flags,
+            layout: layout.resolve()?,
+            resolved: OnceLockCompat::new(),
+        })
     }
 
     /// Returns the number of nodes in the serialized forest.
     pub fn node_count(&self) -> usize {
-        self.forest.node_count()
+        self.layout.node_count
     }
 
     /// Returns `true` when this view uses hashless convention and recomputed digests.
@@ -383,12 +391,12 @@ impl<'a> SerializedMastForest<'a> {
 
     /// Returns the number of procedure roots in the serialized forest.
     pub fn procedure_root_count(&self) -> usize {
-        self.forest.procedure_root_count()
+        self.layout.roots_count
     }
 
     /// Returns the procedure root id at the specified index.
     pub fn procedure_root_at(&self, index: usize) -> Result<MastNodeId, DeserializationError> {
-        self.forest.procedure_root_at(index)
+        self.layout.read_procedure_root_at(self.bytes, index)
     }
 
     /// Returns the `MastNodeInfo` at the specified index.
@@ -422,32 +430,41 @@ impl<'a> SerializedMastForest<'a> {
 
     /// Returns the fixed-width structural node entry at the specified index.
     pub fn node_entry_at(&self, index: usize) -> Result<MastNodeEntry, DeserializationError> {
-        self.forest.node_entry_at(index)
+        self.layout.read_node_entry_at(self.bytes, index)
     }
 
     /// Returns the digest for the node at the specified index.
     pub fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
-        self.forest.node_digest_at(index)
+        self.resolved()?.node_digest_at(index)
     }
 
     #[cfg(test)]
     fn advice_map_offset(&self) -> Result<usize, DeserializationError> {
-        self.forest.advice_map_offset()
+        self.layout.advice_map_offset(self.bytes.len())
     }
 
     #[cfg(test)]
     fn node_entry_offset(&self) -> usize {
-        self.forest.node_entry_offset()
+        self.layout.node_entry_offset
     }
 
     #[cfg(test)]
     fn node_hash_offset(&self) -> Option<usize> {
-        self.forest.node_hash_offset()
+        self.layout.node_hash_offset
     }
 
     #[cfg(test)]
     fn digest_slot_at(&self, index: usize) -> usize {
-        self.forest.digest_slot_at(index)
+        self.resolved()
+            .expect("digest slots should be readable for a valid serialized view")
+            .digest_slot_at(index)
+    }
+
+    fn resolved(&self) -> Result<&ResolvedSerializedForest<'a>, DeserializationError> {
+        self.resolved
+            .get_or_init(|| ResolvedSerializedForest::new(self.bytes, self.layout))
+            .as_ref()
+            .map_err(Clone::clone)
     }
 }
 
@@ -618,6 +635,7 @@ fn decode_from_reader<R: ByteReader>(
 ) -> Result<(WireFlags, super::UntrustedMastForest), DeserializationError> {
     let mut recording = TrackingReader::new_recording(source);
     let (flags, layout) = read_header_and_scan_layout(&mut recording, allow_hashless)?;
+    let layout = layout.resolve()?;
 
     let advice_map = AdviceMap::read_from(&mut recording)?;
     let debug_info = if flags.is_stripped() {

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -109,6 +109,9 @@ pub(crate) mod decorator;
 mod info;
 pub use info::{MastNodeEntry, MastNodeInfo};
 
+mod view;
+pub use view::MastForestView;
+
 mod layout;
 pub(super) use layout::ForestLayout;
 use layout::{TrackingReader, WireFlags, read_header_and_scan_layout};
@@ -544,7 +547,7 @@ impl<'a> SerializedMastForest<'a> {
     }
 }
 
-impl super::MastForestView for SerializedMastForest<'_> {
+impl MastForestView for SerializedMastForest<'_> {
     fn node_count(&self) -> usize {
         SerializedMastForest::node_count(self)
     }
@@ -566,7 +569,7 @@ impl super::MastForestView for SerializedMastForest<'_> {
     }
 }
 
-impl super::MastForestView for MastForest {
+impl MastForestView for MastForest {
     fn node_count(&self) -> usize {
         self.nodes.len()
     }

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -14,8 +14,8 @@
 //! [`ByteReader::max_alloc`]. Callers that opt into validation budgeting also get a second check:
 //! - later stripped/hashless helper allocations are charged against an explicit validation budget
 //!   before the corresponding `Vec` or CSR scaffolding is created
-//! - the default convenience path uses a coarse validation budget derived from the input size;
-//!   this is intentionally a simple bound for common callers, not an exact peak-memory formula
+//! - the default convenience path uses a coarse validation budget derived from the input size; this
+//!   is intentionally a simple bound for common callers, not an exact peak-memory formula
 //!
 //! The main layers fit together like this:
 //!
@@ -336,7 +336,7 @@ fn serialized_size_hint(forest: &MastForest, stripped: bool, hashless: bool) -> 
     }
     size += basic_block_len.get_size_hint() + basic_block_len;
 
-    size += node_count * MastNodeEntry::min_serialized_size();
+    size += node_count * MastNodeEntry::SERIALIZED_SIZE;
     size += external_count * crate::Word::min_serialized_size();
     if !hashless {
         size += non_external_count * crate::Word::min_serialized_size();
@@ -541,28 +541,6 @@ impl<'a> SerializedMastForest<'a> {
         self.resolved()?.node_digest_at(index)
     }
 
-    #[cfg(test)]
-    fn advice_map_offset(&self) -> Result<usize, DeserializationError> {
-        self.layout.advice_map_offset(self.bytes.len())
-    }
-
-    #[cfg(test)]
-    fn node_entry_offset(&self) -> usize {
-        self.layout.node_entry_offset
-    }
-
-    #[cfg(test)]
-    fn node_hash_offset(&self) -> Option<usize> {
-        self.layout.node_hash_offset
-    }
-
-    #[cfg(test)]
-    fn digest_slot_at(&self, index: usize) -> usize {
-        self.resolved()
-            .expect("digest slots should be readable for a valid serialized view")
-            .digest_slot_at(index)
-    }
-
     fn resolved(&self) -> Result<&ResolvedSerializedForest<'a>, DeserializationError> {
         self.resolved
             .get_or_init(|| ResolvedSerializedForest::new(self.bytes, self.layout))
@@ -629,6 +607,30 @@ impl MastForestView for MastForest {
                 self.roots.len()
             ))
         })
+    }
+}
+
+// TEST HELPERS
+// ================================================================================================
+
+#[cfg(test)]
+impl SerializedMastForest<'_> {
+    fn advice_map_offset(&self) -> Result<usize, DeserializationError> {
+        self.layout.advice_map_offset(self.bytes.len())
+    }
+
+    fn node_entry_offset(&self) -> usize {
+        self.layout.node_entry_offset
+    }
+
+    fn node_hash_offset(&self) -> Option<usize> {
+        self.layout.node_hash_offset
+    }
+
+    fn digest_slot_at(&self, index: usize) -> usize {
+        self.resolved()
+            .expect("digest slots should be readable for a valid serialized view")
+            .digest_slot_at(index)
     }
 }
 

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -441,11 +441,6 @@ impl<'a> SerializedMastForest<'a> {
     }
 
     #[cfg(test)]
-    fn node_entry_size(&self) -> usize {
-        self.forest.node_entry_size()
-    }
-
-    #[cfg(test)]
     fn node_hash_offset(&self) -> Option<usize> {
         self.forest.node_hash_offset()
     }

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -33,23 +33,35 @@
 //! When serializing with [`MastForest::write_stripped`], the FLAGS byte has bit 0 set
 //! and the entire DebugInfo section is omitted. Deserialization auto-detects the format
 //! and creates an empty `DebugInfo` with valid CSR structures when reading stripped files.
+//!
+//! # Hashless Format
+//!
+//! When serializing with [`MastForest::write_hashless`], the FLAGS byte has bit 1 set, and
+//! bit 0 is also set (hashless implies stripped). This does not change the wire format.
+//! It is a declaration of intent that stored digests must be recomputed during validation.
+//! The trusted deserializer rejects hashless inputs; use [`UntrustedMastForest`] instead.
 
-use alloc::vec::Vec;
+use alloc::{string::ToString, vec::Vec};
 
-use super::{MastForest, MastNode, MastNodeId};
+use super::{CallNode, DynNode, JoinNode, LoopNode, MastForest, MastNode, MastNodeId, SplitNode};
 use crate::{
+    Felt,
     advice::AdviceMap,
-    serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    chiplets::hasher,
+    serde::{
+        ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
+    },
 };
 
 pub(crate) mod asm_op;
 pub(crate) mod decorator;
 
 mod info;
-use info::MastNodeInfo;
+pub use info::MastNodeInfo;
+use info::MastNodeType;
 
 mod basic_blocks;
-use basic_blocks::{BasicBlockDataBuilder, BasicBlockDataDecoder};
+use basic_blocks::{BasicBlockDataBuilder, BasicBlockDataDecoder, basic_block_data_len};
 
 pub(crate) mod string_table;
 pub(crate) use string_table::StringTable;
@@ -95,10 +107,17 @@ const MAGIC: &[u8; 4] = b"MAST";
 /// The deserializer will create an empty `DebugInfo` with valid CSR structures.
 const FLAG_STRIPPED: u8 = 0x01;
 
+/// Flag indicating the serialized MastForest should be treated as hashless.
+///
+/// This flag does not affect the wire format; digests are still serialized. It declares that
+/// digests must be recomputed during validation, so trusted deserialization rejects it.
+/// This flag implies [`FLAG_STRIPPED`].
+pub(super) const FLAG_HASHLESS: u8 = 0x02;
+
 /// Mask for reserved flag bits that must be zero.
 ///
-/// Bits 1-7 are reserved for future use. If any are set, deserialization fails.
-const FLAGS_RESERVED_MASK: u8 = 0xfe;
+/// Bits 2-7 are reserved for future use. If any are set, deserialization fails.
+const FLAGS_RESERVED_MASK: u8 = 0xfc;
 
 /// The format version.
 ///
@@ -115,14 +134,16 @@ const FLAGS_RESERVED_MASK: u8 = 0xfe;
 /// - [0, 0, 2]: Removed AssemblyOp from Decorator enum serialization. AssemblyOps are now stored
 ///   separately in DebugInfo. Removed `should_break` field from AssemblyOp serialization (#2646).
 ///   Removed `breakpoint` instruction (#2655).
-const VERSION: [u8; 3] = [0, 0, 2];
+/// - [0, 0, 3]: Added HASHLESS flag (bit 1). HASHLESS implies STRIPPED. Trusted deserialization
+///   rejects HASHLESS.
+const VERSION: [u8; 3] = [0, 0, 3];
 
 // MAST FOREST SERIALIZATION/DESERIALIZATION
 // ================================================================================================
 
 impl Serializable for MastForest {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.write_into_with_options(target, false);
+        self.write_into_with_options(target, false, false);
     }
 }
 
@@ -131,12 +152,19 @@ impl MastForest {
     ///
     /// When `stripped` is true, the DebugInfo section is omitted and the FLAGS byte
     /// has bit 0 set.
-    fn write_into_with_options<W: ByteWriter>(&self, target: &mut W, stripped: bool) {
+    fn write_into_with_options<W: ByteWriter>(
+        &self,
+        target: &mut W,
+        stripped: bool,
+        hashless: bool,
+    ) {
         let mut basic_block_data_builder = BasicBlockDataBuilder::new();
 
         // magic & flags
         target.write_bytes(MAGIC);
-        target.write_u8(if stripped { FLAG_STRIPPED } else { 0x00 });
+        let flags = if stripped || hashless { FLAG_STRIPPED } else { 0 }
+            | if hashless { FLAG_HASHLESS } else { 0 };
+        target.write_u8(flags);
 
         // version
         target.write_bytes(&VERSION);
@@ -182,90 +210,869 @@ impl MastForest {
     }
 }
 
-impl Deserializable for MastForest {
-    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let flags = read_and_validate_header(source)?;
-        let is_stripped = flags & FLAG_STRIPPED != 0;
+pub(super) fn stripped_size_hint(forest: &MastForest) -> usize {
+    let node_count = forest.nodes.len();
 
-        // Reading sections metadata
-        let node_count = source.read_usize()?;
-        if node_count > MastForest::MAX_NODES {
+    let mut size = MAGIC.len() + 1 + VERSION.len();
+    size += node_count.get_size_hint();
+    size += 0usize.get_size_hint(); // decorator count (always 0 in stripped)
+
+    let roots_len = forest.roots.len();
+    size += roots_len.get_size_hint();
+    size += roots_len * core::mem::size_of::<u32>();
+
+    let mut basic_block_len = 0usize;
+    for node in forest.nodes.iter() {
+        if let MastNode::Block(block) = node {
+            basic_block_len += basic_block_data_len(block);
+        }
+    }
+    size += basic_block_len.get_size_hint() + basic_block_len;
+
+    let node_info_size = MastNodeInfo::min_serialized_size();
+    size += node_count * node_info_size;
+    size += forest.advice_map.serialized_size_hint();
+
+    size
+}
+
+/// A zero-copy view over a stripped, serialized MAST forest.
+///
+/// This is intended for trusted inputs and supports random access to `MastNodeInfo`
+/// entries without deserializing the full forest.
+///
+/// # Examples
+///
+/// ```
+/// use miden_core::{
+///     mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, SerializedMastForest},
+///     operations::Operation,
+/// };
+///
+/// let mut forest = MastForest::new();
+/// let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+///     .add_to_forest(&mut forest)
+///     .unwrap();
+/// forest.make_root(block_id);
+///
+/// let mut bytes = Vec::new();
+/// forest.write_stripped(&mut bytes);
+///
+/// let view = SerializedMastForest::new(&bytes).unwrap();
+/// assert_eq!(view.node_count(), forest.nodes().len());
+/// assert!(view.node_info_at(0).is_ok());
+/// ```
+#[derive(Debug)]
+pub struct SerializedMastForest<'a> {
+    bytes: &'a [u8],
+    is_stripped: bool,
+    is_hashless: bool,
+    hash_table: Option<Vec<crate::Word>>,
+    node_count: usize,
+    roots_count: usize,
+    roots_offset: usize,
+    basic_block_offset: usize,
+    basic_block_len: usize,
+    node_info_offset: usize,
+    node_info_size: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScannedForestLayout {
+    node_count: usize,
+    roots_count: usize,
+    roots_offset: usize,
+    basic_block_offset: usize,
+    basic_block_len: usize,
+    node_info_offset: usize,
+    node_info_size: usize,
+}
+
+/// Canonical decoded representation for reader-based deserialization paths.
+///
+/// Parsing yields a serialized backing buffer plus section metadata; materialization into
+/// [`MastForest`] is an explicit final step.
+#[derive(Debug, Clone)]
+pub(super) struct DecodedSerializedForest {
+    flags: u8,
+    bytes: Vec<u8>,
+    layout: ScannedForestLayout,
+    advice_map: AdviceMap,
+    debug_info: super::DebugInfo,
+}
+
+impl DecodedSerializedForest {
+    pub(super) fn flags(&self) -> u8 {
+        self.flags
+    }
+
+    pub(super) fn is_hashless(&self) -> bool {
+        self.flags & FLAG_HASHLESS != 0
+    }
+
+    pub(super) fn into_mast_forest(self) -> Result<MastForest, DeserializationError> {
+        let view = SerializedMastForest::from_scanned_parts(&self.bytes, self.flags, self.layout)?;
+        view.to_mast_forest_with_sections(self.advice_map, self.debug_info)
+    }
+}
+
+impl<'a> SerializedMastForest<'a> {
+    /// Creates a new view from serialized bytes.
+    ///
+    /// The input may be either full or stripped format.
+    /// Structural parsing is delegated to the same single-pass scanner used by reader-based
+    /// deserialization paths.
+    ///
+    /// This constructor is layout-oriented: it validates the header and sections needed for
+    /// node/roots/random-access metadata only. It does not validate or fully parse trailing
+    /// `AdviceMap` / `DebugInfo` payloads.
+    ///
+    /// For strict full-payload validation, use
+    /// [`crate::mast::MastForest::read_from_bytes`].
+    ///
+    /// Conventions:
+    /// - If `HASHLESS` is not set, node digests are read from wire data.
+    /// - If `HASHLESS` is set, wire digests are ignored and node digests are recomputed during
+    ///   construction whenever possible.
+    /// - For `External` nodes in `HASHLESS` mode, digests are marshaled opaquely from wire data;
+    ///   this view does not attempt semantic resolution of external references.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use miden_core::{
+    ///     mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, SerializedMastForest},
+    ///     operations::Operation,
+    /// };
+    ///
+    /// let mut forest = MastForest::new();
+    /// let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+    ///     .add_to_forest(&mut forest)
+    ///     .unwrap();
+    /// forest.make_root(block_id);
+    ///
+    /// let mut bytes = Vec::new();
+    /// forest.write_stripped(&mut bytes);
+    ///
+    /// let view = SerializedMastForest::new(&bytes).unwrap();
+    /// assert_eq!(view.node_count(), 1);
+    /// ```
+    pub fn new(bytes: &'a [u8]) -> Result<Self, DeserializationError> {
+        let mut reader = SliceReader::new(bytes);
+        let (flags, _version) = read_and_validate_header(&mut reader)?;
+        let is_stripped = flags & FLAG_STRIPPED != 0;
+        if flags & FLAG_HASHLESS != 0 && !is_stripped {
+            return Err(DeserializationError::InvalidValue(
+                "HASHLESS flag requires STRIPPED flag to be set".to_string(),
+            ));
+        }
+
+        let mut scanner = CountingReader::new(&mut reader);
+        let layout = scan_layout_sections(&mut scanner)?;
+
+        Self::from_scanned_parts(bytes, flags, layout)
+    }
+
+    fn from_scanned_parts(
+        bytes: &'a [u8],
+        flags: u8,
+        layout: ScannedForestLayout,
+    ) -> Result<Self, DeserializationError> {
+        let is_stripped = flags & FLAG_STRIPPED != 0;
+        let is_hashless = flags & FLAG_HASHLESS != 0;
+        if is_hashless && !is_stripped {
+            return Err(DeserializationError::InvalidValue(
+                "HASHLESS flag requires STRIPPED flag to be set".to_string(),
+            ));
+        }
+
+        let header_len = MAGIC.len() + 1 + VERSION.len();
+        let roots_offset = header_len.checked_add(layout.roots_offset).ok_or_else(|| {
+            DeserializationError::InvalidValue("roots offset overflow".to_string())
+        })?;
+        let basic_block_offset =
+            header_len.checked_add(layout.basic_block_offset).ok_or_else(|| {
+                DeserializationError::InvalidValue("basic-block offset overflow".to_string())
+            })?;
+        let node_info_offset =
+            header_len.checked_add(layout.node_info_offset).ok_or_else(|| {
+                DeserializationError::InvalidValue("node info offset overflow".to_string())
+            })?;
+        let hash_table = if is_hashless {
+            Some(recompute_hash_table(
+                bytes,
+                layout.node_count,
+                node_info_offset,
+                layout.node_info_size,
+                basic_block_offset,
+                layout.basic_block_len,
+            )?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            bytes,
+            is_stripped,
+            is_hashless,
+            hash_table,
+            node_count: layout.node_count,
+            roots_count: layout.roots_count,
+            roots_offset,
+            basic_block_offset,
+            basic_block_len: layout.basic_block_len,
+            node_info_offset,
+            node_info_size: layout.node_info_size,
+        })
+    }
+
+    /// Returns the number of nodes in the serialized forest.
+    pub fn node_count(&self) -> usize {
+        self.node_count
+    }
+
+    /// Returns `true` when this view uses hashless convention and recomputed digests.
+    pub fn is_hashless(&self) -> bool {
+        self.is_hashless
+    }
+
+    /// Returns `true` when this view represents stripped serialization.
+    pub fn is_stripped(&self) -> bool {
+        self.is_stripped
+    }
+
+    /// Returns the number of procedure roots in the serialized forest.
+    pub fn procedure_root_count(&self) -> usize {
+        self.roots_count
+    }
+
+    /// Returns the procedure root id at the specified index.
+    pub fn procedure_root_at(&self, index: usize) -> Result<MastNodeId, DeserializationError> {
+        if index >= self.roots_count {
             return Err(DeserializationError::InvalidValue(format!(
-                "node count {} exceeds maximum allowed {}",
-                node_count,
-                MastForest::MAX_NODES
+                "root index {} out of bounds for {} roots",
+                index, self.roots_count
             )));
         }
-        let _decorator_count = source.read_usize()?; // Read for wire format compatibility
 
-        // Reading procedure roots
-        let roots: Vec<u32> = Deserializable::read_from(source)?;
+        let entry_offset = index
+            .checked_mul(core::mem::size_of::<u32>())
+            .and_then(|delta| self.roots_offset.checked_add(delta))
+            .ok_or_else(|| {
+                DeserializationError::InvalidValue("root offset overflow".to_string())
+            })?;
+        let entry_end = entry_offset.checked_add(core::mem::size_of::<u32>()).ok_or_else(|| {
+            DeserializationError::InvalidValue("root length overflow".to_string())
+        })?;
+        if entry_end > self.bytes.len() {
+            return Err(DeserializationError::UnexpectedEOF);
+        }
 
-        // Reading nodes
-        let basic_block_data: Vec<u8> = Deserializable::read_from(source)?;
-        let mast_node_infos: Vec<MastNodeInfo> = node_infos_iter(source, node_count)
-            .collect::<Result<Vec<MastNodeInfo>, DeserializationError>>()?;
+        let mut raw = [0u8; core::mem::size_of::<u32>()];
+        raw.copy_from_slice(&self.bytes[entry_offset..entry_end]);
+        MastNodeId::from_u32_with_node_count(u32::from_le_bytes(raw), self.node_count)
+    }
 
-        let advice_map = AdviceMap::read_from(source)?;
+    /// Returns the `MastNodeInfo` at the specified index.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use miden_core::{
+    ///     mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, SerializedMastForest},
+    ///     operations::Operation,
+    /// };
+    ///
+    /// let mut forest = MastForest::new();
+    /// let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+    ///     .add_to_forest(&mut forest)
+    ///     .unwrap();
+    /// forest.make_root(block_id);
+    ///
+    /// let mut bytes = Vec::new();
+    /// forest.write_stripped(&mut bytes);
+    ///
+    /// let view = SerializedMastForest::new(&bytes).unwrap();
+    /// assert!(view.node_info_at(0).is_ok());
+    /// ```
+    pub fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError> {
+        if index >= self.node_count {
+            return Err(DeserializationError::InvalidValue(format!(
+                "node index {} out of bounds for {} nodes",
+                index, self.node_count
+            )));
+        }
 
-        // Deserialize DebugInfo or create empty one if stripped
-        let debug_info = if is_stripped {
-            super::DebugInfo::empty_for_nodes(node_count)
+        let info =
+            read_node_info_entry(self.bytes, self.node_info_offset, self.node_info_size, index)?;
+        if let Some(hash_table) = &self.hash_table {
+            let digest = hash_table[index];
+            Ok(MastNodeInfo::from_parts(info.node_type(), digest))
         } else {
-            super::DebugInfo::read_from(source)?
-        };
+            Ok(info)
+        }
+    }
 
-        // Constructing MastForest
-        let mast_forest = {
-            let mut mast_forest = MastForest::new();
+    fn basic_block_data(&self) -> Result<&[u8], DeserializationError> {
+        let end = self.basic_block_offset.checked_add(self.basic_block_len).ok_or_else(|| {
+            DeserializationError::InvalidValue("basic-block data overflow".to_string())
+        })?;
+        if end > self.bytes.len() {
+            return Err(DeserializationError::UnexpectedEOF);
+        }
+        Ok(&self.bytes[self.basic_block_offset..end])
+    }
 
-            // Set the fully deserialized debug_info - it already contains all mappings
-            mast_forest.debug_info = debug_info;
+    fn to_mast_forest_with_sections(
+        &self,
+        advice_map: AdviceMap,
+        debug_info: super::DebugInfo,
+    ) -> Result<MastForest, DeserializationError> {
+        let basic_block_data_decoder = BasicBlockDataDecoder::new(self.basic_block_data()?);
+        let mut mast_forest = MastForest::new();
+        mast_forest.debug_info = debug_info;
 
-            // Convert node infos to builders
-            let basic_block_data_decoder = BasicBlockDataDecoder::new(&basic_block_data);
-            let mast_builders = mast_node_infos
-                .into_iter()
-                .map(|node_info| {
-                    node_info.try_into_mast_node_builder(node_count, &basic_block_data_decoder)
-                })
-                .collect::<Result<Vec<_>, _>>()?;
+        for index in 0..self.node_count {
+            let node_info = self.node_info_at(index)?;
+            let mast_node_builder =
+                node_info.try_into_mast_node_builder(self.node_count, &basic_block_data_decoder)?;
 
-            // Add all builders to forest using relaxed validation
-            for mast_node_builder in mast_builders {
-                mast_node_builder.add_to_forest_relaxed(&mut mast_forest).map_err(|e| {
-                    DeserializationError::InvalidValue(format!(
-                        "failed to add node to MAST forest while deserializing: {e}",
-                    ))
-                })?;
-            }
+            mast_node_builder.add_to_forest_relaxed(&mut mast_forest).map_err(|e| {
+                DeserializationError::InvalidValue(format!(
+                    "failed to add node to MAST forest while deserializing: {e}",
+                ))
+            })?;
+        }
 
-            // roots
-            for root in roots {
-                // make sure the root is valid in the context of the MAST forest
-                let root = MastNodeId::from_u32_safe(root, &mast_forest)?;
-                mast_forest.make_root(root);
-            }
+        for index in 0..self.procedure_root_count() {
+            mast_forest.make_root(self.procedure_root_at(index)?);
+        }
 
-            mast_forest.advice_map = advice_map;
-
-            mast_forest
-        };
-
-        // Note: Full validation of deserialized MastForests (e.g., checking that procedure name
-        // digests correspond to procedure roots) is intentionally not performed here.
-        // The serialized format is expected to come from a trusted source (e.g., the assembler
-        // or a verified package). Callers should use MastForest::validate() if validation of
-        // untrusted input is needed.
-
+        mast_forest.advice_map = advice_map;
         Ok(mast_forest)
+    }
+}
+
+fn read_node_info_entry(
+    bytes: &[u8],
+    node_info_offset: usize,
+    node_info_size: usize,
+    index: usize,
+) -> Result<MastNodeInfo, DeserializationError> {
+    let entry_offset = index
+        .checked_mul(node_info_size)
+        .and_then(|delta| node_info_offset.checked_add(delta))
+        .ok_or_else(|| {
+            DeserializationError::InvalidValue("node info offset overflow".to_string())
+        })?;
+    let entry_end = entry_offset.checked_add(node_info_size).ok_or_else(|| {
+        DeserializationError::InvalidValue("node info length overflow".to_string())
+    })?;
+    if entry_end > bytes.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+
+    let mut reader = SliceReader::new(&bytes[entry_offset..entry_end]);
+    MastNodeInfo::read_from(&mut reader)
+}
+
+fn recompute_hash_table(
+    bytes: &[u8],
+    node_count: usize,
+    node_info_offset: usize,
+    node_info_size: usize,
+    basic_block_offset: usize,
+    basic_block_len: usize,
+) -> Result<Vec<crate::Word>, DeserializationError> {
+    let basic_block_end = basic_block_offset.checked_add(basic_block_len).ok_or_else(|| {
+        DeserializationError::InvalidValue("basic-block data overflow".to_string())
+    })?;
+    if basic_block_end > bytes.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+    let basic_block_data_decoder =
+        BasicBlockDataDecoder::new(&bytes[basic_block_offset..basic_block_end]);
+
+    let mut digests = Vec::with_capacity(node_count);
+
+    for index in 0..node_count {
+        let info = read_node_info_entry(bytes, node_info_offset, node_info_size, index)?;
+        let computed = match info.node_type() {
+            MastNodeType::Block { ops_offset } => {
+                let op_batches = basic_block_data_decoder.decode_operations(ops_offset)?;
+                let op_groups: Vec<Felt> =
+                    op_batches.iter().flat_map(|batch| *batch.groups()).collect();
+                hasher::hash_elements(&op_groups)
+            },
+            MastNodeType::Join { left_child_id, right_child_id } => {
+                let left = checked_child_index(index, left_child_id, node_count)?;
+                let right = checked_child_index(index, right_child_id, node_count)?;
+                hasher::merge_in_domain(&[digests[left], digests[right]], JoinNode::DOMAIN)
+            },
+            MastNodeType::Split { if_branch_id, else_branch_id } => {
+                let on_true = checked_child_index(index, if_branch_id, node_count)?;
+                let on_false = checked_child_index(index, else_branch_id, node_count)?;
+                hasher::merge_in_domain(&[digests[on_true], digests[on_false]], SplitNode::DOMAIN)
+            },
+            MastNodeType::Loop { body_id } => {
+                let body = checked_child_index(index, body_id, node_count)?;
+                hasher::merge_in_domain(&[digests[body], crate::Word::default()], LoopNode::DOMAIN)
+            },
+            MastNodeType::Call { callee_id } => {
+                let callee = checked_child_index(index, callee_id, node_count)?;
+                hasher::merge_in_domain(
+                    &[digests[callee], crate::Word::default()],
+                    CallNode::CALL_DOMAIN,
+                )
+            },
+            MastNodeType::SysCall { callee_id } => {
+                let callee = checked_child_index(index, callee_id, node_count)?;
+                hasher::merge_in_domain(
+                    &[digests[callee], crate::Word::default()],
+                    CallNode::SYSCALL_DOMAIN,
+                )
+            },
+            MastNodeType::Dyn => DynNode::DYN_DEFAULT_DIGEST,
+            MastNodeType::Dyncall => DynNode::DYNCALL_DEFAULT_DIGEST,
+            MastNodeType::External => {
+                // External digests cannot be reconstructed from local structure alone.
+                // In HASHLESS mode we treat them as opaque payload to be resolved by later
+                // semantic checks in higher layers.
+                info.digest()
+            },
+        };
+
+        digests.push(computed);
+    }
+
+    Ok(digests)
+}
+
+fn checked_child_index(
+    parent_index: usize,
+    child_id: u32,
+    node_count: usize,
+) -> Result<usize, DeserializationError> {
+    let child_index = child_id as usize;
+    if child_index >= node_count {
+        return Err(DeserializationError::InvalidValue(format!(
+            "child id {} out of bounds for {} nodes",
+            child_id, node_count
+        )));
+    }
+    if child_index >= parent_index {
+        return Err(DeserializationError::InvalidValue(format!(
+            "forward reference from node {} to {} in HASHLESS data",
+            parent_index, child_id
+        )));
+    }
+    Ok(child_index)
+}
+
+impl super::MastForestView for SerializedMastForest<'_> {
+    fn node_count(&self) -> usize {
+        SerializedMastForest::node_count(self)
+    }
+
+    fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError> {
+        SerializedMastForest::node_info_at(self, index)
+    }
+
+    fn procedure_root_count(&self) -> usize {
+        SerializedMastForest::procedure_root_count(self)
+    }
+
+    fn procedure_root_at(&self, index: usize) -> Result<MastNodeId, DeserializationError> {
+        SerializedMastForest::procedure_root_at(self, index)
+    }
+}
+
+impl super::MastForestView for MastForest {
+    fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError> {
+        let node = self.nodes.as_slice().get(index).ok_or_else(|| {
+            DeserializationError::InvalidValue(format!("node index {index} out of bounds"))
+        })?;
+        let ops_offset = if matches!(node, MastNode::Block(_)) {
+            basic_block_offset_for_node_index(self.nodes.as_slice(), index)?
+        } else {
+            0
+        };
+
+        Ok(MastNodeInfo::new(node, ops_offset))
+    }
+
+    fn all_node_infos(&self) -> Result<Vec<MastNodeInfo>, DeserializationError> {
+        let mut node_infos = Vec::with_capacity(self.nodes.len());
+        let mut basic_block_data_offset = 0usize;
+
+        for node in self.nodes.iter() {
+            let ops_offset = if matches!(node, MastNode::Block(_)) {
+                basic_block_data_offset.try_into().map_err(|_| {
+                    DeserializationError::InvalidValue(
+                        "basic-block data offset does not fit in u32".to_string(),
+                    )
+                })?
+            } else {
+                0
+            };
+
+            node_infos.push(MastNodeInfo::new(node, ops_offset));
+
+            if let MastNode::Block(block) = node {
+                basic_block_data_offset = basic_block_data_offset
+                    .checked_add(basic_block_data_len(block))
+                    .ok_or_else(|| {
+                        DeserializationError::InvalidValue(
+                            "basic-block data offset overflow".to_string(),
+                        )
+                    })?;
+            }
+        }
+
+        Ok(node_infos)
+    }
+
+    fn procedure_root_count(&self) -> usize {
+        self.roots.len()
+    }
+
+    fn procedure_root_at(&self, index: usize) -> Result<MastNodeId, DeserializationError> {
+        self.roots.get(index).copied().ok_or_else(|| {
+            DeserializationError::InvalidValue(format!(
+                "root index {} out of bounds for {} roots",
+                index,
+                self.roots.len()
+            ))
+        })
+    }
+}
+
+fn basic_block_offset_for_node_index(
+    nodes: &[MastNode],
+    node_index: usize,
+) -> Result<u32, DeserializationError> {
+    let mut offset = 0usize;
+    for node in nodes.iter().take(node_index) {
+        if let MastNode::Block(block) = node {
+            offset = offset.checked_add(basic_block_data_len(block)).ok_or_else(|| {
+                DeserializationError::InvalidValue("basic-block data offset overflow".to_string())
+            })?;
+        }
+    }
+
+    offset.try_into().map_err(|_| {
+        DeserializationError::InvalidValue(
+            "basic-block data offset does not fit in u32".to_string(),
+        )
+    })
+}
+
+#[cfg(test)]
+fn read_u8_at(bytes: &[u8], offset: &mut usize) -> Result<u8, DeserializationError> {
+    read_slice_at(bytes, offset, 1).map(|slice| slice[0])
+}
+
+#[cfg(test)]
+fn read_array_at<const N: usize>(
+    bytes: &[u8],
+    offset: &mut usize,
+) -> Result<[u8; N], DeserializationError> {
+    let slice = read_slice_at(bytes, offset, N)?;
+    let mut result = [0u8; N];
+    result.copy_from_slice(slice);
+    Ok(result)
+}
+
+#[cfg(test)]
+fn read_slice_at<'a>(
+    bytes: &'a [u8],
+    offset: &mut usize,
+    len: usize,
+) -> Result<&'a [u8], DeserializationError> {
+    let end = offset
+        .checked_add(len)
+        .ok_or_else(|| DeserializationError::InvalidValue("offset overflow".to_string()))?;
+    if end > bytes.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+    let slice = &bytes[*offset..end];
+    *offset = end;
+    Ok(slice)
+}
+
+// NOTE: Mirrors ByteReader::read_usize (vint64) decoding to preserve wire compatibility.
+#[cfg(test)]
+fn read_usize_at(bytes: &[u8], offset: &mut usize) -> Result<usize, DeserializationError> {
+    if *offset >= bytes.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+    let first_byte = bytes[*offset];
+    let length = first_byte.trailing_zeros() as usize + 1;
+
+    let result = if length == 9 {
+        let _marker = read_u8_at(bytes, offset)?;
+        let value = read_array_at::<8>(bytes, offset)?;
+        u64::from_le_bytes(value)
+    } else {
+        let mut encoded = [0u8; 8];
+        let value = read_slice_at(bytes, offset, length)?;
+        encoded[..length].copy_from_slice(value);
+        u64::from_le_bytes(encoded) >> length
+    };
+
+    if result > usize::MAX as u64 {
+        return Err(DeserializationError::InvalidValue(format!(
+            "Encoded value must be less than {}, but {} was provided",
+            usize::MAX,
+            result
+        )));
+    }
+
+    Ok(result as usize)
+}
+
+impl Deserializable for MastForest {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        decode_from_reader(source, ReaderDecodeMode::Trusted)?.into_mast_forest()
+    }
+}
+
+pub(super) fn read_untrusted_with_flags<R: ByteReader>(
+    source: &mut R,
+) -> Result<(super::UntrustedMastForest, u8), DeserializationError> {
+    let decoded = decode_from_reader(source, ReaderDecodeMode::Untrusted)?;
+    let flags = decoded.flags();
+    Ok((super::UntrustedMastForest { decoded }, flags))
+}
+
+enum ReaderDecodeMode {
+    Trusted,
+    Untrusted,
+}
+
+fn decode_from_reader<R: ByteReader>(
+    source: &mut R,
+    mode: ReaderDecodeMode,
+) -> Result<DecodedSerializedForest, DeserializationError> {
+    let mut recording = RecordingReader::new(source);
+    let (flags, _version) = read_and_validate_header(&mut recording)?;
+    let is_stripped = flags & FLAG_STRIPPED != 0;
+    if flags & FLAG_HASHLESS != 0 && !is_stripped {
+        return Err(DeserializationError::InvalidValue(
+            "HASHLESS flag requires STRIPPED flag to be set".to_string(),
+        ));
+    }
+    if flags & FLAG_HASHLESS != 0 && matches!(mode, ReaderDecodeMode::Trusted) {
+        return Err(DeserializationError::InvalidValue(
+            "HASHLESS flag is set; use UntrustedMastForest for untrusted input".to_string(),
+        ));
+    }
+
+    let layout = scan_layout_sections(&mut recording)?;
+    let advice_map = AdviceMap::read_from(&mut recording)?;
+    let debug_info = if is_stripped {
+        super::DebugInfo::empty_for_nodes(layout.node_count)
+    } else {
+        super::DebugInfo::read_from(&mut recording)?
+    };
+
+    Ok(DecodedSerializedForest {
+        flags,
+        bytes: recording.into_recorded(),
+        layout,
+        advice_map,
+        debug_info,
+    })
+}
+
+/// Scans the structural section layout in a single pass.
+///
+/// This is the canonical structural parser for counts and offsets used by both
+/// reader-based deserialization and [`SerializedMastForest::new`].
+fn scan_layout_sections<R: OffsetTrackingReader>(
+    source: &mut R,
+) -> Result<ScannedForestLayout, DeserializationError> {
+    let body_start = source.offset();
+
+    let node_count = source.read_usize()?;
+    if node_count > MastForest::MAX_NODES {
+        return Err(DeserializationError::InvalidValue(format!(
+            "node count {} exceeds maximum allowed {}",
+            node_count,
+            MastForest::MAX_NODES
+        )));
+    }
+    let _decorator_count = source.read_usize()?;
+
+    let roots_count = source.read_usize()?;
+    let roots_offset = source
+        .offset()
+        .checked_sub(body_start)
+        .ok_or_else(|| DeserializationError::InvalidValue("roots offset underflow".to_string()))?;
+    let roots_len_bytes = roots_count
+        .checked_mul(core::mem::size_of::<u32>())
+        .ok_or_else(|| DeserializationError::InvalidValue("roots length overflow".to_string()))?;
+    let _roots_data = source.read_slice(roots_len_bytes)?;
+
+    let basic_block_len = source.read_usize()?;
+    let basic_block_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
+        DeserializationError::InvalidValue("basic-block offset underflow".to_string())
+    })?;
+    let _basic_block_data = source.read_slice(basic_block_len)?;
+
+    let node_info_size = MastNodeInfo::min_serialized_size();
+    let node_info_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
+        DeserializationError::InvalidValue("node info offset underflow".to_string())
+    })?;
+    let node_infos_len = node_count.checked_mul(node_info_size).ok_or_else(|| {
+        DeserializationError::InvalidValue("node info length overflow".to_string())
+    })?;
+    let _node_infos = source.read_slice(node_infos_len)?;
+
+    Ok(ScannedForestLayout {
+        node_count,
+        roots_count,
+        roots_offset,
+        basic_block_offset,
+        basic_block_len,
+        node_info_offset,
+        node_info_size,
+    })
+}
+
+trait OffsetTrackingReader: ByteReader {
+    fn offset(&self) -> usize;
+}
+
+struct RecordingReader<'a, R> {
+    inner: &'a mut R,
+    recorded: Vec<u8>,
+}
+
+impl<'a, R> RecordingReader<'a, R> {
+    fn new(inner: &'a mut R) -> Self {
+        Self { inner, recorded: Vec::new() }
+    }
+
+    fn into_recorded(self) -> Vec<u8> {
+        self.recorded
+    }
+}
+
+impl<R: ByteReader> ByteReader for RecordingReader<'_, R> {
+    fn read_u8(&mut self) -> Result<u8, DeserializationError> {
+        let byte = self.inner.read_u8()?;
+        self.recorded.push(byte);
+        Ok(byte)
+    }
+
+    fn peek_u8(&self) -> Result<u8, DeserializationError> {
+        self.inner.peek_u8()
+    }
+
+    fn read_slice(&mut self, len: usize) -> Result<&[u8], DeserializationError> {
+        let slice = self.inner.read_slice(len)?;
+        self.recorded.extend_from_slice(slice);
+        Ok(slice)
+    }
+
+    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], DeserializationError> {
+        let array = self.inner.read_array::<N>()?;
+        self.recorded.extend_from_slice(&array);
+        Ok(array)
+    }
+
+    fn check_eor(&self, num_bytes: usize) -> Result<(), DeserializationError> {
+        self.inner.check_eor(num_bytes)
+    }
+
+    fn has_more_bytes(&self) -> bool {
+        self.inner.has_more_bytes()
+    }
+
+    fn max_alloc(&self, element_size: usize) -> usize {
+        self.inner.max_alloc(element_size)
+    }
+}
+
+impl<R: ByteReader> OffsetTrackingReader for RecordingReader<'_, R> {
+    fn offset(&self) -> usize {
+        self.recorded.len()
+    }
+}
+
+struct CountingReader<'a, R> {
+    inner: &'a mut R,
+    offset: usize,
+}
+
+impl<'a, R> CountingReader<'a, R> {
+    fn new(inner: &'a mut R) -> Self {
+        Self { inner, offset: 0 }
+    }
+}
+
+impl<R: ByteReader> ByteReader for CountingReader<'_, R> {
+    fn read_u8(&mut self) -> Result<u8, DeserializationError> {
+        let byte = self.inner.read_u8()?;
+        self.offset = self
+            .offset
+            .checked_add(1)
+            .ok_or_else(|| DeserializationError::InvalidValue("offset overflow".to_string()))?;
+        Ok(byte)
+    }
+
+    fn peek_u8(&self) -> Result<u8, DeserializationError> {
+        self.inner.peek_u8()
+    }
+
+    fn read_slice(&mut self, len: usize) -> Result<&[u8], DeserializationError> {
+        let slice = self.inner.read_slice(len)?;
+        self.offset = self
+            .offset
+            .checked_add(len)
+            .ok_or_else(|| DeserializationError::InvalidValue("offset overflow".to_string()))?;
+        Ok(slice)
+    }
+
+    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], DeserializationError> {
+        let array = self.inner.read_array::<N>()?;
+        self.offset = self
+            .offset
+            .checked_add(N)
+            .ok_or_else(|| DeserializationError::InvalidValue("offset overflow".to_string()))?;
+        Ok(array)
+    }
+
+    fn check_eor(&self, num_bytes: usize) -> Result<(), DeserializationError> {
+        self.inner.check_eor(num_bytes)
+    }
+
+    fn has_more_bytes(&self) -> bool {
+        self.inner.has_more_bytes()
+    }
+
+    fn max_alloc(&self, element_size: usize) -> usize {
+        self.inner.max_alloc(element_size)
+    }
+}
+
+impl<R: ByteReader> OffsetTrackingReader for CountingReader<'_, R> {
+    fn offset(&self) -> usize {
+        self.offset
     }
 }
 
 /// Reads and validates the MAST header (magic, flags, version).
 ///
 /// Returns the flags byte on success.
-fn read_and_validate_header<R: ByteReader>(source: &mut R) -> Result<u8, DeserializationError> {
+fn read_and_validate_header<R: ByteReader>(
+    source: &mut R,
+) -> Result<(u8, [u8; 3]), DeserializationError> {
     // Read magic
     let magic: [u8; 4] = source.read_array()?;
     if magic != *MAGIC {
@@ -275,14 +1082,8 @@ fn read_and_validate_header<R: ByteReader>(source: &mut R) -> Result<u8, Deseria
         )));
     }
 
-    // Read and validate flags
+    // Read flags
     let flags: u8 = source.read_u8()?;
-    if flags & FLAGS_RESERVED_MASK != 0 {
-        return Err(DeserializationError::InvalidValue(format!(
-            "Unknown flags set in MAST header: {:#04x}. Reserved bits must be zero.",
-            flags & FLAGS_RESERVED_MASK
-        )));
-    }
 
     // Read and validate version
     let version: [u8; 3] = source.read_array()?;
@@ -292,24 +1093,15 @@ fn read_and_validate_header<R: ByteReader>(source: &mut R) -> Result<u8, Deseria
         )));
     }
 
-    Ok(flags)
-}
+    // Validate flags
+    if flags & FLAGS_RESERVED_MASK != 0 {
+        return Err(DeserializationError::InvalidValue(format!(
+            "Unknown flags set in MAST header: {:#04x}. Reserved bits must be zero.",
+            flags & FLAGS_RESERVED_MASK
+        )));
+    }
 
-fn node_infos_iter<'a, R>(
-    source: &'a mut R,
-    node_count: usize,
-) -> impl Iterator<Item = Result<MastNodeInfo, DeserializationError>> + 'a
-where
-    R: ByteReader + 'a,
-{
-    let mut remaining = node_count;
-    core::iter::from_fn(move || {
-        if remaining == 0 {
-            return None;
-        }
-        remaining -= 1;
-        Some(MastNodeInfo::read_from(source))
-    })
+    Ok((flags, version))
 }
 
 // UNTRUSTED DESERIALIZATION
@@ -325,8 +1117,7 @@ impl Deserializable for super::UntrustedMastForest {
     /// to verify structural integrity and recompute all node hashes before using
     /// the forest.
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let forest = MastForest::read_from(source)?;
-        Ok(super::UntrustedMastForest(forest))
+        read_untrusted_with_flags(source).map(|(forest, _flags)| forest)
     }
 
     /// Deserializes an [`super::UntrustedMastForest`] from bytes using budgeted deserialization.
@@ -357,6 +1148,23 @@ pub(super) struct StrippedMastForest<'a>(pub(super) &'a MastForest);
 
 impl Serializable for StrippedMastForest<'_> {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        self.0.write_into_with_options(target, true);
+        self.0.write_into_with_options(target, true, false);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        stripped_size_hint(self.0)
+    }
+}
+
+/// Wrapper for serializing a [`MastForest`] with the HASHLESS flag set.
+pub(super) struct HashlessMastForest<'a>(pub(super) &'a MastForest);
+
+impl Serializable for HashlessMastForest<'_> {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        self.0.write_into_with_options(target, true, true);
+    }
+
+    fn get_size_hint(&self) -> usize {
+        stripped_size_hint(self.0)
     }
 }

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -47,13 +47,13 @@
 //! is omitted entirely. Trusted deserialization rejects hashless inputs; use
 //! [`UntrustedMastForest`] instead.
 
-use alloc::{string::ToString, vec::Vec};
+#[cfg(test)]
+use alloc::string::ToString;
+use alloc::vec::Vec;
 
-use super::{CallNode, DynNode, JoinNode, LoopNode, MastForest, MastNode, MastNodeId, SplitNode};
+use super::{MastForest, MastNode, MastNodeId};
 use crate::{
-    Felt,
     advice::AdviceMap,
-    chiplets::hasher,
     mast::node::MastNodeExt,
     serde::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
@@ -64,11 +64,17 @@ pub(crate) mod asm_op;
 pub(crate) mod decorator;
 
 mod info;
-use info::MastNodeType;
 pub use info::{MastNodeEntry, MastNodeInfo};
 
+mod layout;
+pub(super) use layout::ForestLayout;
+use layout::{TrackingReader, WireFlags, read_header_and_scan_layout};
+
+mod resolved;
+use resolved::{ResolvedSerializedForest, basic_block_offset_for_node_index};
+
 mod basic_blocks;
-use basic_blocks::{BasicBlockDataBuilder, BasicBlockDataDecoder, basic_block_data_len};
+use basic_blocks::{BasicBlockDataBuilder, basic_block_data_len};
 
 pub(crate) mod string_table;
 pub(crate) use string_table::StringTable;
@@ -306,65 +312,8 @@ fn serialized_size_hint(forest: &MastForest, stripped: bool, hashless: bool) -> 
 /// ```
 #[derive(Debug)]
 pub struct SerializedMastForest<'a> {
-    bytes: &'a [u8],
-    is_stripped: bool,
-    is_hashless: bool,
-    hash_table: Option<Vec<crate::Word>>,
-    digest_slot_by_node: Vec<u32>,
-    node_count: usize,
-    roots_count: usize,
-    roots_offset: usize,
-    basic_block_offset: usize,
-    basic_block_len: usize,
-    node_entry_offset: usize,
-    node_entry_size: usize,
-    external_digest_offset: usize,
-    #[cfg(test)]
-    external_digest_count: usize,
-    node_hash_offset: Option<usize>,
-    #[cfg(test)]
-    node_hash_count: usize,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct ScannedForestLayout {
-    node_count: usize,
-    roots_count: usize,
-    roots_offset: usize,
-    basic_block_offset: usize,
-    basic_block_len: usize,
-    node_entry_offset: usize,
-    node_entry_size: usize,
-    external_digest_offset: usize,
-    #[cfg(test)]
-    external_digest_count: usize,
-    node_hash_offset: Option<usize>,
-    #[cfg(test)]
-    node_hash_count: usize,
-}
-
-/// Canonical decoded representation for reader-based deserialization paths.
-///
-/// Parsing yields a serialized backing buffer plus section metadata; materialization into
-/// [`MastForest`] is an explicit final step.
-#[derive(Debug, Clone)]
-pub(super) struct DecodedSerializedForest {
-    flags: u8,
-    bytes: Vec<u8>,
-    layout: ScannedForestLayout,
-    advice_map: AdviceMap,
-    debug_info: super::DebugInfo,
-}
-
-impl DecodedSerializedForest {
-    pub(super) fn flags(&self) -> u8 {
-        self.flags
-    }
-
-    pub(super) fn into_mast_forest(self) -> Result<MastForest, DeserializationError> {
-        let view = SerializedMastForest::from_scanned_parts(&self.bytes, self.flags, self.layout)?;
-        view.to_mast_forest_with_sections(self.advice_map, self.debug_info)
-    }
+    flags: WireFlags,
+    forest: ResolvedSerializedForest<'a>,
 }
 
 impl<'a> SerializedMastForest<'a> {
@@ -410,145 +359,36 @@ impl<'a> SerializedMastForest<'a> {
     /// ```
     pub fn new(bytes: &'a [u8]) -> Result<Self, DeserializationError> {
         let mut reader = SliceReader::new(bytes);
-        let (flags, _version) = read_and_validate_header(&mut reader)?;
-        let is_stripped = flags & FLAG_STRIPPED != 0;
-        let is_hashless = flags & FLAG_HASHLESS != 0;
-        if is_hashless && !is_stripped {
-            return Err(DeserializationError::InvalidValue(
-                "HASHLESS flag requires STRIPPED flag to be set".to_string(),
-            ));
-        }
+        let mut scanner = TrackingReader::new(&mut reader);
+        let (flags, layout) = read_header_and_scan_layout(&mut scanner, true)?;
+        let forest = ResolvedSerializedForest::new(bytes, layout)?;
 
-        let mut scanner = CountingReader::new(&mut reader);
-        let layout = scan_layout_sections(&mut scanner, is_hashless)?;
-
-        Self::from_scanned_parts(bytes, flags, layout)
-    }
-
-    fn from_scanned_parts(
-        bytes: &'a [u8],
-        flags: u8,
-        layout: ScannedForestLayout,
-    ) -> Result<Self, DeserializationError> {
-        let is_stripped = flags & FLAG_STRIPPED != 0;
-        let is_hashless = flags & FLAG_HASHLESS != 0;
-        if is_hashless && !is_stripped {
-            return Err(DeserializationError::InvalidValue(
-                "HASHLESS flag requires STRIPPED flag to be set".to_string(),
-            ));
-        }
-
-        let header_len = MAGIC.len() + 1 + VERSION.len();
-        let roots_offset = header_len.checked_add(layout.roots_offset).ok_or_else(|| {
-            DeserializationError::InvalidValue("roots offset overflow".to_string())
-        })?;
-        let basic_block_offset =
-            header_len.checked_add(layout.basic_block_offset).ok_or_else(|| {
-                DeserializationError::InvalidValue("basic-block offset overflow".to_string())
-            })?;
-        let node_entry_offset =
-            header_len.checked_add(layout.node_entry_offset).ok_or_else(|| {
-                DeserializationError::InvalidValue("node entry offset overflow".to_string())
-            })?;
-        let external_digest_offset =
-            header_len.checked_add(layout.external_digest_offset).ok_or_else(|| {
-                DeserializationError::InvalidValue("external digest offset overflow".to_string())
-            })?;
-        let node_hash_offset = layout
-            .node_hash_offset
-            .map(|offset| {
-                header_len.checked_add(offset).ok_or_else(|| {
-                    DeserializationError::InvalidValue("node hash offset overflow".to_string())
-                })
-            })
-            .transpose()?;
-        let digest_slot_by_node = build_digest_slot_by_node(
-            bytes,
-            node_entry_offset,
-            layout.node_entry_size,
-            layout.node_count,
-        )?;
-        let hash_table = if is_hashless {
-            Some(recompute_hash_table(
-                bytes,
-                layout.node_count,
-                node_entry_offset,
-                layout.node_entry_size,
-                basic_block_offset,
-                layout.basic_block_len,
-                external_digest_offset,
-            )?)
-        } else {
-            None
-        };
-
-        Ok(Self {
-            bytes,
-            is_stripped,
-            is_hashless,
-            hash_table,
-            digest_slot_by_node,
-            node_count: layout.node_count,
-            roots_count: layout.roots_count,
-            roots_offset,
-            basic_block_offset,
-            basic_block_len: layout.basic_block_len,
-            node_entry_offset,
-            node_entry_size: layout.node_entry_size,
-            external_digest_offset,
-            #[cfg(test)]
-            external_digest_count: layout.external_digest_count,
-            node_hash_offset,
-            #[cfg(test)]
-            node_hash_count: layout.node_hash_count,
-        })
+        Ok(Self { flags, forest })
     }
 
     /// Returns the number of nodes in the serialized forest.
     pub fn node_count(&self) -> usize {
-        self.node_count
+        self.forest.node_count()
     }
 
     /// Returns `true` when this view uses hashless convention and recomputed digests.
     pub fn is_hashless(&self) -> bool {
-        self.is_hashless
+        self.flags.is_hashless()
     }
 
     /// Returns `true` when this view represents stripped serialization.
     pub fn is_stripped(&self) -> bool {
-        self.is_stripped
+        self.flags.is_stripped()
     }
 
     /// Returns the number of procedure roots in the serialized forest.
     pub fn procedure_root_count(&self) -> usize {
-        self.roots_count
+        self.forest.procedure_root_count()
     }
 
     /// Returns the procedure root id at the specified index.
     pub fn procedure_root_at(&self, index: usize) -> Result<MastNodeId, DeserializationError> {
-        if index >= self.roots_count {
-            return Err(DeserializationError::InvalidValue(format!(
-                "root index {} out of bounds for {} roots",
-                index, self.roots_count
-            )));
-        }
-
-        let entry_offset = index
-            .checked_mul(core::mem::size_of::<u32>())
-            .and_then(|delta| self.roots_offset.checked_add(delta))
-            .ok_or_else(|| {
-                DeserializationError::InvalidValue("root offset overflow".to_string())
-            })?;
-        let entry_end = entry_offset.checked_add(core::mem::size_of::<u32>()).ok_or_else(|| {
-            DeserializationError::InvalidValue("root length overflow".to_string())
-        })?;
-        if entry_end > self.bytes.len() {
-            return Err(DeserializationError::UnexpectedEOF);
-        }
-
-        let mut raw = [0u8; core::mem::size_of::<u32>()];
-        raw.copy_from_slice(&self.bytes[entry_offset..entry_end]);
-        MastNodeId::from_u32_with_node_count(u32::from_le_bytes(raw), self.node_count)
+        self.forest.procedure_root_at(index)
     }
 
     /// Returns the `MastNodeInfo` at the specified index.
@@ -582,271 +422,38 @@ impl<'a> SerializedMastForest<'a> {
 
     /// Returns the fixed-width structural node entry at the specified index.
     pub fn node_entry_at(&self, index: usize) -> Result<MastNodeEntry, DeserializationError> {
-        if index >= self.node_count {
-            return Err(DeserializationError::InvalidValue(format!(
-                "node index {} out of bounds for {} nodes",
-                index, self.node_count
-            )));
-        }
-
-        read_node_entry(self.bytes, self.node_entry_offset, self.node_entry_size, index)
+        self.forest.node_entry_at(index)
     }
 
     /// Returns the digest for the node at the specified index.
     pub fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
-        let entry = self.node_entry_at(index)?;
-        let digest_slot = self.digest_slot_by_node[index] as usize;
-
-        if matches!(entry.node_type(), MastNodeType::External) {
-            return read_digest_entry(self.bytes, self.external_digest_offset, digest_slot);
-        }
-
-        if let Some(hash_table) = &self.hash_table {
-            return Ok(hash_table[index]);
-        }
-
-        let node_hash_offset = self.node_hash_offset.ok_or_else(|| {
-            DeserializationError::InvalidValue(
-                "hash-backed digest lookup requested but node hash section is absent".to_string(),
-            )
-        })?;
-        read_digest_entry(self.bytes, node_hash_offset, digest_slot)
-    }
-
-    fn basic_block_data(&self) -> Result<&[u8], DeserializationError> {
-        let end = self.basic_block_offset.checked_add(self.basic_block_len).ok_or_else(|| {
-            DeserializationError::InvalidValue("basic-block data overflow".to_string())
-        })?;
-        if end > self.bytes.len() {
-            return Err(DeserializationError::UnexpectedEOF);
-        }
-        Ok(&self.bytes[self.basic_block_offset..end])
-    }
-
-    fn to_mast_forest_with_sections(
-        &self,
-        advice_map: AdviceMap,
-        debug_info: super::DebugInfo,
-    ) -> Result<MastForest, DeserializationError> {
-        let basic_block_data_decoder = BasicBlockDataDecoder::new(self.basic_block_data()?);
-        let mut mast_forest = MastForest::new();
-        mast_forest.debug_info = debug_info;
-
-        for index in 0..self.node_count {
-            let mast_node_builder = self.node_entry_at(index)?.try_into_mast_node_builder(
-                self.node_count,
-                &basic_block_data_decoder,
-                self.node_digest_at(index)?,
-            )?;
-
-            mast_node_builder.add_to_forest_relaxed(&mut mast_forest).map_err(|e| {
-                DeserializationError::InvalidValue(format!(
-                    "failed to add node to MAST forest while deserializing: {e}",
-                ))
-            })?;
-        }
-
-        for index in 0..self.procedure_root_count() {
-            mast_forest.make_root(self.procedure_root_at(index)?);
-        }
-
-        mast_forest.advice_map = advice_map;
-        Ok(mast_forest)
+        self.forest.node_digest_at(index)
     }
 
     #[cfg(test)]
     fn advice_map_offset(&self) -> Result<usize, DeserializationError> {
-        let digest_section_end = if let Some(node_hash_offset) = self.node_hash_offset {
-            node_hash_offset
-                .checked_add(self.node_hash_count * crate::Word::min_serialized_size())
-                .ok_or_else(|| {
-                    DeserializationError::InvalidValue("node hash section overflow".to_string())
-                })?
-        } else {
-            self.external_digest_offset
-                .checked_add(self.external_digest_count * crate::Word::min_serialized_size())
-                .ok_or_else(|| {
-                    DeserializationError::InvalidValue(
-                        "external digest section overflow".to_string(),
-                    )
-                })?
-        };
-
-        if digest_section_end > self.bytes.len() {
-            return Err(DeserializationError::UnexpectedEOF);
-        }
-
-        Ok(digest_section_end)
-    }
-}
-
-fn read_node_entry(
-    bytes: &[u8],
-    node_entry_offset: usize,
-    node_entry_size: usize,
-    index: usize,
-) -> Result<MastNodeEntry, DeserializationError> {
-    let entry_offset = index
-        .checked_mul(node_entry_size)
-        .and_then(|delta| node_entry_offset.checked_add(delta))
-        .ok_or_else(|| {
-            DeserializationError::InvalidValue("node entry offset overflow".to_string())
-        })?;
-    let entry_end = entry_offset.checked_add(node_entry_size).ok_or_else(|| {
-        DeserializationError::InvalidValue("node entry length overflow".to_string())
-    })?;
-    if entry_end > bytes.len() {
-        return Err(DeserializationError::UnexpectedEOF);
+        self.forest.advice_map_offset()
     }
 
-    let mut reader = SliceReader::new(&bytes[entry_offset..entry_end]);
-    MastNodeEntry::read_from(&mut reader)
-}
-
-fn read_digest_entry(
-    bytes: &[u8],
-    digest_section_offset: usize,
-    index: usize,
-) -> Result<crate::Word, DeserializationError> {
-    let digest_size = crate::Word::min_serialized_size();
-    let entry_offset = index
-        .checked_mul(digest_size)
-        .and_then(|delta| digest_section_offset.checked_add(delta))
-        .ok_or_else(|| DeserializationError::InvalidValue("digest offset overflow".to_string()))?;
-    let entry_end = entry_offset
-        .checked_add(digest_size)
-        .ok_or_else(|| DeserializationError::InvalidValue("digest length overflow".to_string()))?;
-    if entry_end > bytes.len() {
-        return Err(DeserializationError::UnexpectedEOF);
+    #[cfg(test)]
+    fn node_entry_offset(&self) -> usize {
+        self.forest.node_entry_offset()
     }
 
-    let mut reader = SliceReader::new(&bytes[entry_offset..entry_end]);
-    crate::Word::read_from(&mut reader)
-}
-
-fn build_digest_slot_by_node(
-    bytes: &[u8],
-    node_entry_offset: usize,
-    node_entry_size: usize,
-    node_count: usize,
-) -> Result<Vec<u32>, DeserializationError> {
-    let mut slots = Vec::with_capacity(node_count);
-    let mut external_slot = 0u32;
-    let mut node_hash_slot = 0u32;
-
-    for index in 0..node_count {
-        let entry = read_node_entry(bytes, node_entry_offset, node_entry_size, index)?;
-        if matches!(entry.node_type(), MastNodeType::External) {
-            slots.push(external_slot);
-            external_slot = external_slot.checked_add(1).ok_or_else(|| {
-                DeserializationError::InvalidValue("external digest slot overflow".to_string())
-            })?;
-        } else {
-            slots.push(node_hash_slot);
-            node_hash_slot = node_hash_slot.checked_add(1).ok_or_else(|| {
-                DeserializationError::InvalidValue("node hash slot overflow".to_string())
-            })?;
-        }
+    #[cfg(test)]
+    fn node_entry_size(&self) -> usize {
+        self.forest.node_entry_size()
     }
 
-    Ok(slots)
-}
-
-fn recompute_hash_table(
-    bytes: &[u8],
-    node_count: usize,
-    node_entry_offset: usize,
-    node_entry_size: usize,
-    basic_block_offset: usize,
-    basic_block_len: usize,
-    external_digest_offset: usize,
-) -> Result<Vec<crate::Word>, DeserializationError> {
-    let basic_block_end = basic_block_offset.checked_add(basic_block_len).ok_or_else(|| {
-        DeserializationError::InvalidValue("basic-block data overflow".to_string())
-    })?;
-    if basic_block_end > bytes.len() {
-        return Err(DeserializationError::UnexpectedEOF);
-    }
-    let basic_block_data_decoder =
-        BasicBlockDataDecoder::new(&bytes[basic_block_offset..basic_block_end]);
-
-    let mut digests = Vec::with_capacity(node_count);
-    let mut external_digest_index = 0usize;
-
-    for index in 0..node_count {
-        let entry = read_node_entry(bytes, node_entry_offset, node_entry_size, index)?;
-        let computed = match entry.node_type() {
-            MastNodeType::Block { ops_offset } => {
-                let op_batches = basic_block_data_decoder.decode_operations(ops_offset)?;
-                let op_groups: Vec<Felt> =
-                    op_batches.iter().flat_map(|batch| *batch.groups()).collect();
-                hasher::hash_elements(&op_groups)
-            },
-            MastNodeType::Join { left_child_id, right_child_id } => {
-                let left = checked_child_index(index, left_child_id, node_count)?;
-                let right = checked_child_index(index, right_child_id, node_count)?;
-                hasher::merge_in_domain(&[digests[left], digests[right]], JoinNode::DOMAIN)
-            },
-            MastNodeType::Split { if_branch_id, else_branch_id } => {
-                let on_true = checked_child_index(index, if_branch_id, node_count)?;
-                let on_false = checked_child_index(index, else_branch_id, node_count)?;
-                hasher::merge_in_domain(&[digests[on_true], digests[on_false]], SplitNode::DOMAIN)
-            },
-            MastNodeType::Loop { body_id } => {
-                let body = checked_child_index(index, body_id, node_count)?;
-                hasher::merge_in_domain(&[digests[body], crate::Word::default()], LoopNode::DOMAIN)
-            },
-            MastNodeType::Call { callee_id } => {
-                let callee = checked_child_index(index, callee_id, node_count)?;
-                hasher::merge_in_domain(
-                    &[digests[callee], crate::Word::default()],
-                    CallNode::CALL_DOMAIN,
-                )
-            },
-            MastNodeType::SysCall { callee_id } => {
-                let callee = checked_child_index(index, callee_id, node_count)?;
-                hasher::merge_in_domain(
-                    &[digests[callee], crate::Word::default()],
-                    CallNode::SYSCALL_DOMAIN,
-                )
-            },
-            MastNodeType::Dyn => DynNode::DYN_DEFAULT_DIGEST,
-            MastNodeType::Dyncall => DynNode::DYNCALL_DEFAULT_DIGEST,
-            MastNodeType::External => {
-                let digest =
-                    read_digest_entry(bytes, external_digest_offset, external_digest_index)?;
-                external_digest_index = external_digest_index.checked_add(1).ok_or_else(|| {
-                    DeserializationError::InvalidValue("external digest index overflow".to_string())
-                })?;
-                digest
-            },
-        };
-
-        digests.push(computed);
+    #[cfg(test)]
+    fn node_hash_offset(&self) -> Option<usize> {
+        self.forest.node_hash_offset()
     }
 
-    Ok(digests)
-}
-
-fn checked_child_index(
-    parent_index: usize,
-    child_id: u32,
-    node_count: usize,
-) -> Result<usize, DeserializationError> {
-    let child_index = child_id as usize;
-    if child_index >= node_count {
-        return Err(DeserializationError::InvalidValue(format!(
-            "child id {} out of bounds for {} nodes",
-            child_id, node_count
-        )));
+    #[cfg(test)]
+    fn digest_slot_at(&self, index: usize) -> usize {
+        self.forest.digest_slot_at(index)
     }
-    if child_index >= parent_index {
-        return Err(DeserializationError::InvalidValue(format!(
-            "forward reference from node {} to {} in HASHLESS data",
-            parent_index, child_id
-        )));
-    }
-    Ok(child_index)
 }
 
 impl super::MastForestView for SerializedMastForest<'_> {
@@ -908,26 +515,6 @@ impl super::MastForestView for MastForest {
             ))
         })
     }
-}
-
-fn basic_block_offset_for_node_index(
-    nodes: &[MastNode],
-    node_index: usize,
-) -> Result<u32, DeserializationError> {
-    let mut offset = 0usize;
-    for node in nodes.iter().take(node_index) {
-        if let MastNode::Block(block) = node {
-            offset = offset.checked_add(basic_block_data_len(block)).ok_or_else(|| {
-                DeserializationError::InvalidValue("basic-block data offset overflow".to_string())
-            })?;
-        }
-    }
-
-    offset.try_into().map_err(|_| {
-        DeserializationError::InvalidValue(
-            "basic-block data offset does not fit in u32".to_string(),
-        )
-    })
 }
 
 #[cfg(test)]
@@ -996,34 +583,34 @@ fn read_usize_at(bytes: &[u8], offset: &mut usize) -> Result<usize, Deserializat
 
 impl Deserializable for MastForest {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        decode_from_reader(source, ReaderDecodeMode::Trusted)?.into_mast_forest()
+        let (_flags, forest) = decode_from_reader(source, false)?;
+        forest.into_materialized()
+    }
+}
+
+impl super::UntrustedMastForest {
+    pub(super) fn into_materialized(self) -> Result<MastForest, DeserializationError> {
+        ResolvedSerializedForest::new(&self.bytes, self.layout)?
+            .materialize(self.advice_map, self.debug_info)
     }
 }
 
 pub(super) fn read_untrusted_with_flags<R: ByteReader>(
     source: &mut R,
 ) -> Result<(super::UntrustedMastForest, u8), DeserializationError> {
-    let decoded = decode_from_reader(source, ReaderDecodeMode::Untrusted)?;
-    let flags = decoded.flags();
-    Ok((super::UntrustedMastForest { decoded }, flags))
+    let (flags, forest) = decode_from_reader(source, true)?;
+    log_untrusted_overspecification(flags);
+    Ok((forest, flags.bits()))
 }
 
-enum ReaderDecodeMode {
-    Trusted,
-    Untrusted,
-}
-
-fn log_untrusted_overspecification(flags: u8) {
-    let is_stripped = flags & FLAG_STRIPPED != 0;
-    let is_hashless = flags & FLAG_HASHLESS != 0;
-
-    if !is_hashless {
+fn log_untrusted_overspecification(flags: WireFlags) {
+    if !flags.is_hashless() {
         log::error!(
             "UntrustedMastForest expected HASHLESS input; supplied artifact includes wire node hashes that will be ignored and recomputed during validation"
         );
     }
 
-    if !is_stripped {
+    if !flags.is_stripped() {
         log::error!(
             "UntrustedMastForest expected STRIPPED input; supplied artifact includes DebugInfo and other optional payloads over the wire"
         );
@@ -1032,294 +619,27 @@ fn log_untrusted_overspecification(flags: u8) {
 
 fn decode_from_reader<R: ByteReader>(
     source: &mut R,
-    mode: ReaderDecodeMode,
-) -> Result<DecodedSerializedForest, DeserializationError> {
-    let mut recording = RecordingReader::new(source);
-    let (flags, _version) = read_and_validate_header(&mut recording)?;
-    let is_stripped = flags & FLAG_STRIPPED != 0;
-    if flags & FLAG_HASHLESS != 0 && !is_stripped {
-        return Err(DeserializationError::InvalidValue(
-            "HASHLESS flag requires STRIPPED flag to be set".to_string(),
-        ));
-    }
-    if flags & FLAG_HASHLESS != 0 && matches!(mode, ReaderDecodeMode::Trusted) {
-        return Err(DeserializationError::InvalidValue(
-            "HASHLESS flag is set; use UntrustedMastForest for untrusted input".to_string(),
-        ));
-    }
-    if matches!(mode, ReaderDecodeMode::Untrusted) {
-        log_untrusted_overspecification(flags);
-    }
+    allow_hashless: bool,
+) -> Result<(WireFlags, super::UntrustedMastForest), DeserializationError> {
+    let mut recording = TrackingReader::new_recording(source);
+    let (flags, layout) = read_header_and_scan_layout(&mut recording, allow_hashless)?;
 
-    let layout = scan_layout_sections(&mut recording, flags & FLAG_HASHLESS != 0)?;
     let advice_map = AdviceMap::read_from(&mut recording)?;
-    let debug_info = if is_stripped {
+    let debug_info = if flags.is_stripped() {
         super::DebugInfo::empty_for_nodes(layout.node_count)
     } else {
         super::DebugInfo::read_from(&mut recording)?
     };
 
-    Ok(DecodedSerializedForest {
+    Ok((
         flags,
-        bytes: recording.into_recorded(),
-        layout,
-        advice_map,
-        debug_info,
-    })
-}
-
-/// Scans the structural section layout in a single pass.
-///
-/// This is the canonical structural parser for counts and offsets used by both
-/// reader-based deserialization and [`SerializedMastForest::new`].
-fn scan_layout_sections<R: OffsetTrackingReader>(
-    source: &mut R,
-    is_hashless: bool,
-) -> Result<ScannedForestLayout, DeserializationError> {
-    let body_start = source.offset();
-
-    let node_count = source.read_usize()?;
-    if node_count > MastForest::MAX_NODES {
-        return Err(DeserializationError::InvalidValue(format!(
-            "node count {} exceeds maximum allowed {}",
-            node_count,
-            MastForest::MAX_NODES
-        )));
-    }
-    let _decorator_count = source.read_usize()?;
-
-    let roots_count = source.read_usize()?;
-    let roots_offset = source
-        .offset()
-        .checked_sub(body_start)
-        .ok_or_else(|| DeserializationError::InvalidValue("roots offset underflow".to_string()))?;
-    let roots_len_bytes = roots_count
-        .checked_mul(core::mem::size_of::<u32>())
-        .ok_or_else(|| DeserializationError::InvalidValue("roots length overflow".to_string()))?;
-    let _roots_data = source.read_slice(roots_len_bytes)?;
-
-    let basic_block_len = source.read_usize()?;
-    let basic_block_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
-        DeserializationError::InvalidValue("basic-block offset underflow".to_string())
-    })?;
-    let _basic_block_data = source.read_slice(basic_block_len)?;
-
-    let node_entry_size = MastNodeEntry::min_serialized_size();
-    let node_entry_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
-        DeserializationError::InvalidValue("node entry offset underflow".to_string())
-    })?;
-    let mut external_digest_count = 0usize;
-    for _ in 0..node_count {
-        let node_entry = MastNodeEntry::read_from(source)?;
-        if matches!(node_entry.node_type(), MastNodeType::External) {
-            external_digest_count = external_digest_count.checked_add(1).ok_or_else(|| {
-                DeserializationError::InvalidValue("external digest count overflow".to_string())
-            })?;
-        }
-    }
-
-    let external_digest_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
-        DeserializationError::InvalidValue("external digest offset underflow".to_string())
-    })?;
-    let external_digests_len = external_digest_count
-        .checked_mul(crate::Word::min_serialized_size())
-        .ok_or_else(|| {
-            DeserializationError::InvalidValue("external digest length overflow".to_string())
-        })?;
-    let _external_digests = source.read_slice(external_digests_len)?;
-
-    let node_hash_count = node_count.checked_sub(external_digest_count).ok_or_else(|| {
-        DeserializationError::InvalidValue("node hash count underflow".to_string())
-    })?;
-    let node_hash_offset = if is_hashless {
-        None
-    } else {
-        let offset = source.offset().checked_sub(body_start).ok_or_else(|| {
-            DeserializationError::InvalidValue("node hash offset underflow".to_string())
-        })?;
-        let node_hash_len =
-            node_hash_count.checked_mul(crate::Word::min_serialized_size()).ok_or_else(|| {
-                DeserializationError::InvalidValue("node hash length overflow".to_string())
-            })?;
-        let _node_hashes = source.read_slice(node_hash_len)?;
-        Some(offset)
-    };
-
-    Ok(ScannedForestLayout {
-        node_count,
-        roots_count,
-        roots_offset,
-        basic_block_offset,
-        basic_block_len,
-        node_entry_offset,
-        node_entry_size,
-        external_digest_offset,
-        #[cfg(test)]
-        external_digest_count,
-        node_hash_offset,
-        #[cfg(test)]
-        node_hash_count,
-    })
-}
-
-trait OffsetTrackingReader: ByteReader {
-    fn offset(&self) -> usize;
-}
-
-struct RecordingReader<'a, R> {
-    inner: &'a mut R,
-    recorded: Vec<u8>,
-}
-
-impl<'a, R> RecordingReader<'a, R> {
-    fn new(inner: &'a mut R) -> Self {
-        Self { inner, recorded: Vec::new() }
-    }
-
-    fn into_recorded(self) -> Vec<u8> {
-        self.recorded
-    }
-}
-
-impl<R: ByteReader> ByteReader for RecordingReader<'_, R> {
-    fn read_u8(&mut self) -> Result<u8, DeserializationError> {
-        let byte = self.inner.read_u8()?;
-        self.recorded.push(byte);
-        Ok(byte)
-    }
-
-    fn peek_u8(&self) -> Result<u8, DeserializationError> {
-        self.inner.peek_u8()
-    }
-
-    fn read_slice(&mut self, len: usize) -> Result<&[u8], DeserializationError> {
-        let slice = self.inner.read_slice(len)?;
-        self.recorded.extend_from_slice(slice);
-        Ok(slice)
-    }
-
-    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], DeserializationError> {
-        let array = self.inner.read_array::<N>()?;
-        self.recorded.extend_from_slice(&array);
-        Ok(array)
-    }
-
-    fn check_eor(&self, num_bytes: usize) -> Result<(), DeserializationError> {
-        self.inner.check_eor(num_bytes)
-    }
-
-    fn has_more_bytes(&self) -> bool {
-        self.inner.has_more_bytes()
-    }
-
-    fn max_alloc(&self, element_size: usize) -> usize {
-        self.inner.max_alloc(element_size)
-    }
-}
-
-impl<R: ByteReader> OffsetTrackingReader for RecordingReader<'_, R> {
-    fn offset(&self) -> usize {
-        self.recorded.len()
-    }
-}
-
-struct CountingReader<'a, R> {
-    inner: &'a mut R,
-    offset: usize,
-}
-
-impl<'a, R> CountingReader<'a, R> {
-    fn new(inner: &'a mut R) -> Self {
-        Self { inner, offset: 0 }
-    }
-}
-
-impl<R: ByteReader> ByteReader for CountingReader<'_, R> {
-    fn read_u8(&mut self) -> Result<u8, DeserializationError> {
-        let byte = self.inner.read_u8()?;
-        self.offset = self
-            .offset
-            .checked_add(1)
-            .ok_or_else(|| DeserializationError::InvalidValue("offset overflow".to_string()))?;
-        Ok(byte)
-    }
-
-    fn peek_u8(&self) -> Result<u8, DeserializationError> {
-        self.inner.peek_u8()
-    }
-
-    fn read_slice(&mut self, len: usize) -> Result<&[u8], DeserializationError> {
-        let slice = self.inner.read_slice(len)?;
-        self.offset = self
-            .offset
-            .checked_add(len)
-            .ok_or_else(|| DeserializationError::InvalidValue("offset overflow".to_string()))?;
-        Ok(slice)
-    }
-
-    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], DeserializationError> {
-        let array = self.inner.read_array::<N>()?;
-        self.offset = self
-            .offset
-            .checked_add(N)
-            .ok_or_else(|| DeserializationError::InvalidValue("offset overflow".to_string()))?;
-        Ok(array)
-    }
-
-    fn check_eor(&self, num_bytes: usize) -> Result<(), DeserializationError> {
-        self.inner.check_eor(num_bytes)
-    }
-
-    fn has_more_bytes(&self) -> bool {
-        self.inner.has_more_bytes()
-    }
-
-    fn max_alloc(&self, element_size: usize) -> usize {
-        self.inner.max_alloc(element_size)
-    }
-}
-
-impl<R: ByteReader> OffsetTrackingReader for CountingReader<'_, R> {
-    fn offset(&self) -> usize {
-        self.offset
-    }
-}
-
-/// Reads and validates the MAST header (magic, flags, version).
-///
-/// Returns the flags byte on success.
-fn read_and_validate_header<R: ByteReader>(
-    source: &mut R,
-) -> Result<(u8, [u8; 3]), DeserializationError> {
-    // Read magic
-    let magic: [u8; 4] = source.read_array()?;
-    if magic != *MAGIC {
-        return Err(DeserializationError::InvalidValue(format!(
-            "Invalid magic bytes. Expected '{:?}', got '{:?}'",
-            *MAGIC, magic
-        )));
-    }
-
-    // Read flags
-    let flags: u8 = source.read_u8()?;
-
-    // Read and validate version
-    let version: [u8; 3] = source.read_array()?;
-    if version != VERSION {
-        return Err(DeserializationError::InvalidValue(format!(
-            "Unsupported version. Got '{version:?}', but only '{VERSION:?}' is supported",
-        )));
-    }
-
-    // Validate flags
-    if flags & FLAGS_RESERVED_MASK != 0 {
-        return Err(DeserializationError::InvalidValue(format!(
-            "Unknown flags set in MAST header: {:#04x}. Reserved bits must be zero.",
-            flags & FLAGS_RESERVED_MASK
-        )));
-    }
-
-    Ok((flags, version))
+        super::UntrustedMastForest {
+            bytes: recording.into_recorded(),
+            layout,
+            advice_map,
+            debug_info,
+        },
+    ))
 }
 
 // UNTRUSTED DESERIALIZATION

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -10,6 +10,12 @@
 //! reject hashless payloads. [`crate::mast::UntrustedMastForest`] accepts them and rebuilds
 //! non-external digests before use. If a non-hashless payload is sent down the untrusted path,
 //! validation recomputes those digests and requires them to match the serialized values.
+//! Budgeted untrusted reads always bound wire counts during layout scanning via
+//! [`ByteReader::max_alloc`]. Callers that opt into validation budgeting also get a second check:
+//! - later stripped/hashless helper allocations are charged against an explicit validation budget
+//!   before the corresponding `Vec` or CSR scaffolding is created
+//! - the default convenience path uses a coarse validation budget derived from the input size;
+//!   this is intentionally a simple bound for common callers, not an exact peak-memory formula
 //!
 //! The main layers fit together like this:
 //!
@@ -17,7 +23,7 @@
 //! wire bytes
 //!     |
 //!     +--> ForestLayout -----------> SerializedMastForest --+
-//!     |        scan offsets             structural view      |
+//!     |        absolute offsets         structural view      |
 //!     |                                                     v
 //!     +--> UntrustedMastForest ----validate----> ResolvedSerializedForest ---> MastForest
 //!              bytes + parsed state                digest-backed view            trusted runtime
@@ -74,10 +80,17 @@
 //! Readers recover per-node digest lookup by scanning node entries once and building a compact
 //! "slot by node index" table. This preserves random access without forcing all digests into the
 //! same contiguous array on the wire.
+//!
+//! Public entry points adopt these policies:
+//! - [`MastForest::read_from_bytes`]: trusted full payload, no hashless support.
+//! - [`SerializedMastForest::new`]: trusted structural inspection, including hashless payloads.
+//! - [`crate::mast::UntrustedMastForest::read_from_bytes`] /
+//!   [`crate::mast::UntrustedMastForest::read_from_bytes_with_budgets`]: untrusted parsing plus
+//!   later validation before use.
 
 #[cfg(test)]
 use alloc::string::ToString;
-use alloc::vec::Vec;
+use alloc::{format, vec::Vec};
 
 use miden_utils_sync::OnceLockCompat;
 
@@ -129,6 +142,25 @@ type StringDataOffset = usize;
 
 /// Specifies an offset into the strings table of an encoded [`MastForest`].
 type StringIndex = usize;
+
+/// Default multiplier for the untrusted validation allocation budget.
+///
+/// The budgeted byte reader limits wire-driven parsing. Hashless and stripped validation also
+/// needs transient per-node allocations for the slot table, empty debug-info scaffolding, and
+/// rebuilt digest table. The generic untrusted path also retains a recorded copy of the consumed
+/// serialized payload for deferred validation.
+///
+/// This convenience multiplier is therefore a coarse "wire bytes plus worst-case helper
+/// headroom" bound:
+/// - `* 6` covers the helper-allocation model introduced with explicit validation budgeting
+/// - `+ 1 * bytes_len` covers the retained serialized copy recorded during untrusted reads
+///
+/// It is deliberately conservative and exists to make the default
+/// [`crate::mast::UntrustedMastForest::read_from_bytes`] path usable without forcing callers to
+/// size each helper allocation themselves. Callers with stricter limits should use
+/// [`crate::mast::UntrustedMastForest::read_from_bytes_with_budgets`] and choose explicit parsing
+/// and validation budgets.
+const DEFAULT_UNTRUSTED_ALLOCATION_BUDGET_MULTIPLIER: usize = 7;
 
 // CONSTANTS
 // ================================================================================================
@@ -357,6 +389,18 @@ impl<'a> SerializedMastForest<'a> {
     /// node/roots/random-access metadata only. It does not validate or fully parse trailing
     /// `AdviceMap` / `DebugInfo` payloads.
     ///
+    /// Treat this as a trusted inspection API, not as an untrusted-validation entry point. It is
+    /// appropriate for local tools that need random access over serialized structure, but callers
+    /// handling adversarial bytes should use [`crate::mast::UntrustedMastForest`] instead.
+    ///
+    /// In particular, this constructor does **not** protect callers from untrusted-input concerns
+    /// that are enforced by [`crate::mast::UntrustedMastForest::validate`]. It does not:
+    /// - verify that serialized non-external digests match the structure they describe
+    /// - check topological ordering / forward-reference constraints
+    /// - validate basic-block batch invariants or procedure-name-root consistency
+    /// - fully parse or validate trailing `AdviceMap` / `DebugInfo` payloads
+    /// - provide a bounded-work guarantee for hashless digest-backed inspection
+    ///
     /// For strict full-payload validation, use
     /// [`crate::mast::MastForest::read_from_bytes`].
     ///
@@ -398,7 +442,7 @@ impl<'a> SerializedMastForest<'a> {
         Ok(Self {
             bytes,
             flags,
-            layout: layout.resolve()?,
+            layout,
             resolved: OnceLockCompat::new(),
         })
     }
@@ -634,8 +678,17 @@ impl Deserializable for MastForest {
 
 impl super::UntrustedMastForest {
     pub(super) fn into_materialized(self) -> Result<MastForest, DeserializationError> {
-        ResolvedSerializedForest::new(&self.bytes, self.layout)?
-            .materialize(self.advice_map, self.debug_info)
+        let resolved = if let Some(allocation_budget) = self.remaining_allocation_budget {
+            ResolvedSerializedForest::new_with_allocation_budget(
+                &self.bytes,
+                self.layout,
+                allocation_budget,
+            )?
+        } else {
+            ResolvedSerializedForest::new(&self.bytes, self.layout)?
+        };
+
+        resolved.materialize(self.advice_map, self.debug_info)
     }
 }
 
@@ -643,6 +696,15 @@ pub(super) fn read_untrusted_with_flags<R: ByteReader>(
     source: &mut R,
 ) -> Result<(super::UntrustedMastForest, u8), DeserializationError> {
     let (flags, forest) = decode_from_reader(source, true)?;
+    log_untrusted_overspecification(flags);
+    Ok((forest, flags.bits()))
+}
+
+pub(super) fn read_untrusted_with_flags_and_allocation_budget<R: ByteReader>(
+    source: &mut R,
+    allocation_budget: usize,
+) -> Result<(super::UntrustedMastForest, u8), DeserializationError> {
+    let (flags, forest) = decode_from_reader_inner(source, true, Some(allocation_budget))?;
     log_untrusted_overspecification(flags);
     Ok((forest, flags.bits()))
 }
@@ -665,12 +727,28 @@ fn decode_from_reader<R: ByteReader>(
     source: &mut R,
     allow_hashless: bool,
 ) -> Result<(WireFlags, super::UntrustedMastForest), DeserializationError> {
+    decode_from_reader_inner(source, allow_hashless, None)
+}
+
+fn decode_from_reader_inner<R: ByteReader>(
+    source: &mut R,
+    allow_hashless: bool,
+    mut remaining_allocation_budget: Option<usize>,
+) -> Result<(WireFlags, super::UntrustedMastForest), DeserializationError> {
     let mut recording = TrackingReader::new_recording(source);
     let (flags, layout) = read_header_and_scan_layout(&mut recording, allow_hashless)?;
-    let layout = layout.resolve()?;
 
     let advice_map = AdviceMap::read_from(&mut recording)?;
     let debug_info = if flags.is_stripped() {
+        if let Some(allocation_budget) = &mut remaining_allocation_budget {
+            reserve_allocation::<usize>(
+                allocation_budget,
+                layout.node_count.checked_add(1).ok_or_else(|| {
+                    DeserializationError::InvalidValue("debug-info node count overflow".into())
+                })?,
+                "empty debug-info scaffolding",
+            )?;
+        }
         super::DebugInfo::empty_for_nodes(layout.node_count)
     } else {
         super::DebugInfo::read_from(&mut recording)?
@@ -683,8 +761,32 @@ fn decode_from_reader<R: ByteReader>(
             layout,
             advice_map,
             debug_info,
+            remaining_allocation_budget,
         },
     ))
+}
+
+pub(super) fn reserve_allocation<T>(
+    remaining_budget: &mut usize,
+    count: usize,
+    label: &str,
+) -> Result<(), DeserializationError> {
+    let bytes_needed = count
+        .checked_mul(core::mem::size_of::<T>())
+        .ok_or_else(|| DeserializationError::InvalidValue(format!("{label} size overflow")))?;
+    if bytes_needed > *remaining_budget {
+        return Err(DeserializationError::InvalidValue(format!(
+            "{label} requires {bytes_needed} bytes, exceeding the remaining untrusted allocation budget of {} bytes",
+            *remaining_budget
+        )));
+    }
+
+    *remaining_budget -= bytes_needed;
+    Ok(())
+}
+
+pub(super) fn default_untrusted_allocation_budget(bytes_len: usize) -> usize {
+    bytes_len.saturating_mul(DEFAULT_UNTRUSTED_ALLOCATION_BUDGET_MULTIPLIER)
 }
 
 // UNTRUSTED DESERIALIZATION
@@ -705,8 +807,8 @@ impl Deserializable for super::UntrustedMastForest {
 
     /// Deserializes an [`super::UntrustedMastForest`] from bytes using budgeted deserialization.
     ///
-    /// This method uses a [`crate::serde::BudgetedReader`] with a budget equal to the input size
-    /// to protect against denial-of-service attacks from malicious input.
+    /// This method uses the default untrusted wire/validation budget from
+    /// [`super::UntrustedMastForest::read_from_bytes`].
     ///
     /// After deserialization, callers should use [`super::UntrustedMastForest::validate()`]
     /// to verify structural integrity and recompute all node hashes before using

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -10,6 +10,21 @@
 //! reject hashless payloads. [`crate::mast::UntrustedMastForest`] accepts them and rebuilds
 //! non-external digests before use.
 //!
+//! The main layers fit together like this:
+//!
+//! ```text
+//! wire bytes
+//!     |
+//!     +--> ForestLayout -----------> SerializedMastForest --+
+//!     |        scan offsets             structural view      |
+//!     |                                                     v
+//!     +--> UntrustedMastForest ----validate----> ResolvedSerializedForest ---> MastForest
+//!              bytes + parsed state                digest-backed view            trusted runtime
+//!
+//! MastForestView is the shared random-access API implemented by SerializedMastForest and
+//! MastForest.
+//! ```
+//!
 //! The format is:
 //!
 //! (Metadata)

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -13,8 +13,14 @@
 //! (Basic block data section)
 //! - basic block data (padded operations + batch metadata)
 //!
-//! (Node info section)
-//! - MAST node infos (`Vec<MastNodeInfo>`)
+//! (Node entries section)
+//! - fixed-width structural node entries (`Vec<MastNodeEntry>`)
+//!
+//! (External digest section)
+//! - digests for `External` nodes only (`Vec<Word>`, ordered by node index)
+//!
+//! (Node hash section - omitted if FLAGS bit 1 is set)
+//! - digests for all non-external nodes (`Vec<Word>`, ordered by node index)
 //!
 //! (Advice map section)
 //! - Advice map (`AdviceMap`)
@@ -37,9 +43,9 @@
 //! # Hashless Format
 //!
 //! When serializing with [`MastForest::write_hashless`], the FLAGS byte has bit 1 set, and
-//! bit 0 is also set (hashless implies stripped). This does not change the wire format.
-//! It is a declaration of intent that stored digests must be recomputed during validation.
-//! The trusted deserializer rejects hashless inputs; use [`UntrustedMastForest`] instead.
+//! bit 0 is also set (hashless implies stripped). In this format, the general node-hash section
+//! is omitted entirely. Trusted deserialization rejects hashless inputs; use
+//! [`UntrustedMastForest`] instead.
 
 use alloc::{string::ToString, vec::Vec};
 
@@ -48,6 +54,7 @@ use crate::{
     Felt,
     advice::AdviceMap,
     chiplets::hasher,
+    mast::node::MastNodeExt,
     serde::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
     },
@@ -57,8 +64,8 @@ pub(crate) mod asm_op;
 pub(crate) mod decorator;
 
 mod info;
-pub use info::MastNodeInfo;
 use info::MastNodeType;
+pub use info::{MastNodeEntry, MastNodeInfo};
 
 mod basic_blocks;
 use basic_blocks::{BasicBlockDataBuilder, BasicBlockDataDecoder, basic_block_data_len};
@@ -109,9 +116,9 @@ const FLAG_STRIPPED: u8 = 0x01;
 
 /// Flag indicating the serialized MastForest should be treated as hashless.
 ///
-/// This flag does not affect the wire format; digests are still serialized. It declares that
-/// digests must be recomputed during validation, so trusted deserialization rejects it.
-/// This flag implies [`FLAG_STRIPPED`].
+/// When this bit is set, the general node-hash section is omitted. External digests remain
+/// serialized in their dedicated section because they cannot be reconstructed locally.
+/// Trusted deserialization rejects this format. This flag implies [`FLAG_STRIPPED`].
 pub(super) const FLAG_HASHLESS: u8 = 0x02;
 
 /// Mask for reserved flag bits that must be zero.
@@ -136,7 +143,9 @@ const FLAGS_RESERVED_MASK: u8 = 0xfc;
 ///   Removed `breakpoint` instruction (#2655).
 /// - [0, 0, 3]: Added HASHLESS flag (bit 1). HASHLESS implies STRIPPED. Trusted deserialization
 ///   rejects HASHLESS.
-const VERSION: [u8; 3] = [0, 0, 3];
+/// - [0, 0, 4]: Split fixed-width node entries from digest storage. External digests moved to a
+///   dedicated section. Hashless serialization omits the general node-hash section entirely.
+const VERSION: [u8; 3] = [0, 0, 4];
 
 // MAST FOREST SERIALIZATION/DESERIALIZATION
 // ================================================================================================
@@ -177,28 +186,40 @@ impl MastForest {
         let roots: Vec<u32> = self.roots.iter().copied().map(u32::from).collect();
         roots.write_into(target);
 
-        // Prepare MAST node infos, but don't store them yet. We store them at the end to make
-        // deserialization more efficient.
-        let mast_node_infos: Vec<MastNodeInfo> = self
-            .nodes
-            .iter()
-            .map(|mast_node| {
-                let ops_offset = if let MastNode::Block(basic_block) = mast_node {
-                    basic_block_data_builder.encode_basic_block(basic_block)
-                } else {
-                    0
-                };
+        let mut mast_node_entries = Vec::with_capacity(self.nodes.len());
+        let mut external_digests = Vec::new();
+        let mut node_hashes = Vec::new();
 
-                MastNodeInfo::new(mast_node, ops_offset)
-            })
-            .collect();
+        for mast_node in self.nodes.iter() {
+            let ops_offset = if let MastNode::Block(basic_block) = mast_node {
+                basic_block_data_builder.encode_basic_block(basic_block)
+            } else {
+                0
+            };
+
+            mast_node_entries.push(MastNodeEntry::new(mast_node, ops_offset));
+            if mast_node.is_external() {
+                external_digests.push(mast_node.digest());
+            } else if !hashless {
+                node_hashes.push(mast_node.digest());
+            }
+        }
 
         let basic_block_data = basic_block_data_builder.finalize();
         basic_block_data.write_into(target);
 
-        // Write node infos
-        for mast_node_info in mast_node_infos {
-            mast_node_info.write_into(target);
+        for mast_node_entry in mast_node_entries {
+            mast_node_entry.write_into(target);
+        }
+
+        for digest in external_digests {
+            digest.write_into(target);
+        }
+
+        if !hashless {
+            for digest in node_hashes {
+                digest.write_into(target);
+            }
         }
 
         self.advice_map.write_into(target);
@@ -211,11 +232,26 @@ impl MastForest {
 }
 
 pub(super) fn stripped_size_hint(forest: &MastForest) -> usize {
+    serialized_size_hint(forest, true, false)
+}
+
+fn hashless_size_hint(forest: &MastForest) -> usize {
+    serialized_size_hint(forest, true, true)
+}
+
+fn serialized_size_hint(forest: &MastForest, stripped: bool, hashless: bool) -> usize {
     let node_count = forest.nodes.len();
+    let external_count = forest.nodes.iter().filter(|node| node.is_external()).count();
+    let non_external_count = node_count - external_count;
 
     let mut size = MAGIC.len() + 1 + VERSION.len();
     size += node_count.get_size_hint();
-    size += 0usize.get_size_hint(); // decorator count (always 0 in stripped)
+    size += if stripped {
+        0usize
+    } else {
+        forest.debug_info.num_decorators()
+    }
+    .get_size_hint();
 
     let roots_len = forest.roots.len();
     size += roots_len.get_size_hint();
@@ -229,9 +265,15 @@ pub(super) fn stripped_size_hint(forest: &MastForest) -> usize {
     }
     size += basic_block_len.get_size_hint() + basic_block_len;
 
-    let node_info_size = MastNodeInfo::min_serialized_size();
-    size += node_count * node_info_size;
+    size += node_count * MastNodeEntry::min_serialized_size();
+    size += external_count * crate::Word::min_serialized_size();
+    if !hashless {
+        size += non_external_count * crate::Word::min_serialized_size();
+    }
     size += forest.advice_map.serialized_size_hint();
+    if !stripped {
+        size += forest.debug_info.get_size_hint();
+    }
 
     size
 }
@@ -268,13 +310,20 @@ pub struct SerializedMastForest<'a> {
     is_stripped: bool,
     is_hashless: bool,
     hash_table: Option<Vec<crate::Word>>,
+    digest_slot_by_node: Vec<u32>,
     node_count: usize,
     roots_count: usize,
     roots_offset: usize,
     basic_block_offset: usize,
     basic_block_len: usize,
-    node_info_offset: usize,
-    node_info_size: usize,
+    node_entry_offset: usize,
+    node_entry_size: usize,
+    external_digest_offset: usize,
+    #[cfg(test)]
+    external_digest_count: usize,
+    node_hash_offset: Option<usize>,
+    #[cfg(test)]
+    node_hash_count: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -284,8 +333,14 @@ struct ScannedForestLayout {
     roots_offset: usize,
     basic_block_offset: usize,
     basic_block_len: usize,
-    node_info_offset: usize,
-    node_info_size: usize,
+    node_entry_offset: usize,
+    node_entry_size: usize,
+    external_digest_offset: usize,
+    #[cfg(test)]
+    external_digest_count: usize,
+    node_hash_offset: Option<usize>,
+    #[cfg(test)]
+    node_hash_count: usize,
 }
 
 /// Canonical decoded representation for reader-based deserialization paths.
@@ -304,10 +359,6 @@ pub(super) struct DecodedSerializedForest {
 impl DecodedSerializedForest {
     pub(super) fn flags(&self) -> u8 {
         self.flags
-    }
-
-    pub(super) fn is_hashless(&self) -> bool {
-        self.flags & FLAG_HASHLESS != 0
     }
 
     pub(super) fn into_mast_forest(self) -> Result<MastForest, DeserializationError> {
@@ -361,14 +412,15 @@ impl<'a> SerializedMastForest<'a> {
         let mut reader = SliceReader::new(bytes);
         let (flags, _version) = read_and_validate_header(&mut reader)?;
         let is_stripped = flags & FLAG_STRIPPED != 0;
-        if flags & FLAG_HASHLESS != 0 && !is_stripped {
+        let is_hashless = flags & FLAG_HASHLESS != 0;
+        if is_hashless && !is_stripped {
             return Err(DeserializationError::InvalidValue(
                 "HASHLESS flag requires STRIPPED flag to be set".to_string(),
             ));
         }
 
         let mut scanner = CountingReader::new(&mut reader);
-        let layout = scan_layout_sections(&mut scanner)?;
+        let layout = scan_layout_sections(&mut scanner, is_hashless)?;
 
         Self::from_scanned_parts(bytes, flags, layout)
     }
@@ -394,18 +446,37 @@ impl<'a> SerializedMastForest<'a> {
             header_len.checked_add(layout.basic_block_offset).ok_or_else(|| {
                 DeserializationError::InvalidValue("basic-block offset overflow".to_string())
             })?;
-        let node_info_offset =
-            header_len.checked_add(layout.node_info_offset).ok_or_else(|| {
-                DeserializationError::InvalidValue("node info offset overflow".to_string())
+        let node_entry_offset =
+            header_len.checked_add(layout.node_entry_offset).ok_or_else(|| {
+                DeserializationError::InvalidValue("node entry offset overflow".to_string())
             })?;
+        let external_digest_offset =
+            header_len.checked_add(layout.external_digest_offset).ok_or_else(|| {
+                DeserializationError::InvalidValue("external digest offset overflow".to_string())
+            })?;
+        let node_hash_offset = layout
+            .node_hash_offset
+            .map(|offset| {
+                header_len.checked_add(offset).ok_or_else(|| {
+                    DeserializationError::InvalidValue("node hash offset overflow".to_string())
+                })
+            })
+            .transpose()?;
+        let digest_slot_by_node = build_digest_slot_by_node(
+            bytes,
+            node_entry_offset,
+            layout.node_entry_size,
+            layout.node_count,
+        )?;
         let hash_table = if is_hashless {
             Some(recompute_hash_table(
                 bytes,
                 layout.node_count,
-                node_info_offset,
-                layout.node_info_size,
+                node_entry_offset,
+                layout.node_entry_size,
                 basic_block_offset,
                 layout.basic_block_len,
+                external_digest_offset,
             )?)
         } else {
             None
@@ -416,13 +487,20 @@ impl<'a> SerializedMastForest<'a> {
             is_stripped,
             is_hashless,
             hash_table,
+            digest_slot_by_node,
             node_count: layout.node_count,
             roots_count: layout.roots_count,
             roots_offset,
             basic_block_offset,
             basic_block_len: layout.basic_block_len,
-            node_info_offset,
-            node_info_size: layout.node_info_size,
+            node_entry_offset,
+            node_entry_size: layout.node_entry_size,
+            external_digest_offset,
+            #[cfg(test)]
+            external_digest_count: layout.external_digest_count,
+            node_hash_offset,
+            #[cfg(test)]
+            node_hash_count: layout.node_hash_count,
         })
     }
 
@@ -496,6 +574,14 @@ impl<'a> SerializedMastForest<'a> {
     /// assert!(view.node_info_at(0).is_ok());
     /// ```
     pub fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError> {
+        Ok(MastNodeInfo::from_entry(
+            self.node_entry_at(index)?,
+            self.node_digest_at(index)?,
+        ))
+    }
+
+    /// Returns the fixed-width structural node entry at the specified index.
+    pub fn node_entry_at(&self, index: usize) -> Result<MastNodeEntry, DeserializationError> {
         if index >= self.node_count {
             return Err(DeserializationError::InvalidValue(format!(
                 "node index {} out of bounds for {} nodes",
@@ -503,14 +589,28 @@ impl<'a> SerializedMastForest<'a> {
             )));
         }
 
-        let info =
-            read_node_info_entry(self.bytes, self.node_info_offset, self.node_info_size, index)?;
-        if let Some(hash_table) = &self.hash_table {
-            let digest = hash_table[index];
-            Ok(MastNodeInfo::from_parts(info.node_type(), digest))
-        } else {
-            Ok(info)
+        read_node_entry(self.bytes, self.node_entry_offset, self.node_entry_size, index)
+    }
+
+    /// Returns the digest for the node at the specified index.
+    pub fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
+        let entry = self.node_entry_at(index)?;
+        let digest_slot = self.digest_slot_by_node[index] as usize;
+
+        if matches!(entry.node_type(), MastNodeType::External) {
+            return read_digest_entry(self.bytes, self.external_digest_offset, digest_slot);
         }
+
+        if let Some(hash_table) = &self.hash_table {
+            return Ok(hash_table[index]);
+        }
+
+        let node_hash_offset = self.node_hash_offset.ok_or_else(|| {
+            DeserializationError::InvalidValue(
+                "hash-backed digest lookup requested but node hash section is absent".to_string(),
+            )
+        })?;
+        read_digest_entry(self.bytes, node_hash_offset, digest_slot)
     }
 
     fn basic_block_data(&self) -> Result<&[u8], DeserializationError> {
@@ -533,9 +633,11 @@ impl<'a> SerializedMastForest<'a> {
         mast_forest.debug_info = debug_info;
 
         for index in 0..self.node_count {
-            let node_info = self.node_info_at(index)?;
-            let mast_node_builder =
-                node_info.try_into_mast_node_builder(self.node_count, &basic_block_data_decoder)?;
+            let mast_node_builder = self.node_entry_at(index)?.try_into_mast_node_builder(
+                self.node_count,
+                &basic_block_data_decoder,
+                self.node_digest_at(index)?,
+            )?;
 
             mast_node_builder.add_to_forest_relaxed(&mut mast_forest).map_err(|e| {
                 DeserializationError::InvalidValue(format!(
@@ -551,38 +653,113 @@ impl<'a> SerializedMastForest<'a> {
         mast_forest.advice_map = advice_map;
         Ok(mast_forest)
     }
+
+    #[cfg(test)]
+    fn advice_map_offset(&self) -> Result<usize, DeserializationError> {
+        let digest_section_end = if let Some(node_hash_offset) = self.node_hash_offset {
+            node_hash_offset
+                .checked_add(self.node_hash_count * crate::Word::min_serialized_size())
+                .ok_or_else(|| {
+                    DeserializationError::InvalidValue("node hash section overflow".to_string())
+                })?
+        } else {
+            self.external_digest_offset
+                .checked_add(self.external_digest_count * crate::Word::min_serialized_size())
+                .ok_or_else(|| {
+                    DeserializationError::InvalidValue(
+                        "external digest section overflow".to_string(),
+                    )
+                })?
+        };
+
+        if digest_section_end > self.bytes.len() {
+            return Err(DeserializationError::UnexpectedEOF);
+        }
+
+        Ok(digest_section_end)
+    }
 }
 
-fn read_node_info_entry(
+fn read_node_entry(
     bytes: &[u8],
-    node_info_offset: usize,
-    node_info_size: usize,
+    node_entry_offset: usize,
+    node_entry_size: usize,
     index: usize,
-) -> Result<MastNodeInfo, DeserializationError> {
+) -> Result<MastNodeEntry, DeserializationError> {
     let entry_offset = index
-        .checked_mul(node_info_size)
-        .and_then(|delta| node_info_offset.checked_add(delta))
+        .checked_mul(node_entry_size)
+        .and_then(|delta| node_entry_offset.checked_add(delta))
         .ok_or_else(|| {
-            DeserializationError::InvalidValue("node info offset overflow".to_string())
+            DeserializationError::InvalidValue("node entry offset overflow".to_string())
         })?;
-    let entry_end = entry_offset.checked_add(node_info_size).ok_or_else(|| {
-        DeserializationError::InvalidValue("node info length overflow".to_string())
+    let entry_end = entry_offset.checked_add(node_entry_size).ok_or_else(|| {
+        DeserializationError::InvalidValue("node entry length overflow".to_string())
     })?;
     if entry_end > bytes.len() {
         return Err(DeserializationError::UnexpectedEOF);
     }
 
     let mut reader = SliceReader::new(&bytes[entry_offset..entry_end]);
-    MastNodeInfo::read_from(&mut reader)
+    MastNodeEntry::read_from(&mut reader)
+}
+
+fn read_digest_entry(
+    bytes: &[u8],
+    digest_section_offset: usize,
+    index: usize,
+) -> Result<crate::Word, DeserializationError> {
+    let digest_size = crate::Word::min_serialized_size();
+    let entry_offset = index
+        .checked_mul(digest_size)
+        .and_then(|delta| digest_section_offset.checked_add(delta))
+        .ok_or_else(|| DeserializationError::InvalidValue("digest offset overflow".to_string()))?;
+    let entry_end = entry_offset
+        .checked_add(digest_size)
+        .ok_or_else(|| DeserializationError::InvalidValue("digest length overflow".to_string()))?;
+    if entry_end > bytes.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+
+    let mut reader = SliceReader::new(&bytes[entry_offset..entry_end]);
+    crate::Word::read_from(&mut reader)
+}
+
+fn build_digest_slot_by_node(
+    bytes: &[u8],
+    node_entry_offset: usize,
+    node_entry_size: usize,
+    node_count: usize,
+) -> Result<Vec<u32>, DeserializationError> {
+    let mut slots = Vec::with_capacity(node_count);
+    let mut external_slot = 0u32;
+    let mut node_hash_slot = 0u32;
+
+    for index in 0..node_count {
+        let entry = read_node_entry(bytes, node_entry_offset, node_entry_size, index)?;
+        if matches!(entry.node_type(), MastNodeType::External) {
+            slots.push(external_slot);
+            external_slot = external_slot.checked_add(1).ok_or_else(|| {
+                DeserializationError::InvalidValue("external digest slot overflow".to_string())
+            })?;
+        } else {
+            slots.push(node_hash_slot);
+            node_hash_slot = node_hash_slot.checked_add(1).ok_or_else(|| {
+                DeserializationError::InvalidValue("node hash slot overflow".to_string())
+            })?;
+        }
+    }
+
+    Ok(slots)
 }
 
 fn recompute_hash_table(
     bytes: &[u8],
     node_count: usize,
-    node_info_offset: usize,
-    node_info_size: usize,
+    node_entry_offset: usize,
+    node_entry_size: usize,
     basic_block_offset: usize,
     basic_block_len: usize,
+    external_digest_offset: usize,
 ) -> Result<Vec<crate::Word>, DeserializationError> {
     let basic_block_end = basic_block_offset.checked_add(basic_block_len).ok_or_else(|| {
         DeserializationError::InvalidValue("basic-block data overflow".to_string())
@@ -594,10 +771,11 @@ fn recompute_hash_table(
         BasicBlockDataDecoder::new(&bytes[basic_block_offset..basic_block_end]);
 
     let mut digests = Vec::with_capacity(node_count);
+    let mut external_digest_index = 0usize;
 
     for index in 0..node_count {
-        let info = read_node_info_entry(bytes, node_info_offset, node_info_size, index)?;
-        let computed = match info.node_type() {
+        let entry = read_node_entry(bytes, node_entry_offset, node_entry_size, index)?;
+        let computed = match entry.node_type() {
             MastNodeType::Block { ops_offset } => {
                 let op_batches = basic_block_data_decoder.decode_operations(ops_offset)?;
                 let op_groups: Vec<Felt> =
@@ -635,10 +813,12 @@ fn recompute_hash_table(
             MastNodeType::Dyn => DynNode::DYN_DEFAULT_DIGEST,
             MastNodeType::Dyncall => DynNode::DYNCALL_DEFAULT_DIGEST,
             MastNodeType::External => {
-                // External digests cannot be reconstructed from local structure alone.
-                // In HASHLESS mode we treat them as opaque payload to be resolved by later
-                // semantic checks in higher layers.
-                info.digest()
+                let digest =
+                    read_digest_entry(bytes, external_digest_offset, external_digest_index)?;
+                external_digest_index = external_digest_index.checked_add(1).ok_or_else(|| {
+                    DeserializationError::InvalidValue("external digest index overflow".to_string())
+                })?;
+                digest
             },
         };
 
@@ -674,8 +854,12 @@ impl super::MastForestView for SerializedMastForest<'_> {
         SerializedMastForest::node_count(self)
     }
 
-    fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError> {
-        SerializedMastForest::node_info_at(self, index)
+    fn node_entry_at(&self, index: usize) -> Result<MastNodeEntry, DeserializationError> {
+        SerializedMastForest::node_entry_at(self, index)
+    }
+
+    fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
+        SerializedMastForest::node_digest_at(self, index)
     }
 
     fn procedure_root_count(&self) -> usize {
@@ -692,7 +876,7 @@ impl super::MastForestView for MastForest {
         self.nodes.len()
     }
 
-    fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError> {
+    fn node_entry_at(&self, index: usize) -> Result<MastNodeEntry, DeserializationError> {
         let node = self.nodes.as_slice().get(index).ok_or_else(|| {
             DeserializationError::InvalidValue(format!("node index {index} out of bounds"))
         })?;
@@ -702,38 +886,13 @@ impl super::MastForestView for MastForest {
             0
         };
 
-        Ok(MastNodeInfo::new(node, ops_offset))
+        Ok(MastNodeEntry::new(node, ops_offset))
     }
 
-    fn all_node_infos(&self) -> Result<Vec<MastNodeInfo>, DeserializationError> {
-        let mut node_infos = Vec::with_capacity(self.nodes.len());
-        let mut basic_block_data_offset = 0usize;
-
-        for node in self.nodes.iter() {
-            let ops_offset = if matches!(node, MastNode::Block(_)) {
-                basic_block_data_offset.try_into().map_err(|_| {
-                    DeserializationError::InvalidValue(
-                        "basic-block data offset does not fit in u32".to_string(),
-                    )
-                })?
-            } else {
-                0
-            };
-
-            node_infos.push(MastNodeInfo::new(node, ops_offset));
-
-            if let MastNode::Block(block) = node {
-                basic_block_data_offset = basic_block_data_offset
-                    .checked_add(basic_block_data_len(block))
-                    .ok_or_else(|| {
-                        DeserializationError::InvalidValue(
-                            "basic-block data offset overflow".to_string(),
-                        )
-                    })?;
-            }
-        }
-
-        Ok(node_infos)
+    fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
+        self.nodes.as_slice().get(index).map(MastNode::digest).ok_or_else(|| {
+            DeserializationError::InvalidValue(format!("node index {index} out of bounds"))
+        })
     }
 
     fn procedure_root_count(&self) -> usize {
@@ -854,6 +1013,23 @@ enum ReaderDecodeMode {
     Untrusted,
 }
 
+fn log_untrusted_overspecification(flags: u8) {
+    let is_stripped = flags & FLAG_STRIPPED != 0;
+    let is_hashless = flags & FLAG_HASHLESS != 0;
+
+    if !is_hashless {
+        log::error!(
+            "UntrustedMastForest expected HASHLESS input; supplied artifact includes wire node hashes that will be ignored and recomputed during validation"
+        );
+    }
+
+    if !is_stripped {
+        log::error!(
+            "UntrustedMastForest expected STRIPPED input; supplied artifact includes DebugInfo and other optional payloads over the wire"
+        );
+    }
+}
+
 fn decode_from_reader<R: ByteReader>(
     source: &mut R,
     mode: ReaderDecodeMode,
@@ -871,8 +1047,11 @@ fn decode_from_reader<R: ByteReader>(
             "HASHLESS flag is set; use UntrustedMastForest for untrusted input".to_string(),
         ));
     }
+    if matches!(mode, ReaderDecodeMode::Untrusted) {
+        log_untrusted_overspecification(flags);
+    }
 
-    let layout = scan_layout_sections(&mut recording)?;
+    let layout = scan_layout_sections(&mut recording, flags & FLAG_HASHLESS != 0)?;
     let advice_map = AdviceMap::read_from(&mut recording)?;
     let debug_info = if is_stripped {
         super::DebugInfo::empty_for_nodes(layout.node_count)
@@ -895,6 +1074,7 @@ fn decode_from_reader<R: ByteReader>(
 /// reader-based deserialization and [`SerializedMastForest::new`].
 fn scan_layout_sections<R: OffsetTrackingReader>(
     source: &mut R,
+    is_hashless: bool,
 ) -> Result<ScannedForestLayout, DeserializationError> {
     let body_start = source.offset();
 
@@ -924,14 +1104,46 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
     })?;
     let _basic_block_data = source.read_slice(basic_block_len)?;
 
-    let node_info_size = MastNodeInfo::min_serialized_size();
-    let node_info_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
-        DeserializationError::InvalidValue("node info offset underflow".to_string())
+    let node_entry_size = MastNodeEntry::min_serialized_size();
+    let node_entry_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
+        DeserializationError::InvalidValue("node entry offset underflow".to_string())
     })?;
-    let node_infos_len = node_count.checked_mul(node_info_size).ok_or_else(|| {
-        DeserializationError::InvalidValue("node info length overflow".to_string())
+    let mut external_digest_count = 0usize;
+    for _ in 0..node_count {
+        let node_entry = MastNodeEntry::read_from(source)?;
+        if matches!(node_entry.node_type(), MastNodeType::External) {
+            external_digest_count = external_digest_count.checked_add(1).ok_or_else(|| {
+                DeserializationError::InvalidValue("external digest count overflow".to_string())
+            })?;
+        }
+    }
+
+    let external_digest_offset = source.offset().checked_sub(body_start).ok_or_else(|| {
+        DeserializationError::InvalidValue("external digest offset underflow".to_string())
     })?;
-    let _node_infos = source.read_slice(node_infos_len)?;
+    let external_digests_len = external_digest_count
+        .checked_mul(crate::Word::min_serialized_size())
+        .ok_or_else(|| {
+            DeserializationError::InvalidValue("external digest length overflow".to_string())
+        })?;
+    let _external_digests = source.read_slice(external_digests_len)?;
+
+    let node_hash_count = node_count.checked_sub(external_digest_count).ok_or_else(|| {
+        DeserializationError::InvalidValue("node hash count underflow".to_string())
+    })?;
+    let node_hash_offset = if is_hashless {
+        None
+    } else {
+        let offset = source.offset().checked_sub(body_start).ok_or_else(|| {
+            DeserializationError::InvalidValue("node hash offset underflow".to_string())
+        })?;
+        let node_hash_len =
+            node_hash_count.checked_mul(crate::Word::min_serialized_size()).ok_or_else(|| {
+                DeserializationError::InvalidValue("node hash length overflow".to_string())
+            })?;
+        let _node_hashes = source.read_slice(node_hash_len)?;
+        Some(offset)
+    };
 
     Ok(ScannedForestLayout {
         node_count,
@@ -939,8 +1151,14 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
         roots_offset,
         basic_block_offset,
         basic_block_len,
-        node_info_offset,
-        node_info_size,
+        node_entry_offset,
+        node_entry_size,
+        external_digest_offset,
+        #[cfg(test)]
+        external_digest_count,
+        node_hash_offset,
+        #[cfg(test)]
+        node_hash_count,
     })
 }
 
@@ -1165,6 +1383,6 @@ impl Serializable for HashlessMastForest<'_> {
     }
 
     fn get_size_hint(&self) -> usize {
-        stripped_size_hint(self.0)
+        hashless_size_hint(self.0)
     }
 }

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -75,7 +75,10 @@
 //!
 //! In hashless format, the internal node-hash section is omitted and `HASHLESS` also implies
 //! `STRIPPED`. External node digests still stay on the wire because they cannot be rebuilt from
-//! local structure.
+//! local structure. This keeps hashless focused on the untrusted-validation use case: trusted
+//! reads reject `HASHLESS`, and the untrusted path rebuilds the data it actually trusts before
+//! use, so supporting a separate "hashless but with debug info" mode would add another wire mode
+//! without changing the validation semantics.
 //!
 //! Readers recover per-node digest lookup by scanning node entries once and building a compact
 //! "slot by node index" table. This preserves random access without forcing all digests into the
@@ -83,7 +86,8 @@
 //!
 //! Public entry points adopt these policies:
 //! - [`MastForest::read_from_bytes`]: trusted full payload, no hashless support.
-//! - [`SerializedMastForest::new`]: trusted structural inspection, including hashless payloads.
+//! - [`SerializedMastForest::new`]: structural inspection for local tooling, including hashless
+//!   payloads; not an untrusted-validation entry point.
 //! - [`crate::mast::UntrustedMastForest::read_from_bytes`] /
 //!   [`crate::mast::UntrustedMastForest::read_from_bytes_with_budgets`]: untrusted parsing plus
 //!   later validation before use.
@@ -184,7 +188,10 @@ const FLAG_STRIPPED: u8 = 0x01;
 /// Flag indicating that the internal node-hash section is omitted from the wire payload.
 ///
 /// External digests still remain serialized in their own section because they cannot be rebuilt
-/// from local structure. This flag implies [`FLAG_STRIPPED`].
+/// from local structure. This flag implies [`FLAG_STRIPPED`] because no supported consumer treats
+/// wire `DebugInfo` as trusted in hashless mode: [`crate::mast::MastForest`] rejects `HASHLESS`,
+/// [`SerializedMastForest::new`] accepts it only for structural inspection, and the untrusted path
+/// rebuilds the data it actually trusts before use.
 pub(super) const FLAG_HASHLESS: u8 = 0x02;
 
 /// Mask for reserved flag bits that must be zero.
@@ -471,11 +478,18 @@ impl<'a> SerializedMastForest<'a> {
     }
 
     /// Returns the procedure root id at the specified index.
+    ///
+    /// Returns an error if `index >= self.procedure_root_count()`.
     pub fn procedure_root_at(&self, index: usize) -> Result<MastNodeId, DeserializationError> {
         self.layout.read_procedure_root_at(self.bytes, index)
     }
 
     /// Returns the `MastNodeInfo` at the specified index.
+    ///
+    /// On hashless payloads, this may trigger the first digest-backed access and therefore the
+    /// one-time rebuild of the non-external digest table described in [`Self::node_digest_at`].
+    ///
+    /// Returns an error if `index >= self.node_count()`.
     ///
     /// # Examples
     ///
@@ -505,6 +519,8 @@ impl<'a> SerializedMastForest<'a> {
     }
 
     /// Returns the fixed-width structural node entry at the specified index.
+    ///
+    /// Returns an error if `index >= self.node_count()`.
     pub fn node_entry_at(&self, index: usize) -> Result<MastNodeEntry, DeserializationError> {
         self.layout.read_node_entry_at(self.bytes, index)
     }
@@ -513,6 +529,14 @@ impl<'a> SerializedMastForest<'a> {
     ///
     /// This resolves digests lazily. If the internal-hash section is absent, the first
     /// digest-backed access rebuilds all non-external node digests and caches them.
+    ///
+    /// This means the hashless cost model is:
+    /// - `node_count()`, `node_entry_at()`, and `procedure_root_at()` stay cheap and structural
+    /// - the first `node_digest_at()` / `node_info_at()` call does `O(node_count)` digest rebuild
+    ///   work and allocates the cached digest table
+    /// - later digest lookups reuse that cache
+    ///
+    /// Returns an error if `index >= self.node_count()`.
     pub fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
         self.resolved()?.node_digest_at(index)
     }

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -6,10 +6,7 @@ use crate::{
     chiplets::hasher,
     mast::{
         CallNode, DebugInfo, DynNode, JoinNode, LoopNode, SplitNode,
-        serialization::{
-            basic_blocks::BasicBlockDataDecoder, info::MastNodeType,
-            layout::read_fixed_section_entry,
-        },
+        serialization::{basic_blocks::BasicBlockDataDecoder, layout::read_fixed_section_entry},
     },
     serde::{Deserializable, DeserializationError, SliceReader},
 };
@@ -63,7 +60,7 @@ impl ForestDigests {
     ) -> Result<crate::Word, DeserializationError> {
         let digest_slot = self.slot_by_node[index] as usize;
 
-        if matches!(entry.node_type(), MastNodeType::External) {
+        if matches!(entry, MastNodeEntry::External) {
             return read_digest_entry(bytes, layout.external_digest_offset, digest_slot);
         }
 
@@ -208,7 +205,7 @@ fn build_digest_slot_by_node(
 
     for index in 0..layout.node_count {
         let entry = layout.read_node_entry_at(bytes, index)?;
-        if matches!(entry.node_type(), MastNodeType::External) {
+        if matches!(entry, MastNodeEntry::External) {
             slots.push(external_slot);
             external_slot = external_slot.checked_add(1).ok_or_else(|| {
                 DeserializationError::InvalidValue("external digest slot overflow".to_string())
@@ -239,44 +236,44 @@ fn recompute_hash_table(
 
     for index in 0..layout.node_count {
         let entry = layout.read_node_entry_at(bytes, index)?;
-        let computed = match entry.node_type() {
-            MastNodeType::Block { ops_offset } => {
+        let computed = match entry {
+            MastNodeEntry::Block { ops_offset } => {
                 let op_batches = basic_block_data_decoder.decode_operations(ops_offset)?;
                 let op_groups: Vec<Felt> =
                     op_batches.iter().flat_map(|batch| *batch.groups()).collect();
                 hasher::hash_elements(&op_groups)
             },
-            MastNodeType::Join { left_child_id, right_child_id } => {
+            MastNodeEntry::Join { left_child_id, right_child_id } => {
                 let left = checked_child_index(index, left_child_id, layout.node_count)?;
                 let right = checked_child_index(index, right_child_id, layout.node_count)?;
                 hasher::merge_in_domain(&[digests[left], digests[right]], JoinNode::DOMAIN)
             },
-            MastNodeType::Split { if_branch_id, else_branch_id } => {
+            MastNodeEntry::Split { if_branch_id, else_branch_id } => {
                 let on_true = checked_child_index(index, if_branch_id, layout.node_count)?;
                 let on_false = checked_child_index(index, else_branch_id, layout.node_count)?;
                 hasher::merge_in_domain(&[digests[on_true], digests[on_false]], SplitNode::DOMAIN)
             },
-            MastNodeType::Loop { body_id } => {
+            MastNodeEntry::Loop { body_id } => {
                 let body = checked_child_index(index, body_id, layout.node_count)?;
                 hasher::merge_in_domain(&[digests[body], crate::Word::default()], LoopNode::DOMAIN)
             },
-            MastNodeType::Call { callee_id } => {
+            MastNodeEntry::Call { callee_id } => {
                 let callee = checked_child_index(index, callee_id, layout.node_count)?;
                 hasher::merge_in_domain(
                     &[digests[callee], crate::Word::default()],
                     CallNode::CALL_DOMAIN,
                 )
             },
-            MastNodeType::SysCall { callee_id } => {
+            MastNodeEntry::SysCall { callee_id } => {
                 let callee = checked_child_index(index, callee_id, layout.node_count)?;
                 hasher::merge_in_domain(
                     &[digests[callee], crate::Word::default()],
                     CallNode::SYSCALL_DOMAIN,
                 )
             },
-            MastNodeType::Dyn => DynNode::DYN_DEFAULT_DIGEST,
-            MastNodeType::Dyncall => DynNode::DYNCALL_DEFAULT_DIGEST,
-            MastNodeType::External => {
+            MastNodeEntry::Dyn => DynNode::DYN_DEFAULT_DIGEST,
+            MastNodeEntry::Dyncall => DynNode::DYNCALL_DEFAULT_DIGEST,
+            MastNodeEntry::External => {
                 let digest =
                     read_digest_entry(bytes, layout.external_digest_offset, external_digest_index)?;
                 external_digest_index = external_digest_index.checked_add(1).ok_or_else(|| {

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -6,7 +6,10 @@ use crate::{
     chiplets::hasher,
     mast::{
         CallNode, DebugInfo, DynNode, JoinNode, LoopNode, SplitNode,
-        serialization::{basic_blocks::BasicBlockDataDecoder, info::MastNodeType},
+        serialization::{
+            basic_blocks::BasicBlockDataDecoder, info::MastNodeType,
+            layout::read_fixed_section_entry,
+        },
     },
     serde::{Deserializable, DeserializationError, SliceReader},
 };
@@ -64,7 +67,6 @@ impl ForestDigests {
 
 impl<'a> ResolvedSerializedForest<'a> {
     pub(super) fn new(bytes: &'a [u8], layout: ForestLayout) -> Result<Self, DeserializationError> {
-        let layout = layout.resolve()?;
         let digests = ForestDigests::new(bytes, &layout)?;
         Ok(Self { bytes, layout, digests })
     }
@@ -118,41 +120,14 @@ impl<'a> ResolvedSerializedForest<'a> {
         &self,
         index: usize,
     ) -> Result<MastNodeId, DeserializationError> {
-        if index >= self.layout.roots_count {
-            return Err(DeserializationError::InvalidValue(format!(
-                "root index {} out of bounds for {} roots",
-                index, self.layout.roots_count
-            )));
-        }
-
-        let mut raw = [0u8; core::mem::size_of::<u32>()];
-        raw.copy_from_slice(read_fixed_section_entry(
-            self.bytes,
-            self.layout.roots_offset,
-            core::mem::size_of::<u32>(),
-            index,
-            "root",
-        )?);
-        MastNodeId::from_u32_with_node_count(u32::from_le_bytes(raw), self.layout.node_count)
+        self.layout.read_procedure_root_at(self.bytes, index)
     }
 
     pub(super) fn node_entry_at(
         &self,
         index: usize,
     ) -> Result<MastNodeEntry, DeserializationError> {
-        if index >= self.layout.node_count {
-            return Err(DeserializationError::InvalidValue(format!(
-                "node index {} out of bounds for {} nodes",
-                index, self.layout.node_count
-            )));
-        }
-
-        read_node_entry(
-            self.bytes,
-            self.layout.node_entry_offset,
-            self.layout.node_entry_size,
-            index,
-        )
+        self.layout.read_node_entry_at(self.bytes, index)
     }
 
     pub(super) fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
@@ -169,61 +144,9 @@ impl<'a> ResolvedSerializedForest<'a> {
     }
 
     #[cfg(test)]
-    pub(super) fn advice_map_offset(&self) -> Result<usize, DeserializationError> {
-        let digest_section_end = if let Some(node_hash_offset) = self.layout.node_hash_offset {
-            node_hash_offset
-                .checked_add(self.layout.node_hash_count * crate::Word::min_serialized_size())
-                .ok_or_else(|| {
-                    DeserializationError::InvalidValue("node hash section overflow".to_string())
-                })?
-        } else {
-            self.layout
-                .external_digest_offset
-                .checked_add(self.layout.external_digest_count * crate::Word::min_serialized_size())
-                .ok_or_else(|| {
-                    DeserializationError::InvalidValue(
-                        "external digest section overflow".to_string(),
-                    )
-                })?
-        };
-
-        if digest_section_end > self.bytes.len() {
-            return Err(DeserializationError::UnexpectedEOF);
-        }
-
-        Ok(digest_section_end)
-    }
-
-    #[cfg(test)]
-    pub(super) fn node_entry_offset(&self) -> usize {
-        self.layout.node_entry_offset
-    }
-
-    #[cfg(test)]
-    pub(super) fn node_hash_offset(&self) -> Option<usize> {
-        self.layout.node_hash_offset
-    }
-
-    #[cfg(test)]
     pub(super) fn digest_slot_at(&self, index: usize) -> usize {
         self.digests.slot_by_node[index] as usize
     }
-}
-
-fn read_node_entry(
-    bytes: &[u8],
-    node_entry_offset: usize,
-    node_entry_size: usize,
-    index: usize,
-) -> Result<MastNodeEntry, DeserializationError> {
-    let mut reader = SliceReader::new(read_fixed_section_entry(
-        bytes,
-        node_entry_offset,
-        node_entry_size,
-        index,
-        "node entry",
-    )?);
-    MastNodeEntry::read_from(&mut reader)
 }
 
 fn read_digest_entry(
@@ -239,29 +162,6 @@ fn read_digest_entry(
         "digest",
     )?);
     crate::Word::read_from(&mut reader)
-}
-
-fn read_fixed_section_entry<'a>(
-    bytes: &'a [u8],
-    section_offset: usize,
-    entry_size: usize,
-    index: usize,
-    section_name: &str,
-) -> Result<&'a [u8], DeserializationError> {
-    let entry_offset = index
-        .checked_mul(entry_size)
-        .and_then(|delta| section_offset.checked_add(delta))
-        .ok_or_else(|| {
-            DeserializationError::InvalidValue(format!("{section_name} offset overflow"))
-        })?;
-    let entry_end = entry_offset.checked_add(entry_size).ok_or_else(|| {
-        DeserializationError::InvalidValue(format!("{section_name} length overflow"))
-    })?;
-    if entry_end > bytes.len() {
-        return Err(DeserializationError::UnexpectedEOF);
-    }
-
-    Ok(&bytes[entry_offset..entry_end])
 }
 
 fn basic_block_data(
@@ -287,8 +187,7 @@ fn build_digest_slot_by_node(
     let mut node_hash_slot = 0u32;
 
     for index in 0..layout.node_count {
-        let entry =
-            read_node_entry(bytes, layout.node_entry_offset, layout.node_entry_size, index)?;
+        let entry = layout.read_node_entry_at(bytes, index)?;
         if matches!(entry.node_type(), MastNodeType::External) {
             slots.push(external_slot);
             external_slot = external_slot.checked_add(1).ok_or_else(|| {
@@ -319,8 +218,7 @@ fn recompute_hash_table(
     let mut external_digest_index = 0usize;
 
     for index in 0..layout.node_count {
-        let entry =
-            read_node_entry(bytes, layout.node_entry_offset, layout.node_entry_size, index)?;
+        let entry = layout.read_node_entry_at(bytes, index)?;
         let computed = match entry.node_type() {
             MastNodeType::Block { ops_offset } => {
                 let op_batches = basic_block_data_decoder.decode_operations(ops_offset)?;

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -1,0 +1,421 @@
+use alloc::{string::ToString, vec::Vec};
+
+use super::{AdviceMap, ForestLayout, MastForest, MastNodeEntry, MastNodeId, basic_block_data_len};
+use crate::{
+    Felt,
+    chiplets::hasher,
+    mast::{
+        CallNode, DebugInfo, DynNode, JoinNode, LoopNode, SplitNode,
+        serialization::{basic_blocks::BasicBlockDataDecoder, info::MastNodeType},
+    },
+    serde::{Deserializable, DeserializationError, SliceReader},
+};
+
+#[derive(Debug, Clone)]
+struct ForestDigests {
+    slot_by_node: Vec<u32>,
+    hash_table: Option<Vec<crate::Word>>,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ResolvedSerializedForest<'a> {
+    bytes: &'a [u8],
+    layout: ForestLayout,
+    digests: ForestDigests,
+}
+
+impl ForestDigests {
+    fn new(bytes: &[u8], layout: &ForestLayout) -> Result<Self, DeserializationError> {
+        let slot_by_node = build_digest_slot_by_node(bytes, layout)?;
+        let hash_table = if layout.node_hash_offset.is_none() {
+            Some(recompute_hash_table(bytes, layout)?)
+        } else {
+            None
+        };
+
+        Ok(Self { slot_by_node, hash_table })
+    }
+
+    fn digest_at(
+        &self,
+        bytes: &[u8],
+        layout: &ForestLayout,
+        index: usize,
+        entry: MastNodeEntry,
+    ) -> Result<crate::Word, DeserializationError> {
+        let digest_slot = self.slot_by_node[index] as usize;
+
+        if matches!(entry.node_type(), MastNodeType::External) {
+            return read_digest_entry(bytes, layout.external_digest_offset, digest_slot);
+        }
+
+        if let Some(hash_table) = &self.hash_table {
+            return Ok(hash_table[index]);
+        }
+
+        let node_hash_offset = layout.node_hash_offset.ok_or_else(|| {
+            DeserializationError::InvalidValue(
+                "hash-backed digest lookup requested but node hash section is absent".to_string(),
+            )
+        })?;
+        read_digest_entry(bytes, node_hash_offset, digest_slot)
+    }
+}
+
+impl<'a> ResolvedSerializedForest<'a> {
+    pub(super) fn new(bytes: &'a [u8], layout: ForestLayout) -> Result<Self, DeserializationError> {
+        let layout = layout.resolve()?;
+        let digests = ForestDigests::new(bytes, &layout)?;
+        Ok(Self { bytes, layout, digests })
+    }
+
+    pub(super) fn materialize(
+        &self,
+        advice_map: AdviceMap,
+        debug_info: DebugInfo,
+    ) -> Result<MastForest, DeserializationError> {
+        let basic_block_data_decoder = BasicBlockDataDecoder::new(basic_block_data(
+            self.bytes,
+            self.layout.basic_block_offset,
+            self.layout.basic_block_len,
+        )?);
+        let mut mast_forest = MastForest::new();
+        mast_forest.debug_info = debug_info;
+
+        for index in 0..self.node_count() {
+            let entry = self.node_entry_at(index)?;
+            let digest = self.node_digest_for_entry(index, entry)?;
+
+            let mast_node_builder = entry.try_into_mast_node_builder(
+                self.node_count(),
+                &basic_block_data_decoder,
+                digest,
+            )?;
+            mast_node_builder.add_to_forest_relaxed(&mut mast_forest).map_err(|e| {
+                DeserializationError::InvalidValue(format!(
+                    "failed to add node to MAST forest while deserializing: {e}",
+                ))
+            })?;
+        }
+
+        for index in 0..self.procedure_root_count() {
+            mast_forest.make_root(self.procedure_root_at(index)?);
+        }
+
+        mast_forest.advice_map = advice_map;
+        Ok(mast_forest)
+    }
+
+    pub(super) fn node_count(&self) -> usize {
+        self.layout.node_count
+    }
+
+    pub(super) fn procedure_root_count(&self) -> usize {
+        self.layout.roots_count
+    }
+
+    pub(super) fn procedure_root_at(
+        &self,
+        index: usize,
+    ) -> Result<MastNodeId, DeserializationError> {
+        if index >= self.layout.roots_count {
+            return Err(DeserializationError::InvalidValue(format!(
+                "root index {} out of bounds for {} roots",
+                index, self.layout.roots_count
+            )));
+        }
+
+        let mut raw = [0u8; core::mem::size_of::<u32>()];
+        raw.copy_from_slice(read_fixed_section_entry(
+            self.bytes,
+            self.layout.roots_offset,
+            core::mem::size_of::<u32>(),
+            index,
+            "root",
+        )?);
+        MastNodeId::from_u32_with_node_count(u32::from_le_bytes(raw), self.layout.node_count)
+    }
+
+    pub(super) fn node_entry_at(
+        &self,
+        index: usize,
+    ) -> Result<MastNodeEntry, DeserializationError> {
+        if index >= self.layout.node_count {
+            return Err(DeserializationError::InvalidValue(format!(
+                "node index {} out of bounds for {} nodes",
+                index, self.layout.node_count
+            )));
+        }
+
+        read_node_entry(
+            self.bytes,
+            self.layout.node_entry_offset,
+            self.layout.node_entry_size,
+            index,
+        )
+    }
+
+    pub(super) fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
+        let entry = self.node_entry_at(index)?;
+        self.node_digest_for_entry(index, entry)
+    }
+
+    fn node_digest_for_entry(
+        &self,
+        index: usize,
+        entry: MastNodeEntry,
+    ) -> Result<crate::Word, DeserializationError> {
+        self.digests.digest_at(self.bytes, &self.layout, index, entry)
+    }
+
+    #[cfg(test)]
+    pub(super) fn advice_map_offset(&self) -> Result<usize, DeserializationError> {
+        let digest_section_end = if let Some(node_hash_offset) = self.layout.node_hash_offset {
+            node_hash_offset
+                .checked_add(self.layout.node_hash_count * crate::Word::min_serialized_size())
+                .ok_or_else(|| {
+                    DeserializationError::InvalidValue("node hash section overflow".to_string())
+                })?
+        } else {
+            self.layout
+                .external_digest_offset
+                .checked_add(self.layout.external_digest_count * crate::Word::min_serialized_size())
+                .ok_or_else(|| {
+                    DeserializationError::InvalidValue(
+                        "external digest section overflow".to_string(),
+                    )
+                })?
+        };
+
+        if digest_section_end > self.bytes.len() {
+            return Err(DeserializationError::UnexpectedEOF);
+        }
+
+        Ok(digest_section_end)
+    }
+
+    #[cfg(test)]
+    pub(super) fn node_entry_offset(&self) -> usize {
+        self.layout.node_entry_offset
+    }
+
+    #[cfg(test)]
+    pub(super) fn node_entry_size(&self) -> usize {
+        self.layout.node_entry_size
+    }
+
+    #[cfg(test)]
+    pub(super) fn node_hash_offset(&self) -> Option<usize> {
+        self.layout.node_hash_offset
+    }
+
+    #[cfg(test)]
+    pub(super) fn digest_slot_at(&self, index: usize) -> usize {
+        self.digests.slot_by_node[index] as usize
+    }
+}
+
+fn read_node_entry(
+    bytes: &[u8],
+    node_entry_offset: usize,
+    node_entry_size: usize,
+    index: usize,
+) -> Result<MastNodeEntry, DeserializationError> {
+    let mut reader = SliceReader::new(read_fixed_section_entry(
+        bytes,
+        node_entry_offset,
+        node_entry_size,
+        index,
+        "node entry",
+    )?);
+    MastNodeEntry::read_from(&mut reader)
+}
+
+fn read_digest_entry(
+    bytes: &[u8],
+    digest_section_offset: usize,
+    index: usize,
+) -> Result<crate::Word, DeserializationError> {
+    let mut reader = SliceReader::new(read_fixed_section_entry(
+        bytes,
+        digest_section_offset,
+        crate::Word::min_serialized_size(),
+        index,
+        "digest",
+    )?);
+    crate::Word::read_from(&mut reader)
+}
+
+fn read_fixed_section_entry<'a>(
+    bytes: &'a [u8],
+    section_offset: usize,
+    entry_size: usize,
+    index: usize,
+    section_name: &str,
+) -> Result<&'a [u8], DeserializationError> {
+    let entry_offset = index
+        .checked_mul(entry_size)
+        .and_then(|delta| section_offset.checked_add(delta))
+        .ok_or_else(|| {
+            DeserializationError::InvalidValue(format!("{section_name} offset overflow"))
+        })?;
+    let entry_end = entry_offset.checked_add(entry_size).ok_or_else(|| {
+        DeserializationError::InvalidValue(format!("{section_name} length overflow"))
+    })?;
+    if entry_end > bytes.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+
+    Ok(&bytes[entry_offset..entry_end])
+}
+
+fn basic_block_data(
+    bytes: &[u8],
+    basic_block_offset: usize,
+    basic_block_len: usize,
+) -> Result<&[u8], DeserializationError> {
+    let end = basic_block_offset.checked_add(basic_block_len).ok_or_else(|| {
+        DeserializationError::InvalidValue("basic-block data overflow".to_string())
+    })?;
+    if end > bytes.len() {
+        return Err(DeserializationError::UnexpectedEOF);
+    }
+    Ok(&bytes[basic_block_offset..end])
+}
+
+fn build_digest_slot_by_node(
+    bytes: &[u8],
+    layout: &ForestLayout,
+) -> Result<Vec<u32>, DeserializationError> {
+    let mut slots = Vec::with_capacity(layout.node_count);
+    let mut external_slot = 0u32;
+    let mut node_hash_slot = 0u32;
+
+    for index in 0..layout.node_count {
+        let entry =
+            read_node_entry(bytes, layout.node_entry_offset, layout.node_entry_size, index)?;
+        if matches!(entry.node_type(), MastNodeType::External) {
+            slots.push(external_slot);
+            external_slot = external_slot.checked_add(1).ok_or_else(|| {
+                DeserializationError::InvalidValue("external digest slot overflow".to_string())
+            })?;
+        } else {
+            slots.push(node_hash_slot);
+            node_hash_slot = node_hash_slot.checked_add(1).ok_or_else(|| {
+                DeserializationError::InvalidValue("node hash slot overflow".to_string())
+            })?;
+        }
+    }
+
+    Ok(slots)
+}
+
+fn recompute_hash_table(
+    bytes: &[u8],
+    layout: &ForestLayout,
+) -> Result<Vec<crate::Word>, DeserializationError> {
+    let basic_block_data_decoder = BasicBlockDataDecoder::new(basic_block_data(
+        bytes,
+        layout.basic_block_offset,
+        layout.basic_block_len,
+    )?);
+
+    let mut digests = Vec::with_capacity(layout.node_count);
+    let mut external_digest_index = 0usize;
+
+    for index in 0..layout.node_count {
+        let entry =
+            read_node_entry(bytes, layout.node_entry_offset, layout.node_entry_size, index)?;
+        let computed = match entry.node_type() {
+            MastNodeType::Block { ops_offset } => {
+                let op_batches = basic_block_data_decoder.decode_operations(ops_offset)?;
+                let op_groups: Vec<Felt> =
+                    op_batches.iter().flat_map(|batch| *batch.groups()).collect();
+                hasher::hash_elements(&op_groups)
+            },
+            MastNodeType::Join { left_child_id, right_child_id } => {
+                let left = checked_child_index(index, left_child_id, layout.node_count)?;
+                let right = checked_child_index(index, right_child_id, layout.node_count)?;
+                hasher::merge_in_domain(&[digests[left], digests[right]], JoinNode::DOMAIN)
+            },
+            MastNodeType::Split { if_branch_id, else_branch_id } => {
+                let on_true = checked_child_index(index, if_branch_id, layout.node_count)?;
+                let on_false = checked_child_index(index, else_branch_id, layout.node_count)?;
+                hasher::merge_in_domain(&[digests[on_true], digests[on_false]], SplitNode::DOMAIN)
+            },
+            MastNodeType::Loop { body_id } => {
+                let body = checked_child_index(index, body_id, layout.node_count)?;
+                hasher::merge_in_domain(&[digests[body], crate::Word::default()], LoopNode::DOMAIN)
+            },
+            MastNodeType::Call { callee_id } => {
+                let callee = checked_child_index(index, callee_id, layout.node_count)?;
+                hasher::merge_in_domain(
+                    &[digests[callee], crate::Word::default()],
+                    CallNode::CALL_DOMAIN,
+                )
+            },
+            MastNodeType::SysCall { callee_id } => {
+                let callee = checked_child_index(index, callee_id, layout.node_count)?;
+                hasher::merge_in_domain(
+                    &[digests[callee], crate::Word::default()],
+                    CallNode::SYSCALL_DOMAIN,
+                )
+            },
+            MastNodeType::Dyn => DynNode::DYN_DEFAULT_DIGEST,
+            MastNodeType::Dyncall => DynNode::DYNCALL_DEFAULT_DIGEST,
+            MastNodeType::External => {
+                let digest =
+                    read_digest_entry(bytes, layout.external_digest_offset, external_digest_index)?;
+                external_digest_index = external_digest_index.checked_add(1).ok_or_else(|| {
+                    DeserializationError::InvalidValue("external digest index overflow".to_string())
+                })?;
+                digest
+            },
+        };
+
+        digests.push(computed);
+    }
+
+    Ok(digests)
+}
+
+fn checked_child_index(
+    parent_index: usize,
+    child_id: u32,
+    node_count: usize,
+) -> Result<usize, DeserializationError> {
+    let child_index = child_id as usize;
+    if child_index >= node_count {
+        return Err(DeserializationError::InvalidValue(format!(
+            "child id {} out of bounds for {} nodes",
+            child_id, node_count
+        )));
+    }
+    if child_index >= parent_index {
+        return Err(DeserializationError::InvalidValue(format!(
+            "forward reference from node {} to {} (child index must be less than parent)",
+            parent_index, child_id
+        )));
+    }
+    Ok(child_index)
+}
+
+pub(super) fn basic_block_offset_for_node_index(
+    nodes: &[super::MastNode],
+    node_index: usize,
+) -> Result<u32, DeserializationError> {
+    let mut offset = 0usize;
+    for node in nodes.iter().take(node_index) {
+        if let super::MastNode::Block(block) = node {
+            offset = offset.checked_add(basic_block_data_len(block)).ok_or_else(|| {
+                DeserializationError::InvalidValue("basic-block data offset overflow".to_string())
+            })?;
+        }
+    }
+
+    offset.try_into().map_err(|_| {
+        DeserializationError::InvalidValue(
+            "basic-block data offset does not fit in u32".to_string(),
+        )
+    })
+}

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -20,6 +20,10 @@ use crate::{
 /// table. External nodes always read from the external-digest section.
 #[derive(Debug, Clone)]
 struct ForestDigests {
+    /// Dense slot index for each node within its digest section.
+    ///
+    /// External nodes index into the external-digest section. All other nodes index into the
+    /// general node-hash section or the rebuilt hash table.
     slot_by_node: Vec<u32>,
     hash_table: Option<Vec<crate::Word>>,
 }
@@ -195,6 +199,9 @@ fn build_digest_slot_by_node(
     bytes: &[u8],
     layout: &ForestLayout,
 ) -> Result<Vec<u32>, DeserializationError> {
+    // Digest sections are packed densely by node kind rather than by absolute node index.
+    // This scan records, for each node index, which slot to read from in the corresponding digest
+    // source.
     let mut slots = Vec::with_capacity(layout.node_count);
     let mut external_slot = 0u32;
     let mut node_hash_slot = 0u32;

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -200,11 +200,6 @@ impl<'a> ResolvedSerializedForest<'a> {
     }
 
     #[cfg(test)]
-    pub(super) fn node_entry_size(&self) -> usize {
-        self.layout.node_entry_size
-    }
-
-    #[cfg(test)]
     pub(super) fn node_hash_offset(&self) -> Option<usize> {
         self.layout.node_hash_offset
     }

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -1,6 +1,9 @@
-use alloc::{string::ToString, vec::Vec};
+use alloc::{format, string::ToString, vec::Vec};
 
-use super::{AdviceMap, ForestLayout, MastForest, MastNodeEntry, MastNodeId, basic_block_data_len};
+use super::{
+    AdviceMap, ForestLayout, MastForest, MastNodeEntry, MastNodeId, basic_block_data_len,
+    reserve_allocation,
+};
 use crate::{
     Felt,
     chiplets::hasher,
@@ -38,12 +41,17 @@ pub(super) struct ResolvedSerializedForest<'a> {
 }
 
 impl ForestDigests {
-    fn new(bytes: &[u8], layout: &ForestLayout) -> Result<Self, DeserializationError> {
-        let slot_by_node = build_digest_slot_by_node(bytes, layout)?;
+    fn new(
+        bytes: &[u8],
+        layout: &ForestLayout,
+        mut remaining_allocation_budget: Option<&mut usize>,
+    ) -> Result<Self, DeserializationError> {
+        let slot_by_node =
+            build_digest_slot_by_node(bytes, layout, remaining_allocation_budget.as_deref_mut())?;
         // If the internal-hash section is absent, rebuild all non-external digests once and cache
         // them for later lookups.
         let hash_table = if layout.node_hash_offset.is_none() {
-            Some(recompute_hash_table(bytes, layout)?)
+            Some(recompute_hash_table(bytes, layout, remaining_allocation_budget)?)
         } else {
             None
         };
@@ -80,7 +88,18 @@ impl ForestDigests {
 impl<'a> ResolvedSerializedForest<'a> {
     /// Resolves digest access for a parsed serialized forest.
     pub(super) fn new(bytes: &'a [u8], layout: ForestLayout) -> Result<Self, DeserializationError> {
-        let digests = ForestDigests::new(bytes, &layout)?;
+        let digests = ForestDigests::new(bytes, &layout, None)?;
+        Ok(Self { bytes, layout, digests })
+    }
+
+    /// Resolves digest access for a parsed serialized forest while charging helper allocations
+    /// against an explicit untrusted validation budget.
+    pub(super) fn new_with_allocation_budget(
+        bytes: &'a [u8],
+        layout: ForestLayout,
+        mut allocation_budget: usize,
+    ) -> Result<Self, DeserializationError> {
+        let digests = ForestDigests::new(bytes, &layout, Some(&mut allocation_budget))?;
         Ok(Self { bytes, layout, digests })
     }
 
@@ -195,11 +214,18 @@ fn basic_block_data(
 fn build_digest_slot_by_node(
     bytes: &[u8],
     layout: &ForestLayout,
+    remaining_allocation_budget: Option<&mut usize>,
 ) -> Result<Vec<u32>, DeserializationError> {
     // Digest sections are packed densely by node kind rather than by absolute node index.
     // This scan records, for each node index, which slot to read from in the corresponding digest
     // source.
-    let mut slots = Vec::with_capacity(layout.node_count);
+    let mut slots = Vec::new();
+    reserve_node_capacity(
+        &mut slots,
+        layout.node_count,
+        "digest slot table",
+        remaining_allocation_budget,
+    )?;
     let mut external_slot = 0u32;
     let mut node_hash_slot = 0u32;
 
@@ -224,6 +250,7 @@ fn build_digest_slot_by_node(
 fn recompute_hash_table(
     bytes: &[u8],
     layout: &ForestLayout,
+    remaining_allocation_budget: Option<&mut usize>,
 ) -> Result<Vec<crate::Word>, DeserializationError> {
     let basic_block_data_decoder = BasicBlockDataDecoder::new(basic_block_data(
         bytes,
@@ -231,7 +258,13 @@ fn recompute_hash_table(
         layout.basic_block_len,
     )?);
 
-    let mut digests = Vec::with_capacity(layout.node_count);
+    let mut digests = Vec::new();
+    reserve_node_capacity(
+        &mut digests,
+        layout.node_count,
+        "hash table",
+        remaining_allocation_budget,
+    )?;
     let mut external_digest_index = 0usize;
 
     for index in 0..layout.node_count {
@@ -287,6 +320,22 @@ fn recompute_hash_table(
     }
 
     Ok(digests)
+}
+
+fn reserve_node_capacity<T>(
+    values: &mut Vec<T>,
+    node_count: usize,
+    label: &str,
+    remaining_allocation_budget: Option<&mut usize>,
+) -> Result<(), DeserializationError> {
+    if let Some(allocation_budget) = remaining_allocation_budget {
+        reserve_allocation::<T>(allocation_budget, node_count, label)?;
+    }
+    values.try_reserve_exact(node_count).map_err(|err| {
+        DeserializationError::InvalidValue(format!(
+            "failed to reserve {label} for {node_count} nodes: {err}",
+        ))
+    })
 }
 
 fn checked_child_index(

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -14,12 +14,21 @@ use crate::{
     serde::{Deserializable, DeserializationError, SliceReader},
 };
 
+/// Digest sources for a parsed serialized forest.
+///
+/// Non-external nodes either read from the internal-hash section or from a rebuilt in-memory hash
+/// table. External nodes always read from the external-digest section.
 #[derive(Debug, Clone)]
 struct ForestDigests {
     slot_by_node: Vec<u32>,
     hash_table: Option<Vec<crate::Word>>,
 }
 
+/// A serialized forest whose digest source has been resolved.
+///
+/// This is the elaborated layer between raw wire layout and a fully materialized [`MastForest`].
+/// It combines structural access from [`ForestLayout`] with digest access from either wire sections
+/// or a rebuilt in-memory hash table.
 #[derive(Debug, Clone)]
 pub(super) struct ResolvedSerializedForest<'a> {
     bytes: &'a [u8],
@@ -30,6 +39,8 @@ pub(super) struct ResolvedSerializedForest<'a> {
 impl ForestDigests {
     fn new(bytes: &[u8], layout: &ForestLayout) -> Result<Self, DeserializationError> {
         let slot_by_node = build_digest_slot_by_node(bytes, layout)?;
+        // If the internal-hash section is absent, rebuild all non-external digests once and cache
+        // them for later lookups.
         let hash_table = if layout.node_hash_offset.is_none() {
             Some(recompute_hash_table(bytes, layout)?)
         } else {
@@ -66,11 +77,13 @@ impl ForestDigests {
 }
 
 impl<'a> ResolvedSerializedForest<'a> {
+    /// Resolves digest access for a parsed serialized forest.
     pub(super) fn new(bytes: &'a [u8], layout: ForestLayout) -> Result<Self, DeserializationError> {
         let digests = ForestDigests::new(bytes, &layout)?;
         Ok(Self { bytes, layout, digests })
     }
 
+    /// Materializes a full [`MastForest`] from the serialized structure and resolved digests.
     pub(super) fn materialize(
         &self,
         advice_map: AdviceMap,

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -25,6 +25,11 @@ struct ForestDigests {
     /// External nodes index into the external-digest section. All other nodes index into the
     /// general node-hash section or the rebuilt hash table.
     slot_by_node: Vec<u32>,
+    /// Source of non-external digests.
+    ///
+    /// `None` means the serialized bytes still contain the internal node-hash section, so
+    /// lookups read directly from the wire. `Some(...)` means the payload was hashless and the
+    /// non-external digests have been recomputed once into this cache.
     hash_table: Option<Vec<crate::Word>>,
 }
 
@@ -41,6 +46,12 @@ pub(super) struct ResolvedSerializedForest<'a> {
 }
 
 impl ForestDigests {
+    /// Resolves how later digest lookups will be served for a parsed serialized forest.
+    ///
+    /// `bytes` and `layout` provide the already-scanned structural wire view. When
+    /// `remaining_allocation_budget` is `Some`, helper allocations needed for untrusted validation
+    /// such as the slot table and rebuilt hash table are charged against that budget. Trusted
+    /// structural views pass `None` here, which keeps the previous unbudgeted inspection behavior.
     fn new(
         bytes: &[u8],
         layout: &ForestLayout,
@@ -66,14 +77,26 @@ impl ForestDigests {
         index: usize,
         entry: MastNodeEntry,
     ) -> Result<crate::Word, DeserializationError> {
-        let digest_slot = self.slot_by_node[index] as usize;
+        let digest_slot = self.slot_by_node.get(index).copied().ok_or_else(|| {
+            DeserializationError::InvalidValue(format!(
+                "node index {} out of bounds for {} digest slots",
+                index,
+                self.slot_by_node.len()
+            ))
+        })? as usize;
 
         if matches!(entry, MastNodeEntry::External) {
             return read_digest_entry(bytes, layout.external_digest_offset, digest_slot);
         }
 
         if let Some(hash_table) = &self.hash_table {
-            return Ok(hash_table[index]);
+            return hash_table.get(index).copied().ok_or_else(|| {
+                DeserializationError::InvalidValue(format!(
+                    "node index {} out of bounds for {} rebuilt digests",
+                    index,
+                    hash_table.len()
+                ))
+            });
         }
 
         let node_hash_offset = layout.node_hash_offset.ok_or_else(|| {
@@ -163,11 +186,16 @@ impl<'a> ResolvedSerializedForest<'a> {
         self.layout.read_node_entry_at(self.bytes, index)
     }
 
+    /// Returns the digest for the node at `index`.
+    ///
+    /// The caller-supplied index is checked via [`Self::node_entry_at`] before the digest lookup
+    /// reaches the internal slot table.
     pub(super) fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
         let entry = self.node_entry_at(index)?;
         self.node_digest_for_entry(index, entry)
     }
 
+    /// Returns the digest for a node whose entry was already read and bounds-checked by the caller.
     fn node_digest_for_entry(
         &self,
         index: usize,
@@ -202,6 +230,8 @@ fn basic_block_data(
     basic_block_offset: usize,
     basic_block_len: usize,
 ) -> Result<&[u8], DeserializationError> {
+    // Layout scanning already established the coarse section boundaries. This helper keeps the
+    // consumer-side slice extraction explicit and local to the basic-block decoder path.
     let end = basic_block_offset.checked_add(basic_block_len).ok_or_else(|| {
         DeserializationError::InvalidValue("basic-block data overflow".to_string())
     })?;

--- a/core/src/mast/serialization/seed_gen.rs
+++ b/core/src/mast/serialization/seed_gen.rs
@@ -22,6 +22,12 @@ use crate::{
 #[test]
 #[ignore = "run manually to generate fuzz seeds"]
 fn generate_fuzz_seeds() {
+    fn write_mast_seed(targets: &[&str], name: &str, bytes: &[u8]) {
+        for target in targets {
+            write_seed(target, name, bytes);
+        }
+    }
+
     fn write_seed(target: &str, name: &str, bytes: &[u8]) {
         let corpus_dir = std::path::Path::new("../miden-core-fuzz/corpus").join(target);
         std::fs::create_dir_all(&corpus_dir).expect("Failed to create corpus directory");
@@ -38,7 +44,18 @@ fn generate_fuzz_seeds() {
         forest.make_root(block_id);
 
         let bytes = forest.to_bytes();
-        write_seed("mast_forest_deserialize", "minimal_block.bin", &bytes);
+        write_mast_seed(
+            &[
+                "mast_forest_deserialize",
+                "mast_forest_validate",
+                "mast_node_info",
+                "serialized_mast_forest_new",
+                "basic_block_data",
+                "debug_info",
+            ],
+            "minimal_block.bin",
+            &bytes,
+        );
     }
 
     // Seed 2: Forest with join node
@@ -54,7 +71,18 @@ fn generate_fuzz_seeds() {
         forest.make_root(join);
 
         let bytes = forest.to_bytes();
-        write_seed("mast_forest_deserialize", "join_node.bin", &bytes);
+        write_mast_seed(
+            &[
+                "mast_forest_deserialize",
+                "mast_forest_validate",
+                "mast_node_info",
+                "serialized_mast_forest_new",
+                "basic_block_data",
+                "debug_info",
+            ],
+            "join_node.bin",
+            &bytes,
+        );
     }
 
     // Seed 3: Stripped forest (no debug info)
@@ -67,19 +95,64 @@ fn generate_fuzz_seeds() {
 
         let mut bytes = Vec::new();
         forest.write_stripped(&mut bytes);
-        write_seed("mast_forest_deserialize", "stripped.bin", &bytes);
+        write_mast_seed(
+            &[
+                "mast_forest_deserialize",
+                "mast_forest_validate",
+                "mast_node_info",
+                "serialized_mast_forest_new",
+                "basic_block_data",
+            ],
+            "stripped.bin",
+            &bytes,
+        );
     }
 
-    // Seed 4: Empty header (just magic + flags + version + minimal counts)
+    // Seed 4: Hashless forest (no internal hash section, no debug info)
+    {
+        let mut forest = MastForest::new();
+        let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+            .add_to_forest(&mut forest)
+            .unwrap();
+        forest.make_root(block_id);
+
+        let mut bytes = Vec::new();
+        forest.write_hashless(&mut bytes);
+        write_mast_seed(
+            &["mast_forest_validate", "mast_node_info", "serialized_mast_forest_new"],
+            "hashless.bin",
+            &bytes,
+        );
+    }
+
+    // Seed 5: Empty header (just magic + flags + version + minimal counts)
     {
         let bytes: &[u8] = b"MAST\x00\x00\x00\x01";
-        write_seed("mast_forest_deserialize", "header_only.bin", bytes);
+        write_mast_seed(
+            &[
+                "mast_forest_deserialize",
+                "mast_forest_validate",
+                "mast_node_info",
+                "serialized_mast_forest_new",
+            ],
+            "header_only.bin",
+            bytes,
+        );
     }
 
-    // Seed 5: Invalid magic
+    // Seed 6: Invalid magic
     {
         let bytes: &[u8] = b"XXXX\x00\x00\x00\x01";
-        write_seed("mast_forest_deserialize", "invalid_magic.bin", bytes);
+        write_mast_seed(
+            &[
+                "mast_forest_deserialize",
+                "mast_forest_validate",
+                "mast_node_info",
+                "serialized_mast_forest_new",
+            ],
+            "invalid_magic.bin",
+            bytes,
+        );
     }
 
     // Program seed

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -1,18 +1,56 @@
-use std::string::ToString;
+use std::{
+    string::{String, ToString},
+    sync::{Mutex, Once},
+};
 
 use super::*;
 use crate::{
     Felt, ONE, Word,
     chiplets::hasher,
     mast::{
-        BasicBlockNodeBuilder, CallNodeBuilder, DynNodeBuilder, ExternalNodeBuilder,
-        JoinNodeBuilder, LoopNodeBuilder, MastForestContributor, MastForestError, MastNodeExt,
-        MastForestView, MastNodeId, OP_BATCH_SIZE, OpBatch, SplitNodeBuilder, UntrustedMastForest,
+        BasicBlockNodeBuilder, CallNodeBuilder, DebugInfo, DynNodeBuilder, ExternalNodeBuilder,
+        JoinNodeBuilder, LoopNodeBuilder, MastForestContributor, MastForestError, MastForestView,
+        MastNodeExt, MastNodeId, OP_BATCH_SIZE, OpBatch, SplitNodeBuilder, UntrustedMastForest,
     },
     operations::{DebugOptions, Decorator, Operation},
-    serde::{ByteReader, DeserializationError, SliceReader},
+    serde::{ByteReader, Deserializable, DeserializationError, Serializable, SliceReader},
     utils::Idx,
 };
+
+struct TestLogger {
+    messages: Mutex<Vec<String>>,
+}
+
+impl log::Log for TestLogger {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
+        metadata.level() <= log::Level::Error
+    }
+
+    fn log(&self, record: &log::Record<'_>) {
+        if self.enabled(record.metadata()) {
+            self.messages.lock().unwrap().push(record.args().to_string());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static TEST_LOGGER: TestLogger = TestLogger { messages: Mutex::new(Vec::new()) };
+static TEST_LOGGER_INIT: Once = Once::new();
+static TEST_LOGGER_GUARD: Mutex<()> = Mutex::new(());
+
+fn with_captured_error_logs<T>(f: impl FnOnce() -> T) -> (T, Vec<String>) {
+    TEST_LOGGER_INIT.call_once(|| {
+        log::set_logger(&TEST_LOGGER).expect("test logger should be installed once");
+        log::set_max_level(log::LevelFilter::Error);
+    });
+
+    let _guard = TEST_LOGGER_GUARD.lock().unwrap();
+    TEST_LOGGER.messages.lock().unwrap().clear();
+    let result = f();
+    let messages = TEST_LOGGER.messages.lock().unwrap().clone();
+    (result, messages)
+}
 
 /// If this test fails to compile, it means that `Operation` or `Decorator` was changed. Make sure
 /// that all tests in this file are updated accordingly. For example, if a new `Operation` variant
@@ -604,7 +642,7 @@ fn sample_full_view_bytes_with_debug_info() -> Vec<u8> {
 
 fn debug_info_offset_after_advice_map(bytes: &[u8]) -> usize {
     let view = SerializedMastForest::new(bytes).unwrap();
-    let mut offset = view.node_info_offset + view.node_count * view.node_info_size;
+    let mut offset = view.advice_map_offset().unwrap();
     let entry_count = read_usize_at(bytes, &mut offset).unwrap();
     for _ in 0..entry_count {
         for _ in 0..4 {
@@ -618,11 +656,41 @@ fn debug_info_offset_after_advice_map(bytes: &[u8]) -> usize {
     offset
 }
 
+fn node_hash_digest_offset(view: &SerializedMastForest<'_>, node_index: usize) -> usize {
+    let digest_slot = view.digest_slot_by_node[node_index] as usize;
+    view.node_hash_offset.unwrap() + digest_slot * Word::min_serialized_size()
+}
+
+fn rewrite_debug_info_procedure_name_digest(
+    bytes: &[u8],
+    from_digest: Word,
+    to_digest: Word,
+) -> Vec<u8> {
+    let debug_info_offset = debug_info_offset_after_advice_map(bytes);
+    let mut reader = SliceReader::new(&bytes[debug_info_offset..]);
+    let mut debug_info = DebugInfo::read_from(&mut reader).unwrap();
+
+    let procedure_names: Vec<_> = debug_info
+        .procedure_names()
+        .map(|(digest, name)| {
+            let remapped_digest = if digest == from_digest { to_digest } else { digest };
+            (remapped_digest, name.to_string().into())
+        })
+        .collect();
+
+    debug_info.clear_procedure_names();
+    debug_info.extend_procedure_names(procedure_names);
+
+    let mut rewritten = bytes[..debug_info_offset].to_vec();
+    debug_info.write_into(&mut rewritten);
+    rewritten
+}
+
 #[test]
 fn test_serialized_mast_forest_allows_truncated_after_node_info() {
     let bytes = sample_serialized_view_bytes();
     let view = SerializedMastForest::new(&bytes).unwrap();
-    let node_info_end = view.node_info_offset + view.node_count * view.node_info_size;
+    let node_info_end = view.advice_map_offset().unwrap();
 
     let truncated = bytes[..node_info_end].to_vec();
     let truncated_view = SerializedMastForest::new(&truncated).unwrap();
@@ -633,7 +701,7 @@ fn test_serialized_mast_forest_allows_truncated_after_node_info() {
 fn test_trusted_deserialize_rejects_truncated_after_node_info() {
     let bytes = sample_serialized_view_bytes();
     let view = SerializedMastForest::new(&bytes).unwrap();
-    let node_info_end = view.node_info_offset + view.node_count * view.node_info_size;
+    let node_info_end = view.advice_map_offset().unwrap();
 
     let truncated = bytes[..node_info_end].to_vec();
     assert_matches!(
@@ -646,7 +714,7 @@ fn test_trusted_deserialize_rejects_truncated_after_node_info() {
 fn test_serialized_mast_forest_rejects_truncated_inside_node_info() {
     let bytes = sample_serialized_view_bytes();
     let view = SerializedMastForest::new(&bytes).unwrap();
-    let truncation_point = view.node_info_offset + view.node_info_size - 1;
+    let truncation_point = view.node_entry_offset + view.node_entry_size - 1;
 
     let truncated = bytes[..truncation_point].to_vec();
     assert_matches!(
@@ -706,7 +774,7 @@ fn test_serialized_mast_forest_new_ignores_malformed_advice_map_felt() {
     let mut bytes = sample_serialized_view_bytes();
     let view = SerializedMastForest::new(&bytes).unwrap();
 
-    let advice_map_offset = view.node_info_offset + view.node_count * view.node_info_size;
+    let advice_map_offset = view.advice_map_offset().unwrap();
     let mut offset = advice_map_offset;
     let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
 
@@ -723,7 +791,7 @@ fn test_trusted_deserialize_rejects_malformed_advice_map_felt() {
     let mut bytes = sample_serialized_view_bytes();
     let view = SerializedMastForest::new(&bytes).unwrap();
 
-    let advice_map_offset = view.node_info_offset + view.node_count * view.node_info_size;
+    let advice_map_offset = view.advice_map_offset().unwrap();
     let mut offset = advice_map_offset;
     let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
 
@@ -744,7 +812,7 @@ fn test_serialized_mast_forest_new_ignores_malformed_advice_map_value_felt() {
     let mut bytes = sample_serialized_view_bytes();
     let view = SerializedMastForest::new(&bytes).unwrap();
 
-    let advice_map_offset = view.node_info_offset + view.node_count * view.node_info_size;
+    let advice_map_offset = view.advice_map_offset().unwrap();
     let mut offset = advice_map_offset;
     let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
     for _ in 0..4 {
@@ -766,7 +834,7 @@ fn test_trusted_deserialize_rejects_malformed_advice_map_value_felt() {
     let mut bytes = sample_serialized_view_bytes();
     let view = SerializedMastForest::new(&bytes).unwrap();
 
-    let advice_map_offset = view.node_info_offset + view.node_count * view.node_info_size;
+    let advice_map_offset = view.advice_map_offset().unwrap();
     let mut offset = advice_map_offset;
     let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
     for _ in 0..4 {
@@ -812,7 +880,7 @@ fn test_trusted_deserialize_rejects_truncated_debug_info_in_full_format() {
 }
 
 #[test]
-fn test_serialized_mast_forest_hashless_recomputes_digests() {
+fn test_serialized_mast_forest_hashless_omits_hash_section_and_recomputes_digests() {
     let mut forest = MastForest::new();
     let block1 = BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Mul], Vec::new())
         .add_to_forest(&mut forest)
@@ -825,45 +893,29 @@ fn test_serialized_mast_forest_hashless_recomputes_digests() {
 
     let mut bytes = Vec::new();
     forest.write_hashless(&mut bytes);
-    let baseline_view = SerializedMastForest::new(&bytes).unwrap();
-    assert!(baseline_view.is_hashless());
-
-    let mut corrupted = bytes.clone();
-    for index in 0..baseline_view.node_count {
-        let digest_offset =
-            baseline_view.node_info_offset + index * baseline_view.node_info_size + 8;
-        corrupted[digest_offset..digest_offset + 32].fill(0);
-    }
-
-    let corrupted_view = SerializedMastForest::new(&corrupted).unwrap();
-    assert!(corrupted_view.is_hashless());
-    for index in 0..baseline_view.node_count() {
-        assert_eq!(
-            baseline_view.node_info_at(index).unwrap().digest(),
-            corrupted_view.node_info_at(index).unwrap().digest()
-        );
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    assert!(view.is_hashless());
+    assert!(view.node_hash_offset.is_none());
+    for index in 0..view.node_count() {
+        assert_eq!(forest.nodes()[index].digest(), view.node_info_at(index).unwrap().digest());
     }
 }
 
 #[test]
 fn test_serialized_mast_forest_hashless_accepts_external_nodes_parse_only() {
     let mut forest = MastForest::new();
-    let external_id = ExternalNodeBuilder::new(Word::new([
-        Felt::new(1),
-        Felt::new(2),
-        Felt::new(3),
-        Felt::new(4),
-    ]))
-    .add_to_forest(&mut forest)
-    .unwrap();
+    let external_digest = Word::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
+    let external_id = ExternalNodeBuilder::new(external_digest).add_to_forest(&mut forest).unwrap();
     forest.make_root(external_id);
 
     let mut bytes = Vec::new();
     forest.write_hashless(&mut bytes);
     let view = SerializedMastForest::new(&bytes).unwrap();
     assert!(view.is_hashless());
+    assert!(view.node_hash_offset.is_none());
     assert_eq!(view.node_count(), 1);
     assert!(view.node_info_at(0).is_ok());
+    assert_eq!(view.node_digest_at(0).unwrap(), external_digest);
 }
 
 /// Test that a forest with a node whose child ids are larger than its own id serializes and
@@ -1091,19 +1143,17 @@ fn mast_forest_deserialize_invalid_ops_offset_fails() {
     let _node_count: usize = reader.read().unwrap();
     let _decorator_count: usize = reader.read().unwrap();
     let _roots: Vec<u32> = Deserializable::read_from(&mut reader).unwrap();
-    let basic_block_data: Vec<u8> = Deserializable::read_from(&mut reader).unwrap();
+    let _basic_block_data: Vec<u8> = Deserializable::read_from(&mut reader).unwrap();
 
-    // Calculate offset to MastNodeInfo:
-    // magic (4) + flags (1) + version (3) + node_count (8) + decorator_count (8) +
-    // roots_len (8) + 1 root (4) + bb_data_len (8) + bb_data
-    let node_info_offset = 4 + 1 + 3 + 8 + 8 + 8 + 4 + 8 + basic_block_data.len();
+    let view = SerializedMastForest::new(&serialized).unwrap();
+    let node_entry_offset = view.node_entry_offset;
 
     // Corrupt the ops_offset field with an out-of-bounds value
     let block_discriminant: u64 = 3;
     let corrupted_value = (block_discriminant << 60) | u32::MAX as u64;
 
     let mut corrupted = serialized;
-    corrupted_value.write_into(&mut &mut corrupted[node_info_offset..node_info_offset + 8]);
+    corrupted_value.write_into(&mut &mut corrupted[node_entry_offset..node_entry_offset + 8]);
 
     let result = MastForest::read_from_bytes(&corrupted);
     assert_matches!(result, Err(DeserializationError::InvalidValue(_)));
@@ -1413,8 +1463,8 @@ fn test_header_backward_compatible() {
     // Check header structure: MAST (4 bytes) + flags (1 byte) + version (3 bytes)
     assert_eq!(&bytes[0..4], b"MAST", "Magic should be MAST");
     assert_eq!(bytes[4], 0x00, "Flags should be 0x00 for full serialization");
-    // Version [0, 0, 3] includes: HASHLESS flag addition
-    assert_eq!(&bytes[5..8], &[0, 0, 3], "Version should be [0, 0, 3]");
+    // Version [0, 0, 4] splits node entries from digest sections.
+    assert_eq!(&bytes[5..8], &[0, 0, 4], "Version should be [0, 0, 4]");
 }
 
 /// Test that legacy version headers are rejected.
@@ -1465,6 +1515,39 @@ fn test_stripped_serialization_smaller_than_full() {
         stripped_bytes.len(),
         full_bytes.len()
     );
+}
+
+/// Test that hashless serialization saves bytes by omitting the general node-hash section.
+#[test]
+fn test_hashless_serialization_smaller_than_stripped() {
+    let mut forest = MastForest::new();
+
+    let block1 = BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Mul], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let block2 = BasicBlockNodeBuilder::new(vec![Operation::U32div], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut forest).unwrap();
+    forest.make_root(join);
+
+    let mut stripped_bytes = Vec::new();
+    forest.write_stripped(&mut stripped_bytes);
+
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+
+    assert!(
+        hashless_bytes.len() < stripped_bytes.len(),
+        "Hashless ({} bytes) should be smaller than stripped ({} bytes)",
+        hashless_bytes.len(),
+        stripped_bytes.len()
+    );
+
+    let stripped_view = SerializedMastForest::new(&stripped_bytes).unwrap();
+    let hashless_view = SerializedMastForest::new(&hashless_bytes).unwrap();
+    assert!(stripped_view.node_hash_offset.is_some());
+    assert!(hashless_view.node_hash_offset.is_none());
 }
 
 /// Test that stripped serialization round-trips correctly with empty DebugInfo.
@@ -1583,8 +1666,8 @@ fn test_stripped_header_flags() {
     // Check header structure
     assert_eq!(&stripped_bytes[0..4], b"MAST", "Magic should be MAST");
     assert_eq!(stripped_bytes[4], 0x01, "Flags should be 0x01 for stripped serialization");
-    // Version [0, 0, 3] includes: HASHLESS flag addition
-    assert_eq!(&stripped_bytes[5..8], &[0, 0, 3], "Version should be [0, 0, 3]");
+    // Version [0, 0, 4] splits node entries from digest sections.
+    assert_eq!(&stripped_bytes[5..8], &[0, 0, 4], "Version should be [0, 0, 4]");
 }
 
 /// Test that node digests are preserved in stripped serialization.
@@ -1654,7 +1737,7 @@ fn test_hashless_header_flags() {
         hashless_bytes[4], 0x03,
         "Flags should be 0x03 for hashless serialization (STRIPPED + HASHLESS)"
     );
-    assert_eq!(&hashless_bytes[5..8], &[0, 0, 3], "Version should be [0, 0, 3]");
+    assert_eq!(&hashless_bytes[5..8], &[0, 0, 4], "Version should be [0, 0, 4]");
 }
 
 /// Test that trusted deserialization rejects hashless inputs.
@@ -1726,6 +1809,71 @@ fn test_untrusted_read_with_flags() {
     assert_eq!(hashless_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
 }
 
+#[test]
+fn test_untrusted_hashless_input_emits_no_overspecification_logs() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+
+    let (result, logs) = with_captured_error_logs(|| {
+        UntrustedMastForest::read_from_bytes_with_flags(&hashless_bytes)
+    });
+
+    let (untrusted, flags) = result.unwrap();
+    assert_eq!(flags, 0x03);
+    assert!(logs.is_empty());
+    assert_eq!(untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+}
+
+#[test]
+fn test_untrusted_stripped_with_hashes_logs_overspecification() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let mut stripped_bytes = Vec::new();
+    forest.write_stripped(&mut stripped_bytes);
+
+    let (result, logs) = with_captured_error_logs(|| {
+        UntrustedMastForest::read_from_bytes_with_flags(&stripped_bytes)
+    });
+
+    let (untrusted, flags) = result.unwrap();
+    assert_eq!(flags, 0x01);
+    assert_eq!(logs.len(), 1);
+    assert!(logs[0].contains("wire node hashes"));
+    assert_eq!(untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+}
+
+#[test]
+fn test_untrusted_full_input_logs_overspecification() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+    forest.insert_procedure_name(forest[block_id].digest(), "test".into());
+
+    let bytes = forest.to_bytes();
+
+    let (result, logs) =
+        with_captured_error_logs(|| UntrustedMastForest::read_from_bytes_with_flags(&bytes));
+
+    let (untrusted, flags) = result.unwrap();
+    assert_eq!(flags, 0x00);
+    assert_eq!(logs.len(), 2);
+    assert!(logs.iter().any(|msg| msg.contains("wire node hashes")));
+    assert!(logs.iter().any(|msg| msg.contains("DebugInfo")));
+    assert_eq!(untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+}
+
 /// Test that budgeted flag-returning APIs expose the correct header flags.
 #[test]
 fn test_untrusted_read_with_budget_and_flags() {
@@ -1765,10 +1913,10 @@ fn test_untrusted_read_with_budget_and_flags() {
     assert_eq!(hashless_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
 }
 
-/// Test that untrusted validation in hashless mode recomputes non-external digests
-/// instead of trusting serialized digest bytes.
+/// Test that untrusted validation in hashless mode recomputes non-external digests without any
+/// general wire hash section.
 #[test]
-fn test_untrusted_hashless_validate_ignores_wire_digests() {
+fn test_untrusted_hashless_validate_recomputes_without_wire_hash_section() {
     let mut forest = MastForest::new();
     let block1 = BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Mul], Vec::new())
         .add_to_forest(&mut forest)
@@ -1784,14 +1932,7 @@ fn test_untrusted_hashless_validate_ignores_wire_digests() {
     let mut hashless_bytes = Vec::new();
     forest.write_hashless(&mut hashless_bytes);
     let view = SerializedMastForest::new(&hashless_bytes).unwrap();
-    let node_count = view.node_count;
-    let node_info_offset = view.node_info_offset;
-    let node_info_size = view.node_info_size;
-
-    for index in 0..node_count {
-        let digest_offset = node_info_offset + index * node_info_size + 8;
-        hashless_bytes[digest_offset..digest_offset + 32].fill(0);
-    }
+    assert!(view.node_hash_offset.is_none());
 
     let (untrusted, flags) =
         UntrustedMastForest::read_from_bytes_with_flags(&hashless_bytes).unwrap();
@@ -2294,9 +2435,9 @@ fn test_untrusted_forest_detects_forward_reference() {
     assert_matches!(result, Err(MastForestError::ForwardReference(_, _)));
 }
 
-/// Test that UntrustedMastForest::validate detects hash mismatches.
+/// Test that untrusted validation ignores wire hash mismatches and recomputes digests instead.
 #[test]
-fn test_untrusted_forest_detects_hash_mismatch() {
+fn test_untrusted_forest_ignores_wire_hash_mismatch() {
     let mut forest = MastForest::new();
     let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
         .add_to_forest(&mut forest)
@@ -2304,32 +2445,110 @@ fn test_untrusted_forest_detects_hash_mismatch() {
     forest.make_root(block_id);
 
     let bytes = forest.to_bytes();
+    let expected = forest.clone();
 
-    // Corrupt the digest of the node by modifying bytes in the node info section
-    // Format: magic (4) + flags (1) + version (3) + node_count (8) + decorator_count (8) +
-    //         roots_len (8) + 1 root (4) + bb_data_len (8) + bb_data + node_info
-    //
-    // First, determine where the node info section starts
-    let mut reader = SliceReader::new(&bytes);
-    let _header: [u8; 8] = reader.read_array().unwrap();
-    let _node_count: usize = reader.read().unwrap();
-    let _decorator_count: usize = reader.read().unwrap();
-    let _roots: Vec<u32> = Deserializable::read_from(&mut reader).unwrap();
-    let basic_block_data: Vec<u8> = Deserializable::read_from(&mut reader).unwrap();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    let digest_offset = node_hash_digest_offset(&view, 0);
 
-    // Node info starts after: 4 + 1 + 3 + 8 + 8 + 8 + 4 + 8 + bb_data.len()
-    let node_info_offset = 4 + 1 + 3 + 8 + 8 + 8 + 4 + 8 + basic_block_data.len();
-
-    // Node info format: type (8 bytes) + digest (32 bytes = 4 x 8 bytes)
-    // Corrupt one byte in the digest (byte 8-15 of node info)
+    // Corrupt one byte in the node-hash section.
     let mut corrupted = bytes.clone();
-    corrupted[node_info_offset + 8] ^= 0xff; // Flip bits in first word of digest
+    corrupted[digest_offset] ^= 0xff;
 
-    // Deserialize as untrusted and try to validate
+    // Deserialize as untrusted and validate. The corrupted wire digest should be ignored.
     let untrusted = UntrustedMastForest::read_from_bytes(&corrupted).unwrap();
-    let result = untrusted.validate();
+    let validated = untrusted.validate().unwrap();
+    assert_eq!(validated, expected);
+}
 
-    assert_matches!(result, Err(MastForestError::HashMismatch { .. }));
+#[test]
+fn test_untrusted_forest_remaps_procedure_names_after_hash_recompute() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+    let expected_digest = forest[block_id].digest();
+    forest.insert_procedure_name(expected_digest, "proc".into());
+
+    let bytes = forest.to_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    let digest_offset = node_hash_digest_offset(&view, block_id.to_usize());
+    let bogus_digest: Word = [Felt::new(9), Felt::new(8), Felt::new(7), Felt::new(6)].into();
+
+    let mut corrupted =
+        rewrite_debug_info_procedure_name_digest(&bytes, expected_digest, bogus_digest);
+    bogus_digest.write_into(
+        &mut &mut corrupted[digest_offset..digest_offset + Word::min_serialized_size()],
+    );
+
+    let untrusted = UntrustedMastForest::read_from_bytes(&corrupted).unwrap();
+    let validated = untrusted.validate().unwrap();
+
+    assert_eq!(validated[block_id].digest(), expected_digest);
+    assert_eq!(validated.procedure_name(&expected_digest), Some("proc"));
+    assert_eq!(validated.debug_info().num_procedure_names(), 1);
+}
+
+#[test]
+fn test_untrusted_forest_keeps_procedure_names_when_only_wire_root_hash_is_corrupted() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+    let expected_digest = forest[block_id].digest();
+    forest.insert_procedure_name(expected_digest, "proc".into());
+
+    let bytes = forest.to_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    let digest_offset = node_hash_digest_offset(&view, block_id.to_usize());
+    let bogus_digest: Word = [Felt::new(9), Felt::new(8), Felt::new(7), Felt::new(6)].into();
+
+    let mut corrupted = bytes.clone();
+    bogus_digest.write_into(
+        &mut &mut corrupted[digest_offset..digest_offset + Word::min_serialized_size()],
+    );
+
+    let untrusted = UntrustedMastForest::read_from_bytes(&corrupted).unwrap();
+    let validated = untrusted.validate().unwrap();
+
+    assert_eq!(validated[block_id].digest(), expected_digest);
+    assert_eq!(validated.procedure_name(&expected_digest), Some("proc"));
+    assert_eq!(validated.debug_info().num_procedure_names(), 1);
+}
+
+#[test]
+fn test_untrusted_forest_preserves_incoming_root_resolution_on_digest_collision() {
+    let mut forest = MastForest::new();
+    let left_root = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let right_root = BasicBlockNodeBuilder::new(vec![Operation::Mul], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(left_root);
+    forest.make_root(right_root);
+
+    let left_digest = forest[left_root].digest();
+    let right_digest = forest[right_root].digest();
+    forest.insert_procedure_name(right_digest, "right".into());
+
+    let bytes = forest.to_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    let left_digest_offset = node_hash_digest_offset(&view, left_root.to_usize());
+
+    let mut corrupted = bytes.clone();
+    right_digest.write_into(
+        &mut &mut corrupted[left_digest_offset..left_digest_offset + Word::min_serialized_size()],
+    );
+
+    let untrusted = UntrustedMastForest::read_from_bytes(&corrupted).unwrap();
+    let validated = untrusted.validate().unwrap();
+
+    assert_eq!(validated[left_root].digest(), left_digest);
+    assert_eq!(validated[right_root].digest(), right_digest);
+    assert_eq!(validated.procedure_name(&left_digest), Some("right"));
+    assert_eq!(validated.procedure_name(&right_digest), None);
 }
 
 // UNTRUSTED VALIDATION TEST HELPERS
@@ -2401,8 +2620,8 @@ fn build_malicious_single_block_forest_bytes(push_imm: Felt) -> Vec<u8> {
 
     bytes[indptr_offset..indptr_offset + 4].copy_from_slice(&malicious_packed_indptr);
 
-    // Recompute the correct digest for the now-malformed decoding and patch it into node info, so
-    // that `UntrustedMastForest::validate()` will accept it if the issue exists.
+    // Recompute the correct digest for the now-malformed decoding and patch it into the node-hash
+    // section, so that `UntrustedMastForest::validate()` will accept it if the issue exists.
     if let Some(digest) = compute_single_block_digest_from_decoded_groups(&bytes) {
         bytes[digest_offset..digest_offset + 32].copy_from_slice(&digest.to_bytes());
     }
@@ -2483,13 +2702,12 @@ fn locate_single_block_indptr_and_digest_offsets(bytes: &[u8]) -> (usize, usize)
     let bb_data_len: usize = cursor.read().unwrap();
     let bb_payload_start = cursor.position();
     let bb_payload_end = bb_payload_start + bb_data_len;
+    let view = SerializedMastForest::new(bytes).unwrap();
+    let node_entries_start = view.node_entry_offset;
 
-    // node infos start immediately after basic block data payload
-    let node_infos_start = bb_payload_end;
-
-    // node info: MastNodeType (8 bytes) + digest Word (32 bytes)
+    // node entry: MastNodeType (8 bytes)
     let node_type_u64 = u64::from_le_bytes(
-        bytes[node_infos_start..node_infos_start + 8]
+        bytes[node_entries_start..node_entries_start + 8]
             .try_into()
             .expect("node type bytes"),
     );
@@ -2500,7 +2718,7 @@ fn locate_single_block_indptr_and_digest_offsets(bytes: &[u8]) -> (usize, usize)
     assert!(payload <= u32::MAX as u64, "Block ops_offset payload must fit in u32");
     let ops_offset = payload as usize;
 
-    let digest_offset = node_infos_start + 8;
+    let digest_offset = view.node_hash_offset.unwrap();
 
     // Locate the start of the packed indptr for the first (and only) batch.
     let block_start = bb_payload_start + ops_offset;
@@ -2599,23 +2817,22 @@ fn test_untrusted_forest_rejects_basic_block_indptr_that_breaks_push_immediate_c
 
     // A fix may choose to reject this encoding at validation time. Either (or both) being `Err`
     // is an acceptable outcome: it prevents the commitment gap.
+    let assert_expected_rejection = |result: Result<MastForest, MastForestError>| match result {
+        Err(MastForestError::InvalidBatchPadding(_, msg)) => {
+            assert!(msg.contains("push immediate"));
+        },
+        Err(MastForestError::Deserialization(DeserializationError::InvalidValue(msg))) => {
+            assert!(msg.contains("push immediate"));
+        },
+        Err(err) => panic!("unexpected validation error: {err:?}"),
+        Ok(_) => {},
+    };
+
     let (forest_a, forest_b) = match (validated_a, validated_b) {
         (Ok(forest_a), Ok(forest_b)) => (forest_a, forest_b),
         (validated_a, validated_b) => {
-            match validated_a {
-                Err(MastForestError::InvalidBatchPadding(_, msg)) => {
-                    assert!(msg.contains("push immediate"));
-                },
-                Err(err) => panic!("unexpected validation error: {err:?}"),
-                Ok(_) => {},
-            }
-            match validated_b {
-                Err(MastForestError::InvalidBatchPadding(_, msg)) => {
-                    assert!(msg.contains("push immediate"));
-                },
-                Err(err) => panic!("unexpected validation error: {err:?}"),
-                Ok(_) => {},
-            }
+            assert_expected_rejection(validated_a);
+            assert_expected_rejection(validated_b);
             return;
         },
     };

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -2247,7 +2247,7 @@ fn locate_single_block_indptr_and_digest_offsets(bytes: &[u8]) -> (usize, usize)
     let view = SerializedMastForest::new(bytes).unwrap();
     let node_entries_start = view.node_entry_offset();
 
-    // node entry: MastNodeType (8 bytes)
+    // node entry: MastNodeEntry (8 bytes)
     let node_type_u64 = u64::from_le_bytes(
         bytes[node_entries_start..node_entries_start + 8]
             .try_into()

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -464,7 +464,9 @@ fn test_operation_encoded_size_push_varint_boundaries() {
         72_057_594_037_927_935,
         72_057_594_037_927_936,
     ] {
-        assert_operation_encoded_size_matches_serialized_len(Operation::Push(Felt::new(value)));
+        assert_operation_encoded_size_matches_serialized_len(Operation::Push(Felt::new_unchecked(
+            value,
+        )));
     }
 }
 
@@ -493,7 +495,7 @@ fn test_mast_forest_view_trait_matches_serialized_view() {
     let mut forest = MastForest::new();
 
     let block1 = BasicBlockNodeBuilder::new(
-        vec![Operation::Push(Felt::new(7)), Operation::Add, Operation::Mul],
+        vec![Operation::Push(Felt::new_unchecked(7)), Operation::Add, Operation::Mul],
         Vec::new(),
     )
     .add_to_forest(&mut forest)
@@ -654,7 +656,12 @@ fn test_serialized_mast_forest_hashless_omits_hash_section_and_recomputes_digest
 #[test]
 fn test_serialized_mast_forest_hashless_accepts_external_nodes_parse_only() {
     let mut forest = MastForest::new();
-    let external_digest = Word::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
+    let external_digest = Word::new([
+        Felt::new_unchecked(1),
+        Felt::new_unchecked(2),
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(4),
+    ]);
     let external_id = ExternalNodeBuilder::new(external_digest).add_to_forest(&mut forest).unwrap();
     forest.make_root(external_id);
 
@@ -1300,19 +1307,23 @@ fn assert_stripped_size_hint_matches_serialized_len(forest: &MastForest) {
 fn test_stripped_size_hint_matches_serialized_len() {
     let mut small_forest = MastForest::new();
 
-    let block1 =
-        BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Push(Felt::new(3))], Vec::new())
-            .add_to_forest(&mut small_forest)
-            .unwrap();
+    let block1 = BasicBlockNodeBuilder::new(
+        vec![Operation::Add, Operation::Push(Felt::new_unchecked(3))],
+        Vec::new(),
+    )
+    .add_to_forest(&mut small_forest)
+    .unwrap();
     let block2 = BasicBlockNodeBuilder::new(
-        vec![Operation::U32div, Operation::Assert(Felt::new(1))],
+        vec![Operation::U32div, Operation::Assert(Felt::new_unchecked(1))],
         Vec::new(),
     )
     .add_to_forest(&mut small_forest)
     .unwrap();
     let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut small_forest).unwrap();
     small_forest.make_root(join);
-    small_forest.advice_map_mut().insert(Word::default(), vec![ONE, Felt::new(2)]);
+    small_forest
+        .advice_map_mut()
+        .insert(Word::default(), vec![ONE, Felt::new_unchecked(2)]);
     assert_stripped_size_hint_matches_serialized_len(&small_forest);
 
     let mut forest = MastForest::new();
@@ -1321,21 +1332,31 @@ fn test_stripped_size_hint_matches_serialized_len() {
     for _ in 0..300 {
         operations.push(Operation::Add);
     }
-    operations.push(Operation::Push(Felt::new(7)));
-    operations.push(Operation::Assert(Felt::new(9)));
-    operations.push(Operation::U32assert2(Felt::new(11)));
-    operations.push(Operation::MpVerify(Felt::new(13)));
+    operations.push(Operation::Push(Felt::new_unchecked(7)));
+    operations.push(Operation::Assert(Felt::new_unchecked(9)));
+    operations.push(Operation::U32assert2(Felt::new_unchecked(11)));
+    operations.push(Operation::MpVerify(Felt::new_unchecked(13)));
 
     let block_id = BasicBlockNodeBuilder::new(operations, Vec::new())
         .add_to_forest(&mut forest)
         .unwrap();
     forest.make_root(block_id);
 
-    let key_a = Word::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
-    let key_b = Word::new([Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)]);
+    let key_a = Word::new([
+        Felt::new_unchecked(1),
+        Felt::new_unchecked(2),
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(4),
+    ]);
+    let key_b = Word::new([
+        Felt::new_unchecked(5),
+        Felt::new_unchecked(6),
+        Felt::new_unchecked(7),
+        Felt::new_unchecked(8),
+    ]);
 
-    let values_a: Vec<Felt> = (0..200).map(|i| Felt::new(i as u64)).collect();
-    let values_b: Vec<Felt> = (0..5).map(|i| Felt::new((i + 10) as u64)).collect();
+    let values_a: Vec<Felt> = (0..200).map(|i| Felt::new_unchecked(i as u64)).collect();
+    let values_b: Vec<Felt> = (0..5).map(|i| Felt::new_unchecked((i + 10) as u64)).collect();
 
     forest.advice_map_mut().insert(key_a, values_a);
     forest.advice_map_mut().insert(key_b, values_b);
@@ -1542,10 +1563,10 @@ fn test_untrusted_hashless_validate_recomputes_without_wire_hash_section() {
 fn test_untrusted_hashless_external_parse_and_validate() {
     let mut forest = MastForest::new();
     let external = ExternalNodeBuilder::new(Word::new([
-        Felt::new(10),
-        Felt::new(11),
-        Felt::new(12),
-        Felt::new(13),
+        Felt::new_unchecked(10),
+        Felt::new_unchecked(11),
+        Felt::new_unchecked(12),
+        Felt::new_unchecked(13),
     ]))
     .add_to_forest(&mut forest)
     .unwrap();
@@ -2018,7 +2039,13 @@ fn test_untrusted_forest_rejects_mismatched_wire_root_hash() {
     let bytes = forest.to_bytes();
     let view = SerializedMastForest::new(&bytes).unwrap();
     let digest_offset = node_hash_digest_offset(&view, block_id.to_usize());
-    let bogus_digest: Word = [Felt::new(9), Felt::new(8), Felt::new(7), Felt::new(6)].into();
+    let bogus_digest: Word = [
+        Felt::new_unchecked(9),
+        Felt::new_unchecked(8),
+        Felt::new_unchecked(7),
+        Felt::new_unchecked(6),
+    ]
+    .into();
 
     let mut corrupted =
         rewrite_debug_info_procedure_name_digest(&bytes, expected_digest, bogus_digest);
@@ -2050,7 +2077,13 @@ fn test_untrusted_forest_rejects_invalid_procedure_name_digest_without_remapping
     forest.insert_procedure_name(expected_digest, "proc".into());
 
     let bytes = forest.to_bytes();
-    let bogus_digest: Word = [Felt::new(9), Felt::new(8), Felt::new(7), Felt::new(6)].into();
+    let bogus_digest: Word = [
+        Felt::new_unchecked(9),
+        Felt::new_unchecked(8),
+        Felt::new_unchecked(7),
+        Felt::new_unchecked(6),
+    ]
+    .into();
 
     let corrupted = rewrite_debug_info_procedure_name_digest(&bytes, expected_digest, bogus_digest);
 

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -7,7 +7,7 @@ use crate::{
     mast::{
         BasicBlockNodeBuilder, CallNodeBuilder, DynNodeBuilder, ExternalNodeBuilder,
         JoinNodeBuilder, LoopNodeBuilder, MastForestContributor, MastForestError, MastNodeExt,
-        MastNodeId, OP_BATCH_SIZE, OpBatch, SplitNodeBuilder, UntrustedMastForest,
+        MastForestView, MastNodeId, OP_BATCH_SIZE, OpBatch, SplitNodeBuilder, UntrustedMastForest,
     },
     operations::{DebugOptions, Decorator, Operation},
     serde::{ByteReader, DeserializationError, SliceReader},
@@ -118,91 +118,190 @@ fn confirm_operation_and_decorator_structure() {
     };
 }
 
+/// Returns all currently supported basic-block [`Operation`] variants.
+///
+/// Control-flow instructions (e.g. `join`, `split`, `loop`, `call`) are represented as
+/// [`MastNode`] variants, not as basic-block [`Operation`] values.
+fn sample_basic_block_operations_all_variants() -> Vec<Operation> {
+    vec![
+        Operation::Noop,
+        Operation::Assert(Felt::from_u32(42)),
+        Operation::SDepth,
+        Operation::Caller,
+        Operation::Clk,
+        Operation::Add,
+        Operation::Neg,
+        Operation::Mul,
+        Operation::Inv,
+        Operation::Incr,
+        Operation::And,
+        Operation::Or,
+        Operation::Not,
+        Operation::Eq,
+        Operation::Eqz,
+        Operation::Expacc,
+        Operation::Ext2Mul,
+        Operation::U32split,
+        Operation::U32add,
+        Operation::U32assert2(Felt::from_u32(222)),
+        Operation::U32add3,
+        Operation::U32sub,
+        Operation::U32mul,
+        Operation::U32madd,
+        Operation::U32div,
+        Operation::U32and,
+        Operation::U32xor,
+        Operation::Pad,
+        Operation::Drop,
+        Operation::Dup0,
+        Operation::Dup1,
+        Operation::Dup2,
+        Operation::Dup3,
+        Operation::Dup4,
+        Operation::Dup5,
+        Operation::Dup6,
+        Operation::Dup7,
+        Operation::Dup9,
+        Operation::Dup11,
+        Operation::Dup13,
+        Operation::Dup15,
+        Operation::Swap,
+        Operation::SwapW,
+        Operation::SwapW2,
+        Operation::SwapW3,
+        Operation::SwapDW,
+        Operation::MovUp2,
+        Operation::MovUp3,
+        Operation::MovUp4,
+        Operation::MovUp5,
+        Operation::MovUp6,
+        Operation::MovUp7,
+        Operation::MovUp8,
+        Operation::MovDn2,
+        Operation::MovDn3,
+        Operation::MovDn4,
+        Operation::MovDn5,
+        Operation::MovDn6,
+        Operation::MovDn7,
+        Operation::MovDn8,
+        Operation::CSwap,
+        Operation::CSwapW,
+        Operation::Push(Felt::new_unchecked(45)),
+        Operation::AdvPop,
+        Operation::AdvPopW,
+        Operation::MLoadW,
+        Operation::MStoreW,
+        Operation::MLoad,
+        Operation::MStore,
+        Operation::MStream,
+        Operation::Pipe,
+        Operation::CryptoStream,
+        Operation::HPerm,
+        Operation::MpVerify(Felt::from_u32(1022)),
+        Operation::MrUpdate,
+        Operation::FriE2F4,
+        Operation::HornerBase,
+        Operation::HornerExt,
+        Operation::EvalCircuit,
+        Operation::Emit,
+        Operation::LogPrecompile,
+    ]
+}
+
+fn assert_operation_encoded_size_matches_serialized_len(operation: Operation) {
+    match operation {
+        operation @ (Operation::Noop
+        | Operation::Assert(_)
+        | Operation::SDepth
+        | Operation::Caller
+        | Operation::Clk
+        | Operation::Add
+        | Operation::Neg
+        | Operation::Mul
+        | Operation::Inv
+        | Operation::Incr
+        | Operation::And
+        | Operation::Or
+        | Operation::Not
+        | Operation::Eq
+        | Operation::Eqz
+        | Operation::Expacc
+        | Operation::Ext2Mul
+        | Operation::U32split
+        | Operation::U32add
+        | Operation::U32assert2(_)
+        | Operation::U32add3
+        | Operation::U32sub
+        | Operation::U32mul
+        | Operation::U32madd
+        | Operation::U32div
+        | Operation::U32and
+        | Operation::U32xor
+        | Operation::Pad
+        | Operation::Drop
+        | Operation::Dup0
+        | Operation::Dup1
+        | Operation::Dup2
+        | Operation::Dup3
+        | Operation::Dup4
+        | Operation::Dup5
+        | Operation::Dup6
+        | Operation::Dup7
+        | Operation::Dup9
+        | Operation::Dup11
+        | Operation::Dup13
+        | Operation::Dup15
+        | Operation::Swap
+        | Operation::SwapW
+        | Operation::SwapW2
+        | Operation::SwapW3
+        | Operation::SwapDW
+        | Operation::MovUp2
+        | Operation::MovUp3
+        | Operation::MovUp4
+        | Operation::MovUp5
+        | Operation::MovUp6
+        | Operation::MovUp7
+        | Operation::MovUp8
+        | Operation::MovDn2
+        | Operation::MovDn3
+        | Operation::MovDn4
+        | Operation::MovDn5
+        | Operation::MovDn6
+        | Operation::MovDn7
+        | Operation::MovDn8
+        | Operation::CSwap
+        | Operation::CSwapW
+        | Operation::Push(_)
+        | Operation::AdvPop
+        | Operation::AdvPopW
+        | Operation::MLoadW
+        | Operation::MStoreW
+        | Operation::MLoad
+        | Operation::MStore
+        | Operation::MStream
+        | Operation::Pipe
+        | Operation::CryptoStream
+        | Operation::HPerm
+        | Operation::MpVerify(_)
+        | Operation::MrUpdate
+        | Operation::FriE2F4
+        | Operation::HornerBase
+        | Operation::HornerExt
+        | Operation::EvalCircuit
+        | Operation::Emit
+        | Operation::LogPrecompile) => {
+            assert_eq!(operation.encoded_size(), operation.to_bytes().len());
+        },
+    }
+}
+
 #[test]
 fn serialize_deserialize_all_nodes() {
     let mut mast_forest = MastForest::new();
 
     let basic_block_id = {
-        let operations = vec![
-            Operation::Noop,
-            Operation::Assert(Felt::from_u32(42)),
-            Operation::SDepth,
-            Operation::Caller,
-            Operation::Clk,
-            Operation::Add,
-            Operation::Neg,
-            Operation::Mul,
-            Operation::Inv,
-            Operation::Incr,
-            Operation::And,
-            Operation::Or,
-            Operation::Not,
-            Operation::Eq,
-            Operation::Eqz,
-            Operation::Expacc,
-            Operation::Ext2Mul,
-            Operation::U32split,
-            Operation::U32add,
-            Operation::U32assert2(Felt::from_u32(222)),
-            Operation::U32add3,
-            Operation::U32sub,
-            Operation::U32mul,
-            Operation::U32madd,
-            Operation::U32div,
-            Operation::U32and,
-            Operation::U32xor,
-            Operation::Pad,
-            Operation::Drop,
-            Operation::Dup0,
-            Operation::Dup1,
-            Operation::Dup2,
-            Operation::Dup3,
-            Operation::Dup4,
-            Operation::Dup5,
-            Operation::Dup6,
-            Operation::Dup7,
-            Operation::Dup9,
-            Operation::Dup11,
-            Operation::Dup13,
-            Operation::Dup15,
-            Operation::Swap,
-            Operation::SwapW,
-            Operation::SwapW2,
-            Operation::SwapW3,
-            Operation::SwapDW,
-            Operation::MovUp2,
-            Operation::MovUp3,
-            Operation::MovUp4,
-            Operation::MovUp5,
-            Operation::MovUp6,
-            Operation::MovUp7,
-            Operation::MovUp8,
-            Operation::MovDn2,
-            Operation::MovDn3,
-            Operation::MovDn4,
-            Operation::MovDn5,
-            Operation::MovDn6,
-            Operation::MovDn7,
-            Operation::MovDn8,
-            Operation::CSwap,
-            Operation::CSwapW,
-            Operation::Push(Felt::new_unchecked(45)),
-            Operation::AdvPop,
-            Operation::AdvPopW,
-            Operation::MLoadW,
-            Operation::MStoreW,
-            Operation::MLoad,
-            Operation::MStore,
-            Operation::MStream,
-            Operation::Pipe,
-            Operation::HPerm,
-            Operation::MpVerify(Felt::from_u32(1022)),
-            Operation::MrUpdate,
-            Operation::FriE2F4,
-            Operation::HornerBase,
-            Operation::HornerExt,
-            Operation::Emit,
-        ];
+        let operations = sample_basic_block_operations_all_variants();
 
         let num_operations = operations.len();
 
@@ -218,21 +317,18 @@ fn serialize_deserialize_all_nodes() {
             (num_operations, Decorator::Trace(55)),
         ];
 
-        {
-            // Convert raw decorators to decorator list by adding them to the forest first
-            let decorator_list: Vec<(usize, crate::mast::DecoratorId)> = decorators
+        // Convert raw decorators to decorator list by adding them to the forest first
+        let decorator_list: Vec<(usize, crate::mast::DecoratorId)> = decorators
             .into_iter()
-            .map(|(idx, decorator)| -> Result<(usize, crate::mast::DecoratorId), MastForestError> {
-                let decorator_id = mast_forest.add_decorator(decorator)?;
-                Ok((idx, decorator_id))
+            .map(|(idx, decorator)| {
+                mast_forest.add_decorator(decorator).map(|decorator_id| (idx, decorator_id))
             })
             .collect::<Result<Vec<_>, MastForestError>>()
             .unwrap();
 
-            BasicBlockNodeBuilder::new(operations, decorator_list)
-                .add_to_forest(&mut mast_forest)
-                .unwrap()
-        }
+        BasicBlockNodeBuilder::new(operations, decorator_list)
+            .add_to_forest(&mut mast_forest)
+            .unwrap()
     };
 
     // Decorators to add to following nodes
@@ -307,6 +403,467 @@ fn serialize_deserialize_all_nodes() {
     let deserialized_mast_forest = MastForest::read_from_bytes(&serialized_mast_forest).unwrap();
 
     assert_eq!(mast_forest, deserialized_mast_forest);
+}
+
+#[test]
+fn test_operation_encoded_size_matches_serialized_len() {
+    for operation in sample_basic_block_operations_all_variants() {
+        assert_operation_encoded_size_matches_serialized_len(operation);
+    }
+}
+
+#[test]
+fn test_operation_encoded_size_push_varint_boundaries() {
+    for value in [
+        127u64,
+        128,
+        16_383,
+        16_384,
+        2_097_151,
+        2_097_152,
+        268_435_455,
+        268_435_456,
+        72_057_594_037_927_935,
+        72_057_594_037_927_936,
+    ] {
+        assert_operation_encoded_size_matches_serialized_len(Operation::Push(Felt::new(value)));
+    }
+}
+
+fn assert_serialized_view_matches_forest(forest: &MastForest) {
+    let mut bytes = Vec::new();
+    forest.write_stripped(&mut bytes);
+
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    assert_eq!(view.node_count(), forest.nodes().len());
+
+    let mut bb_builder = super::basic_blocks::BasicBlockDataBuilder::new();
+    for (idx, node) in forest.nodes().iter().enumerate() {
+        let ops_offset = if let MastNode::Block(block) = node {
+            bb_builder.encode_basic_block(block)
+        } else {
+            0
+        };
+        let expected = MastNodeInfo::new(node, ops_offset);
+        let actual = view.node_info_at(idx).unwrap();
+        assert_eq!(expected.to_bytes(), actual.to_bytes());
+    }
+}
+
+#[test]
+fn test_serialized_mast_forest_random_access_node_info() {
+    let mut forest = MastForest::new();
+
+    let block1 = BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Mul], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let block2 = BasicBlockNodeBuilder::new(vec![Operation::U32div], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut forest).unwrap();
+    forest.make_root(join);
+
+    assert_serialized_view_matches_forest(&forest);
+}
+
+#[test]
+fn test_mast_forest_view_trait_matches_serialized_view() {
+    let mut forest = MastForest::new();
+
+    let block1 = BasicBlockNodeBuilder::new(
+        vec![Operation::Push(Felt::new(7)), Operation::Add, Operation::Mul],
+        Vec::new(),
+    )
+    .add_to_forest(&mut forest)
+    .unwrap();
+    let block2 = BasicBlockNodeBuilder::new(vec![Operation::U32div], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut forest).unwrap();
+    forest.make_root(join);
+
+    let mut bytes = Vec::new();
+    forest.write_stripped(&mut bytes);
+    let serialized = SerializedMastForest::new(&bytes).unwrap();
+
+    let in_memory: &dyn MastForestView = &forest;
+    let serialized_view: &dyn MastForestView = &serialized;
+
+    assert!(!in_memory.is_empty());
+    assert!(in_memory.has_node(0));
+    assert!(!in_memory.has_node(in_memory.node_count()));
+
+    assert_eq!(in_memory.node_count(), serialized_view.node_count());
+    for index in 0..in_memory.node_count() {
+        assert_eq!(
+            in_memory.node_info_at(index).unwrap().to_bytes(),
+            serialized_view.node_info_at(index).unwrap().to_bytes()
+        );
+        assert_eq!(
+            in_memory.node_digest_at(index).unwrap(),
+            serialized_view.node_digest_at(index).unwrap()
+        );
+    }
+
+    assert_eq!(in_memory.procedure_root_count(), serialized_view.procedure_root_count());
+    assert_eq!(in_memory.procedure_roots().unwrap(), serialized_view.procedure_roots().unwrap());
+
+    let in_memory_infos = in_memory.all_node_infos().unwrap();
+    let serialized_infos = serialized_view.all_node_infos().unwrap();
+    assert_eq!(in_memory_infos.len(), serialized_infos.len());
+    for (lhs, rhs) in in_memory_infos.iter().zip(serialized_infos.iter()) {
+        assert_eq!(lhs.to_bytes(), rhs.to_bytes());
+    }
+}
+
+#[test]
+fn test_serialized_mast_forest_random_access_all_node_types() {
+    let mut forest = MastForest::new();
+
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let call_id = CallNodeBuilder::new(block_id).add_to_forest(&mut forest).unwrap();
+    let syscall_id = CallNodeBuilder::new_syscall(block_id).add_to_forest(&mut forest).unwrap();
+    let loop_id = LoopNodeBuilder::new(block_id).add_to_forest(&mut forest).unwrap();
+    let join_id = JoinNodeBuilder::new([block_id, call_id]).add_to_forest(&mut forest).unwrap();
+    let split_id = SplitNodeBuilder::new([block_id, call_id]).add_to_forest(&mut forest).unwrap();
+    let dyn_id = DynNodeBuilder::new_dyn().add_to_forest(&mut forest).unwrap();
+    let dyncall_id = DynNodeBuilder::new_dyncall().add_to_forest(&mut forest).unwrap();
+    let external_id = ExternalNodeBuilder::new(Word::default()).add_to_forest(&mut forest).unwrap();
+
+    forest.make_root(join_id);
+    forest.make_root(syscall_id);
+    forest.make_root(loop_id);
+    forest.make_root(split_id);
+    forest.make_root(dyn_id);
+    forest.make_root(dyncall_id);
+    forest.make_root(external_id);
+
+    assert_serialized_view_matches_forest(&forest);
+}
+
+#[test]
+fn test_serialized_mast_forest_large_counts() {
+    let mut forest = MastForest::new();
+    let mut roots = Vec::new();
+
+    for _ in 0..300 {
+        let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+            .add_to_forest(&mut forest)
+            .unwrap();
+        roots.push(block_id);
+    }
+
+    for root in roots.iter().take(200) {
+        forest.make_root(*root);
+    }
+
+    assert_serialized_view_matches_forest(&forest);
+}
+
+#[test]
+fn test_serialized_mast_forest_accepts_full_format() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let bytes = forest.to_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    assert!(!view.is_stripped());
+    assert!(!view.is_hashless());
+    assert_eq!(view.node_count(), 1);
+    assert_eq!(view.procedure_root_count(), 1);
+    assert!(view.node_info_at(0).is_ok());
+}
+
+fn sample_serialized_view_bytes() -> Vec<u8> {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+    forest.advice_map_mut().insert(Word::default(), vec![ONE]);
+
+    let mut bytes = Vec::new();
+    forest.write_stripped(&mut bytes);
+    bytes
+}
+
+fn sample_full_view_bytes_with_debug_info() -> Vec<u8> {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+    forest.insert_procedure_name(forest[block_id].digest(), "proc".into());
+    forest.to_bytes()
+}
+
+fn debug_info_offset_after_advice_map(bytes: &[u8]) -> usize {
+    let view = SerializedMastForest::new(bytes).unwrap();
+    let mut offset = view.node_info_offset + view.node_count * view.node_info_size;
+    let entry_count = read_usize_at(bytes, &mut offset).unwrap();
+    for _ in 0..entry_count {
+        for _ in 0..4 {
+            let _ = read_array_at::<8>(bytes, &mut offset).unwrap();
+        }
+        let values_len = read_usize_at(bytes, &mut offset).unwrap();
+        for _ in 0..values_len {
+            let _ = read_array_at::<8>(bytes, &mut offset).unwrap();
+        }
+    }
+    offset
+}
+
+#[test]
+fn test_serialized_mast_forest_allows_truncated_after_node_info() {
+    let bytes = sample_serialized_view_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    let node_info_end = view.node_info_offset + view.node_count * view.node_info_size;
+
+    let truncated = bytes[..node_info_end].to_vec();
+    let truncated_view = SerializedMastForest::new(&truncated).unwrap();
+    assert_eq!(truncated_view.node_count(), view.node_count());
+}
+
+#[test]
+fn test_trusted_deserialize_rejects_truncated_after_node_info() {
+    let bytes = sample_serialized_view_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    let node_info_end = view.node_info_offset + view.node_count * view.node_info_size;
+
+    let truncated = bytes[..node_info_end].to_vec();
+    assert_matches!(
+        MastForest::read_from_bytes(&truncated),
+        Err(DeserializationError::UnexpectedEOF)
+    );
+}
+
+#[test]
+fn test_serialized_mast_forest_rejects_truncated_inside_node_info() {
+    let bytes = sample_serialized_view_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    let truncation_point = view.node_info_offset + view.node_info_size - 1;
+
+    let truncated = bytes[..truncation_point].to_vec();
+    assert_matches!(
+        SerializedMastForest::new(&truncated),
+        Err(DeserializationError::UnexpectedEOF)
+    );
+}
+
+#[test]
+fn test_serialized_mast_forest_rejects_malformed_varint_length() {
+    let bytes = sample_serialized_view_bytes();
+    let node_count_offset = MAGIC.len() + 1 + VERSION.len();
+
+    // 0x00 encodes a 9-byte usize; truncating immediately after it makes the varint incomplete.
+    let mut malformed = bytes[..=node_count_offset].to_vec();
+    malformed[node_count_offset] = 0x00;
+    assert_matches!(
+        SerializedMastForest::new(&malformed),
+        Err(DeserializationError::UnexpectedEOF)
+    );
+}
+
+#[test]
+fn test_serialized_mast_forest_rejects_unknown_flags() {
+    let mut bytes = sample_serialized_view_bytes();
+    bytes[4] = 0x04;
+
+    assert_matches!(
+        SerializedMastForest::new(&bytes),
+        Err(DeserializationError::InvalidValue(msg)) if msg.contains("Unknown flags")
+    );
+}
+
+#[test]
+fn test_serialized_mast_forest_rejects_hashless_without_stripped() {
+    let mut bytes = sample_serialized_view_bytes();
+    bytes[4] = 0x02;
+
+    assert_matches!(
+        SerializedMastForest::new(&bytes),
+        Err(DeserializationError::InvalidValue(msg))
+            if msg.contains("HASHLESS") && msg.contains("STRIPPED")
+    );
+}
+
+#[test]
+fn test_serialized_mast_forest_allows_trailing_bytes_after_layout_sections() {
+    let mut bytes = sample_serialized_view_bytes();
+    bytes.push(0x00);
+
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    assert!(view.node_count() > 0);
+}
+
+#[test]
+fn test_serialized_mast_forest_new_ignores_malformed_advice_map_felt() {
+    let mut bytes = sample_serialized_view_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+
+    let advice_map_offset = view.node_info_offset + view.node_count * view.node_info_size;
+    let mut offset = advice_map_offset;
+    let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
+
+    // Corrupt the first key limb to a non-canonical field element.
+    bytes[offset..offset + 8].copy_from_slice(&u64::MAX.to_le_bytes());
+
+    // SerializedMastForest::new only needs layout information and does not parse AdviceMap.
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    assert!(view.node_count() > 0);
+}
+
+#[test]
+fn test_trusted_deserialize_rejects_malformed_advice_map_felt() {
+    let mut bytes = sample_serialized_view_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+
+    let advice_map_offset = view.node_info_offset + view.node_count * view.node_info_size;
+    let mut offset = advice_map_offset;
+    let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
+
+    // Corrupt the first key limb to a non-canonical field element.
+    bytes[offset..offset + 8].copy_from_slice(&u64::MAX.to_le_bytes());
+
+    assert_matches!(
+        MastForest::read_from_bytes(&bytes),
+        Err(DeserializationError::InvalidValue(msg))
+            if msg.contains("invalid advice-map field element encoding")
+                || msg.contains("valid felt")
+                || msg.contains("appropriate range")
+    );
+}
+
+#[test]
+fn test_serialized_mast_forest_new_ignores_malformed_advice_map_value_felt() {
+    let mut bytes = sample_serialized_view_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+
+    let advice_map_offset = view.node_info_offset + view.node_count * view.node_info_size;
+    let mut offset = advice_map_offset;
+    let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
+    for _ in 0..4 {
+        let _ = read_array_at::<8>(&bytes, &mut offset).unwrap();
+    }
+    let values_len = read_usize_at(&bytes, &mut offset).unwrap();
+    assert!(values_len > 0);
+
+    // Corrupt the first value limb to a non-canonical field element.
+    bytes[offset..offset + 8].copy_from_slice(&u64::MAX.to_le_bytes());
+
+    // SerializedMastForest::new only needs layout information and does not parse AdviceMap.
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    assert!(view.node_count() > 0);
+}
+
+#[test]
+fn test_trusted_deserialize_rejects_malformed_advice_map_value_felt() {
+    let mut bytes = sample_serialized_view_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+
+    let advice_map_offset = view.node_info_offset + view.node_count * view.node_info_size;
+    let mut offset = advice_map_offset;
+    let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
+    for _ in 0..4 {
+        let _ = read_array_at::<8>(&bytes, &mut offset).unwrap();
+    }
+    let values_len = read_usize_at(&bytes, &mut offset).unwrap();
+    assert!(values_len > 0);
+
+    // Corrupt the first value limb to a non-canonical field element.
+    bytes[offset..offset + 8].copy_from_slice(&u64::MAX.to_le_bytes());
+
+    assert_matches!(
+        MastForest::read_from_bytes(&bytes),
+        Err(DeserializationError::InvalidValue(msg))
+            if msg.contains("invalid advice-map field element encoding")
+                || msg.contains("valid felt")
+                || msg.contains("appropriate range")
+    );
+}
+
+#[test]
+fn test_serialized_mast_forest_new_allows_truncated_debug_info_in_full_format() {
+    let bytes = sample_full_view_bytes_with_debug_info();
+    let debug_info_offset = debug_info_offset_after_advice_map(&bytes);
+    let truncated = bytes[..debug_info_offset].to_vec();
+
+    // SerializedMastForest::new only validates layout up to node metadata.
+    let view = SerializedMastForest::new(&truncated).unwrap();
+    assert!(!view.is_stripped());
+    assert!(view.node_count() > 0);
+}
+
+#[test]
+fn test_trusted_deserialize_rejects_truncated_debug_info_in_full_format() {
+    let bytes = sample_full_view_bytes_with_debug_info();
+    let debug_info_offset = debug_info_offset_after_advice_map(&bytes);
+    let truncated = bytes[..debug_info_offset].to_vec();
+
+    assert_matches!(
+        MastForest::read_from_bytes(&truncated),
+        Err(DeserializationError::UnexpectedEOF)
+    );
+}
+
+#[test]
+fn test_serialized_mast_forest_hashless_recomputes_digests() {
+    let mut forest = MastForest::new();
+    let block1 = BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Mul], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let block2 = BasicBlockNodeBuilder::new(vec![Operation::U32div], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut forest).unwrap();
+    forest.make_root(join);
+
+    let mut bytes = Vec::new();
+    forest.write_hashless(&mut bytes);
+    let baseline_view = SerializedMastForest::new(&bytes).unwrap();
+    assert!(baseline_view.is_hashless());
+
+    let mut corrupted = bytes.clone();
+    for index in 0..baseline_view.node_count {
+        let digest_offset =
+            baseline_view.node_info_offset + index * baseline_view.node_info_size + 8;
+        corrupted[digest_offset..digest_offset + 32].fill(0);
+    }
+
+    let corrupted_view = SerializedMastForest::new(&corrupted).unwrap();
+    assert!(corrupted_view.is_hashless());
+    for index in 0..baseline_view.node_count() {
+        assert_eq!(
+            baseline_view.node_info_at(index).unwrap().digest(),
+            corrupted_view.node_info_at(index).unwrap().digest()
+        );
+    }
+}
+
+#[test]
+fn test_serialized_mast_forest_hashless_accepts_external_nodes_parse_only() {
+    let mut forest = MastForest::new();
+    let external_id = ExternalNodeBuilder::new(Word::new([
+        Felt::new(1),
+        Felt::new(2),
+        Felt::new(3),
+        Felt::new(4),
+    ]))
+    .add_to_forest(&mut forest)
+    .unwrap();
+    forest.make_root(external_id);
+
+    let mut bytes = Vec::new();
+    forest.write_hashless(&mut bytes);
+    let view = SerializedMastForest::new(&bytes).unwrap();
+    assert!(view.is_hashless());
+    assert_eq!(view.node_count(), 1);
+    assert!(view.node_info_at(0).is_ok());
 }
 
 /// Test that a forest with a node whose child ids are larger than its own id serializes and
@@ -722,7 +1279,7 @@ fn test_raw_vs_batched_construction_equivalence() {
     let mut forest2 = MastForest::new();
 
     let decorator_id1 = forest1.add_decorator(Decorator::Trace(1)).unwrap();
-    let _decorator_id2 = forest2.add_decorator(Decorator::Trace(1)).unwrap();
+    let _ = forest2.add_decorator(Decorator::Trace(1)).unwrap();
 
     let operations = vec![
         Operation::Add,
@@ -856,8 +1413,27 @@ fn test_header_backward_compatible() {
     // Check header structure: MAST (4 bytes) + flags (1 byte) + version (3 bytes)
     assert_eq!(&bytes[0..4], b"MAST", "Magic should be MAST");
     assert_eq!(bytes[4], 0x00, "Flags should be 0x00 for full serialization");
-    // Version [0, 0, 2] includes: AssemblyOp removed from Decorator enum serialization
-    assert_eq!(&bytes[5..8], &[0, 0, 2], "Version should be [0, 0, 2]");
+    // Version [0, 0, 3] includes: HASHLESS flag addition
+    assert_eq!(&bytes[5..8], &[0, 0, 3], "Version should be [0, 0, 3]");
+}
+
+/// Test that legacy version headers are rejected.
+#[test]
+fn test_legacy_version_is_rejected() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let mut bytes = forest.to_bytes();
+    bytes[5..8].copy_from_slice(&[0, 0, 2]);
+
+    let result = MastForest::read_from_bytes(&bytes);
+    assert_matches!(
+        result,
+        Err(DeserializationError::InvalidValue(msg)) if msg.contains("Unsupported version")
+    );
 }
 
 /// Test that stripped serialization produces smaller output than full serialization.
@@ -930,6 +1506,68 @@ fn test_stripped_serialization_roundtrip() {
     assert_eq!(restored.procedure_name(&digest), None);
 }
 
+/// Test that stripped size hint matches actual serialized length.
+#[test]
+fn test_stripped_size_hint_matches_serialized_len() {
+    let mut forest = MastForest::new();
+
+    let block1 =
+        BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Push(Felt::new(3))], Vec::new())
+            .add_to_forest(&mut forest)
+            .unwrap();
+
+    let block2 = BasicBlockNodeBuilder::new(
+        vec![Operation::U32div, Operation::Assert(Felt::new(1))],
+        Vec::new(),
+    )
+    .add_to_forest(&mut forest)
+    .unwrap();
+
+    let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut forest).unwrap();
+    forest.make_root(join);
+
+    forest.advice_map_mut().insert(Word::default(), vec![ONE, Felt::new(2)]);
+
+    let mut bytes = Vec::new();
+    forest.write_stripped(&mut bytes);
+
+    assert_eq!(forest.stripped_size_hint(), bytes.len());
+}
+
+/// Test stripped size hint with large counts and multiple advice-map entries.
+#[test]
+fn test_stripped_size_hint_large_counts() {
+    let mut forest = MastForest::new();
+
+    let mut operations = Vec::with_capacity(304);
+    for _ in 0..300 {
+        operations.push(Operation::Add);
+    }
+    operations.push(Operation::Push(Felt::new(7)));
+    operations.push(Operation::Assert(Felt::new(9)));
+    operations.push(Operation::U32assert2(Felt::new(11)));
+    operations.push(Operation::MpVerify(Felt::new(13)));
+
+    let block_id = BasicBlockNodeBuilder::new(operations, Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let key_a = Word::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
+    let key_b = Word::new([Felt::new(5), Felt::new(6), Felt::new(7), Felt::new(8)]);
+
+    let values_a: Vec<Felt> = (0..200).map(|i| Felt::new(i as u64)).collect();
+    let values_b: Vec<Felt> = (0..5).map(|i| Felt::new((i + 10) as u64)).collect();
+
+    forest.advice_map_mut().insert(key_a, values_a);
+    forest.advice_map_mut().insert(key_b, values_b);
+
+    let mut bytes = Vec::new();
+    forest.write_stripped(&mut bytes);
+
+    assert_eq!(forest.stripped_size_hint(), bytes.len());
+}
+
 /// Test that stripped serialization sets the correct header flags.
 #[test]
 fn test_stripped_header_flags() {
@@ -945,8 +1583,8 @@ fn test_stripped_header_flags() {
     // Check header structure
     assert_eq!(&stripped_bytes[0..4], b"MAST", "Magic should be MAST");
     assert_eq!(stripped_bytes[4], 0x01, "Flags should be 0x01 for stripped serialization");
-    // Version [0, 0, 2] includes: AssemblyOp removed from Decorator enum serialization
-    assert_eq!(&stripped_bytes[5..8], &[0, 0, 2], "Version should be [0, 0, 2]");
+    // Version [0, 0, 3] includes: HASHLESS flag addition
+    assert_eq!(&stripped_bytes[5..8], &[0, 0, 3], "Version should be [0, 0, 3]");
 }
 
 /// Test that node digests are preserved in stripped serialization.
@@ -989,14 +1627,202 @@ fn test_deserialize_rejects_unknown_flags() {
 
     let mut bytes = forest.to_bytes();
 
-    // Set an unknown flag (bit 1)
-    bytes[4] = 0x02;
+    // Set an unknown flag (bit 2)
+    bytes[4] = 0x04;
 
     let result = MastForest::read_from_bytes(&bytes);
     assert_matches!(
         result,
         Err(DeserializationError::InvalidValue(msg)) if msg.contains("reserved") || msg.contains("flags")
     );
+}
+
+/// Test that hashless serialization sets the correct header flags.
+#[test]
+fn test_hashless_header_flags() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+
+    assert_eq!(&hashless_bytes[0..4], b"MAST", "Magic should be MAST");
+    assert_eq!(
+        hashless_bytes[4], 0x03,
+        "Flags should be 0x03 for hashless serialization (STRIPPED + HASHLESS)"
+    );
+    assert_eq!(&hashless_bytes[5..8], &[0, 0, 3], "Version should be [0, 0, 3]");
+}
+
+/// Test that trusted deserialization rejects hashless inputs.
+#[test]
+fn test_trusted_rejects_hashless() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+
+    let result = MastForest::read_from_bytes(&hashless_bytes);
+    assert_matches!(
+        result,
+        Err(DeserializationError::InvalidValue(msg)) if msg.contains("HASHLESS")
+    );
+}
+
+/// Test that hashless without stripped is rejected.
+#[test]
+fn test_hashless_requires_stripped() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let mut bytes = forest.to_bytes();
+    // Set HASHLESS without STRIPPED
+    bytes[4] = 0x02;
+
+    let result = UntrustedMastForest::read_from_bytes(&bytes);
+    assert_matches!(
+        result,
+        Err(DeserializationError::InvalidValue(msg)) if msg.contains("HASHLESS") && msg.contains("STRIPPED")
+    );
+}
+
+/// Test that flag-returning APIs expose the correct header flags.
+#[test]
+fn test_untrusted_read_with_flags() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let full_bytes = forest.to_bytes();
+    let (full_untrusted, full_flags) =
+        UntrustedMastForest::read_from_bytes_with_flags(&full_bytes).unwrap();
+    assert_eq!(full_flags, 0x00);
+    assert_eq!(full_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+
+    let mut stripped_bytes = Vec::new();
+    forest.write_stripped(&mut stripped_bytes);
+    let (stripped_untrusted, stripped_flags) =
+        UntrustedMastForest::read_from_bytes_with_flags(&stripped_bytes).unwrap();
+    assert_eq!(stripped_flags, 0x01);
+    assert_eq!(stripped_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+    let (hashless_untrusted, hashless_flags) =
+        UntrustedMastForest::read_from_bytes_with_flags(&hashless_bytes).unwrap();
+    assert_eq!(hashless_flags, 0x03);
+    assert_eq!(hashless_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+}
+
+/// Test that budgeted flag-returning APIs expose the correct header flags.
+#[test]
+fn test_untrusted_read_with_budget_and_flags() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let full_bytes = forest.to_bytes();
+    let (full_untrusted, full_flags) =
+        UntrustedMastForest::read_from_bytes_with_budget_and_flags(&full_bytes, full_bytes.len())
+            .unwrap();
+    assert_eq!(full_flags, 0x00);
+    assert_eq!(full_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+
+    let mut stripped_bytes = Vec::new();
+    forest.write_stripped(&mut stripped_bytes);
+    let (stripped_untrusted, stripped_flags) =
+        UntrustedMastForest::read_from_bytes_with_budget_and_flags(
+            &stripped_bytes,
+            stripped_bytes.len(),
+        )
+        .unwrap();
+    assert_eq!(stripped_flags, 0x01);
+    assert_eq!(stripped_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+    let (hashless_untrusted, hashless_flags) =
+        UntrustedMastForest::read_from_bytes_with_budget_and_flags(
+            &hashless_bytes,
+            hashless_bytes.len(),
+        )
+        .unwrap();
+    assert_eq!(hashless_flags, 0x03);
+    assert_eq!(hashless_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+}
+
+/// Test that untrusted validation in hashless mode recomputes non-external digests
+/// instead of trusting serialized digest bytes.
+#[test]
+fn test_untrusted_hashless_validate_ignores_wire_digests() {
+    let mut forest = MastForest::new();
+    let block1 = BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Mul], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let block2 = BasicBlockNodeBuilder::new(vec![Operation::U32div], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut forest).unwrap();
+    forest.make_root(join);
+
+    let expected_digests: Vec<_> = forest.nodes().iter().map(|node| node.digest()).collect();
+
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+    let view = SerializedMastForest::new(&hashless_bytes).unwrap();
+    let node_count = view.node_count;
+    let node_info_offset = view.node_info_offset;
+    let node_info_size = view.node_info_size;
+
+    for index in 0..node_count {
+        let digest_offset = node_info_offset + index * node_info_size + 8;
+        hashless_bytes[digest_offset..digest_offset + 32].fill(0);
+    }
+
+    let (untrusted, flags) =
+        UntrustedMastForest::read_from_bytes_with_flags(&hashless_bytes).unwrap();
+    assert_eq!(flags, 0x03);
+
+    let validated = untrusted.validate().unwrap();
+    let validated_digests: Vec<_> = validated.nodes().iter().map(|node| node.digest()).collect();
+    assert_eq!(validated_digests, expected_digests);
+}
+
+/// Test that untrusted hashless deserialization accepts external nodes at parse time.
+#[test]
+fn test_untrusted_hashless_external_parse_and_validate() {
+    let mut forest = MastForest::new();
+    let external = ExternalNodeBuilder::new(Word::new([
+        Felt::new(10),
+        Felt::new(11),
+        Felt::new(12),
+        Felt::new(13),
+    ]))
+    .add_to_forest(&mut forest)
+    .unwrap();
+    forest.make_root(external);
+
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+
+    let (untrusted, flags) =
+        UntrustedMastForest::read_from_bytes_with_flags(&hashless_bytes).unwrap();
+    assert_eq!(flags, 0x03);
+    assert_eq!(untrusted.validate().unwrap().num_nodes(), 1);
 }
 
 mod proptests {

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -1468,8 +1468,12 @@ fn assert_untrusted_overspec_logging(
     }
     assert_eq!(untrusted.validate().unwrap().num_nodes(), expected_nodes);
 
-    let (budgeted, budgeted_flags) =
-        UntrustedMastForest::read_from_bytes_with_budget_and_flags(bytes, bytes.len()).unwrap();
+    let (budgeted, budgeted_flags) = UntrustedMastForest::read_from_bytes_with_budgets_and_flags(
+        bytes,
+        bytes.len(),
+        super::default_untrusted_allocation_budget(bytes.len()),
+    )
+    .unwrap();
     assert_eq!(budgeted_flags, expected_flags);
     assert_eq!(budgeted.validate().unwrap().num_nodes(), expected_nodes);
 }
@@ -2518,5 +2522,83 @@ fn test_deserialization_rejects_excessive_node_count() {
     assert!(
         err.to_string().contains("exceeds maximum"),
         "Expected error about exceeding maximum, got: {err}"
+    );
+}
+
+/// Test that untrusted deserialization rejects node counts that exceed the reader allocation
+/// bound before they can drive later allocations.
+#[test]
+fn test_untrusted_deserialization_rejects_node_count_above_budget_bound() {
+    let mut bytes = Vec::new();
+
+    super::MAGIC.write_into(&mut bytes);
+    bytes.write_u8(FLAG_STRIPPED | FLAG_HASHLESS);
+    super::VERSION.write_into(&mut bytes);
+
+    2usize.write_into(&mut bytes);
+
+    let result = UntrustedMastForest::read_from_bytes_with_budget(&bytes, bytes.len());
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("node count 2 exceeds reader allocation bound"),
+        "Expected budget-bound node count error, got: {err}"
+    );
+}
+
+/// Test that custom untrusted budgets also apply to later hashless validation allocations.
+#[test]
+fn test_untrusted_hashless_validation_respects_custom_allocation_budget() {
+    let mut forest = MastForest::new();
+    let left = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let right = BasicBlockNodeBuilder::new(vec![Operation::Mul], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let root = JoinNodeBuilder::new([left, right]).add_to_forest(&mut forest).unwrap();
+    forest.make_root(root);
+
+    let mut bytes = Vec::new();
+    forest.write_hashless(&mut bytes);
+
+    let untrusted =
+        UntrustedMastForest::read_from_bytes_with_budgets(&bytes, bytes.len(), bytes.len())
+            .unwrap();
+    let result = untrusted.validate();
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("remaining untrusted allocation budget"),
+        "Expected validation-allocation budget error, got: {err}"
+    );
+}
+
+/// Test that stripped payloads charge empty debug-info scaffolding with the target pointer width.
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn test_untrusted_stripped_debug_info_budget_uses_usize_slots() {
+    let mut forest = MastForest::new();
+    let left = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let right = BasicBlockNodeBuilder::new(vec![Operation::Mul], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let root = JoinNodeBuilder::new([left, right]).add_to_forest(&mut forest).unwrap();
+    forest.make_root(root);
+
+    let mut bytes = Vec::new();
+    forest.write_stripped(&mut bytes);
+
+    let validation_budget =
+        (usize::try_from(forest.num_nodes()).unwrap() + 1) * core::mem::size_of::<usize>() - 1;
+    let result =
+        UntrustedMastForest::read_from_bytes_with_budgets(&bytes, bytes.len(), validation_budget);
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("empty debug-info scaffolding"),
+        "Expected stripped debug-info budget error, got: {err}"
     );
 }

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -617,29 +617,6 @@ fn test_serialized_mast_forest_accepts_full_format() {
     assert!(view.node_info_at(0).is_ok());
 }
 
-fn sample_serialized_view_bytes() -> Vec<u8> {
-    let mut forest = MastForest::new();
-    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-    forest.advice_map_mut().insert(Word::default(), vec![ONE]);
-
-    let mut bytes = Vec::new();
-    forest.write_stripped(&mut bytes);
-    bytes
-}
-
-fn sample_full_view_bytes_with_debug_info() -> Vec<u8> {
-    let mut forest = MastForest::new();
-    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-    forest.insert_procedure_name(forest[block_id].digest(), "proc".into());
-    forest.to_bytes()
-}
-
 fn debug_info_offset_after_advice_map(bytes: &[u8]) -> usize {
     let view = SerializedMastForest::new(bytes).unwrap();
     let mut offset = view.advice_map_offset().unwrap();
@@ -684,199 +661,6 @@ fn rewrite_debug_info_procedure_name_digest(
     let mut rewritten = bytes[..debug_info_offset].to_vec();
     debug_info.write_into(&mut rewritten);
     rewritten
-}
-
-#[test]
-fn test_serialized_mast_forest_allows_truncated_after_node_info() {
-    let bytes = sample_serialized_view_bytes();
-    let view = SerializedMastForest::new(&bytes).unwrap();
-    let node_info_end = view.advice_map_offset().unwrap();
-
-    let truncated = bytes[..node_info_end].to_vec();
-    let truncated_view = SerializedMastForest::new(&truncated).unwrap();
-    assert_eq!(truncated_view.node_count(), view.node_count());
-}
-
-#[test]
-fn test_trusted_deserialize_rejects_truncated_after_node_info() {
-    let bytes = sample_serialized_view_bytes();
-    let view = SerializedMastForest::new(&bytes).unwrap();
-    let node_info_end = view.advice_map_offset().unwrap();
-
-    let truncated = bytes[..node_info_end].to_vec();
-    assert_matches!(
-        MastForest::read_from_bytes(&truncated),
-        Err(DeserializationError::UnexpectedEOF)
-    );
-}
-
-#[test]
-fn test_serialized_mast_forest_rejects_truncated_inside_node_info() {
-    let bytes = sample_serialized_view_bytes();
-    let view = SerializedMastForest::new(&bytes).unwrap();
-    let truncation_point = view.node_entry_offset() + view.node_entry_size() - 1;
-
-    let truncated = bytes[..truncation_point].to_vec();
-    assert_matches!(
-        SerializedMastForest::new(&truncated),
-        Err(DeserializationError::UnexpectedEOF)
-    );
-}
-
-#[test]
-fn test_serialized_mast_forest_rejects_malformed_varint_length() {
-    let bytes = sample_serialized_view_bytes();
-    let node_count_offset = MAGIC.len() + 1 + VERSION.len();
-
-    // 0x00 encodes a 9-byte usize; truncating immediately after it makes the varint incomplete.
-    let mut malformed = bytes[..=node_count_offset].to_vec();
-    malformed[node_count_offset] = 0x00;
-    assert_matches!(
-        SerializedMastForest::new(&malformed),
-        Err(DeserializationError::UnexpectedEOF)
-    );
-}
-
-#[test]
-fn test_serialized_mast_forest_rejects_unknown_flags() {
-    let mut bytes = sample_serialized_view_bytes();
-    bytes[4] = 0x04;
-
-    assert_matches!(
-        SerializedMastForest::new(&bytes),
-        Err(DeserializationError::InvalidValue(msg)) if msg.contains("Unknown flags")
-    );
-}
-
-#[test]
-fn test_serialized_mast_forest_rejects_hashless_without_stripped() {
-    let mut bytes = sample_serialized_view_bytes();
-    bytes[4] = 0x02;
-
-    assert_matches!(
-        SerializedMastForest::new(&bytes),
-        Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("HASHLESS") && msg.contains("STRIPPED")
-    );
-}
-
-#[test]
-fn test_serialized_mast_forest_allows_trailing_bytes_after_layout_sections() {
-    let mut bytes = sample_serialized_view_bytes();
-    bytes.push(0x00);
-
-    let view = SerializedMastForest::new(&bytes).unwrap();
-    assert!(view.node_count() > 0);
-}
-
-#[test]
-fn test_serialized_mast_forest_new_ignores_malformed_advice_map_felt() {
-    let mut bytes = sample_serialized_view_bytes();
-    let view = SerializedMastForest::new(&bytes).unwrap();
-
-    let advice_map_offset = view.advice_map_offset().unwrap();
-    let mut offset = advice_map_offset;
-    let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
-
-    // Corrupt the first key limb to a non-canonical field element.
-    bytes[offset..offset + 8].copy_from_slice(&u64::MAX.to_le_bytes());
-
-    // SerializedMastForest::new only needs layout information and does not parse AdviceMap.
-    let view = SerializedMastForest::new(&bytes).unwrap();
-    assert!(view.node_count() > 0);
-}
-
-#[test]
-fn test_trusted_deserialize_rejects_malformed_advice_map_felt() {
-    let mut bytes = sample_serialized_view_bytes();
-    let view = SerializedMastForest::new(&bytes).unwrap();
-
-    let advice_map_offset = view.advice_map_offset().unwrap();
-    let mut offset = advice_map_offset;
-    let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
-
-    // Corrupt the first key limb to a non-canonical field element.
-    bytes[offset..offset + 8].copy_from_slice(&u64::MAX.to_le_bytes());
-
-    assert_matches!(
-        MastForest::read_from_bytes(&bytes),
-        Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("invalid advice-map field element encoding")
-                || msg.contains("valid felt")
-                || msg.contains("appropriate range")
-    );
-}
-
-#[test]
-fn test_serialized_mast_forest_new_ignores_malformed_advice_map_value_felt() {
-    let mut bytes = sample_serialized_view_bytes();
-    let view = SerializedMastForest::new(&bytes).unwrap();
-
-    let advice_map_offset = view.advice_map_offset().unwrap();
-    let mut offset = advice_map_offset;
-    let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
-    for _ in 0..4 {
-        let _ = read_array_at::<8>(&bytes, &mut offset).unwrap();
-    }
-    let values_len = read_usize_at(&bytes, &mut offset).unwrap();
-    assert!(values_len > 0);
-
-    // Corrupt the first value limb to a non-canonical field element.
-    bytes[offset..offset + 8].copy_from_slice(&u64::MAX.to_le_bytes());
-
-    // SerializedMastForest::new only needs layout information and does not parse AdviceMap.
-    let view = SerializedMastForest::new(&bytes).unwrap();
-    assert!(view.node_count() > 0);
-}
-
-#[test]
-fn test_trusted_deserialize_rejects_malformed_advice_map_value_felt() {
-    let mut bytes = sample_serialized_view_bytes();
-    let view = SerializedMastForest::new(&bytes).unwrap();
-
-    let advice_map_offset = view.advice_map_offset().unwrap();
-    let mut offset = advice_map_offset;
-    let _entry_count = read_usize_at(&bytes, &mut offset).unwrap();
-    for _ in 0..4 {
-        let _ = read_array_at::<8>(&bytes, &mut offset).unwrap();
-    }
-    let values_len = read_usize_at(&bytes, &mut offset).unwrap();
-    assert!(values_len > 0);
-
-    // Corrupt the first value limb to a non-canonical field element.
-    bytes[offset..offset + 8].copy_from_slice(&u64::MAX.to_le_bytes());
-
-    assert_matches!(
-        MastForest::read_from_bytes(&bytes),
-        Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("invalid advice-map field element encoding")
-                || msg.contains("valid felt")
-                || msg.contains("appropriate range")
-    );
-}
-
-#[test]
-fn test_serialized_mast_forest_new_allows_truncated_debug_info_in_full_format() {
-    let bytes = sample_full_view_bytes_with_debug_info();
-    let debug_info_offset = debug_info_offset_after_advice_map(&bytes);
-    let truncated = bytes[..debug_info_offset].to_vec();
-
-    // SerializedMastForest::new only validates layout up to node metadata.
-    let view = SerializedMastForest::new(&truncated).unwrap();
-    assert!(!view.is_stripped());
-    assert!(view.node_count() > 0);
-}
-
-#[test]
-fn test_trusted_deserialize_rejects_truncated_debug_info_in_full_format() {
-    let bytes = sample_full_view_bytes_with_debug_info();
-    let debug_info_offset = debug_info_offset_after_advice_map(&bytes);
-    let truncated = bytes[..debug_info_offset].to_vec();
-
-    assert_matches!(
-        MastForest::read_from_bytes(&truncated),
-        Err(DeserializationError::UnexpectedEOF)
-    );
 }
 
 #[test]
@@ -1449,22 +1233,29 @@ fn test_batched_construction_preserves_structure() {
 // PROPTEST-BASED ROUND-TRIP SERIALIZATION TESTS
 // ================================================================================================
 
-/// Test that the new header format uses flags=0x00 for full serialization.
+fn assert_header_flags(bytes: &[u8], expected_flags: u8) {
+    assert_eq!(&bytes[0..4], b"MAST", "Magic should be MAST");
+    assert_eq!(bytes[4], expected_flags, "unexpected serialization flags");
+    assert_eq!(&bytes[5..8], &[0, 0, 4], "Version should be [0, 0, 4]");
+}
+
 #[test]
-fn test_header_backward_compatible() {
+fn test_header_flags_for_all_serialization_modes() {
     let mut forest = MastForest::new();
     let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
         .add_to_forest(&mut forest)
         .unwrap();
     forest.make_root(block_id);
 
-    let bytes = forest.to_bytes();
+    assert_header_flags(&forest.to_bytes(), 0x00);
 
-    // Check header structure: MAST (4 bytes) + flags (1 byte) + version (3 bytes)
-    assert_eq!(&bytes[0..4], b"MAST", "Magic should be MAST");
-    assert_eq!(bytes[4], 0x00, "Flags should be 0x00 for full serialization");
-    // Version [0, 0, 4] splits node entries from digest sections.
-    assert_eq!(&bytes[5..8], &[0, 0, 4], "Version should be [0, 0, 4]");
+    let mut stripped_bytes = Vec::new();
+    forest.write_stripped(&mut stripped_bytes);
+    assert_header_flags(&stripped_bytes, 0x01);
+
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+    assert_header_flags(&hashless_bytes, 0x03);
 }
 
 /// Test that legacy version headers are rejected.
@@ -1486,21 +1277,18 @@ fn test_legacy_version_is_rejected() {
     );
 }
 
-/// Test that stripped serialization produces smaller output than full serialization.
+/// Test that stripping and hashless serialization reduce wire size monotonically.
 #[test]
-fn test_stripped_serialization_smaller_than_full() {
+fn test_serialization_sizes_shrink_from_full_to_stripped_to_hashless() {
     let mut forest = MastForest::new();
 
-    // Add decorators
     let decorator_id = forest.add_decorator(Decorator::Trace(42)).unwrap();
-
     let operations = vec![Operation::Add, Operation::Mul, Operation::Drop];
     let block_id = BasicBlockNodeBuilder::new(operations, vec![(0, decorator_id)])
         .add_to_forest(&mut forest)
         .unwrap();
     forest.make_root(block_id);
 
-    // Add procedure name for more debug info
     let digest = forest[block_id].digest();
     forest.insert_procedure_name(digest, "test_proc".into());
 
@@ -1509,34 +1297,15 @@ fn test_stripped_serialization_smaller_than_full() {
     let mut stripped_bytes = Vec::new();
     forest.write_stripped(&mut stripped_bytes);
 
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+
     assert!(
         stripped_bytes.len() < full_bytes.len(),
         "Stripped ({} bytes) should be smaller than full ({} bytes)",
         stripped_bytes.len(),
         full_bytes.len()
     );
-}
-
-/// Test that hashless serialization saves bytes by omitting the general node-hash section.
-#[test]
-fn test_hashless_serialization_smaller_than_stripped() {
-    let mut forest = MastForest::new();
-
-    let block1 = BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Mul], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    let block2 = BasicBlockNodeBuilder::new(vec![Operation::U32div], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut forest).unwrap();
-    forest.make_root(join);
-
-    let mut stripped_bytes = Vec::new();
-    forest.write_stripped(&mut stripped_bytes);
-
-    let mut hashless_bytes = Vec::new();
-    forest.write_hashless(&mut hashless_bytes);
-
     assert!(
         hashless_bytes.len() < stripped_bytes.len(),
         "Hashless ({} bytes) should be smaller than stripped ({} bytes)",
@@ -1550,76 +1319,32 @@ fn test_hashless_serialization_smaller_than_stripped() {
     assert!(hashless_view.node_hash_offset().is_none());
 }
 
-/// Test that stripped serialization round-trips correctly with empty DebugInfo.
-#[test]
-fn test_stripped_serialization_roundtrip() {
-    let mut forest = MastForest::new();
-
-    // Add decorators
-    let decorator_id = forest.add_decorator(Decorator::Trace(42)).unwrap();
-
-    let operations = vec![Operation::Add, Operation::Mul, Operation::Drop];
-    let block_id = BasicBlockNodeBuilder::new(operations, vec![(0, decorator_id)])
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-
-    // Add procedure name and error code
-    let digest = forest[block_id].digest();
-    forest.insert_procedure_name(digest, "test_proc".into());
-    let _ = forest.register_error("test error".into());
-
-    // Serialize stripped
-    let mut stripped_bytes = Vec::new();
-    forest.write_stripped(&mut stripped_bytes);
-
-    // Deserialize
-    let restored = MastForest::read_from_bytes(&stripped_bytes).unwrap();
-
-    // Verify structure is preserved
-    assert_eq!(forest.num_nodes(), restored.num_nodes());
-    assert_eq!(forest.procedure_roots().len(), restored.procedure_roots().len());
-
-    // Verify debug info is empty
-    assert!(
-        restored.debug_info.is_empty(),
-        "DebugInfo should be empty after stripped roundtrip"
-    );
-    assert_eq!(restored.decorators().len(), 0);
-    assert_eq!(restored.procedure_name(&digest), None);
+fn assert_stripped_size_hint_matches_serialized_len(forest: &MastForest) {
+    let mut bytes = Vec::new();
+    forest.write_stripped(&mut bytes);
+    assert_eq!(forest.stripped_size_hint(), bytes.len());
 }
 
-/// Test that stripped size hint matches actual serialized length.
+/// Test that stripped size hints stay exact for both compact and large forests.
 #[test]
 fn test_stripped_size_hint_matches_serialized_len() {
-    let mut forest = MastForest::new();
+    let mut small_forest = MastForest::new();
 
     let block1 =
         BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Push(Felt::new(3))], Vec::new())
-            .add_to_forest(&mut forest)
+            .add_to_forest(&mut small_forest)
             .unwrap();
-
     let block2 = BasicBlockNodeBuilder::new(
         vec![Operation::U32div, Operation::Assert(Felt::new(1))],
         Vec::new(),
     )
-    .add_to_forest(&mut forest)
+    .add_to_forest(&mut small_forest)
     .unwrap();
+    let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut small_forest).unwrap();
+    small_forest.make_root(join);
+    small_forest.advice_map_mut().insert(Word::default(), vec![ONE, Felt::new(2)]);
+    assert_stripped_size_hint_matches_serialized_len(&small_forest);
 
-    let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut forest).unwrap();
-    forest.make_root(join);
-
-    forest.advice_map_mut().insert(Word::default(), vec![ONE, Felt::new(2)]);
-
-    let mut bytes = Vec::new();
-    forest.write_stripped(&mut bytes);
-
-    assert_eq!(forest.stripped_size_hint(), bytes.len());
-}
-
-/// Test stripped size hint with large counts and multiple advice-map entries.
-#[test]
-fn test_stripped_size_hint_large_counts() {
     let mut forest = MastForest::new();
 
     let mut operations = Vec::with_capacity(304);
@@ -1645,29 +1370,7 @@ fn test_stripped_size_hint_large_counts() {
     forest.advice_map_mut().insert(key_a, values_a);
     forest.advice_map_mut().insert(key_b, values_b);
 
-    let mut bytes = Vec::new();
-    forest.write_stripped(&mut bytes);
-
-    assert_eq!(forest.stripped_size_hint(), bytes.len());
-}
-
-/// Test that stripped serialization sets the correct header flags.
-#[test]
-fn test_stripped_header_flags() {
-    let mut forest = MastForest::new();
-    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-
-    let mut stripped_bytes = Vec::new();
-    forest.write_stripped(&mut stripped_bytes);
-
-    // Check header structure
-    assert_eq!(&stripped_bytes[0..4], b"MAST", "Magic should be MAST");
-    assert_eq!(stripped_bytes[4], 0x01, "Flags should be 0x01 for stripped serialization");
-    // Version [0, 0, 4] splits node entries from digest sections.
-    assert_eq!(&stripped_bytes[5..8], &[0, 0, 4], "Version should be [0, 0, 4]");
+    assert_stripped_size_hint_matches_serialized_len(&forest);
 }
 
 /// Test that node digests are preserved in stripped serialization.
@@ -1718,26 +1421,6 @@ fn test_deserialize_rejects_unknown_flags() {
         result,
         Err(DeserializationError::InvalidValue(msg)) if msg.contains("reserved") || msg.contains("flags")
     );
-}
-
-/// Test that hashless serialization sets the correct header flags.
-#[test]
-fn test_hashless_header_flags() {
-    let mut forest = MastForest::new();
-    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-
-    let mut hashless_bytes = Vec::new();
-    forest.write_hashless(&mut hashless_bytes);
-
-    assert_eq!(&hashless_bytes[0..4], b"MAST", "Magic should be MAST");
-    assert_eq!(
-        hashless_bytes[4], 0x03,
-        "Flags should be 0x03 for hashless serialization (STRIPPED + HASHLESS)"
-    );
-    assert_eq!(&hashless_bytes[5..8], &[0, 0, 4], "Version should be [0, 0, 4]");
 }
 
 /// Test that trusted deserialization rejects hashless inputs.
@@ -1798,9 +1481,19 @@ fn test_hashless_requires_stripped() {
     );
 }
 
-/// Test that flag-returning APIs expose the correct header flags.
+fn assert_untrusted_flag_api_reports_mode(bytes: &[u8], expected_flags: u8, expected_nodes: u32) {
+    let (untrusted, flags) = UntrustedMastForest::read_from_bytes_with_flags(bytes).unwrap();
+    assert_eq!(flags, expected_flags);
+    assert_eq!(untrusted.validate().unwrap().num_nodes(), expected_nodes);
+
+    let (budgeted, budgeted_flags) =
+        UntrustedMastForest::read_from_bytes_with_budget_and_flags(bytes, bytes.len()).unwrap();
+    assert_eq!(budgeted_flags, expected_flags);
+    assert_eq!(budgeted.validate().unwrap().num_nodes(), expected_nodes);
+}
+
 #[test]
-fn test_untrusted_read_with_flags() {
+fn test_untrusted_flag_apis_report_expected_modes() {
     let mut forest = MastForest::new();
     let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
         .add_to_forest(&mut forest)
@@ -1808,128 +1501,64 @@ fn test_untrusted_read_with_flags() {
     forest.make_root(block_id);
 
     let full_bytes = forest.to_bytes();
-    let (full_untrusted, full_flags) =
-        UntrustedMastForest::read_from_bytes_with_flags(&full_bytes).unwrap();
-    assert_eq!(full_flags, 0x00);
-    assert_eq!(full_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+    assert_untrusted_flag_api_reports_mode(&full_bytes, 0x00, forest.num_nodes());
 
     let mut stripped_bytes = Vec::new();
     forest.write_stripped(&mut stripped_bytes);
-    let (stripped_untrusted, stripped_flags) =
-        UntrustedMastForest::read_from_bytes_with_flags(&stripped_bytes).unwrap();
-    assert_eq!(stripped_flags, 0x01);
-    assert_eq!(stripped_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+    assert_untrusted_flag_api_reports_mode(&stripped_bytes, 0x01, forest.num_nodes());
 
     let mut hashless_bytes = Vec::new();
     forest.write_hashless(&mut hashless_bytes);
-    let (hashless_untrusted, hashless_flags) =
-        UntrustedMastForest::read_from_bytes_with_flags(&hashless_bytes).unwrap();
-    assert_eq!(hashless_flags, 0x03);
-    assert_eq!(hashless_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+    assert_untrusted_flag_api_reports_mode(&hashless_bytes, 0x03, forest.num_nodes());
 }
 
-#[test]
-fn test_untrusted_hashless_input_emits_no_overspecification_logs() {
-    let mut forest = MastForest::new();
-    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-
-    let mut hashless_bytes = Vec::new();
-    forest.write_hashless(&mut hashless_bytes);
-
-    let (result, logs) = with_captured_error_logs(|| {
-        UntrustedMastForest::read_from_bytes_with_flags(&hashless_bytes)
-    });
-
-    let (untrusted, flags) = result.unwrap();
-    assert_eq!(flags, 0x03);
-    assert!(logs.is_empty());
-    assert_eq!(untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
-}
-
-#[test]
-fn test_untrusted_stripped_with_hashes_logs_overspecification() {
-    let mut forest = MastForest::new();
-    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-
-    let mut stripped_bytes = Vec::new();
-    forest.write_stripped(&mut stripped_bytes);
-
-    let (result, logs) = with_captured_error_logs(|| {
-        UntrustedMastForest::read_from_bytes_with_flags(&stripped_bytes)
-    });
-
-    let (untrusted, flags) = result.unwrap();
-    assert_eq!(flags, 0x01);
-    assert_eq!(logs.len(), 1);
-    assert!(logs[0].contains("wire node hashes"));
-    assert_eq!(untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
-}
-
-#[test]
-fn test_untrusted_full_input_logs_overspecification() {
-    let mut forest = MastForest::new();
-    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-    forest.insert_procedure_name(forest[block_id].digest(), "test".into());
-
-    let bytes = forest.to_bytes();
-
+fn assert_untrusted_overspec_logging(
+    bytes: &[u8],
+    expected_flags: u8,
+    expected_nodes: u32,
+    expected_log_fragments: &[&str],
+) {
     let (result, logs) =
-        with_captured_error_logs(|| UntrustedMastForest::read_from_bytes_with_flags(&bytes));
+        with_captured_error_logs(|| UntrustedMastForest::read_from_bytes_with_flags(bytes));
 
     let (untrusted, flags) = result.unwrap();
-    assert_eq!(flags, 0x00);
-    assert_eq!(logs.len(), 2);
-    assert!(logs.iter().any(|msg| msg.contains("wire node hashes")));
-    assert!(logs.iter().any(|msg| msg.contains("DebugInfo")));
-    assert_eq!(untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+    assert_eq!(flags, expected_flags);
+    assert_eq!(logs.len(), expected_log_fragments.len());
+    for expected in expected_log_fragments {
+        assert!(logs.iter().any(|msg| msg.contains(expected)));
+    }
+    assert_eq!(untrusted.validate().unwrap().num_nodes(), expected_nodes);
 }
 
-/// Test that budgeted flag-returning APIs expose the correct header flags.
 #[test]
-fn test_untrusted_read_with_budget_and_flags() {
+fn test_untrusted_overspecification_logging_matches_wire_mode() {
     let mut forest = MastForest::new();
     let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
         .add_to_forest(&mut forest)
         .unwrap();
     forest.make_root(block_id);
 
-    let full_bytes = forest.to_bytes();
-    let (full_untrusted, full_flags) =
-        UntrustedMastForest::read_from_bytes_with_budget_and_flags(&full_bytes, full_bytes.len())
-            .unwrap();
-    assert_eq!(full_flags, 0x00);
-    assert_eq!(full_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+    assert_untrusted_overspec_logging(&hashless_bytes, 0x03, forest.num_nodes(), &[]);
 
     let mut stripped_bytes = Vec::new();
     forest.write_stripped(&mut stripped_bytes);
-    let (stripped_untrusted, stripped_flags) =
-        UntrustedMastForest::read_from_bytes_with_budget_and_flags(
-            &stripped_bytes,
-            stripped_bytes.len(),
-        )
-        .unwrap();
-    assert_eq!(stripped_flags, 0x01);
-    assert_eq!(stripped_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+    assert_untrusted_overspec_logging(
+        &stripped_bytes,
+        0x01,
+        forest.num_nodes(),
+        &["wire node hashes"],
+    );
 
-    let mut hashless_bytes = Vec::new();
-    forest.write_hashless(&mut hashless_bytes);
-    let (hashless_untrusted, hashless_flags) =
-        UntrustedMastForest::read_from_bytes_with_budget_and_flags(
-            &hashless_bytes,
-            hashless_bytes.len(),
-        )
-        .unwrap();
-    assert_eq!(hashless_flags, 0x03);
-    assert_eq!(hashless_untrusted.validate().unwrap().num_nodes(), forest.num_nodes());
+    forest.insert_procedure_name(forest[block_id].digest(), "test".into());
+    let bytes = forest.to_bytes();
+    assert_untrusted_overspec_logging(
+        &bytes,
+        0x00,
+        forest.num_nodes(),
+        &["wire node hashes", "DebugInfo"],
+    );
 }
 
 /// Test that untrusted validation in hashless mode recomputes non-external digests without any

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -489,22 +489,6 @@ fn assert_serialized_view_matches_forest(forest: &MastForest) {
 }
 
 #[test]
-fn test_serialized_mast_forest_random_access_node_info() {
-    let mut forest = MastForest::new();
-
-    let block1 = BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Mul], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    let block2 = BasicBlockNodeBuilder::new(vec![Operation::U32div], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut forest).unwrap();
-    forest.make_root(join);
-
-    assert_serialized_view_matches_forest(&forest);
-}
-
-#[test]
 fn test_mast_forest_view_trait_matches_serialized_view() {
     let mut forest = MastForest::new();
 
@@ -600,23 +584,6 @@ fn test_serialized_mast_forest_large_counts() {
     assert_serialized_view_matches_forest(&forest);
 }
 
-#[test]
-fn test_serialized_mast_forest_accepts_full_format() {
-    let mut forest = MastForest::new();
-    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-
-    let bytes = forest.to_bytes();
-    let view = SerializedMastForest::new(&bytes).unwrap();
-    assert!(!view.is_stripped());
-    assert!(!view.is_hashless());
-    assert_eq!(view.node_count(), 1);
-    assert_eq!(view.procedure_root_count(), 1);
-    assert!(view.node_info_at(0).is_ok());
-}
-
 fn debug_info_offset_after_advice_map(bytes: &[u8]) -> usize {
     let view = SerializedMastForest::new(bytes).unwrap();
     let mut offset = view.advice_map_offset().unwrap();
@@ -678,7 +645,6 @@ fn test_serialized_mast_forest_hashless_omits_hash_section_and_recomputes_digest
     let mut bytes = Vec::new();
     forest.write_hashless(&mut bytes);
     let view = SerializedMastForest::new(&bytes).unwrap();
-    assert!(view.is_hashless());
     assert!(view.node_hash_offset().is_none());
     for index in 0..view.node_count() {
         assert_eq!(forest.nodes()[index].digest(), view.node_info_at(index).unwrap().digest());
@@ -695,8 +661,6 @@ fn test_serialized_mast_forest_hashless_accepts_external_nodes_parse_only() {
     let mut bytes = Vec::new();
     forest.write_hashless(&mut bytes);
     let view = SerializedMastForest::new(&bytes).unwrap();
-    assert!(view.is_hashless());
-    assert!(view.node_hash_offset().is_none());
     assert_eq!(view.node_count(), 1);
     assert!(view.node_info_at(0).is_ok());
     assert_eq!(view.node_digest_at(0).unwrap(), external_digest);
@@ -1300,6 +1264,13 @@ fn test_serialization_sizes_shrink_from_full_to_stripped_to_hashless() {
     let mut hashless_bytes = Vec::new();
     forest.write_hashless(&mut hashless_bytes);
 
+    let full_view = SerializedMastForest::new(&full_bytes).unwrap();
+    assert!(!full_view.is_stripped());
+    assert!(!full_view.is_hashless());
+    assert_eq!(full_view.node_count(), forest.num_nodes() as usize);
+    assert_eq!(full_view.procedure_root_count(), 1);
+    assert!(full_view.node_info_at(0).is_ok());
+
     assert!(
         stripped_bytes.len() < full_bytes.len(),
         "Stripped ({} bytes) should be smaller than full ({} bytes)",
@@ -1481,37 +1452,6 @@ fn test_hashless_requires_stripped() {
     );
 }
 
-fn assert_untrusted_flag_api_reports_mode(bytes: &[u8], expected_flags: u8, expected_nodes: u32) {
-    let (untrusted, flags) = UntrustedMastForest::read_from_bytes_with_flags(bytes).unwrap();
-    assert_eq!(flags, expected_flags);
-    assert_eq!(untrusted.validate().unwrap().num_nodes(), expected_nodes);
-
-    let (budgeted, budgeted_flags) =
-        UntrustedMastForest::read_from_bytes_with_budget_and_flags(bytes, bytes.len()).unwrap();
-    assert_eq!(budgeted_flags, expected_flags);
-    assert_eq!(budgeted.validate().unwrap().num_nodes(), expected_nodes);
-}
-
-#[test]
-fn test_untrusted_flag_apis_report_expected_modes() {
-    let mut forest = MastForest::new();
-    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-
-    let full_bytes = forest.to_bytes();
-    assert_untrusted_flag_api_reports_mode(&full_bytes, 0x00, forest.num_nodes());
-
-    let mut stripped_bytes = Vec::new();
-    forest.write_stripped(&mut stripped_bytes);
-    assert_untrusted_flag_api_reports_mode(&stripped_bytes, 0x01, forest.num_nodes());
-
-    let mut hashless_bytes = Vec::new();
-    forest.write_hashless(&mut hashless_bytes);
-    assert_untrusted_flag_api_reports_mode(&hashless_bytes, 0x03, forest.num_nodes());
-}
-
 fn assert_untrusted_overspec_logging(
     bytes: &[u8],
     expected_flags: u8,
@@ -1528,6 +1468,11 @@ fn assert_untrusted_overspec_logging(
         assert!(logs.iter().any(|msg| msg.contains(expected)));
     }
     assert_eq!(untrusted.validate().unwrap().num_nodes(), expected_nodes);
+
+    let (budgeted, budgeted_flags) =
+        UntrustedMastForest::read_from_bytes_with_budget_and_flags(bytes, bytes.len()).unwrap();
+    assert_eq!(budgeted_flags, expected_flags);
+    assert_eq!(budgeted.validate().unwrap().num_nodes(), expected_nodes);
 }
 
 #[test]
@@ -1579,8 +1524,6 @@ fn test_untrusted_hashless_validate_recomputes_without_wire_hash_section() {
 
     let mut hashless_bytes = Vec::new();
     forest.write_hashless(&mut hashless_bytes);
-    let view = SerializedMastForest::new(&hashless_bytes).unwrap();
-    assert!(view.node_hash_offset().is_none());
 
     let (untrusted, flags) =
         UntrustedMastForest::read_from_bytes_with_flags(&hashless_bytes).unwrap();
@@ -1610,7 +1553,7 @@ fn test_untrusted_hashless_external_parse_and_validate() {
 
     let (untrusted, flags) =
         UntrustedMastForest::read_from_bytes_with_flags(&hashless_bytes).unwrap();
-    assert_eq!(flags, 0x03);
+    assert_eq!(flags, 0x03, "hashless untrusted path should preserve wire mode");
     assert_eq!(untrusted.validate().unwrap().num_nodes(), 1);
 }
 
@@ -2028,30 +1971,6 @@ fn test_debuginfo_serialization_dense() {
 // UNTRUSTED MAST FOREST VALIDATION TESTS
 // ================================================================================================
 
-/// Test that UntrustedMastForest::validate succeeds for a valid forest.
-#[test]
-fn test_untrusted_forest_valid_roundtrip() {
-    let mut forest = MastForest::new();
-
-    let block1_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    let block2_id = BasicBlockNodeBuilder::new(vec![Operation::Mul], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    let join_id = JoinNodeBuilder::new([block1_id, block2_id]).add_to_forest(&mut forest).unwrap();
-    forest.make_root(join_id);
-
-    // Serialize
-    let bytes = forest.to_bytes();
-
-    // Deserialize as untrusted and validate
-    let untrusted = UntrustedMastForest::read_from_bytes(&bytes).unwrap();
-    let validated = untrusted.validate().unwrap();
-
-    assert_eq!(forest, validated);
-}
-
 /// Test that UntrustedMastForest::validate detects forward references.
 #[test]
 fn test_untrusted_forest_detects_forward_reference() {
@@ -2081,31 +2000,6 @@ fn test_untrusted_forest_detects_forward_reference() {
     let result = untrusted.validate();
 
     assert_matches!(result, Err(MastForestError::ForwardReference(_, _)));
-}
-
-/// Test that untrusted validation ignores wire hash mismatches and recomputes digests instead.
-#[test]
-fn test_untrusted_forest_ignores_wire_hash_mismatch() {
-    let mut forest = MastForest::new();
-    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-
-    let bytes = forest.to_bytes();
-    let expected = forest.clone();
-
-    let view = SerializedMastForest::new(&bytes).unwrap();
-    let digest_offset = node_hash_digest_offset(&view, 0);
-
-    // Corrupt one byte in the node-hash section.
-    let mut corrupted = bytes.clone();
-    corrupted[digest_offset] ^= 0xff;
-
-    // Deserialize as untrusted and validate. The corrupted wire digest should be ignored.
-    let untrusted = UntrustedMastForest::read_from_bytes(&corrupted).unwrap();
-    let validated = untrusted.validate().unwrap();
-    assert_eq!(validated, expected);
 }
 
 #[test]

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -1200,7 +1200,7 @@ fn test_batched_construction_preserves_structure() {
 fn assert_header_flags(bytes: &[u8], expected_flags: u8) {
     assert_eq!(&bytes[0..4], b"MAST", "Magic should be MAST");
     assert_eq!(bytes[4], expected_flags, "unexpected serialization flags");
-    assert_eq!(&bytes[5..8], &[0, 0, 4], "Version should be [0, 0, 4]");
+    assert_eq!(&bytes[5..8], &[0, 0, 3], "Version should be [0, 0, 3]");
 }
 
 #[test]

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -657,8 +657,8 @@ fn debug_info_offset_after_advice_map(bytes: &[u8]) -> usize {
 }
 
 fn node_hash_digest_offset(view: &SerializedMastForest<'_>, node_index: usize) -> usize {
-    let digest_slot = view.digest_slot_by_node[node_index] as usize;
-    view.node_hash_offset.unwrap() + digest_slot * Word::min_serialized_size()
+    let digest_slot = view.digest_slot_at(node_index);
+    view.node_hash_offset().unwrap() + digest_slot * Word::min_serialized_size()
 }
 
 fn rewrite_debug_info_procedure_name_digest(
@@ -714,7 +714,7 @@ fn test_trusted_deserialize_rejects_truncated_after_node_info() {
 fn test_serialized_mast_forest_rejects_truncated_inside_node_info() {
     let bytes = sample_serialized_view_bytes();
     let view = SerializedMastForest::new(&bytes).unwrap();
-    let truncation_point = view.node_entry_offset + view.node_entry_size - 1;
+    let truncation_point = view.node_entry_offset() + view.node_entry_size() - 1;
 
     let truncated = bytes[..truncation_point].to_vec();
     assert_matches!(
@@ -895,7 +895,7 @@ fn test_serialized_mast_forest_hashless_omits_hash_section_and_recomputes_digest
     forest.write_hashless(&mut bytes);
     let view = SerializedMastForest::new(&bytes).unwrap();
     assert!(view.is_hashless());
-    assert!(view.node_hash_offset.is_none());
+    assert!(view.node_hash_offset().is_none());
     for index in 0..view.node_count() {
         assert_eq!(forest.nodes()[index].digest(), view.node_info_at(index).unwrap().digest());
     }
@@ -912,7 +912,7 @@ fn test_serialized_mast_forest_hashless_accepts_external_nodes_parse_only() {
     forest.write_hashless(&mut bytes);
     let view = SerializedMastForest::new(&bytes).unwrap();
     assert!(view.is_hashless());
-    assert!(view.node_hash_offset.is_none());
+    assert!(view.node_hash_offset().is_none());
     assert_eq!(view.node_count(), 1);
     assert!(view.node_info_at(0).is_ok());
     assert_eq!(view.node_digest_at(0).unwrap(), external_digest);
@@ -1146,7 +1146,7 @@ fn mast_forest_deserialize_invalid_ops_offset_fails() {
     let _basic_block_data: Vec<u8> = Deserializable::read_from(&mut reader).unwrap();
 
     let view = SerializedMastForest::new(&serialized).unwrap();
-    let node_entry_offset = view.node_entry_offset;
+    let node_entry_offset = view.node_entry_offset();
 
     // Corrupt the ops_offset field with an out-of-bounds value
     let block_discriminant: u64 = 3;
@@ -1546,8 +1546,8 @@ fn test_hashless_serialization_smaller_than_stripped() {
 
     let stripped_view = SerializedMastForest::new(&stripped_bytes).unwrap();
     let hashless_view = SerializedMastForest::new(&hashless_bytes).unwrap();
-    assert!(stripped_view.node_hash_offset.is_some());
-    assert!(hashless_view.node_hash_offset.is_none());
+    assert!(stripped_view.node_hash_offset().is_some());
+    assert!(hashless_view.node_hash_offset().is_none());
 }
 
 /// Test that stripped serialization round-trips correctly with empty DebugInfo.
@@ -1759,6 +1759,25 @@ fn test_trusted_rejects_hashless() {
     );
 }
 
+#[test]
+fn test_trusted_rejects_truncated_hashless_before_layout_scan() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let mut hashless_bytes = Vec::new();
+    forest.write_hashless(&mut hashless_bytes);
+    hashless_bytes.truncate(8);
+
+    let result = MastForest::read_from_bytes(&hashless_bytes);
+    assert_matches!(
+        result,
+        Err(DeserializationError::InvalidValue(msg)) if msg.contains("HASHLESS")
+    );
+}
+
 /// Test that hashless without stripped is rejected.
 #[test]
 fn test_hashless_requires_stripped() {
@@ -1932,7 +1951,7 @@ fn test_untrusted_hashless_validate_recomputes_without_wire_hash_section() {
     let mut hashless_bytes = Vec::new();
     forest.write_hashless(&mut hashless_bytes);
     let view = SerializedMastForest::new(&hashless_bytes).unwrap();
-    assert!(view.node_hash_offset.is_none());
+    assert!(view.node_hash_offset().is_none());
 
     let (untrusted, flags) =
         UntrustedMastForest::read_from_bytes_with_flags(&hashless_bytes).unwrap();
@@ -2703,7 +2722,7 @@ fn locate_single_block_indptr_and_digest_offsets(bytes: &[u8]) -> (usize, usize)
     let bb_payload_start = cursor.position();
     let bb_payload_end = bb_payload_start + bb_data_len;
     let view = SerializedMastForest::new(bytes).unwrap();
-    let node_entries_start = view.node_entry_offset;
+    let node_entries_start = view.node_entry_offset();
 
     // node entry: MastNodeType (8 bytes)
     let node_type_u64 = u64::from_le_bytes(
@@ -2718,7 +2737,7 @@ fn locate_single_block_indptr_and_digest_offsets(bytes: &[u8]) -> (usize, usize)
     assert!(payload <= u32::MAX as u64, "Block ops_offset payload must fit in u32");
     let ops_offset = payload as usize;
 
-    let digest_offset = view.node_hash_offset.unwrap();
+    let digest_offset = view.node_hash_offset().unwrap();
 
     // Locate the start of the packed indptr for the first (and only) batch.
     let block_start = bb_payload_start + ops_offset;

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -889,7 +889,6 @@ fn mast_forest_deserialize_invalid_ops_offset_fails() {
 
     let _: [u8; 8] = reader.read_array().unwrap(); // magic (4) + flags (1) + version (3)
     let _node_count: usize = reader.read().unwrap();
-    let _decorator_count: usize = reader.read().unwrap();
     let _roots: Vec<u32> = Deserializable::read_from(&mut reader).unwrap();
     let _basic_block_data: Vec<u8> = Deserializable::read_from(&mut reader).unwrap();
 
@@ -2003,7 +2002,7 @@ fn test_untrusted_forest_detects_forward_reference() {
 }
 
 #[test]
-fn test_untrusted_forest_remaps_procedure_names_after_hash_recompute() {
+fn test_untrusted_forest_rejects_mismatched_wire_root_hash() {
     let mut forest = MastForest::new();
     let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
         .add_to_forest(&mut forest)
@@ -2024,15 +2023,20 @@ fn test_untrusted_forest_remaps_procedure_names_after_hash_recompute() {
     );
 
     let untrusted = UntrustedMastForest::read_from_bytes(&corrupted).unwrap();
-    let validated = untrusted.validate().unwrap();
+    let result = untrusted.validate();
 
-    assert_eq!(validated[block_id].digest(), expected_digest);
-    assert_eq!(validated.procedure_name(&expected_digest), Some("proc"));
-    assert_eq!(validated.debug_info().num_procedure_names(), 1);
+    assert_matches!(
+        result,
+        Err(MastForestError::HashMismatch {
+            node_id,
+            expected,
+            computed,
+        }) if node_id == block_id && expected == bogus_digest && computed == expected_digest
+    );
 }
 
 #[test]
-fn test_untrusted_forest_keeps_procedure_names_when_only_wire_root_hash_is_corrupted() {
+fn test_untrusted_forest_rejects_invalid_procedure_name_digest_without_remapping() {
     let mut forest = MastForest::new();
     let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
         .add_to_forest(&mut forest)
@@ -2042,25 +2046,18 @@ fn test_untrusted_forest_keeps_procedure_names_when_only_wire_root_hash_is_corru
     forest.insert_procedure_name(expected_digest, "proc".into());
 
     let bytes = forest.to_bytes();
-    let view = SerializedMastForest::new(&bytes).unwrap();
-    let digest_offset = node_hash_digest_offset(&view, block_id.to_usize());
     let bogus_digest: Word = [Felt::new(9), Felt::new(8), Felt::new(7), Felt::new(6)].into();
 
-    let mut corrupted = bytes.clone();
-    bogus_digest.write_into(
-        &mut &mut corrupted[digest_offset..digest_offset + Word::min_serialized_size()],
-    );
+    let corrupted = rewrite_debug_info_procedure_name_digest(&bytes, expected_digest, bogus_digest);
 
     let untrusted = UntrustedMastForest::read_from_bytes(&corrupted).unwrap();
-    let validated = untrusted.validate().unwrap();
+    let result = untrusted.validate();
 
-    assert_eq!(validated[block_id].digest(), expected_digest);
-    assert_eq!(validated.procedure_name(&expected_digest), Some("proc"));
-    assert_eq!(validated.debug_info().num_procedure_names(), 1);
+    assert_matches!(result, Err(MastForestError::InvalidProcedureNameDigest(digest)) if digest == bogus_digest);
 }
 
 #[test]
-fn test_untrusted_forest_preserves_incoming_root_resolution_on_digest_collision() {
+fn test_untrusted_forest_rejects_digest_collision_in_wire_hashes() {
     let mut forest = MastForest::new();
     let left_root = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
         .add_to_forest(&mut forest)
@@ -2085,12 +2082,16 @@ fn test_untrusted_forest_preserves_incoming_root_resolution_on_digest_collision(
     );
 
     let untrusted = UntrustedMastForest::read_from_bytes(&corrupted).unwrap();
-    let validated = untrusted.validate().unwrap();
+    let result = untrusted.validate();
 
-    assert_eq!(validated[left_root].digest(), left_digest);
-    assert_eq!(validated[right_root].digest(), right_digest);
-    assert_eq!(validated.procedure_name(&left_digest), Some("right"));
-    assert_eq!(validated.procedure_name(&right_digest), None);
+    assert_matches!(
+        result,
+        Err(MastForestError::HashMismatch {
+            node_id,
+            expected,
+            computed,
+        }) if node_id == left_root && expected == right_digest && computed == left_digest
+    );
 }
 
 // UNTRUSTED VALIDATION TEST HELPERS
@@ -2237,7 +2238,6 @@ fn locate_single_block_indptr_and_digest_offsets(bytes: &[u8]) -> (usize, usize)
     let node_count: usize = cursor.read().unwrap();
     assert_eq!(node_count, 1);
 
-    let _decorator_count: usize = cursor.read().unwrap();
     let _roots: Vec<u32> = Deserializable::read_from(&mut cursor).unwrap();
 
     // basic block data section: Vec<u8>
@@ -2510,9 +2510,6 @@ fn test_deserialization_rejects_excessive_node_count() {
     // Write excessive node count (MAX_NODES + 1)
     let excessive_count: usize = MastForest::MAX_NODES + 1;
     excessive_count.write_into(&mut bytes);
-
-    // Write decorator count
-    0usize.write_into(&mut bytes);
 
     // Attempt to deserialize - should fail before any large allocation
     let result = MastForest::read_from_bytes(&bytes);

--- a/core/src/mast/serialization/view.rs
+++ b/core/src/mast/serialization/view.rs
@@ -1,13 +1,13 @@
 use alloc::vec::Vec;
 
-use super::{MastNodeEntry, MastNodeId, MastNodeInfo, Word};
-use crate::serde::DeserializationError;
+use super::{MastNodeEntry, MastNodeInfo};
+use crate::{Word, mast::MastNodeId, serde::DeserializationError};
 
-/// Read-only view over MAST node metadata.
+/// Read-only view over serialization-oriented MAST node metadata.
 ///
-/// This trait is implemented by both in-memory [`super::MastForest`] and serialized
-/// [`super::SerializedMastForest`] representations, enabling callers to consume a shared
-/// random-access API independent of backing storage.
+/// This trait lives alongside [`super::SerializedMastForest`] because its surface is defined in
+/// terms of serialized-equivalent node entries and digests, even though both
+/// [`super::SerializedMastForest`] and in-memory [`crate::mast::MastForest`] implement it.
 pub trait MastForestView {
     /// Returns the number of nodes in the forest.
     fn node_count(&self) -> usize;

--- a/core/src/mast/serialization/view.rs
+++ b/core/src/mast/serialization/view.rs
@@ -13,12 +13,18 @@ pub trait MastForestView {
     fn node_count(&self) -> usize;
 
     /// Returns fixed-width structural metadata for a node at the specified index.
+    ///
+    /// Returns an error if `index >= self.node_count()`.
     fn node_entry_at(&self, index: usize) -> Result<MastNodeEntry, DeserializationError>;
 
     /// Returns the digest of the node at the specified index.
+    ///
+    /// Returns an error if `index >= self.node_count()`.
     fn node_digest_at(&self, index: usize) -> Result<Word, DeserializationError>;
 
     /// Returns serialized-equivalent metadata for a node at the specified index.
+    ///
+    /// Returns an error if `index >= self.node_count()`.
     fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError> {
         Ok(MastNodeInfo::from_entry(
             self.node_entry_at(index)?,
@@ -30,6 +36,8 @@ pub trait MastForestView {
     fn procedure_root_count(&self) -> usize;
 
     /// Returns the procedure root id at the specified index.
+    ///
+    /// Returns an error if `index >= self.procedure_root_count()`.
     fn procedure_root_at(&self, index: usize) -> Result<MastNodeId, DeserializationError>;
 
     /// Returns true when the forest contains no nodes.

--- a/core/src/mast/view.rs
+++ b/core/src/mast/view.rs
@@ -1,0 +1,56 @@
+use alloc::vec::Vec;
+
+use super::{MastNodeEntry, MastNodeId, MastNodeInfo, Word};
+use crate::serde::DeserializationError;
+
+/// Read-only view over MAST node metadata.
+///
+/// This trait is implemented by both in-memory [`super::MastForest`] and serialized
+/// [`super::SerializedMastForest`] representations, enabling callers to consume a shared
+/// random-access API independent of backing storage.
+pub trait MastForestView {
+    /// Returns the number of nodes in the forest.
+    fn node_count(&self) -> usize;
+
+    /// Returns fixed-width structural metadata for a node at the specified index.
+    fn node_entry_at(&self, index: usize) -> Result<MastNodeEntry, DeserializationError>;
+
+    /// Returns the digest of the node at the specified index.
+    fn node_digest_at(&self, index: usize) -> Result<Word, DeserializationError>;
+
+    /// Returns serialized-equivalent metadata for a node at the specified index.
+    fn node_info_at(&self, index: usize) -> Result<MastNodeInfo, DeserializationError> {
+        Ok(MastNodeInfo::from_entry(
+            self.node_entry_at(index)?,
+            self.node_digest_at(index)?,
+        ))
+    }
+
+    /// Returns the number of procedure roots in the forest.
+    fn procedure_root_count(&self) -> usize;
+
+    /// Returns the procedure root id at the specified index.
+    fn procedure_root_at(&self, index: usize) -> Result<MastNodeId, DeserializationError>;
+
+    /// Returns true when the forest contains no nodes.
+    fn is_empty(&self) -> bool {
+        self.node_count() == 0
+    }
+
+    /// Returns true when `index` is a valid node index.
+    fn has_node(&self, index: usize) -> bool {
+        index < self.node_count()
+    }
+
+    /// Returns all node infos in index order.
+    fn all_node_infos(&self) -> Result<Vec<MastNodeInfo>, DeserializationError> {
+        (0..self.node_count()).map(|index| self.node_info_at(index)).collect()
+    }
+
+    /// Returns all procedure roots in index order.
+    fn procedure_roots(&self) -> Result<Vec<MastNodeId>, DeserializationError> {
+        (0..self.procedure_root_count())
+            .map(|index| self.procedure_root_at(index))
+            .collect()
+    }
+}

--- a/core/src/operations/mod.rs
+++ b/core/src/operations/mod.rs
@@ -904,6 +904,101 @@ impl Serializable for Operation {
     }
 }
 
+impl Operation {
+    /// Returns the serialized size of this operation in bytes.
+    pub(crate) fn encoded_size(&self) -> usize {
+        let mut size = core::mem::size_of::<u8>();
+        match self {
+            Operation::Assert(err_code)
+            | Operation::MpVerify(err_code)
+            | Operation::U32assert2(err_code) => {
+                size += err_code.get_size_hint();
+            },
+            Operation::Push(value) => {
+                size += value.as_canonical_u64().get_size_hint();
+            },
+            Operation::Noop
+            | Operation::SDepth
+            | Operation::Caller
+            | Operation::Clk
+            | Operation::Add
+            | Operation::Neg
+            | Operation::Mul
+            | Operation::Inv
+            | Operation::Incr
+            | Operation::And
+            | Operation::Or
+            | Operation::Not
+            | Operation::Eq
+            | Operation::Eqz
+            | Operation::Expacc
+            | Operation::Ext2Mul
+            | Operation::U32split
+            | Operation::U32add
+            | Operation::U32add3
+            | Operation::U32sub
+            | Operation::U32mul
+            | Operation::U32madd
+            | Operation::U32div
+            | Operation::U32and
+            | Operation::U32xor
+            | Operation::Pad
+            | Operation::Drop
+            | Operation::Dup0
+            | Operation::Dup1
+            | Operation::Dup2
+            | Operation::Dup3
+            | Operation::Dup4
+            | Operation::Dup5
+            | Operation::Dup6
+            | Operation::Dup7
+            | Operation::Dup9
+            | Operation::Dup11
+            | Operation::Dup13
+            | Operation::Dup15
+            | Operation::Swap
+            | Operation::SwapW
+            | Operation::SwapW2
+            | Operation::SwapW3
+            | Operation::SwapDW
+            | Operation::Emit
+            | Operation::MovUp2
+            | Operation::MovUp3
+            | Operation::MovUp4
+            | Operation::MovUp5
+            | Operation::MovUp6
+            | Operation::MovUp7
+            | Operation::MovUp8
+            | Operation::MovDn2
+            | Operation::MovDn3
+            | Operation::MovDn4
+            | Operation::MovDn5
+            | Operation::MovDn6
+            | Operation::MovDn7
+            | Operation::MovDn8
+            | Operation::CSwap
+            | Operation::CSwapW
+            | Operation::AdvPop
+            | Operation::AdvPopW
+            | Operation::MLoadW
+            | Operation::MStoreW
+            | Operation::MLoad
+            | Operation::MStore
+            | Operation::MStream
+            | Operation::Pipe
+            | Operation::CryptoStream
+            | Operation::HPerm
+            | Operation::MrUpdate
+            | Operation::FriE2F4
+            | Operation::HornerBase
+            | Operation::HornerExt
+            | Operation::EvalCircuit
+            | Operation::LogPrecompile => (),
+        }
+        size
+    }
+}
+
 impl Deserializable for Operation {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let op_code = source.read_u8()?;

--- a/crates/lib/core/tests/mast_forest_merge.rs
+++ b/crates/lib/core/tests/mast_forest_merge.rs
@@ -88,3 +88,15 @@ fn test_core_lib_serialization_roundtrip() {
         }
     }
 }
+
+/// Tests that stripped size hint matches the serialized length for the core library.
+#[test]
+fn test_core_lib_stripped_size_hint() {
+    let std_lib = miden_core_lib::CoreLibrary::default();
+    let forest = std_lib.mast_forest().as_ref();
+
+    let mut stripped_bytes = Vec::new();
+    forest.write_stripped(&mut stripped_bytes);
+
+    assert_eq!(forest.stripped_size_hint(), stripped_bytes.len());
+}

--- a/miden-core-fuzz/Cargo.toml
+++ b/miden-core-fuzz/Cargo.toml
@@ -66,6 +66,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "serialized_mast_forest_new"
+path = "fuzz_targets/serialized_mast_forest_new.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "basic_block_data"
 path = "fuzz_targets/basic_block_data.rs"
 test = false

--- a/miden-core-fuzz/fuzz_targets/mast_forest_validate.rs
+++ b/miden-core-fuzz/fuzz_targets/mast_forest_validate.rs
@@ -3,7 +3,8 @@
 //! This target tests the full untrusted deserialization pipeline:
 //! 1. UntrustedMastForest::read_from_bytes (budgeted deserialization)
 //! 2. UntrustedMastForest::validate() (structural + hash validation)
-//! 3. UntrustedMastForest::read_from_bytes_with_budget with small budget
+//! 3. Budgeted parsing-only and parsing+validation entry points
+//! 4. Flag-returning variants for callers that need serializer intent bits
 //!
 //! The validation path should never panic on any input.
 //!
@@ -15,8 +16,35 @@ use libfuzzer_sys::fuzz_target;
 use miden_core::mast::UntrustedMastForest;
 
 fuzz_target!(|data: &[u8]| {
+    let validate_untrusted = |result| {
+        if let Ok(untrusted) = result {
+            let _ = untrusted.validate();
+        }
+    };
+    let validate_untrusted_with_flags = |result| {
+        if let Ok((untrusted, _flags)) = result {
+            let _ = untrusted.validate();
+        }
+    };
+
     // Test the full untrusted deserialization + validation pipeline
     let Ok(untrusted) = UntrustedMastForest::read_from_bytes(data) else {
+        // Even if the default path rejects early, exercise the explicit-budget variants too.
+        validate_untrusted(UntrustedMastForest::read_from_bytes_with_budget(data, 64));
+        validate_untrusted_with_flags(UntrustedMastForest::read_from_bytes_with_budget_and_flags(
+            data, 64,
+        ));
+        validate_untrusted(UntrustedMastForest::read_from_bytes_with_budgets(
+            data,
+            data.len(),
+            data.len(),
+        ));
+        validate_untrusted_with_flags(UntrustedMastForest::read_from_bytes_with_budgets_and_flags(
+            data,
+            data.len(),
+            data.len(),
+        ));
+        validate_untrusted_with_flags(UntrustedMastForest::read_from_bytes_with_flags(data));
         return;
     };
 
@@ -25,5 +53,19 @@ fuzz_target!(|data: &[u8]| {
 
     // Test budgeted deserialization with a very small budget
     // This should reject most inputs early without panicking
-    let _ = UntrustedMastForest::read_from_bytes_with_budget(data, 64);
+    validate_untrusted(UntrustedMastForest::read_from_bytes_with_budget(data, 64));
+    validate_untrusted_with_flags(UntrustedMastForest::read_from_bytes_with_budget_and_flags(
+        data, 64,
+    ));
+    validate_untrusted(UntrustedMastForest::read_from_bytes_with_budgets(
+        data,
+        data.len(),
+        data.len(),
+    ));
+    validate_untrusted_with_flags(UntrustedMastForest::read_from_bytes_with_budgets_and_flags(
+        data,
+        data.len(),
+        data.len(),
+    ));
+    validate_untrusted_with_flags(UntrustedMastForest::read_from_bytes_with_flags(data));
 });

--- a/miden-core-fuzz/fuzz_targets/mast_node_info.rs
+++ b/miden-core-fuzz/fuzz_targets/mast_node_info.rs
@@ -1,21 +1,32 @@
 //! Fuzz target for MastNodeInfo deserialization.
 //!
-//! MastNodeInfo is a fixed-width structure (8 bytes type + 32 bytes digest = 40 bytes).
-//! This tests the MastNodeType discriminant parsing and payload extraction.
+//! MastNodeInfo is a fixed-width structure (8 bytes node entry + 32 bytes digest = 40 bytes).
+//! This target exercises `MastNodeEntry` decoding plus `MastNodeInfo` materialization through the
+//! serialized-view API.
 //!
 //! Run with: cargo +nightly fuzz run mast_node_info --fuzz-dir miden-core-fuzz
 
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-
-// Note: MastNodeInfo is pub(crate), so we test via the full deserialization path
-// with crafted inputs that exercise node info parsing specifically.
-
-use miden_core::{mast::MastForest, serde::Deserializable};
+use miden_core::mast::SerializedMastForest;
 
 fuzz_target!(|data: &[u8]| {
-    // MastNodeInfo is internal, but we can exercise it through MastForest
-    // The fuzzer will find inputs that reach the node info parsing code
-    let _ = MastForest::read_from_bytes(data);
+    let Ok(view) = SerializedMastForest::new(data) else {
+        return;
+    };
+
+    if view.node_count() == 0 {
+        return;
+    }
+
+    let last = view.node_count() - 1;
+
+    let _ = view.node_entry_at(0);
+    let _ = view.node_info_at(0);
+    let _ = view.node_digest_at(0);
+
+    let _ = view.node_entry_at(last);
+    let _ = view.node_info_at(last);
+    let _ = view.node_digest_at(last);
 });

--- a/miden-core-fuzz/fuzz_targets/serialized_mast_forest_new.rs
+++ b/miden-core-fuzz/fuzz_targets/serialized_mast_forest_new.rs
@@ -1,0 +1,35 @@
+//! Fuzz target for SerializedMastForest structural inspection.
+//!
+//! This target focuses on the trusted inspection path exposed by
+//! `SerializedMastForest::new()`. It exercises layout scanning and cheap random-access helpers
+//! without going through full trusted or untrusted materialization.
+//!
+//! Run with: cargo +nightly fuzz run serialized_mast_forest_new --fuzz-dir miden-core-fuzz
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use miden_core::mast::SerializedMastForest;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(view) = SerializedMastForest::new(data) else {
+        return;
+    };
+
+    let _ = view.is_hashless();
+    let _ = view.is_stripped();
+    let root_count = view.procedure_root_count();
+    let node_count = view.node_count();
+
+    if root_count > 0 {
+        let last_root = root_count - 1;
+        let _ = view.procedure_root_at(0);
+        let _ = view.procedure_root_at(last_root);
+    }
+
+    if node_count > 0 {
+        let last_node = node_count - 1;
+        let _ = view.node_entry_at(0);
+        let _ = view.node_entry_at(last_node);
+    }
+});


### PR DESCRIPTION
## Summary


This PR rewrites MAST forest serialization around one fixed structural layout.

The main change is that node structure and node digests are no longer stored in the same section. Each node still has a fixed-width entry, so stripped and hashless payloads keep random access by node index. Internal node hashes now live in their own section. Hashless bytes omit that section. External node digests stay serialized because they cannot be rebuilt from local structure.

The trust boundary is now explicit. On the wire, flags only say what the serializer intended to send. They do not change what the reader trusts.

Trusted `MastForest` deserialization accepts full and stripped payloads with hashes. It rejects hashless payloads. If a caller wants to read hashless bytes, it must use `UntrustedMastForest`.

Untrusted `UntrustedMastForest` deserialization accepts full, stripped, and hashless payloads. It expects hashless input. If extra hashes or `DebugInfo` are sent, it logs an error-level message and ignores that extra data. On validation, it always recomputes all non-external node hashes from structure and uses the rebuilt table after that.

`DebugInfo` keeps one format. It is either present as one trailing section or omitted as a whole. 

This PR also makes a hard format cut-over. The new wire format is version `0.0.3`. Older MAST bytes are rejected.


## Testing & Benchmarking

<details><summary>Details</summary>
Invariants we test:

- one structural wire layout for full, stripped, and hashless payloads
- fixed-width node entries, so node count and node offsets stay cheap to read
- `HASHLESS` implies `STRIPPED`
- hashless bytes omit the general internal-hash section
- external node digests are still serialized
- trusted deserialization rejects hashless before deeper parsing
- untrusted deserialization accepts overspecified payloads but logs that extra wire data was sent
- untrusted validation recomputes non-external hashes once and then serves digest lookups from the rebuilt table
- stripped payloads round-trip without `DebugInfo`
- invalid flags, truncated sections, bad offsets, forward references, malformed batch layouts, and oversized node counts are rejected
- procedure names stay well-defined after hash recomputation, including root-hash corruption and digest-collision cases

Measured on the Miden core library `MastForest`, serialized from `CoreLibrary::default().mast_forest()`.

| Ref | Full | Stripped | Hashless |
| --- | ---: | ---: | ---: |
| `origin/next` (`bd42aeff8`) | 472,034 | 299,972 | n/a |
| `mast-serialization` (`3298fc464`) | 472,066 | 299,972 | 273,732 |

This keeps stripped size flat on the core library. Hashless saves 26,240 bytes vs stripped, or 8.75%, as expected in #2628. It saves 198,334 bytes vs full, or 42.01%.

Measured with the existing criterion benchmark in `miden-vm/benches/deserialize_core_lib.rs`, which times `Library::read_from_bytes(CoreLibrary::SERIALIZED)`.

| Ref | Benchmark | Time |
| --- | --- | ---: |
| `origin/next` (`bd42aeff8`) | `deserialize_core_lib/read_from_bytes` | 3.3250 ms |
| `mast-serialization` (`3298fc464`) | `deserialize_core_lib/read_from_bytes` | 3.1959 ms |

This benchmark measures trusted deserialization of the bundled core library package through `Library::read_from_bytes(CoreLibrary::SERIALIZED)`. On the MAST side, that reaches `MastForest::read_from` and the full trusted materialization path (see #2863). It does not measure hashless bytes, `UntrustedMastForest::validate()`, hash recomputation cost, or stripped/hashless random access.

Measured with a [standalone Criterion benchmark over bare core-library MAST bytes](https://gist.github.com/huitseeker/dd70fc331cd954a4bed265968abd3f57), timing `UntrustedMastForest::read_from_bytes(&bytes)?.validate()`.

| Ref | Mode | Time |
| --- | --- | ---: |
| `origin/next` (`bd42aeff8`) | `full` | 6.4803 ms |
| `origin/next` (`bd42aeff8`) | `stripped` | 4.8023 ms |
| `mast-serialization` (`3298fc464`) | `full` | 7.5294 ms |
| `mast-serialization` (`3298fc464`) | `stripped` | 5.1212 ms |
| `mast-serialization` (`3298fc464`) | `hashless` | 5.5215 ms |

This benchmark measures the untrusted MAST path directly, including validation and hash recomputation, without package-level `Library` overhead. `origin/next` has no hashless mode, so there is no before number for that case. But the numbers there are consistent with #2863.

Edit: Updated `MastForest` deserialization fuzzing to take the new structs into account and ran fuzzing.

</details>



## Issues

Fixes #2726: this addresses the main design point, and improves on the plan laid out in that issue. Hashless bytes no longer carry the internal node hashes, so we no longer burn fixed digest bytes just to keep the slot empty. At the same time, we keep one fixed structural layout, keep random access for stripped and hashless payloads, and keep the strict trusted vs untrusted read paths.

Fixes #2504 (maybe): this addresses the size-accounting goal for *stripped* serialization. `stripped_size_hint()` is exact, and the sectioned layout makes the byte cost of each part explicit. The fixed node-entry section also keeps the format easy to size and scan without full materialization. Hopefully we don't need size accounting for `DebugInfo` (which is gnarly), but for note size limits, this should be enough (/cc @PhilippGackstatter).

Fixes #2628: Hashless payloads now save the internal-hash bytes, which is the cleanest size win available without changing the fixed structural layout. This PR does not add a second compressed wire format, and it does not try to optimize the full or stripped formats beyond this split.

## Web explainer

https://gisthost.github.io/?cc5e99ad466cae75bdfb4b447b5509ac

## Video explainer (<100s)

https://github.com/user-attachments/assets/8e7d4d45-4ecc-4a12-af59-8b2ded533598


