### PR TITLE
fix(processor): propagate error code in u32assert2 operation

### DIFF
--- a/processor/src/execution/operations/u32_ops/mod.rs
+++ b/processor/src/execution/operations/u32_ops/mod.rs
@@ -296,14 +296,19 @@ where
 
 /// Pops top two element off the stack, splits them into low and high 32-bit values, checks if
 /// the high values are equal to 0; if they are, puts the original elements back onto the
-/// stack; if they are not, returns an error.
+/// stack; if they are not, returns an error with the user-specified error code.
 #[inline(always)]
 pub(super) fn op_u32assert2<P: Processor, T: Tracer>(
     processor: &mut P,
-    _err_code: Felt,
+    err_code: Felt,
     tracer: &mut T,
 ) -> Result<OperationHelperRegisters, OperationError> {
-    let (first, second) = require_u32_operands!(processor, [0, 1]);
+    let first = processor.stack().get(0);
+    let second = processor.stack().get(1);
+
+    if first.as_canonical_u64() > U32_MAX || second.as_canonical_u64() > U32_MAX {
+        return Err(OperationError::FailedAssertion { err_code, err_msg: None });
+    }
 
     tracer.record_u32_range_checks(processor.system().clock(), first, second);
 

--- a/processor/src/execution/operations/u32_ops/tests.rs
+++ b/processor/src/execution/operations/u32_ops/tests.rs
@@ -11,6 +11,7 @@ use super::{
     op_u32sub, op_u32xor,
 };
 use crate::fast::{FastProcessor, NoopTracer};
+use crate::operation::OperationError;
 
 // CASTING OPERATIONS
 // --------------------------------------------------------------------------------------------
@@ -77,7 +78,12 @@ fn test_op_u32assert2_both_invalid() {
     let mut tracer = NoopTracer;
 
     let result = op_u32assert2(&mut processor, Felt::from_u32(123u32), &mut tracer);
-    assert!(result.is_err());
+    match result {
+        Err(OperationError::FailedAssertion { err_code, .. }) => {
+            assert_eq!(err_code, Felt::from_u32(123u32));
+        },
+        other => panic!("expected FailedAssertion, got: {other:?}"),
+    }
 }
 
 #[test]
@@ -89,7 +95,12 @@ fn test_op_u32assert2_second_invalid() {
     let mut tracer = NoopTracer;
 
     let result = op_u32assert2(&mut processor, Felt::from_u32(456u32), &mut tracer);
-    assert!(result.is_err());
+    match result {
+        Err(OperationError::FailedAssertion { err_code, .. }) => {
+            assert_eq!(err_code, Felt::from_u32(456u32));
+        },
+        other => panic!("expected FailedAssertion, got: {other:?}"),
+    }
 }
 
 #[test]
@@ -101,7 +112,12 @@ fn test_op_u32assert2_first_invalid() {
     let mut tracer = NoopTracer;
 
     let result = op_u32assert2(&mut processor, Felt::from_u32(789), &mut tracer);
-    assert!(result.is_err());
+    match result {
+        Err(OperationError::FailedAssertion { err_code, .. }) => {
+            assert_eq!(err_code, Felt::from_u32(789));
+        },
+        other => panic!("expected FailedAssertion, got: {other:?}"),
+    }
 }
 
 // ARITHMETIC OPERATIONS


### PR DESCRIPTION
## Summary

`op_u32assert2` receives an `err_code` parameter from the dispatcher but never uses it - the parameter was prefixed with `_` and the `require_u32_operands!` macro returned a generic `OperationError::NotU32Values` that discards the user error code.

## Root Cause

```rust
// Before - err_code is silently discarded
pub(super) fn op_u32assert2<P: Processor, T: Tracer>(
    processor: &mut P,
    _err_code: Felt,    // unused
    tracer: &mut T,
) -> Result<OperationHelperRegisters, OperationError> {
    let (first, second) = require_u32_operands!(processor, [0, 1]);
    // ^^ macro returns NotU32Values with no error code
```

## Fix

Replace the macro call with an inline u32 check and return `OperationError::FailedAssertion` with the user error code, consistent with how `op_assert` handles its error code:

```rust
// After - err_code is propagated
pub(super) fn op_u32assert2<P: Processor, T: Tracer>(
    processor: &mut P,
    err_code: Felt,
    tracer: &mut T,
) -> Result<OperationHelperRegisters, OperationError> {
    let first = processor.stack().get(0);
    let second = processor.stack().get(1);

    if first.as_canonical_u64() > U32_MAX || second.as_canonical_u64() > U32_MAX {
        return Err(OperationError::FailedAssertion { err_code, err_msg: None });
    }
```

No signature change - the dispatcher already passes `err_code` correctly. Tests updated to verify the error code is preserved in all three failure paths (both invalid, first invalid, second invalid).

Closes #2844
