### PR TITLE
Introduce FastProcessor safe stack access methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixes an possible u64 overflow issue in `op_eval_circuit()` [#2799](https://github.com/0xMiden/miden-vm/pull/2799)
 - Preserved dynexec/dyncall distinction (and digests) when remapping or merging MAST forests ([#2784](https://github.com/0xMiden/miden-vm/pull/2784)).
 - Hardened MASM parsing and constants handling (lexer invalid-token spans, repeat count bounds, constant range checks, field division folding, and `push.WORD[...]` index validation) ([#2803](https://github.com/0xMiden/miden-vm/pull/2803)).
+- Introduced `FastProcessor` safe stack method accesses for event handlers ([#2797](https://github.com/0xMiden/miden-vm/pull/2797)).
 
 ## 0.21.1 (2026-02-24)
 

--- a/processor/src/fast/basic_block/sys_event_handlers.rs
+++ b/processor/src/fast/basic_block/sys_event_handlers.rs
@@ -167,7 +167,7 @@ fn insert_hqword_into_adv_map(processor: &mut FastProcessor) -> Result<(), Syste
     let a = processor.stack_get_word(1);
     let b = processor.stack_get_word(5);
     let c = processor.stack_get_word(9);
-    let d = processor.stack_get_word(13);
+    let d = processor.stack_get_word_safe(13);
 
     // Hash in natural stack order [A, B, C, D].
     let key = Poseidon2::hash_elements(&[*a, *b, *c, *d].concat());

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -298,12 +298,37 @@ impl FastProcessor {
     }
 
     /// Returns the element on the stack at index `idx`.
+    ///
+    /// This method is only meant to be used to access the stack top by operation handlers, and
+    /// system event handlers.
+    ///
+    /// # Preconditions
+    /// - `idx` must be less than or equal to 15.
     #[inline(always)]
     pub fn stack_get(&self, idx: usize) -> Felt {
         self.stack[self.stack_top_idx - idx - 1]
     }
 
+    /// Same as [`Self::stack_get()`], but returns [`ZERO`] if `idx` falls below index 0 in the
+    /// stack buffer.
+    ///
+    /// Use this instead of `stack_get()` when `idx` may exceed 15.
+    #[inline(always)]
+    pub fn stack_get_safe(&self, idx: usize) -> Felt {
+        if idx < self.stack_top_idx {
+            self.stack[self.stack_top_idx - idx - 1]
+        } else {
+            ZERO
+        }
+    }
+
     /// Mutable variant of `stack_get()`.
+    ///
+    /// This method is only meant to be used to access the stack top by operation handlers, and
+    /// system event handlers.
+    ///
+    /// # Preconditions
+    /// - `idx` must be less than or equal to 15.
     #[inline(always)]
     pub fn stack_get_mut(&mut self, idx: usize) -> &mut Felt {
         &mut self.stack[self.stack_top_idx - idx - 1]
@@ -323,6 +348,12 @@ impl FastProcessor {
     /// - `stack_get_word(0)` returns `[a, b, c, d]`,
     /// - `stack_get_word(1)` returns `[b, c, d, e]`,
     /// - etc.
+    ///
+    /// This method is only meant to be used to access the stack top by operation handlers, and
+    /// system event handlers.
+    ///
+    /// # Preconditions
+    /// - `start_idx` must be less than or equal to 12.
     #[inline(always)]
     pub fn stack_get_word(&self, start_idx: usize) -> Word {
         // Ensure we have enough elements to form a complete word
@@ -336,6 +367,30 @@ impl FastProcessor {
             self.stack[range(word_start_idx, WORD_SIZE)].try_into().unwrap();
         // Reverse so top of stack (idx 0) goes to word[0]
         result.reverse();
+        result.into()
+    }
+
+    /// Same as [`Self::stack_get_word()`], but returns [`ZERO`] for any element that falls below
+    /// index 0 in the stack buffer.
+    ///
+    /// Use this instead of `stack_get_word()` when `start_idx + WORD_SIZE` may exceed
+    /// `stack_top_idx`.
+    #[inline(always)]
+    pub fn stack_get_word_safe(&self, start_idx: usize) -> Word {
+        let buf_end = self.stack_top_idx.saturating_sub(start_idx);
+        let buf_start = self.stack_top_idx.saturating_sub(start_idx.saturating_add(WORD_SIZE));
+        let num_elements_to_read_from_buf = buf_end - buf_start;
+
+        let mut result = [ZERO; WORD_SIZE];
+        if num_elements_to_read_from_buf == WORD_SIZE {
+            result.copy_from_slice(&self.stack[range(buf_start, WORD_SIZE)]);
+        } else if num_elements_to_read_from_buf > 0 {
+            let offset = WORD_SIZE - num_elements_to_read_from_buf;
+            result[offset..]
+                .copy_from_slice(&self.stack[range(buf_start, num_elements_to_read_from_buf)]);
+        }
+        result.reverse();
+
         result.into()
     }
 

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -57,6 +57,43 @@ fn stack_get_word_out_of_bounds_read() {
     processor.execute_sync(&program, &mut host).unwrap();
 }
 
+#[test]
+fn stack_get_safe_boundary() {
+    let inputs = StackInputs::try_from_ints(1..=16_u64).unwrap();
+    let processor = FastProcessor::new(inputs);
+
+    // idx == stack_top_idx: out of bounds, should return ZERO.
+    assert_eq!(processor.stack_get_safe(INITIAL_STACK_TOP_IDX), ZERO);
+
+    // idx == stack_top_idx - 1: below the stack (buffer index 0 is zeroed), should return ZERO.
+    assert_eq!(processor.stack_get_safe(INITIAL_STACK_TOP_IDX - 1), ZERO);
+
+    // idx == stack_top_idx + 1: out of bounds, should return ZERO.
+    assert_eq!(processor.stack_get_safe(INITIAL_STACK_TOP_IDX + 1), ZERO);
+
+    // idx == usize::MAX: far out of bounds, should return ZERO.
+    assert_eq!(processor.stack_get_safe(usize::MAX), ZERO);
+}
+
+#[test]
+fn stack_get_word_safe_partial_read() {
+    let inputs = StackInputs::try_from_ints(1..=16_u64).unwrap();
+    let processor = FastProcessor::new(inputs);
+
+    // The stack has 16 elements (indices 0..=15). Reading a word at start_idx=15 means we want
+    // elements at indices 15, 16, 17, 18. Only index 15 is valid; the rest should be ZERO.
+    let word = processor.stack_get_word_safe(15);
+    // Index 15 is the bottom of the stack (value 16, since inputs are in stack order: top first).
+    assert_eq!(word, [Felt::new(16), ZERO, ZERO, ZERO].into());
+}
+
+#[test]
+fn stack_get_word_safe_usize_max() {
+    let processor = FastProcessor::new(StackInputs::default());
+    let word = processor.stack_get_word_safe(usize::MAX);
+    assert_eq!(word, Word::default());
+}
+
 /// Ensures that the stack is correctly reset in the buffer when the stack is reset in the buffer
 /// as a result of underflow.
 ///

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -184,7 +184,7 @@ impl<'a> ProcessorState<'a> {
     /// This method can access elements beyond the top 16 positions by using the overflow table.
     #[inline(always)]
     pub fn get_stack_item(&self, pos: usize) -> Felt {
-        self.processor.stack_get(pos)
+        self.processor.stack_get_safe(pos)
     }
 
     /// Returns a word starting at the specified element index on the stack.
@@ -200,7 +200,7 @@ impl<'a> ProcessorState<'a> {
     /// Creating a word does not change the state of the stack.
     #[inline(always)]
     pub fn get_stack_word(&self, start_idx: usize) -> Word {
-        self.processor.stack_get_word(start_idx)
+        self.processor.stack_get_word_safe(start_idx)
     }
 
     /// Returns stack state at the current clock cycle. This includes the top 16 items of the

--- a/processor/src/processor.rs
+++ b/processor/src/processor.rs
@@ -150,9 +150,13 @@ pub(crate) trait StackInterface {
     fn top(&self) -> &[Felt];
 
     /// Returns the element on the stack at index `idx`.
+    ///
+    /// `idx` must be less than or equal to 15.
     fn get(&self, idx: usize) -> Felt;
 
     /// Mutable variant of `stack_get()`.
+    ///
+    /// `idx` must be less than or equal to 15.
     fn get_mut(&mut self, idx: usize) -> &mut Felt;
 
     /// Returns the word on the stack starting at index `start_idx` in "stack order".
@@ -172,6 +176,8 @@ pub(crate) trait StackInterface {
     /// - etc.
     ///
     /// Word\[0\] corresponds to the top of stack.
+    ///
+    /// `start_idx` must be less than or equal to 12.
     fn get_word(&self, start_idx: usize) -> Word;
 
     /// Returns two words (8 elements) from the stack starting at index `start_idx`.
@@ -186,6 +192,8 @@ pub(crate) trait StackInterface {
     /// a | b | c | d | e | f | g | h | i | j | k | l | m | n | o | p
     ///
     /// Then `get_double_word(0)` returns `[a, b, c, d, e, f, g, h]`.
+    ///
+    /// `start_idx` must be less than or equal to 8.
     fn get_double_word(&self, start_idx: usize) -> [Felt; 8] {
         core::array::from_fn(|i| self.get(start_idx + i))
     }
@@ -194,14 +202,20 @@ pub(crate) trait StackInterface {
     fn depth(&self) -> u32;
 
     /// Writes an element to the stack at the given index.
+    ///
+    /// `idx` must be less than or equal to 15.
     fn set(&mut self, idx: usize, element: Felt);
 
     /// Writes a word to the stack starting at the given index.
     ///
     /// Word\[0\] goes to stack position start_idx (top), word\[1\] to start_idx+1, etc.
+    ///
+    /// `start_idx` must be less than or equal to 12.
     fn set_word(&mut self, start_idx: usize, word: &Word);
 
     /// Swaps the elements at the given indices on the stack.
+    ///
+    /// `idx1` and `idx2` must be less than or equal to 15.
     fn swap(&mut self, idx1: usize, idx2: usize);
 
     /// Swaps the nth word from the top of the stack with the top word of the stack.


### PR DESCRIPTION
Introduces safe stack access methods that will never read outside the stack buffer for use by event handlers.

Fixes audit issue 66:

> A crafted program can deterministically panic the fast processor in release builds by triggering an out-of-bounds stack word read through a system event invoked via emit.

This PR introduces safe access methods (which are slower than the existing ones), only to be used by event handlers (through the `ProcessorState` type), and our internal system event handlers.