### PR TITLE
chore(processor): remove `NodeEndFlags` from `NodeEndData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [BREAKING] `StructType::new` now expects an optional name to be specified ([#2848](https://github.com/0xMiden/miden-vm/pull/2848))
 - [BREAKING] `Variant::new` now expects an optional payload type to be specified ([#2848](https://github.com/0xMiden/miden-vm/pull/2848))
 - [BREAKING] Enum types are now exported from libraries as a `midenc_hir_type::EnumType`, rather than the type of the discriminant. ([#2848](https://github.com/0xMiden/miden-vm/pull/2848))
+- In `ExecutionTracer`, we no longer record node flags in `CoreTraceFragmentContext` when entering a node (they are redundant) ([#2866](https://github.com/0xMiden/miden-vm/pull/2866))
 
 #### Fixes
 

--- a/processor/src/execution/loop.rs
+++ b/processor/src/execution/loop.rs
@@ -53,8 +53,12 @@ where
 
     // execute the loop body as long as the condition is true
     if condition == ONE {
-        // Push the loop to check condition again after body
-        // executes
+        // Push the loop to check condition again after body executes.
+        //
+        // WARNING: if we eventually push another continuation in between the `FinishLoop` and the
+        // `StartNode` continuations, then the logic in `ExecutionTracer::start_clock_cycle()` that
+        // computes the value for the `is_loop_body` flag will be incorrect and needs to be
+        // adjusted.
         state.continuation_stack.push_finish_loop_entered(current_node_id);
         state.continuation_stack.push_start_node(loop_node.body());
 

--- a/processor/src/trace/decoder/block_stack.rs
+++ b/processor/src/trace/decoder/block_stack.rs
@@ -1,14 +1,19 @@
 use alloc::vec::Vec;
 
 use miden_air::Felt;
-use miden_core::{ONE, Word, ZERO};
+use miden_core::{Word, ZERO};
 
 use crate::ContextId;
 
 // BLOCK STACK
 // ================================================================================================
 
-/// Keeps track of code blocks which are currently being executed by the VM.
+/// Tracks per-block data needed for trace generation that the [`ContinuationStack`] does not
+/// carry. Specifically, it stores the hasher chiplet addresses (`addr`, `parent_addr`) assigned
+/// during execution, and for CALL/SYSCALL/DYNCALL blocks, the caller's execution context so it
+/// can be restored on END.
+///
+/// [`ContinuationStack`]: crate::continuation_stack::ContinuationStack
 #[derive(Debug, Default, Clone)]
 pub struct BlockStack {
     blocks: Vec<BlockInfo>,
@@ -20,68 +25,24 @@ impl BlockStack {
 
     /// Pushes a new code block onto the block stack and returns the address of the block's parent.
     ///
-    /// The block is identified by its address, and we also need to know what type of a block this
-    /// is. Additionally, for CALL, SYSCALL and DYNCALL blocks, execution context info must be
-    /// provided. Other information (i.e., the block's parent, whether the block is a body of a loop
-    /// or a first child of a JOIN block) is determined from the information already on the stack.
-    pub fn push(
-        &mut self,
-        addr: Felt,
-        block_type: BlockType,
-        ctx_info: Option<ExecutionContextInfo>,
-    ) -> Felt {
-        // make sure execution context was provided for CALL, SYSCALL and DYNCALL blocks
-        if block_type == BlockType::Call
-            || block_type == BlockType::SysCall
-            || block_type == BlockType::Dyncall
-        {
-            debug_assert!(ctx_info.is_some(), "no execution context provided for a CALL block");
-        } else {
-            debug_assert!(ctx_info.is_none(), "execution context provided for a non-CALL block");
-        }
-
-        // determine additional info about the new block based on its parent
-        let (parent_addr, is_loop_body, _is_first_child) = match self.blocks.last() {
-            Some(parent) => match parent.block_type {
-                // if the parent block is a LOOP block, the new block must be a loop body
-                BlockType::Loop(loop_entered) => {
-                    debug_assert!(loop_entered, "parent is un-entered loop");
-                    (parent.addr, true, false)
-                },
-                // if the parent block is a JOIN block, figure out if the new block is the first
-                // or the second child
-                BlockType::Join(first_child_executed) => {
-                    (parent.addr, false, !first_child_executed)
-                },
-                _ => (parent.addr, false, false),
-            },
-            // if the block stack is empty, a new block is neither a body of a loop nor the first
-            // child of a JOIN block; also, we set the parent address to ZERO.
-            None => (ZERO, false, false),
+    /// The block is identified by its address. For CALL, SYSCALL and DYNCALL blocks, execution
+    /// context info must be provided so that the caller's context can be restored on END.
+    ///
+    /// When the block is later popped (on END), the flags for the trace row are fully reconstructed
+    /// from the continuation stack, and hence do not need to be stored in this data structure.
+    pub fn push(&mut self, addr: Felt, ctx_info: Option<ExecutionContextInfo>) -> Felt {
+        let parent_addr = match self.blocks.last() {
+            Some(parent) => parent.addr,
+            None => ZERO,
         };
 
-        self.blocks.push(BlockInfo {
-            addr,
-            block_type,
-            parent_addr,
-            ctx_info,
-            is_loop_body,
-        });
+        self.blocks.push(BlockInfo { addr, parent_addr, ctx_info });
         parent_addr
     }
 
     /// Removes a block from the top of the stack and returns it.
     pub fn pop(&mut self) -> BlockInfo {
-        let block = self.blocks.pop().expect("block stack is empty");
-        // if the parent block is a JOIN block (i.e., we just finished executing a child of a JOIN
-        // block) and if the first_child_executed hasn't been set to true yet, set it to true
-        if let Some(parent) = self.blocks.last_mut()
-            && let BlockType::Join(first_child_executed) = parent.block_type
-            && !first_child_executed
-        {
-            parent.block_type = BlockType::Join(true);
-        }
-        block
+        self.blocks.pop().expect("block stack is empty")
     }
 
     /// Returns true if the block stack is empty.
@@ -107,43 +68,8 @@ impl BlockStack {
 #[derive(Debug, Clone)]
 pub struct BlockInfo {
     pub addr: Felt,
-    block_type: BlockType,
     pub parent_addr: Felt,
     pub ctx_info: Option<ExecutionContextInfo>,
-    pub is_loop_body: bool,
-}
-
-impl BlockInfo {
-    /// Returns ONE if the this block is a LOOP block and the body of the loop was executed at
-    /// least once; otherwise, returns ZERO.
-    pub fn is_entered_loop(&self) -> Felt {
-        if self.block_type == BlockType::Loop(true) {
-            ONE
-        } else {
-            ZERO
-        }
-    }
-
-    /// Returns ONE if this block is a body of a LOOP block; otherwise returns ZERO.
-    pub const fn is_loop_body(&self) -> Felt {
-        if self.is_loop_body { ONE } else { ZERO }
-    }
-
-    /// Returns ONE if this block is a CALL or DYNCALL block; otherwise returns ZERO.
-    pub const fn is_call(&self) -> Felt {
-        match self.block_type {
-            BlockType::Call | BlockType::Dyncall => ONE,
-            _ => ZERO,
-        }
-    }
-
-    /// Returns ONE if this block is a SYSCALL block; otherwise returns ZERO.
-    pub const fn is_syscall(&self) -> Felt {
-        match self.block_type {
-            BlockType::SysCall => ONE,
-            _ => ZERO,
-        }
-    }
 }
 
 // EXECUTION CONTEXT INFO
@@ -179,20 +105,4 @@ impl ExecutionContextInfo {
             parent_next_overflow_addr,
         }
     }
-}
-
-// BLOCK TYPE
-// ================================================================================================
-
-/// Specifies type of a code block with additional info for some block types.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BlockType {
-    Join(bool), // internal value set to true when the first child is fully executed
-    Split,
-    Loop(bool), // internal value set to false if the loop is never entered
-    Call,
-    Dyn,
-    Dyncall,
-    SysCall,
-    BasicBlock,
 }

--- a/processor/src/trace/execution_tracer.rs
+++ b/processor/src/trace/execution_tracer.rs
@@ -4,13 +4,13 @@ use miden_air::trace::chiplets::hasher::{HASH_CYCLE_LEN, HASH_CYCLE_LEN_FELT, ST
 use miden_core::{FMP_ADDR, FMP_INIT_VALUE, operations::Operation};
 
 use super::{
-    decoder::block_stack::{BlockInfo, BlockStack, BlockType, ExecutionContextInfo},
+    decoder::block_stack::{BlockInfo, BlockStack, ExecutionContextInfo},
     stack::OverflowTable,
     trace_state::{
         AceReplay, AdviceReplay, BitwiseReplay, BlockAddressReplay, BlockStackReplay,
         CoreTraceFragmentContext, CoreTraceState, DecoderState, ExecutionContextReplay,
         ExecutionContextSystemInfo, ExecutionReplay, HasherRequestReplay, HasherResponseReplay,
-        KernelReplay, MastForestResolutionReplay, MemoryReadsReplay, MemoryWritesReplay, NodeFlags,
+        KernelReplay, MastForestResolutionReplay, MemoryReadsReplay, MemoryWritesReplay,
         RangeCheckerReplay, StackOverflowReplay, StackState, SystemState,
     },
     utils::split_u32_into_u16,
@@ -233,7 +233,7 @@ impl ExecutionTracer {
         processor: &P,
         current_forest: &MastForest,
     ) {
-        let (ctx_info, block_type) = match node {
+        let ctx_info = match node {
             MastNode::Join(node) => {
                 let child1_hash = current_forest
                     .get_node_by_id(node.first())
@@ -250,7 +250,7 @@ impl ExecutionTracer {
                     node.digest(),
                 );
 
-                (None, BlockType::Join(false))
+                None
             },
             MastNode::Split(node) => {
                 let child1_hash = current_forest
@@ -268,7 +268,7 @@ impl ExecutionTracer {
                     node.digest(),
                 );
 
-                (None, BlockType::Split)
+                None
             },
             MastNode::Loop(node) => {
                 let body_hash = current_forest
@@ -283,12 +283,7 @@ impl ExecutionTracer {
                     node.digest(),
                 );
 
-                let loop_entered = {
-                    let condition = processor.stack().get(0);
-                    condition == ONE
-                };
-
-                (None, BlockType::Loop(loop_entered))
+                None
             },
             MastNode::Call(node) => {
                 let callee_hash = current_forest
@@ -303,22 +298,13 @@ impl ExecutionTracer {
                     node.digest(),
                 );
 
-                let exec_ctx = {
-                    let overflow_addr = self.overflow_table.last_update_clk_in_current_ctx();
-                    ExecutionContextInfo::new(
-                        processor.system().ctx(),
-                        processor.system().caller_hash(),
-                        processor.stack().depth(),
-                        overflow_addr,
-                    )
-                };
-                let block_type = if node.is_syscall() {
-                    BlockType::SysCall
-                } else {
-                    BlockType::Call
-                };
-
-                (Some(exec_ctx), block_type)
+                let overflow_addr = self.overflow_table.last_update_clk_in_current_ctx();
+                Some(ExecutionContextInfo::new(
+                    processor.system().ctx(),
+                    processor.system().caller_hash(),
+                    processor.stack().depth(),
+                    overflow_addr,
+                ))
             },
             MastNode::Dyn(dyn_node) => {
                 self.hasher_for_chiplet.record_hash_control_block(
@@ -329,27 +315,24 @@ impl ExecutionTracer {
                 );
 
                 if dyn_node.is_dyncall() {
-                    let exec_ctx = {
-                        let overflow_addr = self.overflow_table.last_update_clk_in_current_ctx();
-                        // Note: the stack depth to record is the `current_stack_depth - 1` due to
-                        // the semantics of DYNCALL. That is, the top of the
-                        // stack contains the memory address to where the
-                        // address to dynamically call is located. Then, the
-                        // DYNCALL operation performs a drop, and
-                        // records the stack depth after the drop as the beginning of
-                        // the new context. For more information, look at the docs for how the
-                        // constraints are designed; it's a bit tricky but it works.
-                        let stack_depth_after_drop = processor.stack().depth() - 1;
-                        ExecutionContextInfo::new(
-                            processor.system().ctx(),
-                            processor.system().caller_hash(),
-                            stack_depth_after_drop,
-                            overflow_addr,
-                        )
-                    };
-                    (Some(exec_ctx), BlockType::Dyncall)
+                    let overflow_addr = self.overflow_table.last_update_clk_in_current_ctx();
+                    // Note: the stack depth to record is the `current_stack_depth - 1` due to
+                    // the semantics of DYNCALL. That is, the top of the
+                    // stack contains the memory address to where the
+                    // address to dynamically call is located. Then, the
+                    // DYNCALL operation performs a drop, and
+                    // records the stack depth after the drop as the beginning of
+                    // the new context. For more information, look at the docs for how the
+                    // constraints are designed; it's a bit tricky but it works.
+                    let stack_depth_after_drop = processor.stack().depth() - 1;
+                    Some(ExecutionContextInfo::new(
+                        processor.system().ctx(),
+                        processor.system().caller_hash(),
+                        stack_depth_after_drop,
+                        overflow_addr,
+                    ))
                 } else {
-                    (None, BlockType::Dyn)
+                    None
                 }
             },
             MastNode::Block(_) => panic!(
@@ -361,31 +344,21 @@ impl ExecutionTracer {
         };
 
         let block_addr = self.hasher_chiplet_shim.record_hash_control_block();
-        let parent_addr = self.block_stack.push(block_addr, block_type, ctx_info);
+        let parent_addr = self.block_stack.push(block_addr, ctx_info);
         self.block_stack_replay.record_node_start_parent_addr(parent_addr);
     }
 
-    /// Records the block address and flags for an END operation based on the block being popped.
+    /// Records the block address for an END operation based on the block being popped.
     #[inline(always)]
     fn record_node_end(&mut self, block_info: &BlockInfo) {
-        let flags = NodeFlags::new(
-            block_info.is_loop_body() == ONE,
-            block_info.is_entered_loop() == ONE,
-            block_info.is_call() == ONE,
-            block_info.is_syscall() == ONE,
-        );
         let (prev_addr, prev_parent_addr) = if self.block_stack.is_empty() {
             (ZERO, ZERO)
         } else {
             let prev_block = self.block_stack.peek();
             (prev_block.addr, prev_block.parent_addr)
         };
-        self.block_stack_replay.record_node_end(
-            block_info.addr,
-            flags,
-            prev_addr,
-            prev_parent_addr,
-        );
+        self.block_stack_replay
+            .record_node_end(block_info.addr, prev_addr, prev_parent_addr);
     }
 
     /// Records the execution context system info for CALL/SYSCALL/DYNCALL operations.
@@ -546,7 +519,7 @@ impl Tracer for ExecutionTracer {
                     let block_addr =
                         self.hasher_chiplet_shim.record_hash_basic_block(basic_block_node);
                     let parent_addr =
-                        self.block_stack.push(block_addr, BlockType::BasicBlock, None);
+                        self.block_stack.push(block_addr, None);
                     self.block_stack_replay.record_node_start_parent_addr(parent_addr);
                 },
                 MastNode::External(_) => unreachable!(

--- a/processor/src/trace/parallel/tracer/mod.rs
+++ b/processor/src/trace/parallel/tracer/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     continuation_stack::{Continuation, ContinuationStack},
     errors::MapExecErrNoCtx,
     mast::{MastForest, MastNode, MastNodeExt, MastNodeId},
+    trace::trace_state::NodeFlags,
     tracer::{OperationHelperRegisters, Tracer},
 };
 
@@ -91,6 +92,13 @@ pub(crate) struct CoreTraceGenerationTracer<'a> {
     /// this cycle.
     continuation: Option<Continuation>,
 
+    /// Whether the node ending in this clock cycle is a body of a LOOP node. This is determined
+    /// by peeking at the continuation stack in [`start_clock_cycle`](Tracer::start_clock_cycle)
+    /// to check if the next clock-incrementing continuation is a `FinishLoop`.
+    ///
+    /// This is only relevant for END operations (Finish* continuations).
+    is_loop_body: bool,
+
     /// If an error is encountered during trace generation, it is stored here. Once set, all
     /// subsequent `start_clock_cycle` and `finalize_clock_cycle` calls become no-ops, and the
     /// error is returned by [`into_parts`](Self::into_parts).
@@ -116,6 +124,7 @@ impl<'a> CoreTraceGenerationTracer<'a> {
             finish_loop_condition: None,
             dyn_callee_hash: None,
             continuation: None,
+            is_loop_body: false,
             error_encountered: None,
         }
     }
@@ -288,6 +297,52 @@ impl<'a> CoreTraceGenerationTracer<'a> {
         None
     }
 
+    /// Returns the `NodeFlags` for an END operation based on the continuation type and state
+    /// captured in `start_clock_cycle`.
+    fn compute_node_flags(
+        &self,
+        continuation: &Continuation,
+        current_forest: &MastForest,
+    ) -> Result<NodeFlags, ExecutionError> {
+        let is_loop_body = self.is_loop_body;
+
+        match continuation {
+            Continuation::FinishLoop { was_entered, .. } => {
+                // The Loop node itself is ending. `loop_entered` = `was_entered`.
+                Ok(NodeFlags::new(is_loop_body, *was_entered, false, false))
+            },
+            Continuation::FinishCall(node_id) => {
+                let node = get_node_in_forest(current_forest, *node_id)?;
+                let MastNode::Call(call_node) = node else {
+                    return Err(ExecutionError::Internal(
+                        "expected call node in FinishCall continuation",
+                    ));
+                };
+                let is_syscall = call_node.is_syscall();
+                let is_call = !is_syscall;
+                Ok(NodeFlags::new(is_loop_body, false, is_call, is_syscall))
+            },
+            Continuation::FinishDyn(node_id) => {
+                let node = get_node_in_forest(current_forest, *node_id)?;
+                let MastNode::Dyn(dyn_node) = node else {
+                    return Err(ExecutionError::Internal(
+                        "expected dyn node in FinishDyn continuation",
+                    ));
+                };
+                let is_call = dyn_node.is_dyncall();
+                Ok(NodeFlags::new(is_loop_body, false, is_call, false))
+            },
+            Continuation::FinishJoin(_)
+            | Continuation::FinishSplit(_)
+            | Continuation::FinishBasicBlock(_) => {
+                Ok(NodeFlags::new(is_loop_body, false, false, false))
+            },
+            _ => {
+                Err(ExecutionError::Internal("compute_node_flags called for non-END continuation"))
+            },
+        }
+    }
+
     /// Returns the callee hash for a `Dyn` node, or `None` if the continuation is not a
     /// `StartNode` for a `Dyn` node.
     ///
@@ -329,7 +384,7 @@ impl Tracer for CoreTraceGenerationTracer<'_> {
         &mut self,
         processor: &ReplayProcessor,
         continuation: Continuation,
-        _continuation_stack: &ContinuationStack,
+        continuation_stack: &ContinuationStack,
         current_forest: &Arc<MastForest>,
     ) {
         if self.error_encountered.is_some() {
@@ -344,6 +399,13 @@ impl Tracer for CoreTraceGenerationTracer<'_> {
             self.finish_loop_condition = self.get_finish_loop_condition(&continuation, processor);
             self.dyn_callee_hash =
                 self.get_dyn_callee_hash(&continuation, processor, current_forest)?;
+
+            // For END operations, determine if the ending node is a body of a LOOP by checking
+            // whether the next clock-incrementing continuation is a FinishLoop.
+            self.is_loop_body = matches!(
+                continuation_stack.iter_continuations_for_next_clock().last(),
+                Some(Continuation::FinishLoop { was_entered: true, .. })
+            );
 
             // Store state for finalizing the clock cycle later.
             self.continuation = Some(continuation);
@@ -384,11 +446,23 @@ impl Tracer for CoreTraceGenerationTracer<'_> {
                 },
                 FinishJoin(node_id) => {
                     let node = get_node_in_forest(current_forest, *node_id)?;
-                    self.fill_end_trace_row(&processor.system, &processor.stack, node.digest())?;
+                    let flags = self.compute_node_flags(continuation, current_forest)?;
+                    self.fill_end_trace_row(
+                        &processor.system,
+                        &processor.stack,
+                        node.digest(),
+                        flags.to_hasher_state_second_word(),
+                    )?;
                 },
                 FinishSplit(node_id) => {
                     let node = get_node_in_forest(current_forest, *node_id)?;
-                    self.fill_end_trace_row(&processor.system, &processor.stack, node.digest())?;
+                    let flags = self.compute_node_flags(continuation, current_forest)?;
+                    self.fill_end_trace_row(
+                        &processor.system,
+                        &processor.stack,
+                        node.digest(),
+                        flags.to_hasher_state_second_word(),
+                    )?;
                 },
                 FinishLoop { node_id, was_entered: _ } => {
                     let loop_condition = self.finish_loop_condition.take().ok_or(
@@ -418,20 +492,34 @@ impl Tracer for CoreTraceGenerationTracer<'_> {
                     } else {
                         // Loop is finished, so fill in an END row.
                         let node = get_node_in_forest(current_forest, *node_id)?;
+                        let flags = self.compute_node_flags(continuation, current_forest)?;
                         self.fill_end_trace_row(
                             &processor.system,
                             &processor.stack,
                             node.digest(),
+                            flags.to_hasher_state_second_word(),
                         )?;
                     }
                 },
                 FinishCall(node_id) => {
                     let node = get_node_in_forest(current_forest, *node_id)?;
-                    self.fill_end_trace_row(&processor.system, &processor.stack, node.digest())?;
+                    let flags = self.compute_node_flags(continuation, current_forest)?;
+                    self.fill_end_trace_row(
+                        &processor.system,
+                        &processor.stack,
+                        node.digest(),
+                        flags.to_hasher_state_second_word(),
+                    )?;
                 },
                 FinishDyn(node_id) => {
                     let node = get_node_in_forest(current_forest, *node_id)?;
-                    self.fill_end_trace_row(&processor.system, &processor.stack, node.digest())?;
+                    let flags = self.compute_node_flags(continuation, current_forest)?;
+                    self.fill_end_trace_row(
+                        &processor.system,
+                        &processor.stack,
+                        node.digest(),
+                        flags.to_hasher_state_second_word(),
+                    )?;
                 },
                 ResumeBasicBlock { node_id, batch_index, op_idx_in_batch } => {
                     let MastNode::Block(basic_block_node) =
@@ -502,10 +590,12 @@ impl Tracer for CoreTraceGenerationTracer<'_> {
                         ));
                     };
 
+                    let flags = self.compute_node_flags(continuation, current_forest)?;
                     self.fill_basic_block_end_trace_row(
                         &processor.system,
                         &processor.stack,
                         basic_block_node,
+                        flags.to_hasher_state_second_word(),
                     )?;
                 },
                 FinishExternal(_)

--- a/processor/src/trace/parallel/tracer/trace_row.rs
+++ b/processor/src/trace/parallel/tracer/trace_row.rs
@@ -176,13 +176,13 @@ impl<'a> CoreTraceGenerationTracer<'a> {
         system: &SystemState,
         stack: &StackState,
         basic_block_node: &BasicBlockNode,
+        hasher_state_second_word: Word,
     ) -> Result<(), ExecutionError> {
-        let (ended_node_addr, flags) =
-            self.decoder_state.replay_node_end(&mut self.block_stack_replay)?;
+        let ended_node_addr = self.decoder_state.replay_node_end(&mut self.block_stack_replay)?;
 
         let decoder_row = DecoderRow::new_control_flow(
             opcodes::END,
-            (basic_block_node.digest(), flags.to_hasher_state_second_word()),
+            (basic_block_node.digest(), hasher_state_second_word),
             ended_node_addr,
         );
 
@@ -447,14 +447,14 @@ impl<'a> CoreTraceGenerationTracer<'a> {
         system: &SystemState,
         stack: &StackState,
         node_digest: Word,
+        hasher_state_second_word: Word,
     ) -> Result<(), ExecutionError> {
         // Pop the block from stack and use its info for END operations
-        let (ended_node_addr, flags) =
-            self.decoder_state.replay_node_end(&mut self.block_stack_replay)?;
+        let ended_node_addr = self.decoder_state.replay_node_end(&mut self.block_stack_replay)?;
 
         let decoder_row = DecoderRow::new_control_flow(
             opcodes::END,
-            (node_digest, flags.to_hasher_state_second_word()),
+            (node_digest, hasher_state_second_word),
             ended_node_addr,
         );
 

--- a/processor/src/trace/trace_state.rs
+++ b/processor/src/trace/trace_state.rs
@@ -128,18 +128,17 @@ impl DecoderState {
 
     /// This function is called when we hit an `END` operation, signaling the end of execution for a
     /// node. It updates the decoder state to point to the previous node in the block stack (which
-    /// could be renamed to "node stack"), and returns the address of the node that just ended,
-    /// along with any flags associated with it.
+    /// could be renamed to "node stack"), and returns the address of the node that just ended.
     pub fn replay_node_end(
         &mut self,
         block_stack_replay: &mut BlockStackReplay,
-    ) -> Result<(Felt, NodeFlags), ExecutionError> {
+    ) -> Result<Felt, ExecutionError> {
         let node_end_data = block_stack_replay.replay_node_end()?;
 
         self.current_addr = node_end_data.prev_addr;
         self.parent_addr = node_end_data.prev_parent_addr;
 
-        Ok((node_end_data.ended_node_addr, node_end_data.flags))
+        Ok(node_end_data.ended_node_addr)
     }
 }
 
@@ -348,13 +347,11 @@ impl BlockStackReplay {
     pub fn record_node_end(
         &mut self,
         ended_node_addr: Felt,
-        flags: NodeFlags,
         prev_addr: Felt,
         prev_parent_addr: Felt,
     ) {
         self.node_end.push_back(NodeEndData {
             ended_node_addr,
-            flags,
             prev_addr,
             prev_parent_addr,
         });
@@ -425,16 +422,13 @@ impl NodeFlags {
 
 /// The data needed to fully recover the state on an END operation.
 ///
-/// We record `ended_node_addr` and `flags` in order to be able to properly populate the trace
-/// row for the node operation. Additionally, we record `prev_addr` and `prev_parent_addr` to
-/// allow emulating peeking into the block stack, which is needed when processing REPEAT or RESPAN
-/// nodes.
+/// We record `ended_node_addr` in order to be able to properly populate the trace row for the
+/// node operation. Additionally, we record `prev_addr` and `prev_parent_addr` to allow emulating
+/// peeking into the block stack, which is needed when processing REPEAT or RESPAN nodes.
 #[derive(Debug)]
 pub struct NodeEndData {
     /// the address of the node that is ending
     pub ended_node_addr: Felt,
-    /// the flags associated with the node that is ending
-    pub flags: NodeFlags,
     /// the address of the node sitting on top of the block stack after the END operation (or 0 if
     /// the block stack is empty)
     pub prev_addr: Felt,

--- a/processor/src/tracer.rs
+++ b/processor/src/tracer.rs
@@ -66,7 +66,7 @@ pub trait Tracer {
     /// the current clock cycle.
     ///
     /// `continuation` represents what is to be executed at the beginning of this clock cycle, while
-    /// `continuation_stack` represents whatever comes after execution `continuation`.
+    /// `continuation_stack` represents whatever comes after executing `continuation`.
     ///
     /// The following continuations do not occur at the start of a clock cycle, and hence will never
     /// be passed to this method:


### PR DESCRIPTION
Closes #2644 

The flags were redundant with the information present on the continuation stack. This ended up cleaning the `BlockStack` quite a bit, as we got rid of `BlockType`, and a lot of complex logic around it.