### PR TITLE
chore: add AMD Ryzen 9 9950X benchmarks with AVX-512

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ In the benchmarks below, the VM executes the same Blake3 example program for 2<s
 | Apple M4 Max (16 threads)      |     11.1 ms    |   5.9 sec    |    0.2%     |      170 KHz      |
 | Amazon Graviton 4 (64 threads) |     10.7 ms    |   5.7 sec    |    0.2%     |      175 KHz      |
 | AMD EPYC 9R45 (64 threads)     |     7.5 ms     |   4.5 sec    |    0.2%     |      220 KHz      |
+| AMD Ryzen 9 9950X (16 threads) |     7.6 ms     |   7.6 sec    |    0.1%     |      138 KHz      |
+| AMD Ryzen 9 9950X (32 threads) |     7.3 ms     |   6.8 sec    |    0.1%     |      154 KHz      |
 
 ### Recursing-friendly proofs
 
@@ -130,6 +132,8 @@ In the benchmarks below we execute the same Blake3 example program for 2<sup>20<
 | Apple M4 Max (16 threads)      |     11.1 ms    |   12.9 sec   |     2.2x           |
 | Amazon Graviton 4 (64 threads) |     10.7 ms    |   9.5 sec    |     1.7x           |
 | AMD EPYC 9R45 (64 threads)     |     7.5 ms     |   8.6 sec    |     1.9x           |
+| AMD Ryzen 9 9950X (16 threads) |     7.4 ms     |   18.9 sec   |     2.5x           |
+| AMD Ryzen 9 9950X (32 threads) |     7.3 ms     |   14.8 sec   |     2.2x           |
 
 ## References
 


### PR DESCRIPTION
Add local benchmark results for AMD Ryzen 9 9950X (16-core, AVX-512) compiled with target-cpu=native. Results include both 16 and 32 thread configurations for BLAKE3 and Poseidon2 hash functions at 2^20 cycles.

<details><summary>AMD Ryzen 9 9950X Benchmark Details</summary>

Compiled with `RUSTFLAGS="-C target-cpu=native"` to enable AVX-512.

## BLAKE3 (16 threads) - Total: 7.58 sec

| Stage | Time |
|:---|:---:|
| Execute | 7.6 ms |
| Build trace | 122 ms |
| To row-major | 175 ms |
| Commit to main traces | 1.71 sec |
| Build aux trace | 513 ms |
| Commit to aux traces | 527 ms |
| Evaluate constraints | 3.28 sec |
| Commit to quotient poly chunks | 686 ms |
| PCS opening (DEEP + FRI) | 467 ms |

## BLAKE3 (32 threads) - Total: 6.79 sec

| Stage | Time |
|:---|:---:|
| Execute | 7.3 ms |
| Build trace | 117 ms |
| To row-major | 169 ms |
| Commit to main traces | 1.63 sec |
| Build aux trace | 503 ms |
| Commit to aux traces | 475 ms |
| Evaluate constraints | 2.69 sec |
| Commit to quotient poly chunks | 631 ms |
| PCS opening (DEEP + FRI) | 485 ms |

## Poseidon2 (16 threads) - Total: 18.9 sec

| Stage | Time |
|:---|:---:|
| Execute | 7.4 ms |
| Build trace | 119 ms |
| To row-major | 173 ms |
| Commit to main traces | 8.51 sec |
| Build aux trace | 519 ms |
| Commit to aux traces | 2.56 sec |
| Evaluate constraints | 3.28 sec |
| Commit to quotient poly chunks | 2.71 sec |
| PCS opening (DEEP + FRI) | 976 ms |

## Poseidon2 (32 threads) - Total: 14.8 sec

| Stage | Time |
|:---|:---:|
| Execute | 7.3 ms |
| Build trace | 117 ms |
| To row-major | 169 ms |
| Commit to main traces | 6.35 sec |
| Build aux trace | 507 ms |
| Commit to aux traces | 1.93 sec |
| Evaluate constraints | 2.69 sec |
| Commit to quotient poly chunks | 2.09 sec |
| PCS opening (DEEP + FRI) | 840 ms |

## Commands Used

```bash
# Build with AVX-512
RUSTFLAGS="-C target-cpu=native" make exec-info

# Run benchmarks
MIDEN_LOG=info RAYON_NUM_THREADS=16 ./target/optimized/miden-vm prove ./miden-vm/masm-examples/hashing/blake3_1to1/blake3_1to1.masm --release
MIDEN_LOG=info RAYON_NUM_THREADS=16 ./target/optimized/miden-vm prove ./miden-vm/masm-examples/hashing/blake3_1to1/blake3_1to1.masm --release --hasher poseidon2
MIDEN_LOG=info RAYON_NUM_THREADS=32 ./target/optimized/miden-vm prove ./miden-vm/masm-examples/hashing/blake3_1to1/blake3_1to1.masm --release
MIDEN_LOG=info RAYON_NUM_THREADS=32 ./target/optimized/miden-vm prove ./miden-vm/masm-examples/hashing/blake3_1to1/blake3_1to1.masm --release --hasher poseidon2
```
</details>