### PR TITLE
Harden MASM parsing and constant evaluation (lexer, repeats, constants, push slices)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Hardened AEAD decrypt size calculations ([#2789](https://github.com/0xMiden/miden-vm/pull/2789)).
 - Fixes an possible u64 overflow issue in `op_eval_circuit()` [#2799](https://github.com/0xMiden/miden-vm/pull/2799)
 - Preserved dynexec/dyncall distinction (and digests) when remapping or merging MAST forests ([#2784](https://github.com/0xMiden/miden-vm/pull/2784)).
+- Hardened MASM parsing and constants handling (lexer invalid-token spans, repeat count bounds, constant range checks, field division folding, and `push.WORD[...]` index validation) ([#2803](https://github.com/0xMiden/miden-vm/pull/2803)).
 
 ## 0.21.1 (2026-02-24)
 

--- a/crates/assembly-syntax/src/ast/constants/eval.rs
+++ b/crates/assembly-syntax/src/ast/constants/eval.rs
@@ -6,9 +6,11 @@ use alloc::{sync::Arc, vec::Vec};
 use smallvec::SmallVec;
 
 use crate::{
+    Felt,
     ast::*,
     debuginfo::{SourceFile, SourceSpan, Span, Spanned},
     diagnostics::{Diagnostic, RelatedLabel, miette},
+    parser::IntValue,
 };
 
 /// An error raised during evaluation of a constant expression
@@ -351,12 +353,24 @@ where
                                     source_file: env.get_source_file_for(span),
                                 }
                             })?,
-                            ConstantOp::Div | ConstantOp::IntDiv => lhs
-                                .checked_div(rhs)
-                                .ok_or_else(|| ConstEvalError::DivisionByZero {
+                            ConstantOp::IntDiv => lhs.checked_div(rhs).ok_or_else(|| {
+                                ConstEvalError::DivisionByZero {
                                     span,
                                     source_file: env.get_source_file_for(span),
-                                })?,
+                                }
+                            })?,
+                            ConstantOp::Div => {
+                                if rhs.as_int() == 0 {
+                                    return Err(ConstEvalError::DivisionByZero {
+                                        span,
+                                        source_file: env.get_source_file_for(span),
+                                    }
+                                    .into());
+                                }
+                                let lhs = Felt::new(lhs.as_int());
+                                let rhs = Felt::new(rhs.as_int());
+                                IntValue::from(lhs / rhs)
+                            },
                         };
                         stack.push(ConstantExpr::Int(Span::new(span, result)));
                     },

--- a/crates/assembly-syntax/src/ast/constants/expr.rs
+++ b/crates/assembly-syntax/src/ast/constants/expr.rs
@@ -168,7 +168,7 @@ impl ConstantExpr {
                                     let rhs = rhs.into_inner();
                                     let is_division =
                                         matches!(op, ConstantOp::Div | ConstantOp::IntDiv);
-                                    let is_division_by_zero = is_division && rhs == Felt::ZERO;
+                                    let is_division_by_zero = is_division && rhs.as_int() == 0;
                                     if is_division_by_zero {
                                         return Err(ParsingError::DivisionByZero { span });
                                     }
@@ -176,8 +176,11 @@ impl ConstantExpr {
                                         ConstantOp::Add => lhs.checked_add(rhs),
                                         ConstantOp::Sub => lhs.checked_sub(rhs),
                                         ConstantOp::Mul => lhs.checked_mul(rhs),
-                                        ConstantOp::Div | ConstantOp::IntDiv => {
-                                            lhs.checked_div(rhs)
+                                        ConstantOp::IntDiv => lhs.checked_div(rhs),
+                                        ConstantOp::Div => {
+                                            let lhs = Felt::new(lhs.as_int());
+                                            let rhs = Felt::new(rhs.as_int());
+                                            Some(IntValue::from(lhs / rhs))
                                         },
                                     }
                                     .ok_or(

--- a/crates/assembly-syntax/src/ast/constants/expr.rs
+++ b/crates/assembly-syntax/src/ast/constants/expr.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     Felt, Path,
     ast::{ConstantValue, Ident},
-    parser::{IntValue, ParsingError, WordValue},
+    parser::{IntValue, LiteralErrorKind, ParsingError, WordValue},
 };
 
 /// Maximum allowed nesting depth for constant-expression folding.
@@ -172,23 +172,21 @@ impl ConstantExpr {
                                     if is_division_by_zero {
                                         return Err(ParsingError::DivisionByZero { span });
                                     }
-                                    match op {
-                                        ConstantOp::Add => {
-                                            Ok(Self::Int(Span::new(span, lhs + rhs)))
-                                        },
-                                        ConstantOp::Sub => {
-                                            Ok(Self::Int(Span::new(span, lhs - rhs)))
-                                        },
-                                        ConstantOp::Mul => {
-                                            Ok(Self::Int(Span::new(span, lhs * rhs)))
-                                        },
-                                        ConstantOp::Div => {
-                                            Ok(Self::Int(Span::new(span, lhs / rhs)))
-                                        },
-                                        ConstantOp::IntDiv => {
-                                            Ok(Self::Int(Span::new(span, lhs / rhs)))
+                                    let result = match op {
+                                        ConstantOp::Add => lhs.checked_add(rhs),
+                                        ConstantOp::Sub => lhs.checked_sub(rhs),
+                                        ConstantOp::Mul => lhs.checked_mul(rhs),
+                                        ConstantOp::Div | ConstantOp::IntDiv => {
+                                            lhs.checked_div(rhs)
                                         },
                                     }
+                                    .ok_or(
+                                        ParsingError::InvalidLiteral {
+                                            span,
+                                            kind: LiteralErrorKind::FeltOverflow,
+                                        },
+                                    )?;
+                                    Ok(Self::Int(Span::new(span, result)))
                                 },
                                 lhs => Ok(Self::BinaryOp {
                                     span,

--- a/crates/assembly-syntax/src/lib.rs
+++ b/crates/assembly-syntax/src/lib.rs
@@ -35,5 +35,8 @@ pub use self::{
     sema::SemanticAnalysisError,
 };
 
+/// Maximum allowed iteration count for `repeat.<count>` blocks.
+pub const MAX_REPEAT_COUNT: u32 = 1_000_000;
+
 /// The modulus of the Miden field as a raw u64 integer
 pub(crate) const FIELD_MODULUS: u64 = miden_core::Felt::ORDER_U64;

--- a/crates/assembly-syntax/src/parser/grammar.lalrpop
+++ b/crates/assembly-syntax/src/parser/grammar.lalrpop
@@ -1680,24 +1680,27 @@ InstWithBitSizeImmediate: Instruction = {
 }
 
 Push: SmallOpsVec = {
-    <l:@L> "push" "." <imm_value:WordImm> "[" <i:uint> "]" <r:@R> => {
-        smallvec![Op::Inst(Span::new(
+    <l:@L> "push" "." <imm_value:WordImm> "[" <i:UsizeIndex> "]" <r:@R> =>? {
+        let end = i.checked_add(1).ok_or_else(|| ParseError::User {
+            error: ParsingError::ImmediateOutOfRange {
+                span: span!(source_id, l, r),
+                range: 0..usize::MAX,
+            }
+        })?;
+        Ok(smallvec![Op::Inst(Span::new(
             span!(source_id, l, r),
-            Instruction::PushSlice(
-                imm_value,
-                Range { start: i as usize, end: i as usize + 1 }
-            )
-        ))]
+            Instruction::PushSlice(imm_value, Range { start: i, end })
+        ))])
     },
 
-    <l:@L> "push" "." <imm_value:WordImm> "[" <l_range:uint> ".." <r_range:uint> "]" <r:@R> => {
-        smallvec![Op::Inst(Span::new(
+    <l:@L> "push" "." <imm_value:WordImm> "[" <l_range:UsizeIndex> ".." <r_range:UsizeIndex> "]" <r:@R> =>? {
+        Ok(smallvec![Op::Inst(Span::new(
             span!(source_id, l, r),
             Instruction::PushSlice(
                 imm_value,
-                Range { start: l_range as usize, end: r_range as usize }
+                Range { start: l_range, end: r_range }
             )
-        ))]
+        ))])
     },
 
     <l:@L> "push" "." <imm_value:WordLiteral> <r:@R> => {
@@ -1814,6 +1817,17 @@ U32: u32 = {
             BinEncodedValue::U16(v) => Ok(v as u32),
             BinEncodedValue::U32(v) => Ok(v),
         }
+    }
+}
+
+UsizeIndex: usize = {
+    <l:@L> <n:uint> <r:@R> =>? {
+        usize::try_from(n).map_err(|error| ParseError::User {
+            error: ParsingError::ImmediateOutOfRange {
+                span: span!(source_id, l, r),
+                range: 0..usize::MAX,
+            },
+        })
     }
 }
 

--- a/crates/assembly-syntax/src/parser/lexer.rs
+++ b/crates/assembly-syntax/src/parser/lexer.rs
@@ -174,6 +174,7 @@ impl<'input> Lexer<'input> {
         }
 
         self.token_start = position;
+        self.token_end = position;
     }
 
     #[inline]
@@ -213,6 +214,12 @@ impl<'input> Lexer<'input> {
         assert!(self.token_start <= self.token_end, "invalid range");
         assert!(self.token_end <= u32::MAX as usize, "file too large");
         SourceSpan::new(self.source_id, (self.token_start as u32)..(self.token_end as u32))
+    }
+
+    #[inline]
+    fn char_span(&self, pos: usize, c: char) -> SourceSpan {
+        let end = pos + c.len_utf8();
+        SourceSpan::new(self.source_id, (pos as u32)..(end as u32))
     }
 
     #[inline]
@@ -272,7 +279,9 @@ impl<'input> Lexer<'input> {
             self.skip_whitespace();
         }
 
-        match self.read() {
+        let pos = self.token_start;
+        let c = self.read();
+        match c {
             '@' => pop!(self, Token::At),
             '!' => pop!(self, Token::Bang),
             ':' => match self.peek() {
@@ -325,9 +334,9 @@ impl<'input> Lexer<'input> {
             'A'..='Z' => self.lex_identifier(),
             '_' => match self.peek() {
                 c if c.is_ascii_alphanumeric() => self.lex_identifier(),
-                _ => Err(ParsingError::InvalidToken { span: self.span() }),
+                _ => Err(ParsingError::InvalidToken { span: self.char_span(pos, c) }),
             },
-            _ => Err(ParsingError::InvalidToken { span: self.span() }),
+            _ => Err(ParsingError::InvalidToken { span: self.char_span(pos, c) }),
         }
     }
 

--- a/crates/assembly-syntax/src/parser/mod.rs
+++ b/crates/assembly-syntax/src/parser/mod.rs
@@ -416,4 +416,40 @@ end
         assert_matches!(lexer.next(), Some(Ok(Token::End)));
         assert_matches!(lexer.next(), Some(Ok(Token::Eof)));
     }
+
+    #[test]
+    fn lex_invalid_token_after_whitespace_returns_error() {
+        let source_id = SourceId::default();
+        let scanner = Scanner::new("begin \u{0001}\nend\n");
+        let mut lexer = Lexer::new(source_id, scanner).map(|result| result.map(|(_, t, _)| t));
+
+        assert_matches!(lexer.next(), Some(Ok(Token::Begin)));
+        assert_matches!(
+            lexer.next(),
+            Some(Err(ParsingError::InvalidToken { span })) if span.into_range() == (6..7)
+        );
+    }
+
+    #[test]
+    fn lex_invalid_underscore_token_span() {
+        let source_id = SourceId::default();
+        let scanner = Scanner::new("begin _-\nend\n");
+        let mut lexer = Lexer::new(source_id, scanner).map(|result| result.map(|(_, t, _)| t));
+
+        assert_matches!(lexer.next(), Some(Ok(Token::Begin)));
+        assert_matches!(
+            lexer.next(),
+            Some(Err(ParsingError::InvalidToken { span })) if span.into_range() == (6..7)
+        );
+    }
+
+    #[test]
+    fn lex_single_char_token_and_ident_spans() {
+        let source_id = SourceId::default();
+        let scanner = Scanner::new("@\nA\n");
+        let mut lexer = Lexer::new(source_id, scanner);
+
+        assert_matches!(lexer.next(), Some(Ok((0, Token::At, 1))));
+        assert_matches!(lexer.next(), Some(Ok((2, Token::ConstantIdent("A"), 3))));
+    }
 }

--- a/crates/assembly-syntax/src/parser/token.rs
+++ b/crates/assembly-syntax/src/parser/token.rs
@@ -268,19 +268,35 @@ impl IntValue {
     }
 
     pub fn checked_add(&self, rhs: Self) -> Option<Self> {
-        self.as_int().checked_add(rhs.as_int()).map(super::lexer::shrink_u64_hex)
+        let value = self.as_int().checked_add(rhs.as_int())?;
+        if value >= crate::FIELD_MODULUS {
+            return None;
+        }
+        Some(super::lexer::shrink_u64_hex(value))
     }
 
     pub fn checked_sub(&self, rhs: Self) -> Option<Self> {
-        self.as_int().checked_sub(rhs.as_int()).map(super::lexer::shrink_u64_hex)
+        let value = self.as_int().checked_sub(rhs.as_int())?;
+        if value >= crate::FIELD_MODULUS {
+            return None;
+        }
+        Some(super::lexer::shrink_u64_hex(value))
     }
 
     pub fn checked_mul(&self, rhs: Self) -> Option<Self> {
-        self.as_int().checked_mul(rhs.as_int()).map(super::lexer::shrink_u64_hex)
+        let value = self.as_int().checked_mul(rhs.as_int())?;
+        if value >= crate::FIELD_MODULUS {
+            return None;
+        }
+        Some(super::lexer::shrink_u64_hex(value))
     }
 
     pub fn checked_div(&self, rhs: Self) -> Option<Self> {
-        self.as_int().checked_div(rhs.as_int()).map(super::lexer::shrink_u64_hex)
+        let value = self.as_int().checked_div(rhs.as_int())?;
+        if value >= crate::FIELD_MODULUS {
+            return None;
+        }
+        Some(super::lexer::shrink_u64_hex(value))
     }
 }
 

--- a/crates/assembly-syntax/src/sema/errors.rs
+++ b/crates/assembly-syntax/src/sema/errors.rs
@@ -167,6 +167,14 @@ pub enum SemanticAnalysisError {
         #[label]
         span: SourceSpan,
     },
+    #[error("invalid repeat count")]
+    #[diagnostic(help("repeat count must be in the range {min}..={max}"))]
+    InvalidRepeatCount {
+        #[label]
+        span: SourceSpan,
+        min: u32,
+        max: u32,
+    },
     #[error("invalid immediate: value is larger than expected range")]
     #[diagnostic()]
     ImmediateOverflow {

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -1,6 +1,8 @@
 mod context;
 mod errors;
 mod passes;
+#[cfg(test)]
+mod tests;
 
 use alloc::{
     boxed::Box,
@@ -16,7 +18,7 @@ use smallvec::SmallVec;
 pub use self::{
     context::AnalysisContext,
     errors::{SemanticAnalysisError, SyntaxError},
-    passes::{ConstEvalVisitor, VerifyInvokeTargets},
+    passes::{ConstEvalVisitor, VerifyInvokeTargets, VerifyRepeatCounts},
 };
 use crate::{ast::*, parser::WordValue};
 
@@ -194,6 +196,13 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
                             analyzer.error(err);
                         }
                     }
+                }
+
+                // Ensure repeat counts are within acceptable bounds.
+                log::debug!(target: "verify-repeat", "visiting procedure {}", procedure.name());
+                {
+                    let mut visitor = VerifyRepeatCounts::new(analyzer);
+                    let _ = visitor.visit_mut_procedure(&mut procedure);
                 }
 
                 // Next, verify invoke targets:

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -202,7 +202,7 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
                 log::debug!(target: "verify-repeat", "visiting procedure {}", procedure.name());
                 {
                     let mut visitor = VerifyRepeatCounts::new(analyzer);
-                    let _ = visitor.visit_mut_procedure(&mut procedure);
+                    let _ = visitor.visit_procedure(&procedure);
                 }
 
                 // Next, verify invoke targets:

--- a/crates/assembly-syntax/src/sema/passes/mod.rs
+++ b/crates/assembly-syntax/src/sema/passes/mod.rs
@@ -1,4 +1,8 @@
 mod const_eval;
 mod verify_invoke;
+mod verify_repeat;
 
-pub use self::{const_eval::ConstEvalVisitor, verify_invoke::VerifyInvokeTargets};
+pub use self::{
+    const_eval::ConstEvalVisitor, verify_invoke::VerifyInvokeTargets,
+    verify_repeat::VerifyRepeatCounts,
+};

--- a/crates/assembly-syntax/src/sema/passes/verify_repeat.rs
+++ b/crates/assembly-syntax/src/sema/passes/verify_repeat.rs
@@ -1,0 +1,38 @@
+use core::ops::ControlFlow;
+
+use miden_debug_types::Spanned;
+
+use crate::{
+    MAX_REPEAT_COUNT,
+    ast::{Immediate, Op, VisitMut, visit::visit_mut_op},
+    sema::{AnalysisContext, SemanticAnalysisError},
+};
+
+pub struct VerifyRepeatCounts<'a> {
+    analyzer: &'a mut AnalysisContext,
+}
+
+impl<'a> VerifyRepeatCounts<'a> {
+    pub fn new(analyzer: &'a mut AnalysisContext) -> Self {
+        Self { analyzer }
+    }
+}
+
+impl VisitMut for VerifyRepeatCounts<'_> {
+    fn visit_mut_op(&mut self, op: &mut Op) -> ControlFlow<()> {
+        if let Op::Repeat { count, .. } = op
+            && let Immediate::Value(value) = count
+        {
+            let repeat_count = value.into_inner();
+            if repeat_count == 0 || repeat_count > MAX_REPEAT_COUNT {
+                self.analyzer.error(SemanticAnalysisError::InvalidRepeatCount {
+                    span: count.span(),
+                    min: 1,
+                    max: MAX_REPEAT_COUNT,
+                });
+            }
+        }
+
+        visit_mut_op(self, op)
+    }
+}

--- a/crates/assembly-syntax/src/sema/passes/verify_repeat.rs
+++ b/crates/assembly-syntax/src/sema/passes/verify_repeat.rs
@@ -4,7 +4,7 @@ use miden_debug_types::Spanned;
 
 use crate::{
     MAX_REPEAT_COUNT,
-    ast::{Immediate, Op, VisitMut, visit::visit_mut_op},
+    ast::{Immediate, Op, Visit, visit::visit_op},
     sema::{AnalysisContext, SemanticAnalysisError},
 };
 
@@ -18,8 +18,8 @@ impl<'a> VerifyRepeatCounts<'a> {
     }
 }
 
-impl VisitMut for VerifyRepeatCounts<'_> {
-    fn visit_mut_op(&mut self, op: &mut Op) -> ControlFlow<()> {
+impl Visit for VerifyRepeatCounts<'_> {
+    fn visit_op(&mut self, op: &Op) -> ControlFlow<()> {
         if let Op::Repeat { count, .. } = op
             && let Immediate::Value(value) = count
         {
@@ -33,6 +33,6 @@ impl VisitMut for VerifyRepeatCounts<'_> {
             }
         }
 
-        visit_mut_op(self, op)
+        visit_op(self, op)
     }
 }

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -1,0 +1,67 @@
+use crate::{
+    MAX_REPEAT_COUNT, diagnostics::reporting::PrintDiagnostic, testing::SyntaxTestContext,
+};
+
+#[test]
+fn repeat_count_zero_rejected_in_analysis() {
+    let context = SyntaxTestContext::default();
+    let error = context
+        .parse_program("begin repeat.0 nop end end")
+        .expect_err("expected repeat.0 to be rejected during analysis");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("invalid repeat count"));
+}
+
+#[test]
+fn repeat_count_too_large_rejected_in_analysis() {
+    let context = SyntaxTestContext::default();
+    let repeat_count = MAX_REPEAT_COUNT + 1;
+    let source = format!("begin repeat.{repeat_count} nop end end");
+    let error = context
+        .parse_program(source)
+        .expect_err("expected repeat count above limit to be rejected during analysis");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("invalid repeat count"));
+}
+
+#[test]
+fn repeat_count_at_limit_allowed_in_analysis() {
+    let context = SyntaxTestContext::default();
+    let source = format!("begin repeat.{MAX_REPEAT_COUNT} nop end end");
+    let _module = context
+        .parse_program(source)
+        .expect("expected repeat count at limit to be accepted during analysis");
+}
+
+#[test]
+fn repeat_count_constant_zero_rejected_in_analysis() {
+    let context = SyntaxTestContext::default();
+    let error = context
+        .parse_program("const REPEAT_COUNT = 0\nbegin repeat.REPEAT_COUNT nop end end")
+        .expect_err("expected repeat.0 from constant to be rejected during analysis");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("invalid repeat count"));
+}
+
+#[test]
+fn repeat_count_constant_at_limit_allowed_in_analysis() {
+    let context = SyntaxTestContext::default();
+    let source =
+        format!("const REPEAT_COUNT = {MAX_REPEAT_COUNT}\nbegin repeat.REPEAT_COUNT nop end end");
+    let _module = context
+        .parse_program(source)
+        .expect("expected repeat count at limit from constant to be accepted during analysis");
+}
+
+#[test]
+fn repeat_count_constant_too_large_rejected_in_analysis() {
+    let context = SyntaxTestContext::default();
+    let repeat_count = MAX_REPEAT_COUNT + 1;
+    let source =
+        format!("const REPEAT_COUNT = {repeat_count}\nbegin repeat.REPEAT_COUNT nop end end");
+    let error = context.parse_program(source).expect_err(
+        "expected repeat count above limit from constant to be rejected during analysis",
+    );
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("invalid repeat count"));
+}

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -1,7 +1,7 @@
 use alloc::{collections::BTreeMap, string::ToString, sync::Arc, vec::Vec};
 
 use miden_assembly_syntax::{
-    KernelLibrary, Library, Parse, ParseOptions, SemanticAnalysisError,
+    KernelLibrary, Library, MAX_REPEAT_COUNT, Parse, ParseOptions, SemanticAnalysisError,
     ast::{
         self, Ident, InvocationTarget, InvokeKind, ItemIndex, ModuleKind, SymbolResolution,
         Visibility, types::FunctionType,
@@ -1021,6 +1021,29 @@ impl Assembler {
                     )?;
 
                     let iteration_count = (*count).expect_value();
+                    if iteration_count == 0 {
+                        return Err(RelatedLabel::error("invalid repeat count")
+                            .with_help("repeat count must be greater than 0")
+                            .with_labeled_span(count.span(), "repeat count must be at least 1")
+                            .with_source_file(
+                                proc_ctx.source_manager().get(proc_ctx.span().source_id()).ok(),
+                            )
+                            .into());
+                    }
+                    if iteration_count > MAX_REPEAT_COUNT {
+                        return Err(RelatedLabel::error("invalid repeat count")
+                            .with_help(format!(
+                                "repeat count must be less than or equal to {MAX_REPEAT_COUNT}",
+                            ))
+                            .with_labeled_span(
+                                count.span(),
+                                format!("repeat count exceeds {MAX_REPEAT_COUNT}"),
+                            )
+                            .with_source_file(
+                                proc_ctx.source_manager().get(proc_ctx.span().source_id()).ok(),
+                            )
+                            .into());
+                    }
 
                     if let Some(decorator_ids) = block_builder.drain_decorators() {
                         // Attach the decorators before the first instance of the repeated node
@@ -1034,7 +1057,24 @@ impl Assembler {
                             .ensure_node(first_repeat_builder)?;
 
                         body_node_ids.push(first_repeat_node_id);
-                        for _ in 0..(iteration_count - 1) {
+                        let remaining_iterations =
+                            iteration_count.checked_sub(1).ok_or_else(|| {
+                                Report::new(
+                                    RelatedLabel::error("invalid repeat count")
+                                        .with_help("repeat count must be greater than 0")
+                                        .with_labeled_span(
+                                            count.span(),
+                                            "repeat count must be at least 1",
+                                        )
+                                        .with_source_file(
+                                            proc_ctx
+                                                .source_manager()
+                                                .get(proc_ctx.span().source_id())
+                                                .ok(),
+                                        ),
+                                )
+                            })?;
+                        for _ in 0..remaining_iterations {
                             body_node_ids.push(repeat_node_id);
                         }
                     } else {

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -9,7 +9,9 @@ use std::{
     sync::{Arc, LazyLock},
 };
 
-use miden_assembly_syntax::{ast::Path, diagnostics::WrapErr, library::LibraryExport};
+use miden_assembly_syntax::{
+    MAX_REPEAT_COUNT, ast::Path, diagnostics::WrapErr, library::LibraryExport,
+};
 use miden_core::{
     Felt, Word, assert_matches,
     events::EventId,
@@ -3406,6 +3408,101 @@ fn invalid_repeat() -> TestResult {
         "4 |                     add",
         "  `----"
     );
+    Ok(())
+}
+
+#[test]
+fn invalid_repeat_count_zero() -> TestResult {
+    let context = TestContext::default();
+    let source = source_file!(&context, "begin repeat.0 nop end end");
+    let error = context.assemble(source).expect_err("expected repeat.0 to be rejected");
+    let rendered =
+        format!("{}", crate::diagnostics::reporting::PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("invalid repeat count"));
+    Ok(())
+}
+
+#[test]
+fn invalid_repeat_count_zero_with_decorator() -> TestResult {
+    let context = TestContext::default();
+    let source = source_file!(
+        &context,
+        "\
+proc foo
+    trace.1
+    repeat.0
+        nop
+    end
+end
+
+begin
+    call.foo
+end"
+    );
+    let error = context
+        .assemble(source)
+        .expect_err("expected repeat.0 with decorator to be rejected");
+    let rendered =
+        format!("{}", crate::diagnostics::reporting::PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("invalid repeat count"));
+    Ok(())
+}
+
+#[test]
+fn invalid_repeat_count_too_large() -> TestResult {
+    let context = TestContext::default();
+    let repeat_count = MAX_REPEAT_COUNT + 1;
+    let source = source_file!(&context, format!("begin repeat.{repeat_count} nop end end"));
+    let error = context
+        .assemble(source)
+        .expect_err("expected repeat count above limit to be rejected");
+    let rendered =
+        format!("{}", crate::diagnostics::reporting::PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("invalid repeat count"));
+    Ok(())
+}
+
+#[test]
+fn invalid_repeat_count_constant_zero() -> TestResult {
+    let context = TestContext::default();
+    let source =
+        source_file!(&context, "const REPEAT_COUNT = 0\nbegin repeat.REPEAT_COUNT nop end end");
+    let error = context
+        .assemble(source)
+        .expect_err("expected repeat.0 from constant to be rejected");
+    let rendered =
+        format!("{}", crate::diagnostics::reporting::PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("invalid repeat count"));
+    Ok(())
+}
+
+#[test]
+fn invalid_repeat_count_constant_too_large() -> TestResult {
+    let context = TestContext::default();
+    let repeat_count = MAX_REPEAT_COUNT + 1;
+    let source = source_file!(
+        &context,
+        format!("const REPEAT_COUNT = {repeat_count}\nbegin repeat.REPEAT_COUNT nop end end")
+    );
+    let error = context
+        .assemble(source)
+        .expect_err("expected repeat count above limit from constant to be rejected");
+    let rendered =
+        format!("{}", crate::diagnostics::reporting::PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("invalid repeat count"));
+    Ok(())
+}
+
+#[test]
+fn repeat_count_constant_at_limit_allowed() -> TestResult {
+    let context = TestContext::default();
+    let source = source_file!(
+        &context,
+        format!("const REPEAT_COUNT = {MAX_REPEAT_COUNT}\nbegin repeat.REPEAT_COUNT nop end end")
+    );
+    context
+        .assemble(source)
+        .expect("expected repeat count at limit from constant to be accepted");
     Ok(())
 }
 

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -3586,6 +3586,58 @@ end
 }
 
 #[test]
+fn const_division_slash_must_not_match_int_division() {
+    let program_src = r#"
+const A1 = 3/2
+const B1 = 3//2
+
+const X = 3
+const Y = 2
+const A2 = X/Y
+const B2 = X//Y
+
+begin
+    push.A1
+    push.B1
+    push.A2
+    push.B2
+end
+"#;
+
+    let program = Assembler::default()
+        .assemble_program(program_src)
+        .expect("program assembly must succeed");
+
+    let entry = program.get_node_by_id(program.entrypoint()).expect("missing entrypoint node");
+    let mast = format!("{}", entry.to_display(program.mast_forest()));
+
+    let toks: Vec<&str> = mast.split_whitespace().collect();
+    let pad_incr_pairs = toks.windows(2).filter(|w| w[0] == "pad" && w[1] == "incr").count();
+
+    assert_eq!(
+        pad_incr_pairs, 2,
+        "expected `/` (field division) to not fold to the same value as `//` (integer division)"
+    );
+}
+
+#[test]
+fn const_division_by_zero_must_error() {
+    let program_src = r#"
+const BAD = 1/0
+
+begin
+    push.BAD
+end
+"#;
+
+    let assembled = Assembler::default().assemble_program(program_src);
+    assert!(
+        assembled.is_err(),
+        "expected division by zero in constant expressions to be rejected"
+    );
+}
+
+#[test]
 fn invalid_while() -> TestResult {
     let context = TestContext::default();
 

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -3638,6 +3638,84 @@ end
 }
 
 #[test]
+fn push_word_slice_u64_max_must_not_panic_and_must_error() {
+    let program_src = r#"
+const WORD = [1,2,3,4]
+
+begin
+    push.WORD[18446744073709551615]
+end
+"#;
+
+    let assembled = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        Assembler::default().assemble_program(program_src)
+    }));
+
+    assert!(
+        assembled.is_ok(),
+        "assembler panicked while parsing push.WORD[...] with an out-of-range index"
+    );
+
+    let assembled = assembled.unwrap();
+    assert!(
+        assembled.is_err(),
+        "expected push.WORD[...] with an out-of-range index to be rejected with an error"
+    );
+}
+
+#[test]
+fn push_word_slice_range_u64_max_end_must_not_panic_and_must_error() {
+    let program_src = r#"
+const WORD = [1,2,3,4]
+
+begin
+    push.WORD[0..18446744073709551615]
+end
+"#;
+
+    let assembled = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        Assembler::default().assemble_program(program_src)
+    }));
+
+    assert!(
+        assembled.is_ok(),
+        "assembler panicked while parsing push.WORD[0..] with an out-of-range index"
+    );
+
+    let assembled = assembled.unwrap();
+    assert!(
+        assembled.is_err(),
+        "expected push.WORD[0..] with an out-of-range index to be rejected with an error"
+    );
+}
+
+#[test]
+fn push_word_slice_range_u64_max_start_must_not_panic_and_must_error() {
+    let program_src = r#"
+const WORD = [1,2,3,4]
+
+begin
+    push.WORD[18446744073709551615..0]
+end
+"#;
+
+    let assembled = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        Assembler::default().assemble_program(program_src)
+    }));
+
+    assert!(
+        assembled.is_ok(),
+        "assembler panicked while parsing push.WORD[..0] with an out-of-range index"
+    );
+
+    let assembled = assembled.unwrap();
+    assert!(
+        assembled.is_err(),
+        "expected push.WORD[..0] with an out-of-range index to be rejected with an error"
+    );
+}
+
+#[test]
 fn invalid_while() -> TestResult {
     let context = TestContext::default();
 

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -3507,6 +3507,85 @@ fn repeat_count_constant_at_limit_allowed() -> TestResult {
 }
 
 #[test]
+fn const_folding_modulus_aliasing_must_be_rejected() {
+    let program_src = r#"
+const ALIAS = 18446744069414584320+1
+
+begin
+    push.ALIAS
+end
+"#;
+
+    let assembled = Assembler::default().assemble_program(program_src);
+    assert!(
+        assembled.is_err(),
+        "expected constants >= field modulus to be rejected (must not silently alias to 0)"
+    );
+}
+
+#[test]
+fn const_evaluator_modulus_aliasing_must_be_rejected() {
+    let program_src = r#"
+const X = 18446744069414584320
+const Y = 1
+const ALIAS = X+Y
+
+begin
+    push.ALIAS
+end
+"#;
+
+    let assembled = Assembler::default().assemble_program(program_src);
+    assert!(
+        assembled.is_err(),
+        "expected out-of-range constant results to be rejected (must not silently alias via `Felt::new`)"
+    );
+}
+
+#[test]
+fn const_folding_u64_overflow_must_not_panic_and_must_error() {
+    let program_src = r#"
+const WRAP = 18446744069414584320+18446744069414584320
+
+begin
+    push.WRAP
+end
+"#;
+
+    let assembled = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        Assembler::default().assemble_program(program_src)
+    }));
+
+    assert!(
+        assembled.is_ok(),
+        "assembler panicked while folding a constant expression with u64 overflow"
+    );
+
+    let assembled = assembled.unwrap();
+    assert!(
+        assembled.is_err(),
+        "expected the assembler to reject constant expressions which overflow u64 during folding"
+    );
+}
+
+#[test]
+fn const_folding_subtraction_underflow_must_be_rejected() {
+    let program_src = r#"
+const UNDERFLOW = 0-1
+
+begin
+    push.UNDERFLOW
+end
+"#;
+
+    let assembled = Assembler::default().assemble_program(program_src);
+    assert!(
+        assembled.is_err(),
+        "expected subtraction underflow in constant expressions to be rejected"
+    );
+}
+
+#[test]
 fn invalid_while() -> TestResult {
     let context = TestContext::default();
 

--- a/docs/src/user_docs/assembly/flow_control.md
+++ b/docs/src/user_docs/assembly/flow_control.md
@@ -75,7 +75,7 @@ end
 where:
 
 - `instructions` can be a sequence of any instructions, including nested control structures.
-- `count` is the number of times the `instructions` sequence should be repeated (e.g. `repeat.10`). `count` must be an integer or a [constant](./code_organization.md#constants) greater than $0$.
+- `count` is the number of times the `instructions` sequence should be repeated (e.g. `repeat.10`). `count` must be an integer or a [constant](./code_organization.md#constants) in the range 1..=1,000,000.
 
 > **Note**: During compilation the `repeat.<count>` blocks are unrolled and expanded into `<count>` copies of its inner block, there is no additional cost for counting variables in this case.
 

--- a/docs/src/user_docs/assembly/instruction_reference.md
+++ b/docs/src/user_docs/assembly/instruction_reference.md
@@ -290,7 +290,7 @@ High-level constructs for controlling the execution flow.
   ```
 - **Cycles:** No additional cost for counting; the block is unrolled `COUNT` times during compilation.
 - **Notes:**
-  - `COUNT` must be an integer or a named constant greater than 0.
+- `COUNT` must be an integer or a named constant in the range 1..=1,000,000.
   - Instructions inside can include nested control structures.
 
 ### Condition-Controlled Loops: `while.true ... end`


### PR DESCRIPTION
- Fix lexer span handling for invalid tokens after whitespace to avoid panics and return structured errors.
- Enforce repeat count bounds (including decorators) and document the max; add regression tests for zero/too-large counts.
- Enforce constant range checks during folding and evaluation, preventing modulus aliasing and overflows; add tests.
- Implement field division for / in constant folding to match docs; add tests.
- Validate push.WORD[...] slice indices with checked conversions and overflow guards; add single-index and range-index regression tests.

Per-commit review recommended.