### PR TITLE
fix: return structured errors for unsafe assembly resolution paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Memoized semantic constant evaluation in `AnalysisContext` to prevent exponential work from shared constant-dependency graphs during parsing and semantic analysis ([#2858](https://github.com/0xMiden/miden-vm/pull/2858)).
 - Fixed quote-equivalent path ambiguity in library deserialization and linker symbol resolution ([#2836](https://github.com/0xMiden/miden-vm/pull/2836)).
 - Treat serialized libraries and kernel libraries as untrusted MAST forests during deserialization, rejecting spoofed node digests ([#2863](https://github.com/0xMiden/miden-vm/pull/2863)).
+- Return typed cycle errors for self-recursive and rootless procedure call graphs, and roll back linker state on failure ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
+- [BREAKING] Reject oversized modules at resolver construction instead of building partial resolver state or panicking ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
+- Return a normal assembly error when `pub use <digest> -> <name>` does not resolve to an exported procedure ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
+- [BREAKING] Reject non-procedure invoke targets during semantic analysis, and return an assembly error instead of panicking if one still reaches assembly ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
 
 ## 0.22.0 (TBD)
 

--- a/crates/assembly-syntax/src/ast/item/index.rs
+++ b/crates/assembly-syntax/src/ast/item/index.rs
@@ -3,9 +3,22 @@
 #[repr(transparent)]
 pub struct ItemIndex(u16);
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid item index: too many items")]
+pub struct ItemIndexError {
+    attempted: usize,
+}
+
 impl ItemIndex {
+    pub const MAX_ITEMS: usize = u16::MAX as usize + 1;
+
     pub fn new(id: usize) -> Self {
-        Self(id.try_into().expect("invalid item index: too many items"))
+        Self::try_new(id).expect("invalid item index: too many items")
+    }
+
+    pub fn try_new(id: usize) -> Result<Self, ItemIndexError> {
+        let raw = id.try_into().map_err(|_| ItemIndexError { attempted: id })?;
+        Ok(Self(raw))
     }
 
     #[inline(always)]
@@ -97,5 +110,86 @@ impl core::ops::Add<ItemIndex> for ModuleIndex {
 impl core::fmt::Display for ModuleIndex {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", &self.as_usize())
+    }
+}
+
+#[cfg(test)]
+mod regression_tests {
+    use std::{string::String, sync::Arc};
+
+    use miden_debug_types::{DefaultSourceManager, SourceSpan, Span};
+
+    use super::ItemIndex;
+    use crate::{
+        Parse, ParseOptions, Path,
+        ast::{
+            Constant, ConstantExpr, Export, Ident, Module, ModuleKind, SymbolResolutionError,
+            Visibility,
+        },
+        parser::IntValue,
+        sema::{LimitKind, SemanticAnalysisError, SyntaxError},
+    };
+
+    fn huge_library_masm() -> String {
+        let num_consts = usize::from(u16::MAX) + 2;
+        let mut masm = String::with_capacity(num_consts * 16);
+        for i in 0..num_consts {
+            masm.push_str("const A");
+            masm.push_str(&format!("{i}"));
+            masm.push_str(" = 0\n");
+        }
+        masm
+    }
+
+    fn oversized_module_for_resolver() -> Module {
+        let mut module = Module::new(ModuleKind::Library, Path::new("::m::huge"));
+        for i in 0..=ItemIndex::MAX_ITEMS {
+            module.items.push(Export::Constant(Constant::new(
+                SourceSpan::UNKNOWN,
+                Visibility::Private,
+                Ident::new(format!("A{i}")).expect("valid identifier"),
+                ConstantExpr::Int(Span::unknown(IntValue::from(0u8))),
+            )));
+        }
+        module
+    }
+
+    #[test]
+    fn too_many_items_in_module_is_rejected_during_analysis() {
+        let source_manager = Arc::new(DefaultSourceManager::default());
+        let err = huge_library_masm()
+            .parse_with_options(
+                source_manager,
+                ParseOptions::new(ModuleKind::Library, Path::new("::m::huge")),
+            )
+            .expect_err("expected oversized module to be rejected during analysis");
+
+        let syntax_error = err.downcast_ref::<SyntaxError>().expect("expected SyntaxError report");
+        assert!(
+            syntax_error.errors.iter().any(|error| {
+                matches!(error, SemanticAnalysisError::LimitExceeded { kind: LimitKind::Items, .. })
+            }),
+            "expected item-limit error, got {:?}",
+            syntax_error.errors
+        );
+    }
+
+    #[test]
+    fn resolving_name_in_too_large_module_returns_structured_error() {
+        let source_manager = Arc::new(DefaultSourceManager::default());
+        let module = oversized_module_for_resolver();
+        let result = module.resolve(Span::unknown("A0"), source_manager);
+
+        assert!(matches!(result, Err(SymbolResolutionError::TooManyItemsInModule { .. })));
+    }
+
+    #[test]
+    fn resolver_construction_for_too_large_module_returns_structured_error() {
+        let source_manager = Arc::new(DefaultSourceManager::default());
+        let module = oversized_module_for_resolver();
+
+        let result = module.resolver(source_manager);
+
+        assert!(matches!(result, Err(SymbolResolutionError::TooManyItemsInModule { .. })));
     }
 }

--- a/crates/assembly-syntax/src/ast/item/resolver/error.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/error.rs
@@ -5,7 +5,10 @@ use alloc::sync::Arc;
 
 use miden_debug_types::{SourceFile, SourceManager, SourceSpan};
 
-use crate::diagnostics::{Diagnostic, RelatedLabel, miette};
+use crate::{
+    ast::ItemIndex,
+    diagnostics::{Diagnostic, RelatedLabel, miette},
+};
 
 /// Represents an error that occurs during symbol resolution
 #[derive(Debug, Clone, thiserror::Error, Diagnostic)]
@@ -76,6 +79,15 @@ pub enum SymbolResolutionError {
         #[source_code]
         source_file: Option<Arc<SourceFile>>,
         max_depth: usize,
+    },
+    #[error("too many items in module")]
+    #[diagnostic(help("break this module up into smaller modules"))]
+    TooManyItemsInModule {
+        #[label("module item count exceeds the supported limit of {max_items}")]
+        span: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        max_items: usize,
     },
 }
 
@@ -174,6 +186,14 @@ impl SymbolResolutionError {
             span,
             source_file: source_manager.get(span.source_id()).ok(),
             max_depth,
+        }
+    }
+
+    pub fn too_many_items_in_module(span: SourceSpan, source_manager: &dyn SourceManager) -> Self {
+        Self::TooManyItemsInModule {
+            span,
+            source_file: source_manager.get(span.source_id()).ok(),
+            max_items: ItemIndex::MAX_ITEMS,
         }
     }
 }

--- a/crates/assembly-syntax/src/ast/item/resolver/mod.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/mod.rs
@@ -65,18 +65,21 @@ impl Spanned for SymbolResolution {
 ///
 /// This is used as a low-level symbol resolution primitive in the linker as well.
 pub struct LocalSymbolResolver {
+    source_manager: Arc<dyn SourceManager>,
     symbols: LocalSymbolTable,
 }
 
 impl LocalSymbolResolver {
     /// Create a new resolver using the provided [SymbolTable] and [SourceManager].
-    pub fn new<S>(symbols: S, source_manager: Arc<dyn SourceManager>) -> Self
+    pub fn new<S>(
+        symbols: S,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self, SymbolResolutionError>
     where
         S: SymbolTable,
     {
-        Self {
-            symbols: LocalSymbolTable::new(symbols, source_manager),
-        }
+        let symbols = LocalSymbolTable::new(symbols, source_manager.clone())?;
+        Ok(Self { source_manager, symbols })
     }
 
     /// Expand `path` using `get_import` to resolve a raw symbol name to an import in the current
@@ -97,7 +100,7 @@ impl LocalSymbolResolver {
 
     #[inline]
     pub fn source_manager(&self) -> Arc<dyn SourceManager> {
-        self.symbols.source_manager_arc()
+        self.source_manager.clone()
     }
 
     /// Try to resolve `name` to an item, either local or external
@@ -142,7 +145,7 @@ impl LocalSymbolResolver {
                 Err(SymbolResolutionError::invalid_sub_path(
                     path.span(),
                     item.span(),
-                    self.symbols.source_manager(),
+                    &*self.source_manager,
                 ))
             },
             SymbolResolution::MastRoot(digest) => {
@@ -156,7 +159,7 @@ impl LocalSymbolResolver {
                 Err(SymbolResolutionError::invalid_sub_path(
                     path.span(),
                     digest.span(),
-                    self.symbols.source_manager(),
+                    &*self.source_manager,
                 ))
             },
             SymbolResolution::Module { id, path, .. } => {

--- a/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
@@ -1,6 +1,6 @@
 use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 
-use miden_debug_types::{SourceManager, Span, Spanned};
+use miden_debug_types::{SourceManager, SourceSpan, Span, Spanned};
 
 use super::{SymbolResolution, SymbolResolutionError};
 use crate::{
@@ -15,6 +15,9 @@ use crate::{
 const MAX_ALIAS_EXPANSION_DEPTH: usize = 128;
 
 /// This trait abstracts over any type which acts as a symbol table, e.g. a [crate::ast::Module].
+///
+/// Resolver construction uses [Self::checked_symbols], which must either return the full symbol
+/// set or a structured error.
 pub trait SymbolTable {
     /// The concrete iterator type for the container.
     type SymbolIter: Iterator<Item = LocalSymbol>;
@@ -22,27 +25,50 @@ pub trait SymbolTable {
     /// Get an iterator over the symbols in this symbol table, using the provided [SourceManager]
     /// to emit errors for symbols which are invalid/unresolvable.
     fn symbols(&self, source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter;
+
+    /// Get an iterator over the symbols in this symbol table, returning a structured error if the
+    /// full symbol set cannot be represented exactly.
+    ///
+    /// Override this when exact resolver construction needs validation, such as rejecting oversized
+    /// symbol sets.
+    fn checked_symbols(
+        &self,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self::SymbolIter, SymbolResolutionError> {
+        Ok(self.symbols(source_manager))
+    }
 }
 
 impl SymbolTable for &crate::library::ModuleInfo {
     type SymbolIter = alloc::vec::IntoIter<LocalSymbol>;
 
     fn symbols(&self, _source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter {
-        let module_items = self.items();
-        let mut items = Vec::with_capacity(module_items.len());
+        let mut items = Vec::with_capacity(self.raw_items().len());
 
-        for (index, item) in module_items {
+        for (i, item) in self.raw_items().iter().enumerate() {
             let name = item.name().clone();
             let span = name.span();
-
-            assert_eq!(index.as_usize(), items.len());
             items.push(LocalSymbol::Item {
                 name,
-                resolved: SymbolResolution::Local(Span::new(span, index)),
+                resolved: SymbolResolution::Local(Span::new(span, ItemIndex::new(i))),
             });
         }
 
         items.into_iter()
+    }
+
+    fn checked_symbols(
+        &self,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self::SymbolIter, SymbolResolutionError> {
+        if self.raw_items().len() > ItemIndex::MAX_ITEMS {
+            Err(SymbolResolutionError::too_many_items_in_module(
+                SourceSpan::UNKNOWN,
+                &*source_manager,
+            ))
+        } else {
+            Ok(self.symbols(source_manager))
+        }
     }
 }
 
@@ -90,6 +116,17 @@ impl SymbolTable for &crate::ast::Module {
 
         items.into_iter()
     }
+
+    fn checked_symbols(
+        &self,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self::SymbolIter, SymbolResolutionError> {
+        if self.items.len() > ItemIndex::MAX_ITEMS {
+            Err(SymbolResolutionError::too_many_items_in_module(self.span(), &*source_manager))
+        } else {
+            Ok(self.symbols(source_manager))
+        }
+    }
 }
 
 /// Represents a symbol within the context of a single module
@@ -130,20 +167,30 @@ impl core::ops::Index<ItemIndex> for LocalSymbolTable {
 }
 
 impl LocalSymbolTable {
-    pub fn new<S>(iter: S, source_manager: Arc<dyn SourceManager>) -> Self
+    fn build<I>(iter: I, source_manager: Arc<dyn SourceManager>) -> Self
     where
-        S: SymbolTable,
+        I: Iterator<Item = LocalSymbol>,
     {
         let mut symbols = BTreeMap::default();
         let mut items = Vec::with_capacity(16);
 
-        for (i, symbol) in iter.symbols(source_manager.clone()).enumerate() {
+        for (i, symbol) in iter.enumerate() {
+            let id = ItemIndex::try_new(i)
+                .expect("symbol iterators used by LocalSymbolTable::build must be pre-validated");
+            let symbol = match symbol {
+                LocalSymbol::Item {
+                    name,
+                    resolved: SymbolResolution::Local(local),
+                } => LocalSymbol::Item {
+                    name,
+                    resolved: SymbolResolution::Local(Span::new(local.span(), id)),
+                },
+                symbol => symbol,
+            };
             log::debug!(target: "symbol-table::new", "registering {} symbol: {}", match symbol {
                 LocalSymbol::Item { .. } => "local",
                 LocalSymbol::Import { .. } => "imported",
             }, symbol.name());
-
-            let id = ItemIndex::new(i);
             let name = match &symbol {
                 LocalSymbol::Item { name, .. } => name.clone().into_inner(),
                 LocalSymbol::Import { name, .. } => name.clone().into_inner(),
@@ -163,14 +210,15 @@ impl LocalSymbolTable {
         Self { source_manager, symbols, items }
     }
 
-    #[inline(always)]
-    pub fn source_manager(&self) -> &dyn SourceManager {
-        &self.source_manager
-    }
-
-    #[inline(always)]
-    pub fn source_manager_arc(&self) -> Arc<dyn SourceManager> {
-        self.source_manager.clone()
+    pub fn new<S>(
+        iter: S,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self, SymbolResolutionError>
+    where
+        S: SymbolTable,
+    {
+        let symbols = iter.checked_symbols(source_manager.clone())?;
+        Ok(Self::build(symbols, source_manager))
     }
 }
 
@@ -486,6 +534,54 @@ mod tests {
         }
     }
 
+    #[test]
+    fn checked_symbols_rejects_oversized_module() {
+        let source_manager: Arc<dyn SourceManager> = Arc::new(DefaultSourceManager::default());
+        let mut module =
+            crate::ast::Module::new(crate::ast::ModuleKind::Library, crate::Path::new("::m::huge"));
+
+        for i in 0..=ItemIndex::MAX_ITEMS {
+            module.items.push(crate::ast::Export::Constant(crate::ast::Constant::new(
+                SourceSpan::UNKNOWN,
+                crate::ast::Visibility::Private,
+                crate::ast::Ident::new(format!("A{i}")).expect("valid identifier"),
+                crate::ast::ConstantExpr::Int(Span::unknown(crate::parser::IntValue::from(0u8))),
+            )));
+        }
+
+        let result = (&module).checked_symbols(source_manager);
+
+        assert!(matches!(result, Err(SymbolResolutionError::TooManyItemsInModule { .. })));
+    }
+
+    #[test]
+    fn checked_symbols_guard_custom_symbol_table_exact() {
+        struct ExactTooManySymbols;
+
+        impl SymbolTable for ExactTooManySymbols {
+            type SymbolIter = alloc::vec::IntoIter<LocalSymbol>;
+
+            fn symbols(&self, _source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter {
+                panic!("exact construction must not request unchecked symbols")
+            }
+
+            fn checked_symbols(
+                &self,
+                source_manager: Arc<dyn SourceManager>,
+            ) -> Result<Self::SymbolIter, SymbolResolutionError> {
+                Err(SymbolResolutionError::too_many_items_in_module(
+                    SourceSpan::UNKNOWN,
+                    &*source_manager,
+                ))
+            }
+        }
+
+        let source_manager: Arc<dyn SourceManager> = Arc::new(DefaultSourceManager::default());
+        let result = LocalSymbolTable::new(ExactTooManySymbols, source_manager);
+
+        assert!(matches!(result, Err(SymbolResolutionError::TooManyItemsInModule { .. })));
+    }
+
     #[cfg(test)]
     struct DuplicateSymbolsForInvariantTest;
 
@@ -529,7 +625,9 @@ mod tests {
                 "debug builds should panic when duplicates reach local resolver construction"
             );
         } else {
-            let table = result.expect("release builds should not panic on duplicate symbols");
+            let table = result
+                .expect("release builds should not panic on duplicate symbols")
+                .expect("release builds should still construct a table");
             let resolved = table
                 .get(Span::unknown("dup"))
                 .expect("release behavior should keep a deterministic symbol mapping");

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -18,7 +18,7 @@ use crate::{
     PathBuf,
     ast::{self, Ident, types},
     parser::ModuleParser,
-    sema::SemanticAnalysisError,
+    sema::{LimitKind, SemanticAnalysisError},
 };
 
 // MODULE KIND
@@ -198,6 +198,20 @@ impl Module {
         self.span = span;
     }
 
+    fn ensure_item_capacity(&self, span: SourceSpan) -> Result<(), SemanticAnalysisError> {
+        if self.items.len() >= ItemIndex::MAX_ITEMS {
+            return Err(SemanticAnalysisError::LimitExceeded { span, kind: LimitKind::Items });
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn push_export(&mut self, item: Export) -> Result<(), SemanticAnalysisError> {
+        self.ensure_item_capacity(item.span())?;
+        self.items.push(item);
+        Ok(())
+    }
+
     /// Defines a constant, raising an error if the constant conflicts with a previous definition
     pub fn define_constant(&mut self, constant: Constant) -> Result<(), SemanticAnalysisError> {
         if let Some(prev) = self.items.iter().find(|item| item.name() == &constant.name) {
@@ -206,7 +220,7 @@ impl Module {
                 prev_span: prev.span(),
             });
         }
-        self.items.push(Export::Constant(constant));
+        self.push_export(Export::Constant(constant))?;
         Ok(())
     }
 
@@ -218,7 +232,7 @@ impl Module {
                 prev_span: prev.span(),
             });
         }
-        self.items.push(Export::Type(ty.into()));
+        self.push_export(Export::Type(ty.into()))?;
         Ok(())
     }
 
@@ -283,7 +297,7 @@ impl Module {
             })?;
         }
 
-        self.items.push(Export::Type(alias.into()));
+        self.push_export(Export::Type(alias.into()))?;
 
         Ok(())
     }
@@ -303,7 +317,7 @@ impl Module {
                 prev_span: prev.name().span(),
             });
         }
-        self.items.push(Export::Procedure(procedure));
+        self.push_export(Export::Procedure(procedure))?;
         Ok(())
     }
 
@@ -327,7 +341,7 @@ impl Module {
                 prev_span: prev.name().span(),
             });
         }
-        self.items.push(Export::Alias(item));
+        self.push_export(Export::Alias(item))?;
         Ok(())
     }
 }
@@ -552,7 +566,7 @@ impl Module {
         name: Span<&str>,
         source_manager: Arc<dyn SourceManager>,
     ) -> Result<SymbolResolution, SymbolResolutionError> {
-        let resolver = self.resolver(source_manager);
+        let resolver = self.resolver(source_manager)?;
         resolver.resolve(name)
     }
 
@@ -562,13 +576,16 @@ impl Module {
         path: Span<&Path>,
         source_manager: Arc<dyn SourceManager>,
     ) -> Result<SymbolResolution, SymbolResolutionError> {
-        let resolver = self.resolver(source_manager);
+        let resolver = self.resolver(source_manager)?;
         resolver.resolve_path(path)
     }
 
     /// Construct a search structure that can resolve procedure names local to this module
     #[inline]
-    pub fn resolver(&self, source_manager: Arc<dyn SourceManager>) -> LocalSymbolResolver {
+    pub fn resolver(
+        &self,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<LocalSymbolResolver, SymbolResolutionError> {
         LocalSymbolResolver::new(self, source_manager)
     }
 
@@ -594,7 +611,7 @@ impl Module {
         ty: &ast::TypeExpr,
         source_manager: Arc<dyn SourceManager>,
     ) -> Result<Option<types::Type>, SymbolResolutionError> {
-        let type_resolver = ModuleTypeResolver::new(self, source_manager);
+        let type_resolver = self.type_resolver(source_manager)?;
         type_resolver.resolve(ty)
     }
 
@@ -602,7 +619,7 @@ impl Module {
     pub fn type_resolver(
         &self,
         source_manager: Arc<dyn SourceManager>,
-    ) -> impl TypeResolver<SymbolResolutionError> + '_ {
+    ) -> Result<impl TypeResolver<SymbolResolutionError> + '_, SymbolResolutionError> {
         ModuleTypeResolver::new(self, source_manager)
     }
 }
@@ -696,9 +713,12 @@ struct ModuleTypeResolver<'a> {
 }
 
 impl<'a> ModuleTypeResolver<'a> {
-    pub fn new(module: &'a Module, source_manager: Arc<dyn SourceManager>) -> Self {
-        let resolver = module.resolver(source_manager);
-        Self { module, resolver }
+    pub fn new(
+        module: &'a Module,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self, SymbolResolutionError> {
+        let resolver = module.resolver(source_manager)?;
+        Ok(Self { module, resolver })
     }
 }
 

--- a/crates/assembly-syntax/src/library/module.rs
+++ b/crates/assembly-syntax/src/library/module.rs
@@ -18,6 +18,10 @@ pub struct ModuleInfo {
 }
 
 impl ModuleInfo {
+    pub(crate) fn raw_items(&self) -> &[ItemInfo] {
+        &self.items
+    }
+
     /// Returns a new [`ModuleInfo`] instantiated library path.
     pub fn new(path: Arc<Path>) -> Self {
         Self { path, items: Vec::new() }

--- a/crates/assembly-syntax/src/sema/errors.rs
+++ b/crates/assembly-syntax/src/sema/errors.rs
@@ -240,6 +240,8 @@ impl From<SymbolResolutionError> for SemanticAnalysisError {
 /// Represents a system limit that was exceeded
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LimitKind {
+    /// The total number of items in a module
+    Items,
     /// The total number of procedures in a module
     Procedures,
     /// The total number of procedure locals
@@ -257,6 +259,7 @@ pub enum LimitKind {
 impl fmt::Display for LimitKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Self::Items => f.write_str("too many items in module"),
             Self::Procedures => f.write_str("too many procedures in module"),
             Self::Locals => f.write_str("too many procedure locals"),
             Self::Imports => f.write_str("too many imported procedures"),

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use alloc::{
     boxed::Box,
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     string::ToString,
     sync::Arc,
     vec::Vec,
@@ -189,6 +189,7 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
             .iter()
             .map(|item| (item.name().as_str().to_string(), LocalInvokeTarget::from(item))),
     );
+    let mut used_aliases = BTreeSet::default();
     let mut items = VecDeque::from(core::mem::take(&mut module.items));
     while let Some(item) = items.pop_front() {
         match item {
@@ -230,6 +231,7 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
                         analyzer,
                         module,
                         &locals,
+                        &mut used_aliases,
                         Some(procedure.name().clone()),
                     );
                     let _ = visitor.visit_mut_procedure(&mut procedure);
@@ -241,7 +243,13 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
             Export::Alias(mut alias) => {
                 log::debug!(target: "verify-invoke", "visiting alias {}", alias.target());
                 {
-                    let mut visitor = VerifyInvokeTargets::new(analyzer, module, &locals, None);
+                    let mut visitor = VerifyInvokeTargets::new(
+                        analyzer,
+                        module,
+                        &locals,
+                        &mut used_aliases,
+                        None,
+                    );
                     let _ = visitor.visit_mut_alias(&mut alias);
                 }
                 if let Err(err) = module.push_export(Export::Alias(alias)) {
@@ -251,7 +259,13 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
             Export::Constant(mut constant) => {
                 log::debug!(target: "verify-invoke", "visiting constant {}", constant.name());
                 {
-                    let mut visitor = VerifyInvokeTargets::new(analyzer, module, &locals, None);
+                    let mut visitor = VerifyInvokeTargets::new(
+                        analyzer,
+                        module,
+                        &locals,
+                        &mut used_aliases,
+                        None,
+                    );
                     let _ = visitor.visit_mut_constant(&mut constant);
                 }
                 if let Err(err) = module.push_export(Export::Constant(constant)) {
@@ -261,13 +275,25 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
             Export::Type(mut ty) => {
                 log::debug!(target: "verify-invoke", "visiting type {}", ty.name());
                 {
-                    let mut visitor = VerifyInvokeTargets::new(analyzer, module, &locals, None);
+                    let mut visitor = VerifyInvokeTargets::new(
+                        analyzer,
+                        module,
+                        &locals,
+                        &mut used_aliases,
+                        None,
+                    );
                     let _ = visitor.visit_mut_type_decl(&mut ty);
                 }
                 if let Err(err) = module.push_export(Export::Type(ty)) {
                     analyzer.error(err);
                 }
             },
+        }
+    }
+
+    for alias in module.aliases_mut() {
+        if alias.uses == 0 && used_aliases.contains(alias.name().as_str()) {
+            alias.uses = 1;
         }
     }
 

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -6,7 +6,8 @@ mod tests;
 
 use alloc::{
     boxed::Box,
-    collections::{BTreeSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
+    string::ToString,
     sync::Arc,
     vec::Vec,
 };
@@ -15,10 +16,11 @@ use miden_core::{Word, crypto::hash::Poseidon2};
 use miden_debug_types::{SourceFile, SourceManager, Span, Spanned};
 use smallvec::SmallVec;
 
+use self::passes::{LocalInvokeTarget, VerifyInvokeTargets};
 pub use self::{
     context::AnalysisContext,
     errors::{LimitKind, SemanticAnalysisError, SyntaxError},
-    passes::{ConstEvalVisitor, VerifyInvokeTargets, VerifyRepeatCounts},
+    passes::{ConstEvalVisitor, VerifyRepeatCounts},
 };
 use crate::{ast::*, parser::WordValue};
 
@@ -181,7 +183,12 @@ pub fn analyze(
 /// of a module graph and global program analysis to perform any remaining transformations.
 fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<(), SyntaxError> {
     let is_kernel = module.is_kernel();
-    let locals = BTreeSet::from_iter(module.items().iter().map(|p| p.name().clone()));
+    let locals = BTreeMap::from_iter(
+        module
+            .items()
+            .iter()
+            .map(|item| (item.name().as_str().to_string(), LocalInvokeTarget::from(item))),
+    );
     let mut items = VecDeque::from(core::mem::take(&mut module.items));
     while let Some(item) = items.pop_front() {
         match item {

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -17,7 +17,7 @@ use smallvec::SmallVec;
 
 pub use self::{
     context::AnalysisContext,
-    errors::{SemanticAnalysisError, SyntaxError},
+    errors::{LimitKind, SemanticAnalysisError, SyntaxError},
     passes::{ConstEvalVisitor, VerifyInvokeTargets, VerifyRepeatCounts},
 };
 use crate::{ast::*, parser::WordValue};
@@ -227,7 +227,9 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
                     );
                     let _ = visitor.visit_mut_procedure(&mut procedure);
                 }
-                module.items.push(Export::Procedure(procedure));
+                if let Err(err) = module.push_export(Export::Procedure(procedure)) {
+                    analyzer.error(err);
+                }
             },
             Export::Alias(mut alias) => {
                 log::debug!(target: "verify-invoke", "visiting alias {}", alias.target());
@@ -235,7 +237,9 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
                     let mut visitor = VerifyInvokeTargets::new(analyzer, module, &locals, None);
                     let _ = visitor.visit_mut_alias(&mut alias);
                 }
-                module.items.push(Export::Alias(alias));
+                if let Err(err) = module.push_export(Export::Alias(alias)) {
+                    analyzer.error(err);
+                }
             },
             Export::Constant(mut constant) => {
                 log::debug!(target: "verify-invoke", "visiting constant {}", constant.name());
@@ -243,7 +247,9 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
                     let mut visitor = VerifyInvokeTargets::new(analyzer, module, &locals, None);
                     let _ = visitor.visit_mut_constant(&mut constant);
                 }
-                module.items.push(Export::Constant(constant));
+                if let Err(err) = module.push_export(Export::Constant(constant)) {
+                    analyzer.error(err);
+                }
             },
             Export::Type(mut ty) => {
                 log::debug!(target: "verify-invoke", "visiting type {}", ty.name());
@@ -251,7 +257,9 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
                     let mut visitor = VerifyInvokeTargets::new(analyzer, module, &locals, None);
                     let _ = visitor.visit_mut_type_decl(&mut ty);
                 }
-                module.items.push(Export::Type(ty));
+                if let Err(err) = module.push_export(Export::Type(ty)) {
+                    analyzer.error(err);
+                }
             },
         }
     }

--- a/crates/assembly-syntax/src/sema/passes/mod.rs
+++ b/crates/assembly-syntax/src/sema/passes/mod.rs
@@ -2,7 +2,5 @@ mod const_eval;
 mod verify_invoke;
 mod verify_repeat;
 
-pub use self::{
-    const_eval::ConstEvalVisitor, verify_invoke::VerifyInvokeTargets,
-    verify_repeat::VerifyRepeatCounts,
-};
+pub(super) use self::verify_invoke::{LocalInvokeTarget, VerifyInvokeTargets};
+pub use self::{const_eval::ConstEvalVisitor, verify_repeat::VerifyRepeatCounts};

--- a/crates/assembly-syntax/src/sema/passes/verify_invoke.rs
+++ b/crates/assembly-syntax/src/sema/passes/verify_invoke.rs
@@ -1,4 +1,9 @@
-use alloc::{boxed::Box, collections::BTreeSet, sync::Arc};
+use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet},
+    string::{String, ToString},
+    sync::Arc,
+};
 use core::ops::ControlFlow;
 
 use miden_debug_types::{SourceSpan, Span, Spanned};
@@ -8,6 +13,25 @@ use crate::{
     ast::*,
     sema::{AnalysisContext, SemanticAnalysisError},
 };
+
+const MAX_ALIAS_EXPANSION_DEPTH: usize = 128;
+
+#[derive(Debug, Clone)]
+pub(crate) enum LocalInvokeTarget {
+    Procedure,
+    Alias(AliasTarget),
+    Other(SourceSpan),
+}
+
+impl From<&Export> for LocalInvokeTarget {
+    fn from(item: &Export) -> Self {
+        match item {
+            Export::Procedure(_) => Self::Procedure,
+            Export::Alias(alias) => Self::Alias(alias.target().clone()),
+            Export::Constant(_) | Export::Type(_) => Self::Other(item.span()),
+        }
+    }
+}
 
 /// This visitor visits every `exec`, `call`, `syscall`, and `procref`, and ensures that the
 /// invocation target for that call is resolvable to the extent possible within the current
@@ -20,25 +44,25 @@ use crate::{
 /// We attempt to apply as many call-related validations as we can here, however we are limited
 /// until later stages of compilation on what we can know in the context of a single module.
 /// As a result, more complex analyses are reserved until assembly.
-pub struct VerifyInvokeTargets<'a> {
+pub(crate) struct VerifyInvokeTargets<'a> {
     analyzer: &'a mut AnalysisContext,
     module: &'a mut Module,
-    procedures: &'a BTreeSet<Ident>,
+    locals: &'a BTreeMap<String, LocalInvokeTarget>,
     current_procedure: Option<ProcedureName>,
     invoked: BTreeSet<Invoke>,
 }
 
 impl<'a> VerifyInvokeTargets<'a> {
-    pub fn new(
+    pub(crate) fn new(
         analyzer: &'a mut AnalysisContext,
         module: &'a mut Module,
-        procedures: &'a BTreeSet<Ident>,
+        locals: &'a BTreeMap<String, LocalInvokeTarget>,
         current_procedure: Option<ProcedureName>,
     ) -> Self {
         Self {
             analyzer,
             module,
-            procedures,
+            locals,
             current_procedure,
             invoked: Default::default(),
         }
@@ -47,11 +71,98 @@ impl<'a> VerifyInvokeTargets<'a> {
 
 impl VerifyInvokeTargets<'_> {
     fn resolve_local(&mut self, name: &Ident) -> ControlFlow<()> {
-        if !self.procedures.contains(name) {
+        let mut visited = BTreeSet::default();
+        self.resolve_local_name(name.span(), name.as_str(), &mut visited)
+    }
+
+    fn resolve_local_name(
+        &mut self,
+        span: SourceSpan,
+        name: &str,
+        visited: &mut BTreeSet<String>,
+    ) -> ControlFlow<()> {
+        if visited.len() > MAX_ALIAS_EXPANSION_DEPTH {
             self.analyzer.error(SemanticAnalysisError::SymbolResolutionError(Box::new(
-                SymbolResolutionError::undefined(name.span(), &self.analyzer.source_manager()),
+                SymbolResolutionError::alias_expansion_depth_exceeded(
+                    span,
+                    MAX_ALIAS_EXPANSION_DEPTH,
+                    &self.analyzer.source_manager(),
+                ),
             )));
+            return ControlFlow::Continue(());
         }
+
+        if self.current_procedure.as_ref().is_some_and(|curr| curr.as_str() == name) {
+            self.analyzer.error(SemanticAnalysisError::SelfRecursive { span });
+            return ControlFlow::Continue(());
+        }
+
+        let Some(item) = self.locals.get(name).cloned() else {
+            self.analyzer.error(SemanticAnalysisError::SymbolResolutionError(Box::new(
+                SymbolResolutionError::undefined(span, &self.analyzer.source_manager()),
+            )));
+            return ControlFlow::Continue(());
+        };
+
+        match &item {
+            LocalInvokeTarget::Procedure => ControlFlow::Continue(()),
+            LocalInvokeTarget::Other(actual) => {
+                self.analyzer.error(SemanticAnalysisError::SymbolResolutionError(Box::new(
+                    SymbolResolutionError::invalid_symbol_type(
+                        span,
+                        "procedure",
+                        *actual,
+                        &self.analyzer.source_manager(),
+                    ),
+                )));
+                ControlFlow::Continue(())
+            },
+            LocalInvokeTarget::Alias(target) => {
+                if !visited.insert(name.to_string()) {
+                    self.analyzer.error(SemanticAnalysisError::SymbolResolutionError(Box::new(
+                        SymbolResolutionError::alias_expansion_cycle(
+                            span,
+                            &self.analyzer.source_manager(),
+                        ),
+                    )));
+                    return ControlFlow::Continue(());
+                }
+
+                self.resolve_local_alias_target(span, target, visited)
+            },
+        }
+    }
+
+    fn resolve_local_alias_target(
+        &mut self,
+        span: SourceSpan,
+        target: &AliasTarget,
+        visited: &mut BTreeSet<String>,
+    ) -> ControlFlow<()> {
+        match target {
+            AliasTarget::MastRoot(_) => ControlFlow::Continue(()),
+            AliasTarget::Path(path) => self.resolve_invocation_path(span, path.inner(), visited),
+        }
+    }
+
+    fn resolve_invocation_path(
+        &mut self,
+        span: SourceSpan,
+        path: &Path,
+        visited: &mut BTreeSet<String>,
+    ) -> ControlFlow<()> {
+        if let Some(name) = path.as_ident() {
+            return self.resolve_local_name(span, name.as_str(), visited);
+        }
+
+        if path.parent().is_some_and(|parent| parent == self.module.path()) {
+            return self.resolve_local_name(span, path.last().unwrap(), visited);
+        }
+
+        if self.resolve_external(span, path).is_none() {
+            self.analyzer.error(SemanticAnalysisError::MissingImport { span });
+        }
+
         ControlFlow::Continue(())
     }
     fn resolve_external(&mut self, span: SourceSpan, path: &Path) -> Option<InvocationTarget> {

--- a/crates/assembly-syntax/src/sema/passes/verify_invoke.rs
+++ b/crates/assembly-syntax/src/sema/passes/verify_invoke.rs
@@ -48,6 +48,7 @@ pub(crate) struct VerifyInvokeTargets<'a> {
     analyzer: &'a mut AnalysisContext,
     module: &'a mut Module,
     locals: &'a BTreeMap<String, LocalInvokeTarget>,
+    used_aliases: &'a mut BTreeSet<String>,
     current_procedure: Option<ProcedureName>,
     invoked: BTreeSet<Invoke>,
 }
@@ -57,12 +58,14 @@ impl<'a> VerifyInvokeTargets<'a> {
         analyzer: &'a mut AnalysisContext,
         module: &'a mut Module,
         locals: &'a BTreeMap<String, LocalInvokeTarget>,
+        used_aliases: &'a mut BTreeSet<String>,
         current_procedure: Option<ProcedureName>,
     ) -> Self {
         Self {
             analyzer,
             module,
             locals,
+            used_aliases,
             current_procedure,
             invoked: Default::default(),
         }
@@ -70,6 +73,10 @@ impl<'a> VerifyInvokeTargets<'a> {
 }
 
 impl VerifyInvokeTargets<'_> {
+    fn track_used_alias_name(&mut self, name: &str) {
+        self.used_aliases.insert(name.to_string());
+    }
+
     fn resolve_local(&mut self, name: &Ident) -> ControlFlow<()> {
         let mut visited = BTreeSet::default();
         self.resolve_local_name(name.span(), name.as_str(), &mut visited)
@@ -118,6 +125,8 @@ impl VerifyInvokeTargets<'_> {
                 ControlFlow::Continue(())
             },
             LocalInvokeTarget::Alias(target) => {
+                self.track_used_alias_name(name);
+
                 if !visited.insert(name.to_string()) {
                     self.analyzer.error(SemanticAnalysisError::SymbolResolutionError(Box::new(
                         SymbolResolutionError::alias_expansion_cycle(
@@ -176,12 +185,16 @@ impl VerifyInvokeTargets<'_> {
             log::debug!(target: "verify-invoke", "found import '{}'", import.target());
             import.uses += 1;
             match import.target() {
-                AliasTarget::MastRoot(_) => {
-                    self.analyzer.error(SemanticAnalysisError::InvalidInvokeTargetViaImport {
-                        span,
-                        import: import.span(),
-                    });
-                    None
+                AliasTarget::MastRoot(digest) => {
+                    if rest.is_empty() {
+                        Some(InvocationTarget::MastRoot(*digest))
+                    } else {
+                        self.analyzer.error(SemanticAnalysisError::InvalidInvokeTargetViaImport {
+                            span,
+                            import: import.span(),
+                        });
+                        None
+                    }
                 },
                 // If we have an import like `use lib::lib`, the base `lib` has been shadowed, so
                 // we cannot attempt to resolve further. Instead, we use the target path we have.
@@ -197,13 +210,17 @@ impl VerifyInvokeTargets<'_> {
                     let resolved = self.resolve_external(path.span(), path.inner())?;
                     match resolved {
                         InvocationTarget::MastRoot(digest) => {
-                            self.analyzer.error(
-                                SemanticAnalysisError::InvalidInvokeTargetViaImport {
-                                    span,
-                                    import: digest.span(),
-                                },
-                            );
-                            None
+                            if rest.is_empty() {
+                                Some(InvocationTarget::MastRoot(digest))
+                            } else {
+                                self.analyzer.error(
+                                    SemanticAnalysisError::InvalidInvokeTargetViaImport {
+                                        span,
+                                        import: digest.span(),
+                                    },
+                                );
+                                None
+                            }
                         },
                         // We can consider this path fully-resolved, and mark it absolute, if it is
                         // not already
@@ -222,9 +239,7 @@ impl VerifyInvokeTargets<'_> {
         }
     }
     fn track_used_alias(&mut self, name: &Ident) {
-        if let Some(alias) = self.module.aliases_mut().find(|a| a.name() == name) {
-            alias.uses += 1;
-        }
+        self.track_used_alias_name(name.as_str());
     }
 }
 
@@ -322,10 +337,7 @@ impl VisitMut for VerifyInvokeTargets<'_> {
                     return ControlFlow::Continue(());
                 };
 
-                if let Some(via) = self.module.get_import_mut(ns) {
-                    via.uses += 1;
-                    assert!(via.is_used());
-                }
+                self.track_used_alias_name(ns);
                 ControlFlow::Continue(())
             },
         }
@@ -384,20 +396,16 @@ impl VisitMut for VerifyInvokeTargets<'_> {
     fn visit_mut_type_ref(&mut self, path: &mut Span<Arc<Path>>) -> ControlFlow<()> {
         if let Some(name) = path.as_ident() {
             self.track_used_alias(&name);
-        } else if let Some((module, _)) = path.split_first()
-            && let Some(alias) = self.module.aliases_mut().find(|a| a.name().as_str() == module)
-        {
-            alias.uses += 1;
+        } else if let Some((module, _)) = path.split_first() {
+            self.track_used_alias_name(module);
         }
         ControlFlow::Continue(())
     }
     fn visit_mut_constant_ref(&mut self, path: &mut Span<Arc<Path>>) -> ControlFlow<()> {
         if let Some(name) = path.as_ident() {
             self.track_used_alias(&name);
-        } else if let Some((module, _)) = path.split_first()
-            && let Some(alias) = self.module.aliases_mut().find(|a| a.name().as_str() == module)
-        {
-            alias.uses += 1;
+        } else if let Some((module, _)) = path.split_first() {
+            self.track_used_alias_name(module);
         }
         ControlFlow::Continue(())
     }

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -652,11 +652,48 @@ impl Assembler {
             },
 
             SymbolItem::Alias { alias, resolved } => {
-                // All aliases should've been resolved by now
-                let resolved = resolved.get().unwrap_or_else(|| {
-                    panic!("unresolved alias {symbol_path} targeting: {}", alias.target())
-                });
-                return self.export_symbol(resolved, module_kind, symbol_path, mast_forest_builder);
+                if let Some(resolved) = resolved.get() {
+                    return self.export_symbol(
+                        resolved,
+                        module_kind,
+                        symbol_path,
+                        mast_forest_builder,
+                    );
+                }
+
+                let Some(ResolvedProcedure { node, signature }) = self.resolve_target(
+                    InvokeKind::ProcRef,
+                    &alias.target().into(),
+                    gid,
+                    mast_forest_builder,
+                )?
+                else {
+                    return Err(self.unresolved_alias_report("export", &symbol_path, alias));
+                };
+
+                let digest = mast_forest_builder
+                    .get_mast_node(node)
+                    .expect("resolved alias export node must exist")
+                    .digest();
+                let pctx = ProcedureContext::new(
+                    gid,
+                    /* is_program_entrypoint= */ false,
+                    symbol_path.clone(),
+                    Visibility::Public,
+                    signature.clone(),
+                    module_kind.is_kernel(),
+                    self.source_manager.clone(),
+                );
+                let procedure = pctx.into_procedure(digest, node);
+                self.linker.register_procedure_root(gid, digest)?;
+                mast_forest_builder.insert_procedure(gid, procedure)?;
+
+                return Ok(LibraryExport::Procedure(ProcedureExport {
+                    node,
+                    path: symbol_path,
+                    signature: signature.map(Arc::unwrap_or_clone),
+                    attributes: Default::default(),
+                }));
             },
         };
 
@@ -813,19 +850,27 @@ impl Assembler {
                     mast_forest_builder.insert_procedure(procedure_gid, procedure)?;
                 },
                 SymbolItem::Alias { alias, resolved } => {
-                    let procedure_gid = resolved.get().expect("resolved alias");
-                    match self.linker[procedure_gid].item() {
-                        SymbolItem::Procedure(_) | SymbolItem::Compiled(ItemInfo::Procedure(_)) => {
+                    let path: Arc<Path> = module_path.join(alias.name().as_str()).into();
+                    let procedure_gid = match resolved.get() {
+                        Some(procedure_gid) => {
+                            match self.linker[procedure_gid].item() {
+                                SymbolItem::Procedure(_)
+                                | SymbolItem::Compiled(ItemInfo::Procedure(_)) => {},
+                                SymbolItem::Constant(_)
+                                | SymbolItem::Type(_)
+                                | SymbolItem::Compiled(_) => {
+                                    continue;
+                                },
+                                // A resolved alias will always refer to a non-alias item, this is
+                                // because when aliases are resolved, they are resolved
+                                // recursively. Had the alias chain been cyclical, we would have
+                                // raised an error already.
+                                SymbolItem::Alias { .. } => unreachable!(),
+                            }
+                            procedure_gid
                         },
-                        SymbolItem::Constant(_) | SymbolItem::Type(_) | SymbolItem::Compiled(_) => {
-                            continue;
-                        },
-                        // A resolved alias will always refer to a non-alias item, this is because
-                        // when aliases are resolved, they are resolved recursively. Had the alias
-                        // chain been cyclical, we would have raised an error already.
-                        SymbolItem::Alias { .. } => unreachable!(),
-                    }
-                    let path = module_path.join(alias.name().as_str()).into();
+                        None => procedure_gid,
+                    };
                     // A program entrypoint is never an alias
                     let is_program_entrypoint = false;
                     let mut pctx = ProcedureContext::new(
@@ -872,6 +917,30 @@ impl Assembler {
         }
 
         Ok(())
+    }
+
+    fn unresolved_alias_report(
+        &self,
+        action: &'static str,
+        symbol_path: &Path,
+        alias: &ast::Alias,
+    ) -> Report {
+        let span = alias.target().span();
+        let reason = match alias.target() {
+            ast::AliasTarget::MastRoot(_) => {
+                "this digest target does not resolve to a known procedure"
+            },
+            ast::AliasTarget::Path(_) => "this alias target does not resolve to a concrete item",
+        };
+
+        RelatedLabel::error(format!(
+            "unable to {action} alias '{symbol_path}' targeting '{}'",
+            alias.target()
+        ))
+        .with_labeled_span(span, reason)
+        .with_help("aliases must resolve to a concrete item before they can be used")
+        .with_source_file(self.source_manager.get(span.source_id()).ok())
+        .into()
     }
 
     /// Compiles a single Miden Assembly procedure to its MAST representation.

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -154,6 +154,39 @@ impl Assembler {
         self.warnings_as_errors = yes;
         self
     }
+
+    pub(crate) fn invalid_invoke_target_report(
+        &self,
+        kind: InvokeKind,
+        callee: &InvocationTarget,
+        caller: GlobalItemIndex,
+    ) -> Report {
+        let span = callee.span();
+        let source_file = self.source_manager.get(span.source_id()).ok();
+        let context = SymbolResolutionContext {
+            span,
+            module: caller.module,
+            kind: Some(kind),
+        };
+
+        let path = match self.linker.resolve_invoke_target(&context, callee) {
+            Ok(SymbolResolution::Exact { path, .. })
+            | Ok(SymbolResolution::Module { path, .. })
+            | Ok(SymbolResolution::External(path)) => Some(path.into_inner()),
+            Ok(SymbolResolution::Local(_)) | Ok(SymbolResolution::MastRoot(_)) => None,
+            Err(err) => return Report::new(err),
+        }
+        .or_else(|| match callee {
+            InvocationTarget::Symbol(symbol) => Some(Path::from_ident(symbol).into_owned().into()),
+            InvocationTarget::Path(path) => Some(path.clone().into_inner()),
+            InvocationTarget::MastRoot(_) => None,
+        });
+
+        match path {
+            Some(path) => Report::new(LinkerError::InvalidInvokeTarget { span, source_file, path }),
+            None => Report::msg("invalid procedure reference: target is not a procedure"),
+        }
+    }
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/crates/assembly/src/instruction/procedures.rs
+++ b/crates/assembly/src/instruction/procedures.rs
@@ -33,7 +33,7 @@ impl Assembler {
     ) -> Result<MastNodeId, Report> {
         let resolved = self
             .resolve_target(kind, callee, caller, mast_forest_builder)?
-            .expect("invocation target is not a procedure");
+            .ok_or_else(|| self.invalid_invoke_target_report(kind, callee, caller))?;
 
         match kind {
             InvokeKind::ProcRef | InvokeKind::Exec => Ok(resolved.node),
@@ -82,7 +82,9 @@ impl Assembler {
                     caller,
                     block_builder.mast_forest_builder_mut(),
                 )?
-                .expect("invocation target is not a procedure");
+                .ok_or_else(|| {
+                    self.invalid_invoke_target_report(InvokeKind::ProcRef, callee, caller)
+                })?;
             // Note: it's ok to `unwrap()` here since `proc_body_id` was returned from
             // `mast_forest_builder`
             block_builder

--- a/crates/assembly/src/linker/callgraph.rs
+++ b/crates/assembly/src/linker/callgraph.rs
@@ -11,6 +11,10 @@ use crate::GlobalItemIndex;
 pub struct CycleError(BTreeSet<GlobalItemIndex>);
 
 impl CycleError {
+    pub fn new(nodes: impl IntoIterator<Item = GlobalItemIndex>) -> Self {
+        Self(nodes.into_iter().collect())
+    }
+
     pub fn into_node_ids(self) -> impl ExactSizeIterator<Item = GlobalItemIndex> {
         self.0.into_iter()
     }
@@ -60,11 +64,15 @@ impl CallGraph {
     /// introduce a cycle, or that [Self::toposort] is run once the graph is built, in order to
     /// verify that the graph is valid and has no cycles.
     ///
-    /// NOTE: This function will panic if you attempt to add an edge from a function to itself,
-    /// which trivially introduces a cycle. All other cycle-inducing edges must be caught by a
-    /// call to [Self::toposort].
-    pub fn add_edge(&mut self, caller: GlobalItemIndex, callee: GlobalItemIndex) {
-        assert_ne!(caller, callee, "a procedure cannot call itself");
+    /// Returns an error if adding the edge would introduce a trivial self-cycle.
+    pub fn add_edge(
+        &mut self,
+        caller: GlobalItemIndex,
+        callee: GlobalItemIndex,
+    ) -> Result<(), CycleError> {
+        if caller == callee {
+            return Err(CycleError::new([caller]));
+        }
 
         // Make sure the callee is in the graph
         self.get_or_insert_node(callee);
@@ -72,10 +80,11 @@ impl CallGraph {
         let callees = self.get_or_insert_node(caller);
         // If the caller already references the callee, we're done
         if callees.contains(&callee) {
-            return;
+            return Ok(());
         }
 
         callees.push(callee);
+        Ok(())
     }
 
     /// Removes the edge between `caller` and `callee` from the graph
@@ -113,15 +122,6 @@ impl CallGraph {
         let mut roots =
             VecDeque::from_iter(graph.nodes.keys().copied().filter(|n| !has_preds.contains(n)));
 
-        // If all nodes have predecessors, there must be a cycle, so just pick a node and let the
-        // algorithm find the cycle for that node so we have a useful error. Set a flag so that we
-        // can assert that the cycle was actually found as a sanity check
-        let mut expect_cycle = false;
-        if roots.is_empty() {
-            expect_cycle = true;
-            roots.extend(graph.nodes.keys().next());
-        }
-
         let mut successors = Vec::with_capacity(4);
         while let Some(id) = roots.pop_front() {
             output.push(id);
@@ -150,7 +150,6 @@ impl CallGraph {
             }
             Err(CycleError(in_cycle))
         } else {
-            assert!(!expect_cycle, "we expected a cycle to be found, but one was not identified");
             Ok(output)
         }
     }
@@ -326,6 +325,24 @@ mod tests {
         assert_eq!(err.0.into_iter().collect::<Vec<_>>(), &[A2, A3, B2, B3]);
     }
 
+    #[test]
+    fn callgraph_add_edge_with_self_cycle_is_error() {
+        let mut graph = CallGraph::default();
+
+        let err = graph.add_edge(A1, A1).expect_err("expected self-edge to be rejected");
+        assert_eq!(err.0.into_iter().collect::<Vec<_>>(), &[A1]);
+    }
+
+    #[test]
+    fn callgraph_rootless_cycle_toposort_is_error() {
+        let mut graph = CallGraph::default();
+        graph.add_edge(A1, B1).expect("A1 -> B1 must be accepted");
+        graph.add_edge(B1, A1).expect("B1 -> A1 must be accepted");
+
+        let err = graph.toposort().expect_err("expected topological sort to fail with cycle");
+        assert_eq!(err.0.into_iter().collect::<Vec<_>>(), &[A1, B1]);
+    }
+
     /// a::a1 -> a::a2 -> a::a3
     ///            |        ^
     ///            v        |
@@ -333,12 +350,12 @@ mod tests {
     fn callgraph_simple() -> CallGraph {
         // Construct the graph
         let mut graph = CallGraph::default();
-        graph.add_edge(A1, A2);
-        graph.add_edge(B1, B2);
-        graph.add_edge(A2, B2);
-        graph.add_edge(A2, A3);
-        graph.add_edge(B2, B3);
-        graph.add_edge(B3, A3);
+        graph.add_edge(A1, A2).expect("A1 -> A2 must be accepted");
+        graph.add_edge(B1, B2).expect("B1 -> B2 must be accepted");
+        graph.add_edge(A2, B2).expect("A2 -> B2 must be accepted");
+        graph.add_edge(A2, A3).expect("A2 -> A3 must be accepted");
+        graph.add_edge(B2, B3).expect("B2 -> B3 must be accepted");
+        graph.add_edge(B3, A3).expect("B3 -> A3 must be accepted");
 
         graph
     }
@@ -350,12 +367,12 @@ mod tests {
     fn callgraph_cycle() -> CallGraph {
         // Construct the graph
         let mut graph = CallGraph::default();
-        graph.add_edge(A1, A2);
-        graph.add_edge(B1, B2);
-        graph.add_edge(A2, B2);
-        graph.add_edge(B2, B3);
-        graph.add_edge(B3, A3);
-        graph.add_edge(A3, A2);
+        graph.add_edge(A1, A2).expect("A1 -> A2 must be accepted");
+        graph.add_edge(B1, B2).expect("B1 -> B2 must be accepted");
+        graph.add_edge(A2, B2).expect("A2 -> B2 must be accepted");
+        graph.add_edge(B2, B3).expect("B2 -> B3 must be accepted");
+        graph.add_edge(B3, A3).expect("B3 -> A3 must be accepted");
+        graph.add_edge(A3, A2).expect("A3 -> A2 must be accepted");
 
         graph
     }

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -370,6 +370,17 @@ impl Linker {
 // ------------------------------------------------------------------------------------------------
 /// Analysis
 impl Linker {
+    fn cycle_error(&self, cycle: CycleError) -> LinkerError {
+        let iter = cycle.into_node_ids();
+        let mut nodes = Vec::with_capacity(iter.len());
+        for node in iter {
+            let module = self[node.module].path();
+            let item = self[node].name();
+            nodes.push(module.join(item).to_string());
+        }
+        LinkerError::Cycle { nodes: nodes.into() }
+    }
+
     /// Links `modules` using the current state of the linker.
     ///
     /// Returns the module indices corresponding to the provided modules, which are expected to
@@ -396,7 +407,18 @@ impl Linker {
         &mut self,
         mut kernel: Box<Module>,
     ) -> Result<Vec<ModuleIndex>, LinkerError> {
+        let original_module_len = self.modules.len();
+        let original_callgraph = self.callgraph.clone();
         let module_index = self.link_module(&mut kernel)?;
+        let original_kernel_index = self.kernel_index;
+        let original_module_kinds = self
+            .modules
+            .iter()
+            .enumerate()
+            .take(module_index.as_usize())
+            .filter(|(_, module)| matches!(module.source(), ModuleSource::Ast))
+            .map(|(module_index, module)| (module_index, module.kind()))
+            .collect::<Vec<_>>();
 
         // Set the module kind of all pending AST modules to Kernel, as we are linking a kernel
         for module in self.modules.iter_mut().take(module_index.as_usize()) {
@@ -407,7 +429,16 @@ impl Linker {
 
         self.kernel_index = Some(module_index);
 
-        self.link_and_rewrite()?;
+        if let Err(err) = self.link_and_rewrite() {
+            self.kernel_index = original_kernel_index;
+            self.callgraph = original_callgraph;
+            self.modules.truncate(original_module_len);
+            for (module_index, module_kind) in original_module_kinds {
+                self.modules[module_index].set_kind(module_kind);
+            }
+
+            return Err(err);
+        }
 
         Ok(vec![module_index])
     }
@@ -470,106 +501,124 @@ impl Linker {
 
         // Obtain a set of resolvers for the pending modules so that we can do name resolution
         // before they are added to the graph
-        let resolver = SymbolResolver::new(self);
-        let mut edges = Vec::new();
-        let mut cache = ResolverCache::default();
+        let pending_modules = self
+            .modules
+            .iter()
+            .enumerate()
+            .filter(|(_, module)| module.is_unlinked())
+            .map(|(module_index, module)| (module_index, module.clone()))
+            .collect::<Vec<_>>();
+        let original_callgraph = self.callgraph.clone();
 
-        for (module_index, module) in self.modules.iter().enumerate() {
-            if !module.is_unlinked() {
-                continue;
-            }
+        let result = {
+            let resolver = SymbolResolver::new(self);
+            let mut edges = Vec::new();
+            let mut cache = ResolverCache::default();
+            let mut linked_modules = Vec::new();
 
-            let module_index = ModuleIndex::new(module_index);
-
-            for (symbol_idx, symbol) in module.symbols().enumerate() {
-                assert!(
-                    symbol.is_unlinked(),
-                    "an unlinked module should only have unlinked symbols"
-                );
-
-                let gid = module_index + ItemIndex::new(symbol_idx);
-
-                // Perform any applicable rewrites to this item
-                rewrites::rewrite_symbol(gid, symbol, &resolver, &mut cache)?;
-
-                // Update the linker graph
-                match symbol.item() {
-                    SymbolItem::Compiled(_) | SymbolItem::Type(_) | SymbolItem::Constant(_) => (),
-                    SymbolItem::Alias { alias, resolved } => {
-                        if let Some(resolved) = resolved.get() {
-                            log::debug!(target: "linker", "  | resolved alias {} to item {resolved}", alias.target());
-                            if self[resolved].is_procedure() {
-                                edges.push((gid, resolved));
-                            }
-                        } else {
-                            log::debug!(target: "linker", "  | resolving alias {}..", alias.target());
-
-                            let context = SymbolResolutionContext {
-                                span: alias.target().span(),
-                                module: module_index,
-                                kind: None,
-                            };
-                            if let Some(callee) =
-                                resolver.resolve_alias_target(&context, alias)?.into_global_id()
-                            {
-                                log::debug!(
-                                    target: "linker",
-                                    "  | resolved alias to gid {:?}:{:?}",
-                                    callee.module,
-                                    callee.index
-                                );
-                                edges.push((gid, callee));
-                                resolved.set(Some(callee));
-                            }
-                        }
-                    },
-                    SymbolItem::Procedure(proc) => {
-                        // Add edges to all transitive dependencies of this item due to calls/symbol
-                        // refs
-                        let proc = proc.borrow();
-                        for invoke in proc.invoked() {
-                            log::debug!(target: "linker", "  | recording {} dependency on {}", invoke.kind, &invoke.target);
-
-                            let context = SymbolResolutionContext {
-                                span: invoke.span(),
-                                module: module_index,
-                                kind: None,
-                            };
-                            if let Some(callee) = resolver
-                                .resolve_invoke_target(&context, &invoke.target)?
-                                .into_global_id()
-                            {
-                                log::debug!(
-                                    target: "linker",
-                                    "  | resolved dependency to gid {}:{}",
-                                    callee.module.as_usize(),
-                                    callee.index.as_usize()
-                                );
-                                edges.push((gid, callee));
-                            }
-                        }
-                    },
+            for (module_index, module) in self.modules.iter().enumerate() {
+                if !module.is_unlinked() {
+                    continue;
                 }
+
+                let module_index = ModuleIndex::new(module_index);
+
+                for (symbol_idx, symbol) in module.symbols().enumerate() {
+                    let gid = module_index + ItemIndex::new(symbol_idx);
+
+                    // Perform any applicable rewrites to this item
+                    rewrites::rewrite_symbol(gid, symbol, &resolver, &mut cache)?;
+
+                    // Update the linker graph
+                    match symbol.item() {
+                        SymbolItem::Compiled(_) | SymbolItem::Type(_) | SymbolItem::Constant(_) => {
+                        },
+                        SymbolItem::Alias { alias, resolved } => {
+                            if let Some(resolved) = resolved.get() {
+                                log::debug!(target: "linker", "  | resolved alias {} to item {resolved}", alias.target());
+                                if self[resolved].is_procedure() {
+                                    edges.push((gid, resolved));
+                                }
+                            } else {
+                                log::debug!(target: "linker", "  | resolving alias {}..", alias.target());
+
+                                let context = SymbolResolutionContext {
+                                    span: alias.target().span(),
+                                    module: module_index,
+                                    kind: None,
+                                };
+                                if let Some(callee) =
+                                    resolver.resolve_alias_target(&context, alias)?.into_global_id()
+                                {
+                                    log::debug!(
+                                        target: "linker",
+                                        "  | resolved alias to gid {:?}:{:?}",
+                                        callee.module,
+                                        callee.index
+                                    );
+                                    edges.push((gid, callee));
+                                    resolved.set(Some(callee));
+                                }
+                            }
+                        },
+                        SymbolItem::Procedure(proc) => {
+                            // Add edges to all transitive dependencies of this item due to
+                            // calls/symbol refs
+                            let proc = proc.borrow();
+                            for invoke in proc.invoked() {
+                                log::debug!(target: "linker", "  | recording {} dependency on {}", invoke.kind, &invoke.target);
+
+                                let context = SymbolResolutionContext {
+                                    span: invoke.span(),
+                                    module: module_index,
+                                    kind: None,
+                                };
+                                if let Some(callee) = resolver
+                                    .resolve_invoke_target(&context, &invoke.target)?
+                                    .into_global_id()
+                                {
+                                    log::debug!(
+                                        target: "linker",
+                                        "  | resolved dependency to gid {}:{}",
+                                        callee.module.as_usize(),
+                                        callee.index.as_usize()
+                                    );
+                                    edges.push((gid, callee));
+                                }
+                            }
+                        },
+                    }
+                }
+
+                linked_modules.push(module_index);
             }
 
-            module.set_status(LinkStatus::Linked);
+            let mut callgraph = self.callgraph.clone();
+            for (caller, callee) in edges {
+                callgraph.add_edge(caller, callee).map_err(|cycle| self.cycle_error(cycle))?;
+            }
+
+            // Make sure the graph is free of cycles
+            callgraph.toposort().map_err(|cycle| self.cycle_error(cycle))?;
+
+            Ok::<_, LinkerError>((linked_modules, callgraph))
+        };
+
+        match result {
+            Ok((linked_modules, callgraph)) => {
+                self.callgraph = callgraph;
+                for module_index in linked_modules {
+                    self.modules[module_index.as_usize()].set_status(LinkStatus::Linked);
+                }
+            },
+            Err(err) => {
+                self.callgraph = original_callgraph;
+                for (module_index, module) in pending_modules {
+                    self.modules[module_index] = module;
+                }
+                return Err(err);
+            },
         }
-
-        edges
-            .into_iter()
-            .for_each(|(caller, callee)| self.callgraph.add_edge(caller, callee));
-
-        // Make sure the graph is free of cycles
-        self.callgraph.toposort().map_err(|cycle| {
-            let iter = cycle.into_node_ids();
-            let mut nodes = Vec::with_capacity(iter.len());
-            for node in iter {
-                let module = self[node.module].path();
-                let item = self[node].name();
-                nodes.push(module.join(item).to_string());
-            }
-            LinkerError::Cycle { nodes: nodes.into() }
-        })?;
 
         Ok(())
     }
@@ -847,5 +896,88 @@ impl Index<GlobalItemIndex> for Linker {
 
     fn index(&self, index: GlobalItemIndex) -> &Self::Output {
         &self.modules[index.module.as_usize()][index.index]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miden_assembly_syntax::{
+        ast::{Ident, InvocationTarget, InvokeKind},
+        debuginfo::SourceSpan,
+    };
+
+    use super::*;
+    use crate::testing::{TestContext, source_file};
+
+    #[test]
+    fn failed_kernel_link_restores_kernel_state() {
+        let context = TestContext::default();
+        let source_manager = context.source_manager();
+        let kernel_source = r#"
+                pub proc a
+                    call.b
+                end
+
+                proc b
+                    call.a
+                end
+                "#;
+
+        let userspace = context
+            .parse_module_with_path(
+                "userspace",
+                source_file!(
+                    &context,
+                    r#"
+                    pub proc helper
+                        push.1
+                    end
+                    "#
+                ),
+            )
+            .expect("userspace module parsing must succeed");
+
+        let mut linker = Linker::new(source_manager);
+        let userspace_index = linker
+            .link([userspace])
+            .expect("userspace module must link successfully")
+            .into_iter()
+            .next()
+            .expect("linked module index must be returned");
+
+        let first_err = linker
+            .link_kernel(
+                context
+                    .parse_kernel(source_file!(&context, kernel_source))
+                    .expect("kernel parsing must succeed"),
+            )
+            .expect_err("expected cyclic kernel to be rejected");
+
+        assert!(first_err.to_string().contains("found a cycle in the call graph"));
+        assert!(!linker.has_nonempty_kernel(), "failed kernel link must not leave a kernel set");
+        assert_eq!(linker[userspace_index].kind(), ast::ModuleKind::Library);
+
+        let second_err = linker
+            .link_kernel(
+                context
+                    .parse_kernel(source_file!(&context, kernel_source))
+                    .expect("kernel parsing must succeed"),
+            )
+            .expect_err("expected cyclic kernel retry to be rejected");
+        assert!(second_err.to_string().contains("found a cycle in the call graph"));
+        assert!(!second_err.to_string().contains("duplicate module"));
+
+        let syscall_context = SymbolResolutionContext {
+            span: SourceSpan::UNKNOWN,
+            module: userspace_index,
+            kind: Some(InvokeKind::SysCall),
+        };
+        let err = linker
+            .resolve_invoke_target(
+                &syscall_context,
+                &InvocationTarget::Symbol(Ident::new("a").expect("valid identifier")),
+            )
+            .expect_err("expected syscall without a linked kernel to be rejected");
+        assert!(matches!(err, LinkerError::InvalidSysCallTarget { .. }));
     }
 }

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -901,9 +901,19 @@ impl Index<GlobalItemIndex> for Linker {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        string::String,
+        sync::Arc,
+    };
+
     use miden_assembly_syntax::{
-        ast::{Ident, InvocationTarget, InvokeKind},
-        debuginfo::SourceSpan,
+        ast::{
+            Ident, InvocationTarget, InvokeKind, ItemIndex, Path, SymbolResolutionError,
+            Visibility, types,
+        },
+        debuginfo::{SourceSpan, Span},
+        library::{ItemInfo, TypeInfo},
     };
 
     use super::*;
@@ -979,5 +989,56 @@ mod tests {
             )
             .expect_err("expected syscall without a linked kernel to be rejected");
         assert!(matches!(err, LinkerError::InvalidSysCallTarget { .. }));
+    }
+
+    #[test]
+    fn oversized_link_module_resolution_returns_structured_error() {
+        let context = TestContext::default();
+        let mut linker = Linker::new(context.source_manager());
+        let module_id = ModuleIndex::new(0);
+        let path = Arc::<Path>::from(Path::new("::m::huge"));
+        let mut symbols = Vec::with_capacity(ItemIndex::MAX_ITEMS + 1);
+
+        for i in 0..=ItemIndex::MAX_ITEMS {
+            let name = Ident::new(format!("a{i}")).expect("valid identifier");
+            symbols.push(Symbol::new(
+                name.clone(),
+                Visibility::Private,
+                LinkStatus::Unlinked,
+                SymbolItem::Compiled(ItemInfo::Type(TypeInfo { name, ty: types::Type::Felt })),
+            ));
+        }
+
+        linker.modules.push(
+            LinkModule::new(
+                module_id,
+                ast::ModuleKind::Library,
+                LinkStatus::Unlinked,
+                ModuleSource::Mast,
+                path,
+            )
+            .with_symbols(symbols),
+        );
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            linker[module_id].resolve(Span::unknown("a0"), &SymbolResolver::new(&linker))
+        }));
+
+        let result = match result {
+            Ok(result) => result,
+            Err(panic) => {
+                let message = panic
+                    .downcast_ref::<&str>()
+                    .copied()
+                    .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+                    .expect("panic payload should be a string");
+                panic!("expected graceful error, got panic: {message}");
+            },
+        };
+
+        assert!(matches!(
+            result,
+            Err(err) if matches!(*err, SymbolResolutionError::TooManyItemsInModule { .. })
+        ));
     }
 }

--- a/crates/assembly/src/linker/module.rs
+++ b/crates/assembly/src/linker/module.rs
@@ -7,7 +7,7 @@ use miden_assembly_syntax::{
         self, AliasTarget, ItemIndex, LocalSymbol, LocalSymbolResolver, ModuleIndex, ModuleKind,
         SymbolResolution, SymbolResolutionError, SymbolTable,
     },
-    debuginfo::{SourceManager, Span, Spanned},
+    debuginfo::{SourceManager, SourceSpan, Span, Spanned},
 };
 
 use super::{AdviceMap, LinkStatus, Symbol, SymbolItem, SymbolResolver};
@@ -182,7 +182,8 @@ impl LinkModule {
         resolver: &SymbolResolver<'_>,
     ) -> Result<SymbolResolution, Box<SymbolResolutionError>> {
         let container = LinkModuleIter { resolver, module: self };
-        let local_resolver = LocalSymbolResolver::new(container, resolver.source_manager_arc());
+        let local_resolver =
+            LocalSymbolResolver::new(container, resolver.source_manager_arc()).map_err(Box::new)?;
         local_resolver.resolve(name).map_err(Box::new)
     }
 
@@ -193,7 +194,8 @@ impl LinkModule {
         resolver: &SymbolResolver<'_>,
     ) -> Result<SymbolResolution, Box<SymbolResolutionError>> {
         let container = LinkModuleIter { resolver, module: self };
-        let local_resolver = LocalSymbolResolver::new(container, resolver.source_manager_arc());
+        let local_resolver =
+            LocalSymbolResolver::new(container, resolver.source_manager_arc()).map_err(Box::new)?;
         local_resolver.resolve_path(path).map_err(Box::new)
     }
 }
@@ -216,68 +218,80 @@ impl<'a, 'b: 'a> SymbolTable for LinkModuleIter<'a, 'b> {
     type SymbolIter = alloc::vec::IntoIter<LocalSymbol>;
 
     fn symbols(&self, source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter {
-        let symbols = self
-            .module
-            .symbols
-            .iter()
-            .enumerate()
-            .map(|(i, symbol)| {
-                let index = ItemIndex::new(i);
-                let gid = self.module.id + index;
-                match symbol.item() {
-                    SymbolItem::Compiled(_)
-                    | SymbolItem::Procedure(_)
-                    | SymbolItem::Constant(_)
-                    | SymbolItem::Type(_) => {
-                        let path = self.module.path.join(symbol.name());
-                        ast::LocalSymbol::Item {
-                            name: symbol.name().clone(),
-                            resolved: SymbolResolution::Exact {
-                                gid,
-                                path: Span::new(symbol.name().span(), path.into()),
+        let mut symbols = Vec::with_capacity(self.module.symbols.len());
+        for (i, symbol) in self.module.symbols.iter().enumerate() {
+            let index = ItemIndex::new(i);
+            let gid = self.module.id + index;
+            symbols.push(match symbol.item() {
+                SymbolItem::Compiled(_)
+                | SymbolItem::Procedure(_)
+                | SymbolItem::Constant(_)
+                | SymbolItem::Type(_) => {
+                    let path = self.module.path.join(symbol.name());
+                    ast::LocalSymbol::Item {
+                        name: symbol.name().clone(),
+                        resolved: SymbolResolution::Exact {
+                            gid,
+                            path: Span::new(symbol.name().span(), path.into()),
+                        },
+                    }
+                },
+                SymbolItem::Alias { alias, resolved } => {
+                    let name = alias.name().clone();
+                    let name = Span::new(name.span(), name.into_inner());
+                    if let Some(resolved) = resolved.get() {
+                        let path = self.resolver.item_path(gid);
+                        let span = name.span();
+                        ast::LocalSymbol::Import {
+                            name,
+                            resolution: Ok(SymbolResolution::Exact {
+                                gid: resolved,
+                                path: Span::new(span, path),
+                            }),
+                        }
+                    } else {
+                        match alias.target() {
+                            AliasTarget::MastRoot(root) => ast::LocalSymbol::Import {
+                                name,
+                                resolution: Ok(SymbolResolution::MastRoot(*root)),
+                            },
+                            AliasTarget::Path(path) => {
+                                let resolution = LocalSymbolResolver::expand(
+                                    |name| {
+                                        self.module.get(name).and_then(|sym| match sym.item() {
+                                            SymbolItem::Alias { alias, .. } => {
+                                                Some(alias.target().clone())
+                                            },
+                                            _ => None,
+                                        })
+                                    },
+                                    path.as_deref(),
+                                    &source_manager,
+                                );
+                                ast::LocalSymbol::Import { name, resolution }
                             },
                         }
-                    },
-                    SymbolItem::Alias { alias, resolved } => {
-                        let name = alias.name().clone();
-                        let name = Span::new(name.span(), name.into_inner());
-                        if let Some(resolved) = resolved.get() {
-                            let path = self.resolver.item_path(gid);
-                            let span = name.span();
-                            ast::LocalSymbol::Import {
-                                name,
-                                resolution: Ok(SymbolResolution::Exact {
-                                    gid: resolved,
-                                    path: Span::new(span, path),
-                                }),
-                            }
-                        } else {
-                            match alias.target() {
-                                AliasTarget::MastRoot(root) => ast::LocalSymbol::Import {
-                                    name,
-                                    resolution: Ok(SymbolResolution::MastRoot(*root)),
-                                },
-                                AliasTarget::Path(path) => {
-                                    let resolution = LocalSymbolResolver::expand(
-                                        |name| {
-                                            self.module.get(name).and_then(|sym| match sym.item() {
-                                                SymbolItem::Alias { alias, .. } => {
-                                                    Some(alias.target().clone())
-                                                },
-                                                _ => None,
-                                            })
-                                        },
-                                        path.as_deref(),
-                                        &source_manager,
-                                    );
-                                    ast::LocalSymbol::Import { name, resolution }
-                                },
-                            }
-                        }
-                    },
-                }
-            })
-            .collect::<Vec<_>>();
+                    }
+                },
+            });
+        }
         symbols.into_iter()
+    }
+
+    fn checked_symbols(
+        &self,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self::SymbolIter, SymbolResolutionError> {
+        if self.module.symbols.len() > ItemIndex::MAX_ITEMS {
+            let span = self
+                .module
+                .symbols
+                .first()
+                .map(|symbol| symbol.name().span())
+                .unwrap_or(SourceSpan::UNKNOWN);
+            Err(SymbolResolutionError::too_many_items_in_module(span, &*source_manager))
+        } else {
+            Ok(self.symbols(source_manager))
+        }
     }
 }

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5609,6 +5609,68 @@ fn imported_error_message_cycle_is_rejected_without_panicking() {
 }
 
 #[test]
+fn exporting_unresolved_digest_alias_preserves_digest_without_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let context = TestContext::new();
+    let digest = Word::default();
+    let module = context
+        .parse_module_with_path(
+            "m::n",
+            source_file!(
+                &context,
+                "pub use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo\n"
+            ),
+        )
+        .expect("module parsing must succeed");
+
+    let assembled = catch_unwind(AssertUnwindSafe(|| {
+        Assembler::new(context.source_manager()).assemble_library([module])
+    }));
+
+    assert!(assembled.is_ok(), "assembly panicked, expected library assembly to succeed");
+    let library = assembled
+        .unwrap()
+        .expect("expected digest alias export to assemble successfully");
+    assert_eq!(library.get_procedure_root_by_path("m::n::foo"), Some(digest));
+}
+
+#[test]
+fn path_alias_chain_to_digest_assembles_without_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let context = TestContext::new();
+    let digest = Word::default();
+    let module = context
+        .parse_module_with_path(
+            "m::n",
+            source_file!(
+                &context,
+                r#"
+                    pub use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo
+                    pub use m::n::foo->bar
+
+                    pub proc calls_bar
+                        call.bar
+                    end
+                "#
+            ),
+        )
+        .expect("module parsing must succeed");
+
+    let assembled = catch_unwind(AssertUnwindSafe(|| {
+        Assembler::new(context.source_manager()).assemble_library([module])
+    }));
+
+    assert!(assembled.is_ok(), "assembly panicked, expected library assembly to succeed");
+    let library = assembled
+        .unwrap()
+        .expect("expected digest alias chain to assemble successfully");
+    assert_eq!(library.get_procedure_root_by_path("m::n::bar"), Some(digest));
+    assert!(library.get_procedure_root_by_path("m::n::calls_bar").is_some());
+}
+
+#[test]
 fn test_cross_module_quoted_identifier_resolution() -> TestResult {
     let context = TestContext::default();
 

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5671,6 +5671,157 @@ fn path_alias_chain_to_digest_assembles_without_panicking() {
 }
 
 #[test]
+fn imported_digest_alias_invoke_assembles_without_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let program = r#"
+        use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo
+
+        begin
+            exec.foo
+        end
+    "#;
+
+    let assembled =
+        catch_unwind(AssertUnwindSafe(|| Assembler::default().assemble_program(program)));
+
+    assert!(
+        assembled.is_ok(),
+        "assembly panicked, expected opaque digest invoke to be allowed"
+    );
+    assembled
+        .unwrap()
+        .expect("expected digest-backed invoke alias to assemble successfully");
+}
+
+#[test]
+fn imported_digest_alias_invoke_is_not_reported_unused_when_warnings_are_errors() {
+    use std::sync::Arc;
+
+    use crate::{DefaultSourceManager, Parse, ParseOptions, ast::ModuleKind};
+
+    let source_manager: Arc<dyn crate::SourceManager> = Arc::new(DefaultSourceManager::default());
+    let program = r#"
+        use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo
+
+        begin
+            exec.foo
+        end
+    "#;
+
+    let mut options = ParseOptions::new(ModuleKind::Executable, "main");
+    options.warnings_as_errors = true;
+
+    <&str as Parse>::parse_with_options(program, source_manager, options)
+        .expect("expected digest-backed invoke alias to count as used");
+}
+
+#[test]
+fn imported_digest_alias_forward_decl_is_not_reported_unused_when_warnings_are_errors() {
+    use std::sync::Arc;
+
+    use crate::{DefaultSourceManager, Parse, ParseOptions, ast::ModuleKind};
+
+    let source_manager: Arc<dyn crate::SourceManager> = Arc::new(DefaultSourceManager::default());
+    let program = r#"
+        proc helper
+            exec.foo
+        end
+
+        use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo
+
+        begin
+            call.helper
+        end
+    "#;
+
+    let mut options = ParseOptions::new(ModuleKind::Executable, "main");
+    options.warnings_as_errors = true;
+
+    <&str as Parse>::parse_with_options(program, source_manager, options)
+        .expect("expected forward-declared digest alias to count as used");
+}
+
+#[test]
+fn forward_declared_import_used_by_alias_target_is_not_reported_unused_when_warnings_are_errors() {
+    use std::sync::Arc;
+
+    use crate::{DefaultSourceManager, Parse, ParseOptions, ast::ModuleKind};
+
+    let source_manager: Arc<dyn crate::SourceManager> = Arc::new(DefaultSourceManager::default());
+    let module = r#"
+        pub use foo::bar -> baz
+        use external::module -> foo
+    "#;
+
+    let mut options = ParseOptions::new(ModuleKind::Library, "m");
+    options.warnings_as_errors = true;
+
+    <&str as Parse>::parse_with_options(module, source_manager, options)
+        .expect("expected forward-declared import used by alias target to count as used");
+}
+
+#[test]
+fn forward_declared_import_used_by_type_ref_is_not_reported_unused_when_warnings_are_errors() {
+    use std::sync::Arc;
+
+    use crate::{DefaultSourceManager, Parse, ParseOptions, ast::ModuleKind};
+
+    let source_manager: Arc<dyn crate::SourceManager> = Arc::new(DefaultSourceManager::default());
+    let module = r#"
+        type Local = foo::Type
+        use external::module -> foo
+    "#;
+
+    let mut options = ParseOptions::new(ModuleKind::Library, "m");
+    options.warnings_as_errors = true;
+
+    <&str as Parse>::parse_with_options(module, source_manager, options)
+        .expect("expected forward-declared import used by type ref to count as used");
+}
+
+#[test]
+fn forward_declared_import_used_by_constant_ref_is_not_reported_unused_when_warnings_are_errors() {
+    use std::sync::Arc;
+
+    use crate::{DefaultSourceManager, Parse, ParseOptions, ast::ModuleKind};
+
+    let source_manager: Arc<dyn crate::SourceManager> = Arc::new(DefaultSourceManager::default());
+    let module = r#"
+        const LOCAL = foo::BAR
+        use external::module -> foo
+    "#;
+
+    let mut options = ParseOptions::new(ModuleKind::Library, "m");
+    options.warnings_as_errors = true;
+
+    <&str as Parse>::parse_with_options(module, source_manager, options)
+        .expect("expected forward-declared import used by constant ref to count as used");
+}
+
+#[test]
+fn imported_digest_alias_subpath_is_rejected_without_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let program = r#"
+        use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo
+
+        begin
+            exec.foo::bar
+        end
+    "#;
+
+    let assembled =
+        catch_unwind(AssertUnwindSafe(|| Assembler::default().assemble_program(program)));
+
+    assert!(assembled.is_ok(), "assembly panicked, expected a structured error");
+    let err = assembled
+        .unwrap()
+        .expect_err("expected digest-backed invoke subpath to be rejected");
+    assert_diagnostic!(&err, "invalid procedure path: not an item");
+}
+
+#[test]
 fn invoking_local_type_alias_returns_error_instead_of_panicking() {
     use std::panic::{AssertUnwindSafe, catch_unwind};
 

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5435,6 +5435,97 @@ fn test_issue_2696_imported_constant_with_private_dependency() -> TestResult {
 }
 
 #[test]
+fn imported_main_alias_self_call_is_structured_error() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let context = TestContext::new();
+    let program = r#"
+        use ::$exec::"$main"->alias_main
+
+        begin
+            call.alias_main
+        end
+    "#;
+
+    let assembled = catch_unwind(AssertUnwindSafe(|| {
+        Assembler::new(context.source_manager()).assemble_program(program)
+    }));
+
+    assert!(assembled.is_ok(), "assembler panicked during assembly");
+    let err = assembled
+        .unwrap()
+        .expect_err("expected self-referential alias call to be rejected");
+    assert_diagnostic!(&err, "found a cycle in the call graph");
+    assert_diagnostic!(&err, "::$exec::$main");
+}
+
+#[test]
+fn rootless_call_cycle_is_structured_error() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let context = TestContext::new();
+    let program = r#"
+        begin
+            call.b
+        end
+
+        proc b
+            call."$main"
+        end
+    "#;
+
+    let assembled = catch_unwind(AssertUnwindSafe(|| {
+        Assembler::new(context.source_manager()).assemble_program(program)
+    }));
+
+    assert!(assembled.is_ok(), "assembler panicked during assembly");
+    let err = assembled.unwrap().expect_err("expected cyclic program to be rejected");
+    assert_diagnostic!(&err, "found a cycle in the call graph");
+    assert_diagnostic!(&err, "::$exec::$main");
+    assert_diagnostic!(&err, "b");
+}
+
+#[test]
+fn cyclic_link_retry_is_structured_error_without_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use crate::linker::Linker;
+
+    let context = TestContext::new();
+    let module = context
+        .parse_program(source_file!(
+            &context,
+            r#"
+                begin
+                    call.b
+                end
+
+                proc b
+                    call."$main"
+                end
+            "#
+        ))
+        .expect("program parsing must succeed");
+    let source_manager = context.source_manager();
+
+    let first_attempt = catch_unwind(AssertUnwindSafe(|| {
+        let mut linker = Linker::new(source_manager.clone());
+        let first_err = linker
+            .link([module.clone()])
+            .expect_err("expected cyclic program to be rejected on first link");
+        let second_err = linker
+            .link(core::iter::empty())
+            .expect_err("expected cyclic program to be rejected on second link");
+        (first_err, second_err)
+    }));
+
+    assert!(first_attempt.is_ok(), "linker panicked while retrying a cyclic link");
+    let (first_err, second_err) = first_attempt.unwrap();
+    assert!(first_err.to_string().contains("found a cycle in the call graph"));
+    assert!(second_err.to_string().contains("found a cycle in the call graph"));
+}
+
+#[test]
 fn test_cross_module_constant_cycle_in_procedure_scope_is_structured_error() {
     use std::panic::{AssertUnwindSafe, catch_unwind};
 

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5455,8 +5455,8 @@ fn imported_main_alias_self_call_is_structured_error() {
     let err = assembled
         .unwrap()
         .expect_err("expected self-referential alias call to be rejected");
-    assert_diagnostic!(&err, "found a cycle in the call graph");
-    assert_diagnostic!(&err, "::$exec::$main");
+    assert_diagnostic!(&err, "invalid recursive procedure call");
+    assert_diagnostic!(&err, "this call is self-recursive");
 }
 
 #[test]
@@ -5668,6 +5668,56 @@ fn path_alias_chain_to_digest_assembles_without_panicking() {
         .expect("expected digest alias chain to assemble successfully");
     assert_eq!(library.get_procedure_root_by_path("m::n::bar"), Some(digest));
     assert!(library.get_procedure_root_by_path("m::n::calls_bar").is_some());
+}
+
+#[test]
+fn invoking_local_type_alias_returns_error_instead_of_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let masm = "type foo = u32\nbegin\n    exec.foo\nend\n";
+
+    let result = catch_unwind(AssertUnwindSafe(|| Assembler::default().assemble_program(masm)));
+
+    let result = result.expect("assembly panicked, expected a structured error");
+    let err = result.expect_err("assembly unexpectedly succeeded");
+    assert_diagnostic!(&err, "invalid symbol reference: wrong type");
+    assert_diagnostic!(&err, "expected this symbol to reference a procedure item");
+}
+
+#[test]
+fn invoking_local_type_alias_is_rejected_during_semantic_analysis() {
+    let context = TestContext::new();
+    let masm = source_file!(&context, "type foo = u32\nbegin\n    exec.foo\nend\n");
+
+    let err = context
+        .parse_program(masm)
+        .expect_err("semantic analysis unexpectedly accepted invoking a local type alias");
+    assert_diagnostic!(&err, "invalid symbol reference: wrong type");
+    assert_diagnostic!(&err, "expected this symbol to reference a procedure item");
+}
+
+#[test]
+fn invoking_imported_type_alias_returns_error_instead_of_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let context = TestContext::new();
+    let lib = context
+        .parse_module_with_path("test::types", source_file!(&context, "pub type foo = u32\n"))
+        .expect("library module parsing must succeed");
+    let library = Assembler::new(context.source_manager())
+        .assemble_library([lib])
+        .expect("library assembly must succeed");
+
+    let mut assembler = Assembler::new(context.source_manager());
+    assembler.link_dynamic_library(library).expect("library linking must succeed");
+
+    let program = "use test::types\nbegin\n    exec.types::foo\nend\n";
+    let result = catch_unwind(AssertUnwindSafe(|| assembler.assemble_program(program)));
+
+    let result = result.expect("assembly panicked, expected a structured error");
+    let err = result.expect_err("assembly unexpectedly succeeded");
+    assert_diagnostic!(&err, "invalid procedure reference: path refers to a non-procedure item");
+    assert_diagnostic!(&err, "test::types::foo");
 }
 
 #[test]


### PR DESCRIPTION
This PR turns four panic paths in assembly and syntax handling into normal errors.

- makes cyclic call graphs fail with typed cycle errors. Self-calls and rootless cycles no longer panic, and linker state is rolled back on failure.

- makes oversized modules fail at a hard item limit. Resolver construction now rejects modules that cannot fit in ItemIndex, instead of building partial state or panicking.

- makes unresolved alias exports fail cleanly during library assembly. Digest exports still work when they resolve to a real procedure, and unknown digests now return an error instead of unwinding.

- makes invoke target checks require procedures. Semantic analysis now rejects local aliases, types, and other non-procedure items as invoke targets, and assembly keeps a second guard so invalid targets return an error instead of panicking.

A review reading commit-by-commit is highly encouraged.