### PR TITLE
fix(processor): set a bound on continuation stack size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.23.0 (TBD)
+
+#### Fixes
+- Set a bound on `ContinuationStack` size, checked during execution ([#2824](https://github.com/0xMiden/miden-vm/pull/2824)).
+
 ## 0.22.0 (TBD)
 
 #### Changes

--- a/processor/src/continuation_stack.rs
+++ b/processor/src/continuation_stack.rs
@@ -185,6 +185,11 @@ impl ContinuationStack {
     // PUBLIC ACCESSORS
     // --------------------------------------------------------------------------------------------
 
+    /// Returns the number of continuations on the stack.
+    pub fn len(&self) -> usize {
+        self.stack.len()
+    }
+
     /// Peeks at the next continuation to execute without removing it.
     ///
     /// Note that more than one continuation may execute in the same clock cycle. To get all

--- a/processor/src/execution/basic_block.rs
+++ b/processor/src/execution/basic_block.rs
@@ -49,6 +49,7 @@ where
         state.processor,
         state.tracer,
         state.stopper,
+        state.continuation_stack,
         || {
             Some(Continuation::ResumeBasicBlock {
                 node_id,
@@ -160,6 +161,7 @@ where
                 state.processor,
                 state.tracer,
                 state.stopper,
+                state.continuation_stack,
                 || {
                     Some(Continuation::ResumeBasicBlock {
                         node_id,
@@ -214,6 +216,7 @@ where
         state.processor,
         state.tracer,
         state.stopper,
+        state.continuation_stack,
         || Some(Continuation::AfterExitDecoratorsBasicBlock(node_id)),
         current_forest,
     )?;
@@ -315,6 +318,7 @@ where
             state.processor,
             state.tracer,
             state.stopper,
+            state.continuation_stack,
             || {
                 Some(get_continuation_after_executing_operation(
                     basic_block,
@@ -402,6 +406,7 @@ where
         processor,
         tracer,
         stopper,
+        continuation_stack,
         {
             let post_emit_continuation = post_emit_continuation.clone();
             || Some(post_emit_continuation)

--- a/processor/src/execution/call.rs
+++ b/processor/src/execution/call.rs
@@ -92,7 +92,13 @@ where
     state.continuation_stack.push_start_node(call_node.callee());
 
     // Finalize the clock cycle corresponding to the CALL or SYSCALL operation.
-    finalize_clock_cycle(state.processor, state.tracer, state.stopper, current_forest)
+    finalize_clock_cycle(
+        state.processor,
+        state.tracer,
+        state.stopper,
+        state.continuation_stack,
+        current_forest,
+    )
 }
 
 /// Executes the finish phase of a Call node.
@@ -129,6 +135,7 @@ where
         state.processor,
         state.tracer,
         state.stopper,
+        state.continuation_stack,
         || Some(Continuation::AfterExitDecorators(node_id)),
         current_forest,
     )?;

--- a/processor/src/execution/dyn.rs
+++ b/processor/src/execution/dyn.rs
@@ -119,8 +119,14 @@ where
     }
 
     // Finalize the clock cycle corresponding to the DYN or DYNCALL operation.
-    finalize_clock_cycle(state.processor, state.tracer, state.stopper, current_forest)
-        .map_break(InternalBreakReason::from)
+    finalize_clock_cycle(
+        state.processor,
+        state.tracer,
+        state.stopper,
+        state.continuation_stack,
+        current_forest,
+    )
+    .map_break(InternalBreakReason::from)
 }
 
 /// Function to be called after [`InternalBreakReason::LoadMastForestFromDyn`] is handled. See the
@@ -154,7 +160,7 @@ where
     // Finalize the clock cycle corresponding to the DYN or DYNCALL operation. We pass the old
     // forest because the continuation was set during start_clock_cycle, which referenced the old
     // forest.
-    finalize_clock_cycle(processor, tracer, stopper, &old_forest)?;
+    finalize_clock_cycle(processor, tracer, stopper, continuation_stack, &old_forest)?;
 
     tracer.record_mast_forest_resolution(root_id, current_forest);
 
@@ -198,6 +204,7 @@ where
         state.processor,
         state.tracer,
         state.stopper,
+        state.continuation_stack,
         || Some(Continuation::AfterExitDecorators(node_id)),
         current_forest,
     )?;

--- a/processor/src/execution/join.rs
+++ b/processor/src/execution/join.rs
@@ -44,7 +44,13 @@ where
     state.continuation_stack.push_start_node(join_node.first());
 
     // Finalize the clock cycle corresponding to the JOIN operation.
-    finalize_clock_cycle(state.processor, state.tracer, state.stopper, current_forest)
+    finalize_clock_cycle(
+        state.processor,
+        state.tracer,
+        state.stopper,
+        state.continuation_stack,
+        current_forest,
+    )
 }
 
 /// Executes the finish phase of a Join node.
@@ -72,6 +78,7 @@ where
         state.processor,
         state.tracer,
         state.stopper,
+        state.continuation_stack,
         || Some(Continuation::AfterExitDecorators(node_id)),
         current_forest,
     )?;

--- a/processor/src/execution/loop.rs
+++ b/processor/src/execution/loop.rs
@@ -53,7 +53,13 @@ where
         state.continuation_stack.push_start_node(loop_node.body());
 
         // Finalize the clock cycle corresponding to the LOOP operation.
-        finalize_clock_cycle(state.processor, state.tracer, state.stopper, current_forest)
+        finalize_clock_cycle(
+            state.processor,
+            state.tracer,
+            state.stopper,
+            state.continuation_stack,
+            current_forest,
+        )
     } else if condition == ZERO {
         // Start and exit the loop immediately - corresponding to adding a LOOP and END row
         // immediately since there is no body to execute.
@@ -63,6 +69,7 @@ where
             state.processor,
             state.tracer,
             state.stopper,
+            state.continuation_stack,
             || {
                 Some(Continuation::FinishLoop {
                     node_id: current_node_id,
@@ -132,7 +139,13 @@ where
         state.continuation_stack.push_start_node(loop_node.body());
 
         // Finalize the clock cycle corresponding to the REPEAT operation.
-        finalize_clock_cycle(state.processor, state.tracer, state.stopper, current_forest)
+        finalize_clock_cycle(
+            state.processor,
+            state.tracer,
+            state.stopper,
+            state.continuation_stack,
+            current_forest,
+        )
     } else if condition == ZERO {
         // Exit the loop - start the clock cycle corresponding to the END operation.
         state.tracer.start_clock_cycle(
@@ -159,6 +172,7 @@ where
             state.processor,
             state.tracer,
             state.stopper,
+            state.continuation_stack,
             || Some(Continuation::AfterExitDecorators(current_node_id)),
             current_forest,
         )?;

--- a/processor/src/execution/mod.rs
+++ b/processor/src/execution/mod.rs
@@ -369,6 +369,7 @@ fn finalize_clock_cycle<P, S, T>(
     processor: &mut P,
     tracer: &mut T,
     stopper: &S,
+    continuation_stack: &ContinuationStack,
     current_forest: &Arc<MastForest>,
 ) -> ControlFlow<BreakReason>
 where
@@ -376,7 +377,14 @@ where
     S: Stopper<Processor = P>,
     T: Tracer<Processor = P>,
 {
-    finalize_clock_cycle_with_continuation(processor, tracer, stopper, || None, current_forest)
+    finalize_clock_cycle_with_continuation(
+        processor,
+        tracer,
+        stopper,
+        continuation_stack,
+        || None,
+        current_forest,
+    )
 }
 
 /// This function marks the end of a clock cycle.
@@ -388,6 +396,7 @@ fn finalize_clock_cycle_with_continuation<P, S, T>(
     processor: &mut P,
     tracer: &mut T,
     stopper: &S,
+    continuation_stack: &ContinuationStack,
     continuation_after_stop: impl FnOnce() -> Option<Continuation>,
     current_forest: &Arc<MastForest>,
 ) -> ControlFlow<BreakReason>
@@ -400,6 +409,7 @@ where
         processor,
         tracer,
         stopper,
+        continuation_stack,
         continuation_after_stop,
         OperationHelperRegisters::Empty,
         current_forest,
@@ -430,6 +440,7 @@ fn finalize_clock_cycle_with_continuation_and_op_helpers<P, S, T>(
     processor: &mut P,
     tracer: &mut T,
     stopper: &S,
+    continuation_stack: &ContinuationStack,
     continuation_after_stop: impl FnOnce() -> Option<Continuation>,
     op_helper_registers: OperationHelperRegisters,
     current_forest: &Arc<MastForest>,
@@ -445,7 +456,7 @@ where
     // Increment the processor clock.
     processor.system_mut().increment_clock();
 
-    stopper.should_stop(processor, continuation_after_stop)
+    stopper.should_stop(processor, continuation_stack, continuation_after_stop)
 }
 
 /// Returns the next context ID that would be created given the current state.

--- a/processor/src/execution/split.rs
+++ b/processor/src/execution/split.rs
@@ -61,7 +61,13 @@ where
     };
 
     // Finalize the clock cycle corresponding to the SPLIT operation.
-    finalize_clock_cycle(state.processor, state.tracer, state.stopper, current_forest)
+    finalize_clock_cycle(
+        state.processor,
+        state.tracer,
+        state.stopper,
+        state.continuation_stack,
+        current_forest,
+    )
 }
 
 /// Executes the finish phase of a Split node.
@@ -89,6 +95,7 @@ where
         state.processor,
         state.tracer,
         state.stopper,
+        state.continuation_stack,
         || Some(Continuation::AfterExitDecorators(node_id)),
         current_forest,
     )?;

--- a/processor/src/execution_options.rs
+++ b/processor/src/execution_options.rs
@@ -19,6 +19,9 @@ pub struct ExecutionOptions {
     max_adv_map_value_size: usize,
     /// Maximum number of input bytes allowed for a single hash precompile invocation.
     max_hash_len_bytes: usize,
+    /// Maximum number of continuations allowed on the continuation stack at any point during
+    /// execution.
+    max_num_continuations: usize,
 }
 
 impl Default for ExecutionOptions {
@@ -31,6 +34,7 @@ impl Default for ExecutionOptions {
             enable_debugging: false,
             max_adv_map_value_size: Self::DEFAULT_MAX_ADV_MAP_VALUE_SIZE,
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
+            max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
         }
     }
 }
@@ -52,6 +56,10 @@ impl ExecutionOptions {
     /// Default maximum number of input bytes for a single hash precompile invocation (e.g.
     /// keccak256, sha512, etc.). Set to 2^20 (1 MB).
     pub const DEFAULT_MAX_HASH_LEN_BYTES: usize = 1 << 20;
+
+    /// Default maximum number of continuations allowed on the continuation stack.
+    /// Set to 2^16 (65536).
+    pub const DEFAULT_MAX_NUM_CONTINUATIONS: usize = 1 << 16;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -114,6 +122,7 @@ impl ExecutionOptions {
             enable_debugging,
             max_adv_map_value_size: Self::DEFAULT_MAX_ADV_MAP_VALUE_SIZE,
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
+            max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
         })
     }
 
@@ -207,6 +216,18 @@ impl ExecutionOptions {
     /// Sets the maximum number of input bytes allowed for a single hash precompile invocation.
     pub fn with_max_hash_len_bytes(mut self, size: usize) -> Self {
         self.max_hash_len_bytes = size;
+        self
+    }
+
+    /// Returns the maximum number of continuations allowed on the continuation stack.
+    #[inline]
+    pub fn max_num_continuations(&self) -> usize {
+        self.max_num_continuations
+    }
+
+    /// Sets the maximum number of continuations allowed on the continuation stack.
+    pub fn with_max_num_continuations(mut self, max_num_continuations: usize) -> Self {
+        self.max_num_continuations = max_num_continuations;
         self
     }
 }

--- a/processor/src/fast/step.rs
+++ b/processor/src/fast/step.rs
@@ -53,9 +53,11 @@ impl Stopper for NeverStopper {
     fn should_stop(
         &self,
         processor: &FastProcessor,
+        continuation_stack: &ContinuationStack,
         _continuation_after_stop: impl FnOnce() -> Option<Continuation>,
     ) -> ControlFlow<BreakReason> {
-        check_if_max_cycles_exceeded(processor)
+        check_if_max_cycles_exceeded(processor)?;
+        check_if_continuation_stack_too_large(processor, continuation_stack)
     }
 }
 
@@ -70,9 +72,11 @@ impl Stopper for StepStopper {
     fn should_stop(
         &self,
         processor: &FastProcessor,
+        continuation_stack: &ContinuationStack,
         continuation_after_stop: impl FnOnce() -> Option<Continuation>,
     ) -> ControlFlow<BreakReason> {
         check_if_max_cycles_exceeded(processor)?;
+        check_if_continuation_stack_too_large(processor, continuation_stack)?;
 
         ControlFlow::Break(BreakReason::Stopped(continuation_after_stop()))
     }
@@ -84,6 +88,22 @@ fn check_if_max_cycles_exceeded(processor: &FastProcessor) -> ControlFlow<BreakR
     if processor.clk > processor.options.max_cycles() as usize {
         ControlFlow::Break(BreakReason::Err(ExecutionError::CycleLimitExceeded(
             processor.options.max_cycles(),
+        )))
+    } else {
+        ControlFlow::Continue(())
+    }
+}
+
+/// Checks if the continuation stack size exceeds the maximum allowed, returning a
+/// `BreakReason::Err` if so.
+#[inline(always)]
+fn check_if_continuation_stack_too_large(
+    processor: &FastProcessor,
+    continuation_stack: &ContinuationStack,
+) -> ControlFlow<BreakReason> {
+    if continuation_stack.len() > processor.options.max_num_continuations() {
+        ControlFlow::Break(BreakReason::Err(ExecutionError::Internal(
+            "continuation stack size exceeded the allowed maximum",
         )))
     } else {
         ControlFlow::Continue(())

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -570,6 +570,46 @@ fn test_external_node_decorator_sequencing() {
     );
 }
 
+/// Tests that `ExecutionError::Internal` is correctly emitted when the continuation stack grows
+/// past the maximum allowed size.
+#[test]
+fn test_continuation_stack_limit_exceeded() {
+    let mut host = DefaultHost::default();
+
+    // Build a program with deeply nested join nodes. Each join node pushes 2 continuations
+    // (FinishJoin + StartNode) onto the continuation stack before executing its first child.
+    // With `depth` levels of nesting, the continuation stack will grow to approximately
+    // `2 * depth` entries.
+    let program = {
+        let mut forest = MastForest::new();
+
+        // Create a simple leaf basic block (just a noop).
+        let leaf_id = BasicBlockNodeBuilder::new(vec![Operation::Noop], Vec::new())
+            .add_to_forest(&mut forest)
+            .unwrap();
+
+        // Nest join nodes: join(join(join(..., leaf), leaf), leaf)
+        // Each level adds ~2 continuations to the stack.
+        let depth = 10;
+        let mut current = leaf_id;
+        for _ in 0..depth {
+            current = JoinNodeBuilder::new([current, leaf_id]).add_to_forest(&mut forest).unwrap();
+        }
+
+        forest.make_root(current);
+        Program::new(forest.into(), current)
+    };
+
+    // Set a very small continuation stack limit that will be exceeded by the nested joins.
+    let options = ExecutionOptions::default().with_max_num_continuations(3);
+
+    let processor =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+    let err = processor.execute_sync(&program, &mut host).unwrap_err();
+
+    assert_matches!(err, ExecutionError::Internal(msg) if msg.contains("continuation stack"));
+}
+
 // TEST HELPERS
 // -----------------------------------------------------------------------------------------------
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -24,6 +24,7 @@ mod tracer;
 
 use crate::{
     advice::{AdviceInputs, AdviceProvider},
+    continuation_stack::ContinuationStack,
     errors::MapExecErr,
     processor::{Processor, SystemInterface},
     trace::{ExecutionTrace, RowIndex},
@@ -296,6 +297,7 @@ pub trait Stopper {
     fn should_stop(
         &self,
         processor: &Self::Processor,
+        continuation_stack: &ContinuationStack,
         continuation_after_stop: impl FnOnce() -> Option<continuation_stack::Continuation>,
     ) -> ControlFlow<BreakReason>;
 }

--- a/processor/src/trace/parallel/processor.rs
+++ b/processor/src/trace/parallel/processor.rs
@@ -484,6 +484,7 @@ impl Stopper for ReplayStopper {
     fn should_stop(
         &self,
         processor: &ReplayProcessor,
+        _continuation_stack: &ContinuationStack,
         continuation_after_stop: impl FnOnce() -> Option<Continuation>,
     ) -> ControlFlow<BreakReason> {
         if processor.system().clock() >= processor.maximum_clock {


### PR DESCRIPTION
Addresses the continuation stack part of audit finding 41:

> The processor has no runtime bound on the size of the heap-allocated [ContinuationStack](https://github.com/0xMiden/miden-vm/blob/089dc6a33cbb77dbbbaa7e424fd7cecd0fe7a9ca/processor/src/continuation_stack.rs#L109-L123) (and related call-context stack growth), which enables two distinct memory exhaustion patterns in attacker-controlled programs:
>
> 1. Dynamic invocation recursion that grows the continuation stack monotonically when recursion does not unwind.
> 2. External loading that grows the continuation stack and can retain many [MastForest](https://github.com/0xMiden/miden-vm/blob/089dc6a33cbb77dbbbaa7e424fd7cecd0fe7a9ca/core/src/mast/mod.rs#L95-L117) instances in deployments that resolve external forests on demand.

Note that we do not address (2), since this is solved in the `Host` implementation not present in this repository (i.e. the `Host` needs to have a limit on how many forests it keeps in memory, after which it either refuses to return new forests, or drops some old forests, or whatever other memory management strategy).

As for (1), we solved this problem by adding a check in the `FastProcessor` stoppers (i.e. `NeverStopper` and `StepStopper`), as we don't want to hardcode the "continuation stack length check" logic in the main execution loop. This is because this only makes sense when running untrusted programs, but we want to also give the ability for a processor that wants to run faster to omit these checks if they e.g. are only running trusted programs.