### PR TITLE
feat(air): add optional serde feature

### DIFF
--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -20,6 +20,7 @@ doctest = false
 [features]
 default = ["std"]
 std = ["miden-core/std", "thiserror/std"]
+serde = ["miden-core/serde"]
 concurrent = ["std"]
 testing = []
 


### PR DESCRIPTION
﻿## Summary

Add an opt-in serde feature to miden-air that enables miden-core/serde.

## Problem

As reported in #2744, miden-air was unconditionally enabling serde on miden-core. This causes increased compile times for consumers who don't need serialization.

## Solution

Add an optional serde feature to miden-air/Cargo.toml that enables miden-core/serde. Consumers who need serde can now opt in explicitly.

## Testing

- cargo check -p miden-air passes
- cargo check -p miden-air --features serde passes

Closes #2744
