### PR TITLE
revert(assembly): restore InvokeKind::Exec in visit_mut_procref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.23.0 (TBD)
 
+#### Bug Fixes
+
+- Reverted `InvokeKind::ProcRef` back to `InvokeKind::Exec` in `visit_mut_procref` and added an explanatory comment (#2893).
+
 ## 0.22.0 (2025-03-18)
 
 #### Enhancements

--- a/crates/assembly-syntax/src/sema/passes/verify_invoke.rs
+++ b/crates/assembly-syntax/src/sema/passes/verify_invoke.rs
@@ -168,7 +168,14 @@ impl VisitMut for VerifyInvokeTargets<'_> {
     }
     fn visit_mut_procref(&mut self, target: &mut InvocationTarget) -> ControlFlow<()> {
         self.visit_mut_invoke_target(target)?;
-        self.invoked.insert(Invoke::new(InvokeKind::ProcRef, target.clone()));
+        // We intentionally use `InvokeKind::Exec` here rather than `InvokeKind::ProcRef`.
+        // A `procref` instruction captures a procedure reference for *later* invocation,
+        // but we must pessimistically treat it as an actual invocation because we cannot
+        // know the specific call kind at this point. `Exec` is the most general invocation
+        // kind, and the linker relies on this signal to correctly track procedure
+        // dependencies. Using `ProcRef` would only indicate "named somewhere" and would
+        // not carry the full weight of "this procedure is invoked".
+        self.invoked.insert(Invoke::new(InvokeKind::Exec, target.clone()));
         ControlFlow::Continue(())
     }
     fn visit_mut_invoke_target(&mut self, target: &mut InvocationTarget) -> ControlFlow<()> {


### PR DESCRIPTION
## Summary

Reverts the change introduced in #2893 and adds an explanatory comment.

### What changed
In `visit_mut_procref`, the invoke kind was changed from `InvokeKind::Exec` → `InvokeKind::ProcRef`. This was incorrect.

### Why `InvokeKind::Exec` is correct here
A `procref` instruction captures a procedure reference for *later* invocation. At this point in the pass we cannot know what call kind will ultimately be used — so we must **pessimistically** treat it as an actual invocation. `Exec` is the most general invocation kind, and the linker relies on this signal to correctly track procedure dependencies.

Using `InvokeKind::ProcRef` only communicates "this procedure is named somewhere", which does **not** carry the full weight of "this procedure is invoked". This would cause the linker to under-count invocation dependencies.

An explanatory comment has been added above the line so this does not get accidentally changed again in the future (as suggested by @bobbinth).

### References
- Flagged by @bitwalker in https://github.com/0xMiden/miden-vm/pull/2893#issuecomment-4122254987
- Confirmed by @bobbinth in https://github.com/0xMiden/miden-vm/pull/2893#issuecomment-4122795938

cc @bitwalker @bobbinth @huitseeker
