### PR TITLE
Fix eval_circuit overflow panic (audit issue 48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed `Constant::PartialEq` to include `visibility` field in equality comparison, making it consistent with other exportable items (`Procedure`, `TypeAlias`, `EnumType`).
 - Hardened untrusted deserialization by enforcing budgets and depth limits, plus expanded fuzzing coverage ([#2777](https://github.com/0xMiden/miden-vm/pull/2777)).
 - Hardened AEAD decrypt size calculations ([#2789](https://github.com/0xMiden/miden-vm/pull/2789)).
+- Fixes an possible u64 overflow issue in `op_eval_circuit()` [#2799](https://github.com/0xMiden/miden-vm/pull/2799)
 
 ## 0.21.1 (2026-02-24)
 

--- a/processor/src/execution/operations/eval_circuit.rs
+++ b/processor/src/execution/operations/eval_circuit.rs
@@ -62,7 +62,7 @@ pub(crate) fn eval_circuit_impl(
     let num_vars = num_vars.as_canonical_u64();
     let num_eval = num_eval.as_canonical_u64();
 
-    let num_wires = num_vars + num_eval;
+    let num_wires = num_vars.saturating_add(num_eval);
     if num_wires > MAX_NUM_ACE_WIRES as u64 {
         const {
             // If this fails, update the error message below
@@ -90,7 +90,7 @@ pub(crate) fn eval_circuit_impl(
     }
 
     // Ensure instructions are word-aligned and non-empty
-    let num_read_rows = num_vars as u32 / 2;
+    let num_read_rows = (num_vars / 2) as u32;
     let num_eval_rows = num_eval as u32;
 
     let mut evaluation_context = CircuitEvaluation::new(ctx, clk, num_read_rows, num_eval_rows);

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -41,7 +41,7 @@ mod tests;
 // ================================================================================================
 
 pub use continuation_stack::Continuation;
-pub use errors::{ExecutionError, HostError, MemoryError};
+pub use errors::{AceError, ExecutionError, HostError, MemoryError};
 pub use execution_options::{ExecutionOptions, ExecutionOptionsError};
 pub use fast::{BreakReason, ExecutionOutput, FastProcessor, ResumeContext};
 pub use host::{

--- a/processor/tests/eval_circuit_overflow.rs
+++ b/processor/tests/eval_circuit_overflow.rs
@@ -1,0 +1,43 @@
+use miden_core::{
+    field::PrimeField64,
+    mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor},
+};
+use miden_processor::{
+    AceError, DefaultHost, ExecutionError, FastProcessor, Felt, Program, StackInputs,
+    advice::AdviceInputs, operation::Operation,
+};
+
+#[test]
+fn eval_circuit_overflow_panic_check() {
+    let ptr = Felt::new(0);
+    let n_read = Felt::new(Felt::ORDER_U64 - 3); // = 2^64 - 2^32 - 2
+    let n_eval = Felt::new((1u64 << 32) + 4); // = 2^32 + 4
+
+    let stack_inputs = StackInputs::new(&[ptr, n_read, n_eval]).unwrap();
+
+    let program = {
+        let mut forest = MastForest::new();
+        let root = BasicBlockNodeBuilder::new(vec![Operation::EvalCircuit], Vec::new())
+            .add_to_forest(&mut forest)
+            .unwrap();
+        forest.make_root(root);
+        Program::new(forest.into(), root)
+    };
+
+    let mut host = DefaultHost::default();
+    let processor = FastProcessor::new_with_options(
+        stack_inputs,
+        AdviceInputs::default(),
+        miden_processor::ExecutionOptions::default(),
+    );
+
+    // Namely, this checks that execution doesn't panic due to an overflow.
+    assert!(matches!(
+        processor.execute_sync(&program, &mut host),
+        Err(ExecutionError::AceChipError {
+            label: _,
+            source_file: _,
+            error: AceError(_),
+        })
+    ));
+}


### PR DESCRIPTION
Fixes audit issue 48:

> In release builds, eval_circuit can panic due to unchecked u64 overflow in its wire-count check, followed by unchecked narrowing casts that feed an assert! in the ACE evaluator. A malicious program can use crafted stack values to crash a proving worker.