### PR TITLE
Fix incorrect example path

### DIFF
--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -129,7 +129,7 @@ After a program finishes executing, the elements that remain on the stack become
 
 ## Fibonacci example
 
-In the `miden/masm-examples/fib` directory, we provide a very simple Fibonacci calculator example. This example computes the 1001st term of the Fibonacci sequence. You can execute this example on Miden VM like so:
+In the `miden-vm/masm-examples/fib` directory, we provide a very simple Fibonacci calculator example. This example computes the 1001st term of the Fibonacci sequence. You can execute this example on Miden VM like so:
 
 ```shell
 ./target/optimized/miden-vm run miden-vm/masm-examples/fib/fib.masm


### PR DESCRIPTION
## Changes

The example path in [`docs/src/usage.md`](https://github.com/0xMiden/miden-vm/blob/next/docs/src/usage.md#fibonacci-example) points to:
```
miden/masm-examples/fib
```
However, the actual repository structure and the command shown below use:
```
miden-vm/masm-examples/fib
```
Updated the path to `miden-vm/masm-examples/fib` to ensure the documentation matches the repository structure and the example command.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'