### PR TITLE
ci: Deploy rustdoc to gh-pages/docs 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+# Generates and deploys crate documentation to GitHub Pages
+
+name: docs
+
+on:
+  push:
+    branches:
+      - next
+    paths:
+      - "**/*.rs"
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - "Makefile"
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  docs:
+    name: Generate and deploy crate documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cleanup large tools for build space
+        uses: ./.github/actions/cleanup-runner
+
+      - name: Generate documentation
+        run: |
+          rustup update --no-self-update
+          rustup default stable
+          make doc
+
+      - name: Prepare publish tree
+        run: |
+          set -euo pipefail
+          mkdir -p .gh-pages-publish/docs
+          if git ls-remote --heads origin gh-pages | grep -q gh-pages; then
+            git fetch --depth=1 origin gh-pages
+            git worktree add --detach .gh-pages-worktree FETCH_HEAD
+            rsync -a --delete --exclude ".git" .gh-pages-worktree/ .gh-pages-publish/
+            git worktree remove .gh-pages-worktree --force
+          fi
+          rm -rf .gh-pages-publish/docs
+          mkdir -p .gh-pages-publish/docs
+          rsync -a --delete target/doc/ .gh-pages-publish/docs/
+          touch .gh-pages-publish/.nojekyll
+
+      - name: Deploy documentation
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # pin@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./.gh-pages-publish

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ help:
 
 # -- environment toggles --------------------------------------------------------------------------
 BACKTRACE                := RUST_BACKTRACE=1
-WARNINGS                 := RUSTDOCFLAGS="-D warnings"
 BUILDDOCS                := MIDEN_BUILD_LIB_DOCS=1
+DOCS_NIGHTLY_TOOLCHAIN   ?= nightly
 
 # -- feature configuration ------------------------------------------------------------------------
 ALL_FEATURES             := --all-features
@@ -91,8 +91,9 @@ lint: xclippy xclippy-fix format ## Runs all linting tasks: check with xclippy, 
 # --- docs ----------------------------------------------------------------------------------------
 
 .PHONY: doc
-doc: ## Generates & checks documentation
-	$(WARNINGS) $(BUILDDOCS) cargo doc ${ALL_FEATURES} --keep-going --release
+doc: ## Generates & checks documentation for workspace crates only
+	rm -rf "$${CARGO_TARGET_DIR:-target}/doc"
+	$(BUILDDOCS) RUSTDOCFLAGS="--enable-index-page -Zunstable-options -D warnings" cargo +$(DOCS_NIGHTLY_TOOLCHAIN) doc ${ALL_FEATURES} --keep-going --release --no-deps
 
 .PHONY: serve-docs
 serve-docs: ## Serves the docs


### PR DESCRIPTION
This change publishes Rust API docs to the gh-pages branch under docs/ on pushes to next and on manual runs.

The deploy now rebuilds a publish tree from the current gh-pages branch and replaces only docs/. This keeps existing site files (including the placeholder content) and removes stale rustdoc files inside docs/.

The trigger includes **/*.rs, **/Cargo.toml, Cargo.lock, and Makefile, so crate manifest and doc-build changes also republish docs.

This is an adaptation of https://github.com/0xMiden/crypto/pull/810 https://github.com/0xMiden/crypto/pull/817, which led to https://0xmiden.github.io/crypto/docs