### PR TITLE
Add bounds to allocations in advice map and keccak256/sha512 precompiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Hardened MASM parsing and constants handling (lexer invalid-token spans, repeat count bounds, constant range checks, field division folding, and `push.WORD[...]` index validation) ([#2803](https://github.com/0xMiden/miden-vm/pull/2803)).
 - Introduced `FastProcessor` safe stack method accesses for event handlers ([#2797](https://github.com/0xMiden/miden-vm/pull/2797)).
 - Hardened syscall target validation to avoid panic paths and reject invalid digests at assembly time ([#2804](https://github.com/0xMiden/miden-vm/pull/2804)).
+- Add bounds to attacker-controlled allocation sizes in advice map and keccak256/sha512 precompiles ([#2805](https://github.com/0xMiden/miden-vm/pull/2805)).
 
 ## 0.21.1 (2026-02-24)
 

--- a/crates/lib/core/src/handlers/keccak256.rs
+++ b/crates/lib/core/src/handlers/keccak256.rs
@@ -23,7 +23,7 @@
 //! A Keccak256 digest (256 bits) is represented as 8 field elements `[h0, ..., h7]`,
 //! each containing a u32 value where `hi = u32::from_le_bytes([b_{4i}, ..., b_{4i+3}])`.
 
-use alloc::{vec, vec::Vec};
+use alloc::{format, vec, vec::Vec};
 use core::array;
 
 use miden_core::{
@@ -67,8 +67,23 @@ impl EventHandler for KeccakPrecompile {
         let ptr = process.get_stack_item(1).as_canonical_u64();
         let len_bytes = process.get_stack_item(2).as_canonical_u64();
 
+        // Enforce the maximum precompile input size to prevent host-side resource exhaustion. Make
+        // sure to compare in u64 to avoid truncation on 32-bit targets.
+        let max = process.execution_options().max_hash_len_bytes();
+        if len_bytes > max as u64 {
+            return Err(format!(
+                "keccak256 input length {len_bytes} bytes exceeds maximum of {max} bytes"
+            )
+            .into());
+        }
+        let len_bytes = usize::try_from(len_bytes).map_err(|_| {
+            EventError::from(format!(
+                "keccak256 input length {len_bytes} exceeds addressable range"
+            ))
+        })?;
+
         // Read input bytes from memory using the shared helper (u32-packed, LE, zero-padded)
-        let input_bytes = read_memory_packed_u32(process, ptr, len_bytes as usize)?;
+        let input_bytes = read_memory_packed_u32(process, ptr, len_bytes)?;
 
         // Build preimage from bytes and compute digest
         let preimage = KeccakPreimage::new(input_bytes);

--- a/crates/lib/core/src/handlers/sha512.rs
+++ b/crates/lib/core/src/handlers/sha512.rs
@@ -5,7 +5,7 @@
 //! record calldata for deferred verification. Verification-time logic recomputes the digest and
 //! commits to both input and output using Poseidon2 hashing.
 
-use alloc::{vec, vec::Vec};
+use alloc::{format, vec, vec::Vec};
 use core::array;
 
 use miden_core::{
@@ -43,8 +43,21 @@ impl EventHandler for Sha512Precompile {
         let ptr = process.get_stack_item(1).as_canonical_u64();
         let len_bytes = process.get_stack_item(2).as_canonical_u64();
 
+        // Enforce the maximum precompile input size to prevent host-side resource exhaustion. Make
+        // sure to compare in u64 to avoid truncation on 32-bit targets.
+        let max = process.execution_options().max_hash_len_bytes();
+        if len_bytes > max as u64 {
+            return Err(format!(
+                "sha512 input length {len_bytes} bytes exceeds maximum of {max} bytes"
+            )
+            .into());
+        }
+        let len_bytes = usize::try_from(len_bytes).map_err(|_| {
+            EventError::from(format!("sha512 input length {len_bytes} exceeds addressable range"))
+        })?;
+
         // Read input bytes (u32-packed) from memory.
-        let input_bytes = read_memory_packed_u32(process, ptr, len_bytes as usize)?;
+        let input_bytes = read_memory_packed_u32(process, ptr, len_bytes)?;
         let preimage = Sha512Preimage::new(input_bytes);
         let digest = preimage.digest();
 

--- a/crates/lib/core/tests/crypto/keccak256.rs
+++ b/crates/lib/core/tests/crypto/keccak256.rs
@@ -15,6 +15,7 @@ use miden_core::{
 use miden_core_lib::handlers::keccak256::{
     KECCAK_HASH_BYTES_EVENT_NAME, KeccakPrecompile, KeccakPreimage,
 };
+use miden_processor::ExecutionError;
 
 use crate::helpers::{masm_push_felts, masm_store_felts};
 
@@ -236,4 +237,73 @@ fn test_keccak_merge() {
     let test = build_debug_test!(source, &[]);
     let digest: Vec<u64> = preimage.digest().as_ref().iter().map(Felt::as_canonical_u64).collect();
     test.expect_stack(&digest);
+}
+
+/// Input at exactly `max_hash_len_bytes` must succeed.
+#[test]
+fn test_keccak_max_hash_len_at_boundary() {
+    let max_len = 20;
+    let input: Vec<u8> = (0..max_len as u8).collect();
+    run_keccak_with_max_hash_len(&input, max_len as u64, max_len).unwrap();
+}
+
+/// Input one byte over `max_hash_len_bytes` must be rejected.
+#[test]
+fn test_keccak_max_hash_len_over_boundary() {
+    let max_len = 20;
+    let input: Vec<u8> = (0..=max_len as u8).collect();
+    let err = run_keccak_with_max_hash_len(&input, (max_len + 1) as u64, max_len).unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(msg.contains("exceeds maximum"), "expected limit error, got: {msg}");
+}
+
+// HELPERS
+// ================================================================================================
+
+/// Helper that compiles and runs a keccak256 event with a given `len_bytes` on the stack and a
+/// custom `max_hash_len_bytes` execution option.
+fn run_keccak_with_max_hash_len(
+    input_u8: &[u8],
+    len_bytes_on_stack: u64,
+    max_hash_len_bytes: usize,
+) -> Result<(), ExecutionError> {
+    use miden_assembly::Assembler;
+    use miden_processor::{
+        DefaultHost, ExecutionOptions, FastProcessor, StackInputs, advice::AdviceInputs,
+    };
+
+    let preimage = KeccakPreimage::new(input_u8.to_vec());
+    let input_felts = preimage.as_felts();
+    let memory_stores = masm_store_felts(&input_felts, INPUT_MEMORY_ADDR);
+
+    let source = format!(
+        r#"
+        begin
+            {memory_stores}
+            push.{len_bytes_on_stack}.{INPUT_MEMORY_ADDR}
+            emit.event("{KECCAK_HASH_BYTES_EVENT_NAME}")
+            drop drop
+        end
+        "#,
+    );
+
+    let core_lib = miden_core_lib::CoreLibrary::default();
+    let program = Assembler::default()
+        .with_static_library(core_lib.library())
+        .unwrap()
+        .assemble_program(&source)
+        .unwrap();
+
+    let mut host = DefaultHost::default();
+    host.load_library(core_lib.library().mast_forest()).unwrap();
+    for (event_name, handler) in core_lib.handlers() {
+        host.register_handler(event_name, handler).unwrap();
+    }
+
+    let options = ExecutionOptions::default().with_max_hash_len_bytes(max_hash_len_bytes);
+    let processor =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+
+    processor.execute_sync(&program, &mut host)?;
+    Ok(())
 }

--- a/crates/lib/core/tests/crypto/sha512.rs
+++ b/crates/lib/core/tests/crypto/sha512.rs
@@ -12,6 +12,7 @@ use miden_core::{
 use miden_core_lib::handlers::sha512::{
     SHA512_HASH_BYTES_EVENT_NAME, Sha512Precompile, Sha512Preimage,
 };
+use miden_processor::ExecutionError;
 
 use crate::helpers::masm_store_felts;
 
@@ -140,4 +141,73 @@ fn test_sha512_hash_memory(bytes: &[u8]) {
     let test = build_debug_test!(source, &[]);
     let digest: Vec<u64> = preimage.digest().as_ref().iter().map(Felt::as_canonical_u64).collect();
     test.expect_stack(&digest);
+}
+
+/// Input at exactly `max_hash_len_bytes` must succeed.
+#[test]
+fn test_sha512_max_hash_len_at_boundary() {
+    let max_len = 20;
+    let input: Vec<u8> = (0..max_len as u8).collect();
+    run_sha512_with_max_hash_len(&input, max_len as u64, max_len).unwrap();
+}
+
+/// Input one byte over `max_hash_len_bytes` must be rejected.
+#[test]
+fn test_sha512_max_hash_len_over_boundary() {
+    let max_len = 20;
+    let input: Vec<u8> = (0..=max_len as u8).collect();
+    let err = run_sha512_with_max_hash_len(&input, (max_len + 1) as u64, max_len).unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(msg.contains("exceeds maximum"), "expected limit error, got: {msg}");
+}
+
+// HELPERS
+// ================================================================================
+
+/// Helper that compiles and runs a sha512 event with a given `len_bytes` on the stack and a
+/// custom `max_hash_len_bytes` execution option.
+fn run_sha512_with_max_hash_len(
+    input_u8: &[u8],
+    len_bytes_on_stack: u64,
+    max_hash_len_bytes: usize,
+) -> Result<(), ExecutionError> {
+    use miden_assembly::Assembler;
+    use miden_processor::{
+        DefaultHost, ExecutionOptions, FastProcessor, StackInputs, advice::AdviceInputs,
+    };
+
+    let preimage = Sha512Preimage::new(input_u8.to_vec());
+    let input_felts = preimage.as_felts();
+    let memory_stores = masm_store_felts(&input_felts, INPUT_MEMORY_ADDR);
+
+    let source = format!(
+        r#"
+        begin
+            {memory_stores}
+            push.{len_bytes_on_stack}.{INPUT_MEMORY_ADDR}
+            emit.event("{SHA512_HASH_BYTES_EVENT_NAME}")
+            drop drop
+        end
+        "#,
+    );
+
+    let core_lib = miden_core_lib::CoreLibrary::default();
+    let program = Assembler::default()
+        .with_static_library(core_lib.library())
+        .unwrap()
+        .assemble_program(&source)
+        .unwrap();
+
+    let mut host = DefaultHost::default();
+    host.load_library(core_lib.library().mast_forest()).unwrap();
+    for (event_name, handler) in core_lib.handlers() {
+        host.register_handler(event_name, handler).unwrap();
+    }
+
+    let options = ExecutionOptions::default().with_max_hash_len_bytes(max_hash_len_bytes);
+    let processor =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+
+    processor.execute_sync(&program, &mut host)?;
+    Ok(())
 }

--- a/miden-vm/tests/integration/operations/decorators/advice.rs
+++ b/miden-vm/tests/integration/operations/decorators/advice.rs
@@ -1,4 +1,6 @@
+use miden_assembly::Assembler;
 use miden_core::Felt;
+use miden_processor::{ExecutionOptions, StackInputs, advice::AdviceInputs};
 use miden_prover::Word;
 use miden_utils_testing::{build_test, crypto::MerkleStore};
 
@@ -398,4 +400,65 @@ fn advice_insert_hqword() {
     let test = build_test!(source, &stack_inputs);
     // Values retrieved from advice map in LIFO order
     test.expect_stack(&[11, 12, 13, 14, 21, 22, 23, 24, 31, 32, 33, 34, 41, 42, 43, 44]);
+}
+
+/// Inserting exactly `max_adv_map_value_size` elements must succeed.
+#[test]
+fn test_adv_insert_mem_at_boundary() {
+    let max_size = 8;
+    run_insert_mem_with_max_size(max_size as u32, max_size).unwrap();
+}
+
+/// Inserting one element over `max_adv_map_value_size` must be rejected.
+#[test]
+fn test_adv_insert_mem_over_boundary() {
+    let max_size = 8;
+    let err = run_insert_mem_with_max_size((max_size + 1) as u32, max_size).unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("AdvMapValueSizeExceeded"),
+        "expected size-exceeded error, got: {msg}"
+    );
+}
+
+// HELPERS
+// ================================================================================================
+
+/// Helper that runs `adv.insert_mem` with a memory range of `range_len` elements and a custom
+/// `max_adv_map_value_size`.
+fn run_insert_mem_with_max_size(
+    range_len: u32,
+    max_adv_map_value_size: usize,
+) -> Result<(), miden_processor::ExecutionError> {
+    let start_addr: u32 = 0;
+    let end_addr = start_addr + range_len;
+
+    // Write `range_len` elements to memory, then call adv.insert_mem with a dummy key.
+    let mem_stores: String = (start_addr..end_addr)
+        .map(|addr| format!("push.1 push.{addr} mem_store"))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let source = format!(
+        r#"begin
+            {mem_stores}
+            push.{end_addr} push.{start_addr}
+            push.1.2.3.4
+            adv.insert_mem
+            dropw drop drop
+        end"#,
+    );
+
+    let program = Assembler::default().assemble_program(&source).unwrap();
+    let mut host = super::TestHost::default();
+    let options = ExecutionOptions::default().with_max_adv_map_value_size(max_adv_map_value_size);
+
+    miden_processor::execute_sync(
+        &program,
+        StackInputs::default(),
+        AdviceInputs::default(),
+        &mut host,
+        options,
+    )?;
+    Ok(())
 }

--- a/processor/src/execution_options.rs
+++ b/processor/src/execution_options.rs
@@ -14,6 +14,11 @@ pub struct ExecutionOptions {
     core_trace_fragment_size: usize,
     enable_tracing: bool,
     enable_debugging: bool,
+    /// Maximum number of field elements that can be inserted into the advice map in a single
+    /// `adv.insert_mem` operation.
+    max_adv_map_value_size: usize,
+    /// Maximum number of input bytes allowed for a single hash precompile invocation.
+    max_hash_len_bytes: usize,
 }
 
 impl Default for ExecutionOptions {
@@ -24,6 +29,8 @@ impl Default for ExecutionOptions {
             core_trace_fragment_size: Self::DEFAULT_CORE_TRACE_FRAGMENT_SIZE,
             enable_tracing: false,
             enable_debugging: false,
+            max_adv_map_value_size: Self::DEFAULT_MAX_ADV_MAP_VALUE_SIZE,
+            max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
         }
     }
 }
@@ -37,6 +44,14 @@ impl ExecutionOptions {
 
     /// Default fragment size for core trace generation.
     pub const DEFAULT_CORE_TRACE_FRAGMENT_SIZE: usize = 4096; // 2^12
+
+    /// Default maximum number of field elements in a single advice map value inserted via
+    /// `adv.insert_mem`. Set to 2^17 (~1 MB given 8-byte field elements).
+    pub const DEFAULT_MAX_ADV_MAP_VALUE_SIZE: usize = 1 << 17;
+
+    /// Default maximum number of input bytes for a single hash precompile invocation (e.g.
+    /// keccak256, sha512, etc.). Set to 2^20 (1 MB).
+    pub const DEFAULT_MAX_HASH_LEN_BYTES: usize = 1 << 20;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -97,6 +112,8 @@ impl ExecutionOptions {
             core_trace_fragment_size,
             enable_tracing,
             enable_debugging,
+            max_adv_map_value_size: Self::DEFAULT_MAX_ADV_MAP_VALUE_SIZE,
+            max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
         })
     }
 
@@ -165,6 +182,32 @@ impl ExecutionOptions {
     #[inline]
     pub fn enable_debugging(&self) -> bool {
         self.enable_debugging
+    }
+
+    /// Returns the maximum number of field elements allowed in a single advice map value
+    /// inserted via `adv.insert_mem`.
+    #[inline]
+    pub fn max_adv_map_value_size(&self) -> usize {
+        self.max_adv_map_value_size
+    }
+
+    /// Returns the maximum number of input bytes allowed for a single hash precompile invocation.
+    #[inline]
+    pub fn max_hash_len_bytes(&self) -> usize {
+        self.max_hash_len_bytes
+    }
+
+    /// Sets the maximum number of field elements allowed in a single advice map value
+    /// inserted via `adv.insert_mem`.
+    pub fn with_max_adv_map_value_size(mut self, size: usize) -> Self {
+        self.max_adv_map_value_size = size;
+        self
+    }
+
+    /// Sets the maximum number of input bytes allowed for a single hash precompile invocation.
+    pub fn with_max_hash_len_bytes(mut self, size: usize) -> Self {
+        self.max_hash_len_bytes = size;
+        self
     }
 }
 

--- a/processor/src/fast/basic_block/sys_event_handlers.rs
+++ b/processor/src/fast/basic_block/sys_event_handlers.rs
@@ -100,13 +100,21 @@ fn insert_mem_values_into_adv_map(processor: &mut FastProcessor) -> Result<(), S
     }
 
     let addr_range = start_addr as u32..end_addr as u32;
+
+    let max_value_size = processor.options.max_adv_map_value_size();
+    if addr_range.len() > max_value_size {
+        return Err(AdviceError::AdvMapValueSizeExceeded {
+            size: addr_range.len(),
+            max: max_value_size,
+        }
+        .into());
+    }
+
     let ctx = processor.ctx;
 
-    let mut values = Vec::with_capacity(addr_range.len() * WORD_SIZE);
-    for addr in addr_range {
-        let mem_value = processor.memory().read_element_impl(ctx, addr).unwrap_or(ZERO);
-        values.push(mem_value);
-    }
+    let values: Vec<Felt> = addr_range
+        .map(|addr| processor.memory().read_element_impl(ctx, addr).unwrap_or(ZERO))
+        .collect();
 
     let key = processor.stack_get_word(1);
     processor.advice.insert_into_map(key, values)?;
@@ -291,7 +299,7 @@ fn copy_merkle_node_to_adv_stack(processor: &mut FastProcessor) -> Result<(), Sy
 
     // push_stack_word pushes in reverse order so that node[0] ends up on top of advice stack.
     // AdvPopW then pops the word maintaining structural order on the operand stack.
-    processor.advice.push_stack_word(&node);
+    processor.advice.push_stack_word(&node)?;
 
     Ok(())
 }
@@ -360,7 +368,7 @@ fn copy_map_value_length_to_adv_stack(
     // Note: we assume values_len fits within the field modulus. This is always true
     // in practice since the field modulus (2^64 - 2^32 + 1) is much larger than any
     // practical vector length that could fit in memory.
-    processor.advice.push_stack(Felt::new(values_len as u64));
+    processor.advice.push_stack(Felt::new(values_len as u64))?;
 
     Ok(())
 }
@@ -381,7 +389,7 @@ pub fn push_key_presence_flag(processor: &mut FastProcessor) -> Result<(), Syste
     let map_key = processor.stack_get_word(1);
 
     let presence_flag = processor.advice.contains_map_key(&map_key);
-    processor.advice.push_stack(Felt::from_bool(presence_flag));
+    processor.advice.push_stack(Felt::from_bool(presence_flag))?;
 
     Ok(())
 }
@@ -421,8 +429,8 @@ fn push_ext2_inv_result(processor: &mut FastProcessor) -> Result<(), SystemEvent
     // AdvPop pops from advice top, so push result[0] first (goes to bottom), result[1] second (on
     // top) After AdvPop #1: gets result[1], stack becomes [result[1], b0, b1, ...]
     // After AdvPop #2: gets result[0], stack becomes [result[0], result[1], b0, b1, ...]
-    processor.advice.push_stack(result[0]);
-    processor.advice.push_stack(result[1]);
+    processor.advice.push_stack(result[0])?;
+    processor.advice.push_stack(result[1])?;
     Ok(())
 }
 
@@ -501,7 +509,7 @@ fn push_ilog2(processor: &mut FastProcessor) -> Result<(), SystemEventError> {
         return Err(OperationError::LogArgumentZero.into());
     }
     let ilog2 = Felt::from_u32(n.ilog2());
-    processor.advice.push_stack(ilog2);
+    processor.advice.push_stack(ilog2)?;
 
     Ok(())
 }
@@ -521,7 +529,7 @@ fn push_transformed_stack_top(
         .try_into()
         .map_err(|_| OperationError::NotU32Values { values: vec![stack_top] })?;
     let transformed_stack_top = f(stack_top);
-    processor.advice.push_stack(transformed_stack_top);
+    processor.advice.push_stack(transformed_stack_top)?;
     Ok(())
 }
 

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -405,6 +405,11 @@ impl FastProcessor {
         &self.memory
     }
 
+    /// Returns a reference to the execution options.
+    pub fn execution_options(&self) -> &ExecutionOptions {
+        &self.options
+    }
+
     /// Returns a narrowed interface for reading and updating the processor state.
     #[inline(always)]
     pub fn state(&self) -> ProcessorState<'_> {

--- a/processor/src/host/advice/errors.rs
+++ b/processor/src/host/advice/errors.rs
@@ -23,6 +23,12 @@ pub enum AdviceError {
     #[error("advice stack read failed")]
     StackReadFailed,
     #[error(
+        "advice stack size exceeded: pushing {push_count} elements would exceed the maximum of {max}"
+    )]
+    StackSizeExceeded { push_count: usize, max: usize },
+    #[error("advice map value size of {size} exceeds the maximum of {max}")]
+    AdvMapValueSizeExceeded { size: usize, max: usize },
+    #[error(
         "provided merkle tree {depth} is out of bounds and cannot be represented as an unsigned 8-bit integer"
     )]
     InvalidMerkleTreeDepth { depth: Felt },

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -39,6 +39,10 @@ use crate::{host::AdviceMutation, processor::AdviceProviderInterface};
 ///      or,
 ///    - used to produce a STARK proof using a precompile VM, which can be verified in the epilog of
 ///      the program.
+///
+/// Maximum number of elements allowed on the advice stack. Set to 2^17.
+const MAX_ADVICE_STACK_SIZE: usize = 1 << 17;
+
 #[derive(Debug, Clone, Default)]
 pub struct AdviceProvider {
     stack: VecDeque<Felt>,
@@ -59,7 +63,7 @@ impl AdviceProvider {
     fn apply_mutation(&mut self, mutation: AdviceMutation) -> Result<(), AdviceError> {
         match mutation {
             AdviceMutation::ExtendStack { values } => {
-                self.extend_stack(values);
+                self.extend_stack(values)?;
             },
             AdviceMutation::ExtendMap { other } => {
                 self.extend_map(&other)?;
@@ -120,16 +124,36 @@ impl AdviceProvider {
         Ok([word0, word1])
     }
 
+    /// Checks that pushing `count` elements would not exceed the advice stack size limit.
+    fn check_stack_capacity(&self, count: usize) -> Result<(), AdviceError> {
+        let resulting_size =
+            self.stack.len().checked_add(count).ok_or(AdviceError::StackSizeExceeded {
+                push_count: count,
+                max: MAX_ADVICE_STACK_SIZE,
+            })?;
+        if resulting_size > MAX_ADVICE_STACK_SIZE {
+            return Err(AdviceError::StackSizeExceeded {
+                push_count: count,
+                max: MAX_ADVICE_STACK_SIZE,
+            });
+        }
+        Ok(())
+    }
+
     /// Pushes a single value onto the advice stack.
-    pub fn push_stack(&mut self, value: Felt) {
-        self.stack.push_front(value)
+    pub fn push_stack(&mut self, value: Felt) -> Result<(), AdviceError> {
+        self.check_stack_capacity(1)?;
+        self.stack.push_front(value);
+        Ok(())
     }
 
     /// Pushes a word (4 elements) onto the stack.
-    pub fn push_stack_word(&mut self, word: &Word) {
+    pub fn push_stack_word(&mut self, word: &Word) -> Result<(), AdviceError> {
+        self.check_stack_capacity(4)?;
         for &value in word.iter().rev() {
             self.stack.push_front(value);
         }
+        Ok(())
     }
 
     /// Fetches a list of elements under the specified key from the advice map and pushes them onto
@@ -166,13 +190,26 @@ impl AdviceProvider {
     ) -> Result<(), AdviceError> {
         let values = self.map.get(&key).ok_or(AdviceError::MapKeyNotFound { key })?;
 
+        // Calculate total elements to push including padding and optional length prefix
+        let num_pad_elements = if pad_to != 0 {
+            values.len().next_multiple_of(pad_to as usize) - values.len()
+        } else {
+            0
+        };
+        let total_push = values
+            .len()
+            .checked_add(num_pad_elements)
+            .and_then(|n| n.checked_add(if include_len { 1 } else { 0 }))
+            .ok_or(AdviceError::StackSizeExceeded {
+                push_count: usize::MAX,
+                max: MAX_ADVICE_STACK_SIZE,
+            })?;
+        self.check_stack_capacity(total_push)?;
+
         // if pad_to was provided (not equal 0), push some zeros to the advice stack so that the
         // final (padded) elements list length will be the next multiple of pad_to
-        if pad_to != 0 {
-            let num_pad_elements = values.len().next_multiple_of(pad_to as usize) - values.len();
-            for _ in 0..num_pad_elements {
-                self.stack.push_front(Felt::default());
-            }
+        for _ in 0..num_pad_elements {
+            self.stack.push_front(Felt::default());
         }
 
         // Treat map values as already canonical sequences of FELTs.
@@ -193,14 +230,16 @@ impl AdviceProvider {
     }
 
     /// Extends the stack with the given elements.
-    pub fn extend_stack<I>(&mut self, iter: I)
+    pub fn extend_stack<I>(&mut self, iter: I) -> Result<(), AdviceError>
     where
         I: IntoIterator<Item = Felt>,
     {
         let values: Vec<Felt> = iter.into_iter().collect();
+        self.check_stack_capacity(values.len())?;
         for value in values.into_iter().rev() {
             self.stack.push_front(value);
         }
+        Ok(())
     }
 
     // ADVICE MAP
@@ -403,7 +442,7 @@ impl AdviceProvider {
 
     /// Extends the contents of this instance with the contents of an `AdviceInputs`.
     pub fn extend_from_inputs(&mut self, inputs: &AdviceInputs) -> Result<(), AdviceError> {
-        self.extend_stack(inputs.stack.iter().cloned());
+        self.extend_stack(inputs.stack.iter().cloned())?;
         self.extend_merkle_store(inputs.store.inner_nodes());
         self.extend_map(&inputs.map)
     }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -167,6 +167,12 @@ impl<'a> ProcessorState<'a> {
         self.processor.advice_provider()
     }
 
+    /// Returns the execution options.
+    #[inline(always)]
+    pub fn execution_options(&self) -> &ExecutionOptions {
+        self.processor.execution_options()
+    }
+
     /// Returns the current clock cycle of a process.
     #[inline(always)]
     pub fn clock(&self) -> RowIndex {


### PR DESCRIPTION
Addresses audit issue 36:

> Several host-side handlers derive allocation sizing and loop length from attacker-controlled sizes without explicit caps. In prover-service deployments where the attacker controls the program and advice inputs, adv.insert_mem, adv.push_mapval*, and the keccak256 precompile can be used to force large host-side CPU and memory usage that is not directly metered by VM cycle limits.