### PR TITLE
processor: expose advice, memory and transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.22.1
+
+#### Enhancements
+
+- Added `FastProcessor::into_parts()` to extract advice provider, memory, and precompile transcript after step-based execution ([#2901](https://github.com/0xMiden/miden-vm/pull/2901)).
+
 ## 0.22.0 (2025-03-18)
 
 #### Enhancements

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -405,6 +405,12 @@ impl FastProcessor {
         &self.memory
     }
 
+    /// Consumes the processor and returns the advice provider, memory, and precompile
+    /// transcript.
+    pub fn into_parts(self) -> (AdviceProvider, Memory, PrecompileTranscript) {
+        (self.advice, self.memory, self.pc_transcript)
+    }
+
     /// Returns a reference to the execution options.
     pub fn execution_options(&self) -> &ExecutionOptions {
         &self.options


### PR DESCRIPTION
FastProcessor provides `step()` for external stepping loops but no way to extract the final `advice`, `memory`, and `pc_transcript` state afterward, which is needed to construct a valid `ExecutionOutput` via DAP/debugger while debugging transactions.