### PR TITLE
Add a package content digest for package identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [BREAKING] Reject oversized modules at resolver construction instead of building partial resolver state or panicking ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
 - Return a normal assembly error when `pub use <digest> -> <name>` does not resolve to an exported procedure ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
 - [BREAKING] Reject non-procedure invoke targets during semantic analysis, and return an assembly error instead of panicking if one still reaches assembly ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
+- Added `Package::content_digest()` to identify package contents without changing the MAST digest, including manifest data and semantic package metadata ([#2909](https://github.com/0xMiden/miden-vm/pull/2909)).
 
 ## 0.22.0 (TBD)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,9 +2394,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -82,7 +82,7 @@ impl Package {
         target: &mut W,
         kernel_digest: Option<&Word>,
     ) {
-        target.write_bytes(b"miden.package.content.v1");
+        target.write_bytes(b"miden.package.content.v2");
         self.digest().write_into(target);
         self.name.write_into(target);
         self.version.as_ref().map(|v| v.to_string()).write_into(target);

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -68,8 +68,9 @@ impl Package {
     ///
     /// This is distinct from [`Self::digest`], which is only the digest of the underlying MAST
     /// artifact. The content digest currently binds the MAST digest, package name, semantic
-    /// version, package kind, and manifest. Package descriptions and opaque custom sections are
-    /// intentionally excluded for now; kernel-section binding is added separately.
+    /// version, package kind, manifest, and any semantic package sections. Package descriptions
+    /// and opaque custom sections are intentionally excluded for now; kernel-section binding is
+    /// added separately.
     pub fn content_digest(&self) -> Word {
         let mut bytes = Vec::new();
         self.write_content_digest_preimage(&mut bytes, None);
@@ -87,9 +88,22 @@ impl Package {
         self.version.as_ref().map(|v| v.to_string()).write_into(target);
         target.write_u8(self.kind.into());
         self.manifest.write_into(target);
+        self.write_content_digest_sections(target);
         target.write_bool(kernel_digest.is_some());
         if let Some(kernel_digest) = kernel_digest {
             kernel_digest.write_into(target);
+        }
+    }
+
+    fn write_content_digest_sections<W: ByteWriter>(&self, target: &mut W) {
+        let semantic_sections = self
+            .sections
+            .iter()
+            .filter(|section| section.id == SectionId::ACCOUNT_COMPONENT_METADATA)
+            .collect::<Vec<_>>();
+        target.write_usize(semantic_sections.len());
+        for section in semantic_sections {
+            section.write_into(target);
         }
     }
 

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -5,11 +5,21 @@ mod section;
 mod seed_gen;
 mod serialization;
 
-use alloc::{format, string::String, sync::Arc, vec::Vec};
+use alloc::{
+    format,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
 
 use miden_assembly_syntax::{Library, Report, ast::QualifiedProcedureName};
 pub use miden_assembly_syntax::{Version, VersionError};
-use miden_core::{Word, program::Program};
+use miden_core::{
+    Word,
+    crypto::hash::Poseidon2,
+    program::Program,
+    serde::{ByteWriter, Serializable},
+};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -52,6 +62,35 @@ impl Package {
     /// Returns the digest of the package's MAST artifact
     pub fn digest(&self) -> Word {
         self.mast.digest()
+    }
+
+    /// Returns a digest of the package content relevant to assembly and dependency resolution.
+    ///
+    /// This is distinct from [`Self::digest`], which is only the digest of the underlying MAST
+    /// artifact. The content digest currently binds the MAST digest, package name, semantic
+    /// version, package kind, and manifest. Package descriptions and opaque custom sections are
+    /// intentionally excluded for now; kernel-section binding is added separately.
+    pub fn content_digest(&self) -> Word {
+        let mut bytes = Vec::new();
+        self.write_content_digest_preimage(&mut bytes, None);
+        Poseidon2::hash(&bytes)
+    }
+
+    fn write_content_digest_preimage<W: ByteWriter>(
+        &self,
+        target: &mut W,
+        kernel_digest: Option<&Word>,
+    ) {
+        target.write_bytes(b"miden.package.content.v1");
+        self.digest().write_into(target);
+        self.name.write_into(target);
+        self.version.as_ref().map(|v| v.to_string()).write_into(target);
+        target.write_u8(self.kind.into());
+        self.manifest.write_into(target);
+        target.write_bool(kernel_digest.is_some());
+        if let Some(kernel_digest) = kernel_digest {
+            kernel_digest.write_into(target);
+        }
     }
 
     /// Returns the MastArtifact of the package

--- a/crates/mast-package/src/package/serialization.rs
+++ b/crates/mast-package/src/package/serialization.rs
@@ -556,7 +556,25 @@ mod tests {
     }
 
     #[test]
-    fn package_content_digest_ignores_description_and_custom_sections_for_now() {
+    fn package_content_digest_changes_when_account_component_metadata_changes() {
+        let package = build_package();
+        let digest = package.content_digest();
+
+        let with_metadata = Package {
+            sections: vec![Section::new(SectionId::ACCOUNT_COMPONENT_METADATA, vec![1, 2, 3, 4])],
+            ..package.clone()
+        };
+        assert_ne!(digest, with_metadata.content_digest());
+
+        let with_different_metadata = Package {
+            sections: vec![Section::new(SectionId::ACCOUNT_COMPONENT_METADATA, vec![4, 3, 2, 1])],
+            ..package
+        };
+        assert_ne!(with_metadata.content_digest(), with_different_metadata.content_digest());
+    }
+
+    #[test]
+    fn package_content_digest_ignores_description_and_opaque_custom_sections_for_now() {
         let package = build_package();
         let digest = package.content_digest();
 

--- a/crates/mast-package/src/package/serialization.rs
+++ b/crates/mast-package/src/package/serialization.rs
@@ -435,6 +435,7 @@ mod tests {
         library::{LibraryExport, ProcedureExport as LibraryProcedureExport},
     };
     use miden_core::{
+        Word,
         mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, MastNodeExt, MastNodeId},
         operations::Operation,
         serde::{
@@ -444,9 +445,12 @@ mod tests {
     };
 
     use super::{
-        MAGIC_PACKAGE, MastArtifact, Package, PackageExport, PackageKind, PackageManifest, VERSION,
+        MAGIC_PACKAGE, MastArtifact, Package, PackageExport, PackageKind, PackageManifest, Section,
+        VERSION,
     };
-    use crate::package::manifest::ProcedureExport as PackageProcedureExport;
+    use crate::{
+        Dependency, SectionId, package::manifest::ProcedureExport as PackageProcedureExport,
+    };
 
     fn build_forest() -> (MastForest, MastNodeId) {
         let mut forest = MastForest::new();
@@ -515,6 +519,61 @@ mod tests {
         bytes.write_usize(count);
 
         bytes
+    }
+
+    #[test]
+    fn package_content_digest_changes_when_identity_fields_change() {
+        let package = build_package();
+        let digest = package.content_digest();
+
+        let renamed = Package {
+            name: String::from("renamed_pkg"),
+            ..package.clone()
+        };
+        assert_ne!(digest, renamed.content_digest());
+
+        let versioned = Package {
+            version: Some("1.2.3".parse().expect("valid semver")),
+            ..package.clone()
+        };
+        assert_ne!(digest, versioned.content_digest());
+
+        let executable = Package { kind: PackageKind::Executable, ..package };
+        assert_ne!(digest, executable.content_digest());
+    }
+
+    #[test]
+    fn package_content_digest_changes_when_manifest_changes() {
+        let package = build_package();
+        let digest = package.content_digest();
+
+        let mut with_dependency = package.clone();
+        with_dependency.manifest.add_dependency(Dependency {
+            name: String::from("dep_pkg").into(),
+            digest: Word::from([1_u32, 2, 3, 4]),
+        });
+        assert_ne!(digest, with_dependency.content_digest());
+    }
+
+    #[test]
+    fn package_content_digest_ignores_description_and_custom_sections_for_now() {
+        let package = build_package();
+        let digest = package.content_digest();
+
+        let described = Package {
+            description: Some(String::from("human-facing package description")),
+            ..package.clone()
+        };
+        assert_eq!(digest, described.content_digest());
+
+        let with_section = Package {
+            sections: vec![Section::new(
+                SectionId::custom("opaque").expect("valid custom section id"),
+                vec![1, 2, 3, 4],
+            )],
+            ..package
+        };
+        assert_eq!(digest, with_section.content_digest());
     }
 
     #[test]


### PR DESCRIPTION
This adds `Package::content_digest()` as the digest for package identity and keeps `Package::digest()` as the MAST digest. The content digest covers the MAST digest, package name, version, kind, manifest, and semantic package sections such as `ACCOUNT_COMPONENT_METADATA`.

The content digest format is versioned as `miden.package.content.v2`. Descriptions and opaque custom sections are still left out. Kernel-section binding is still deferred.

The tests check that the content digest changes when package identity, manifest data, or account-component metadata changes, and stays stable when only descriptions or opaque custom sections change.