### PR TITLE
chore(processor): make DebugHandler default method implementations no…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [BREAKING] `Operation` enum now only encodes basic block operations ([#2771](https://github.com/0xMiden/miden-vm/pull/2771)).
 - Added `math::u128` division operations ([#2776](https://github.com/0xMiden/miden-vm/pull/2776)).
 - Introduced `build_trace_with_max_len()` which stops building the trace after a given max, and `build_trace()` no longer allocates more than 2^29 rows ([#2809](https://github.com/0xMiden/miden-vm/pull/2809)).
+- `DebugHandler`'s default method implementations are now no-ops (instead of prints) ([#2837](https://github.com/0xMiden/miden-vm/pull/2837)).
 
 #### Fixes
 

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -6,7 +6,7 @@ use core::{fmt, ops::RangeInclusive};
 
 use miden_core::{FMP_ADDR, Felt, operations::DebugOptions};
 
-use crate::{DebugError, ProcessorState, TraceError, host::handlers::DebugHandler};
+use crate::{DebugError, ProcessorState, host::handlers::DebugHandler};
 
 // WRITER IMPLEMENTATIONS
 // ================================================================================================
@@ -79,17 +79,6 @@ impl<W: fmt::Write + Sync> DebugHandler for DefaultDebugHandler<W> {
             },
         }
         .map_err(DebugError::from)
-    }
-
-    fn on_trace(&mut self, process: &ProcessorState, trace_id: u32) -> Result<(), TraceError> {
-        writeln!(
-            self.writer,
-            "Trace with id {} emitted at step {} in context {}",
-            trace_id,
-            process.clock(),
-            process.ctx()
-        )
-        .map_err(TraceError::from)
     }
 }
 

--- a/processor/src/host/handlers.rs
+++ b/processor/src/host/handlers.rs
@@ -199,25 +199,20 @@ impl Debug for EventHandlerRegistry {
 /// Handler for debug and trace operations
 pub trait DebugHandler: Sync {
     /// This function is invoked when the `Debug` decorator is executed.
+    ///
+    /// The default implementation is a no-op.
     fn on_debug(
         &mut self,
-        process: &ProcessorState,
-        options: &DebugOptions,
+        _process: &ProcessorState,
+        _options: &DebugOptions,
     ) -> Result<(), DebugError> {
-        let mut handler = crate::host::debug::DefaultDebugHandler::default();
-        handler.on_debug(process, options)
+        Ok(())
     }
 
     /// This function is invoked when the `Trace` decorator is executed.
-    fn on_trace(&mut self, process: &ProcessorState, trace_id: u32) -> Result<(), TraceError> {
-        let _ = (&process, trace_id);
-        #[cfg(feature = "std")]
-        std::println!(
-            "Trace with id {} emitted at step {} in context {}",
-            trace_id,
-            process.clock(),
-            process.ctx()
-        );
+    ///
+    /// The default implementation is a no-op.
+    fn on_trace(&mut self, _process: &ProcessorState, _trace_id: u32) -> Result<(), TraceError> {
         Ok(())
     }
 }


### PR DESCRIPTION
Closes https://github.com/0xMiden/miden-vm/issues/2826

Removes prints from `DebugHandler` trait default method implementations, as well as makes `DebugHandler::on_debug()` a no-op. The idea being that the trait doesn't need to guess what implementations need - especially prints which can get obnoxious.