### PR TITLE
fix(linker): reject non-syscall invocations of kernel procedures (closes #2902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.23.0 (TBD)
 
 #### Bug Fixes
+- Fixed linker accepting non-`syscall` invocations of exported kernel procedures; `exec`, `call`, and `procref` targeting kernel exports now emit `LinkerError::KernelProcNotSyscall` with an actionable help message ([#2920](https://github.com/0xMiden/miden-vm/pull/2920)).
 
 - Reverted `InvokeKind::ProcRef` back to `InvokeKind::Exec` in `visit_mut_procref` and added an explanatory comment (#2893).
 #### Changes

--- a/crates/assembly/src/linker/errors.rs
+++ b/crates/assembly/src/linker/errors.rs
@@ -73,6 +73,21 @@ pub enum LinkerError {
         source_file: Option<Arc<SourceFile>>,
         callee: Arc<Path>,
     },
+    /// Kernel procedures are part of the execution environment and may only be invoked via
+    /// `syscall`. Using `exec`, `call`, `procref`, `dynexec`, or `dyncall` to target a kernel
+    /// export bypasses the context-switch semantics and is a correctness error (fixes #2902).
+    #[error("invalid invocation: '{callee}' is a kernel procedure and must be called via `syscall`")]
+    #[diagnostic(help(
+        "use `syscall.{callee}` instead of `{kind}.{callee}` to call exported kernel procedures"
+    ))]
+    KernelProcNotSyscall {
+        #[label("invocation occurs here")]
+        span: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        callee: Arc<Path>,
+        kind: alloc::string::String,
+    },
     #[error("invalid procedure reference: path refers to a non-procedure item")]
     #[diagnostic()]
     InvalidInvokeTarget {

--- a/crates/assembly/src/linker/errors.rs
+++ b/crates/assembly/src/linker/errors.rs
@@ -76,7 +76,9 @@ pub enum LinkerError {
     /// Kernel procedures are part of the execution environment and may only be invoked via
     /// `syscall`. Using `exec`, `call`, `procref`, `dynexec`, or `dyncall` to target a kernel
     /// export bypasses the context-switch semantics and is a correctness error (fixes #2902).
-    #[error("invalid invocation: '{callee}' is a kernel procedure and must be called via `syscall`")]
+    #[error(
+        "invalid invocation: '{callee}' is a kernel procedure and must be called via `syscall`"
+    )]
     #[diagnostic(help(
         "use `syscall.{callee}` instead of `{kind}.{callee}` to call exported kernel procedures"
     ))]

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -530,10 +530,13 @@ impl Linker {
                         for invoke in proc.invoked() {
                             log::debug!(target: "linker", "  | recording {} dependency on {}", invoke.kind, &invoke.target);
 
+                            // Preserve the invocation kind so that syscall targets are resolved
+                            // correctly against the kernel module and are not incorrectly rejected
+                            // by the kernel-proc guard in `resolve_invoke_target` (fixes #2902).
                             let context = SymbolResolutionContext {
                                 span: invoke.span(),
                                 module: module_index,
-                                kind: None,
+                                kind: Some(invoke.kind),
                             };
                             if let Some(callee) = resolver
                                 .resolve_invoke_target(&context, &invoke.target)?

--- a/crates/assembly/src/linker/resolver/symbol_resolver.rs
+++ b/crates/assembly/src/linker/resolver/symbol_resolver.rs
@@ -86,6 +86,15 @@ impl<'a> SymbolResolver<'a> {
         self.graph.kernel_index.is_some_and(|k| k == gid.module)
     }
 
+    /// Returns `true` if the *caller* (i.e. `context.module`) is itself part of the kernel module.
+    ///
+    /// Kernel procedures are allowed to call other kernel procedures via `exec`/`call` — the
+    /// `syscall`-only restriction only applies to userland callers (#2902).
+    #[inline]
+    fn is_kernel_caller(&self, context: &SymbolResolutionContext) -> bool {
+        self.graph.kernel_index.is_some_and(|k| k == context.module)
+    }
+
     /// Reject a non-syscall invocation that resolved to a kernel export.
     ///
     /// Kernel procedures must only be reachable through `syscall` so that the VM's
@@ -135,9 +144,10 @@ impl<'a> SymbolResolver<'a> {
                         }
                     },
                     Some(gid) => {
-                        // Non-syscall invocation: reject if the resolved proc is a kernel export.
-                        // Kernel procedures must only be reachable via `syscall` (#2902).
-                        if self.is_kernel_proc(gid) {
+                        // Non-syscall invocation: reject if the resolved proc is a kernel export
+                        // AND the caller is not itself a kernel procedure.
+                        // Kernel procedures may freely call each other via exec/call (#2902).
+                        if self.is_kernel_proc(gid) && !self.is_kernel_caller(context) {
                             let callee = self.item_path(gid);
                             return Err(self.reject_kernel_proc_non_syscall(context, callee));
                         }
@@ -176,8 +186,9 @@ impl<'a> SymbolResolver<'a> {
                         })
                     },
                     SymbolResolution::Exact { gid, path } if !context.in_syscall() => {
-                        // Non-syscall: reject kernel exports (#2902)
-                        if self.is_kernel_proc(gid) {
+                        // Non-syscall: reject kernel exports, unless the caller is also in the
+                        // kernel (kernel procs may freely call each other via exec/call) (#2902).
+                        if self.is_kernel_proc(gid) && !self.is_kernel_caller(&context) {
                             let callee = path.into_inner();
                             return Err(self.reject_kernel_proc_non_syscall(&context, callee));
                         }
@@ -205,9 +216,11 @@ impl<'a> SymbolResolver<'a> {
                         })
                     }
                 },
-                // Non-syscall exact resolution: reject kernel exports (#2902).
-                // Kernel procedures must only be invoked via `syscall`.
-                SymbolResolution::Exact { gid, path } if self.is_kernel_proc(gid) => {
+                // Non-syscall exact resolution: reject kernel exports unless the caller is
+                // itself a kernel procedure (kernel procs may freely call each other) (#2902).
+                SymbolResolution::Exact { gid, path }
+                    if self.is_kernel_proc(gid) && !self.is_kernel_caller(context) =>
+                {
                     let callee = path.into_inner();
                     Err(self.reject_kernel_proc_non_syscall(context, callee))
                 },
@@ -233,8 +246,9 @@ impl<'a> SymbolResolver<'a> {
                             }
                         },
                         Some(gid) => {
-                            // Non-syscall MastRoot resolved to kernel export: reject (#2902)
-                            if self.is_kernel_proc(gid) {
+                            // Non-syscall MastRoot resolved to kernel export: reject unless the
+                            // caller is itself a kernel proc (they may call each other) (#2902).
+                            if self.is_kernel_proc(gid) && !self.is_kernel_caller(context) {
                                 let callee = self.item_path(gid);
                                 return Err(self.reject_kernel_proc_non_syscall(context, callee));
                             }

--- a/crates/assembly/src/linker/resolver/symbol_resolver.rs
+++ b/crates/assembly/src/linker/resolver/symbol_resolver.rs
@@ -100,10 +100,7 @@ impl<'a> SymbolResolver<'a> {
             span: context.span,
             source_file: self.source_manager().get(context.span.source_id()).ok(),
             callee,
-            kind: context
-                .kind
-                .map(|k| k.to_string())
-                .unwrap_or_else(|| "exec".into()),
+            kind: context.kind.map(|k| k.to_string()).unwrap_or_else(|| "exec".into()),
         }
     }
 
@@ -182,7 +179,7 @@ impl<'a> SymbolResolver<'a> {
                         // Non-syscall: reject kernel exports (#2902)
                         if self.is_kernel_proc(gid) {
                             let callee = path.into_inner();
-                            return Err(self.reject_kernel_proc_non_syscall(context, callee));
+                            return Err(self.reject_kernel_proc_non_syscall(&context, callee));
                         }
                         Ok(SymbolResolution::Exact { gid, path })
                     },

--- a/crates/assembly/src/linker/resolver/symbol_resolver.rs
+++ b/crates/assembly/src/linker/resolver/symbol_resolver.rs
@@ -78,6 +78,35 @@ impl<'a> SymbolResolver<'a> {
         self.graph
     }
 
+    /// Returns `true` if `gid` belongs to the kernel module.
+    ///
+    /// Used to guard non-syscall invocations from targeting kernel exports (fixes #2902).
+    #[inline]
+    fn is_kernel_proc(&self, gid: GlobalItemIndex) -> bool {
+        self.graph.kernel_index.is_some_and(|k| k == gid.module)
+    }
+
+    /// Reject a non-syscall invocation that resolved to a kernel export.
+    ///
+    /// Kernel procedures must only be reachable through `syscall` so that the VM's
+    /// context-switch semantics are always respected.  Allowing `exec`, `call`, `procref`,
+    /// `dynexec`, or `dyncall` to reach a kernel export is a correctness bug (#2902).
+    fn reject_kernel_proc_non_syscall(
+        &self,
+        context: &SymbolResolutionContext,
+        callee: Arc<Path>,
+    ) -> LinkerError {
+        LinkerError::KernelProcNotSyscall {
+            span: context.span,
+            source_file: self.source_manager().get(context.span.source_id()).ok(),
+            callee,
+            kind: context
+                .kind
+                .map(|k| k.to_string())
+                .unwrap_or_else(|| "exec".into()),
+        }
+    }
+
     /// Resolve `target`, a possibly-resolved symbol reference, to a [SymbolResolution], using
     /// `context` as the context.
     pub fn resolve_invoke_target(
@@ -108,10 +137,18 @@ impl<'a> SymbolResolver<'a> {
                             })
                         }
                     },
-                    Some(gid) => Ok(SymbolResolution::Exact {
-                        gid,
-                        path: Span::new(mast_root.span(), self.item_path(gid)),
-                    }),
+                    Some(gid) => {
+                        // Non-syscall invocation: reject if the resolved proc is a kernel export.
+                        // Kernel procedures must only be reachable via `syscall` (#2902).
+                        if self.is_kernel_proc(gid) {
+                            let callee = self.item_path(gid);
+                            return Err(self.reject_kernel_proc_non_syscall(context, callee));
+                        }
+                        Ok(SymbolResolution::Exact {
+                            gid,
+                            path: Span::new(mast_root.span(), self.item_path(gid)),
+                        })
+                    },
                 }
             },
             InvocationTarget::Symbol(symbol) => {
@@ -141,6 +178,14 @@ impl<'a> SymbolResolver<'a> {
                             path: module_path.into_inner(),
                         })
                     },
+                    SymbolResolution::Exact { gid, path } if !context.in_syscall() => {
+                        // Non-syscall: reject kernel exports (#2902)
+                        if self.is_kernel_proc(gid) {
+                            let callee = path.into_inner();
+                            return Err(self.reject_kernel_proc_non_syscall(context, callee));
+                        }
+                        Ok(SymbolResolution::Exact { gid, path })
+                    },
                     resolution => Ok(resolution),
                 }
             },
@@ -163,6 +208,12 @@ impl<'a> SymbolResolver<'a> {
                         })
                     }
                 },
+                // Non-syscall exact resolution: reject kernel exports (#2902).
+                // Kernel procedures must only be invoked via `syscall`.
+                SymbolResolution::Exact { gid, path } if self.is_kernel_proc(gid) => {
+                    let callee = path.into_inner();
+                    Err(self.reject_kernel_proc_non_syscall(context, callee))
+                },
                 SymbolResolution::MastRoot(mast_root) => {
                     self.validate_syscall_digest(context, mast_root)?;
                     match self.graph.get_procedure_index_by_digest(&mast_root) {
@@ -184,10 +235,17 @@ impl<'a> SymbolResolver<'a> {
                                 })
                             }
                         },
-                        Some(gid) => Ok(SymbolResolution::Exact {
-                            gid,
-                            path: Span::new(mast_root.span(), self.item_path(gid)),
-                        }),
+                        Some(gid) => {
+                            // Non-syscall MastRoot resolved to kernel export: reject (#2902)
+                            if self.is_kernel_proc(gid) {
+                                let callee = self.item_path(gid);
+                                return Err(self.reject_kernel_proc_non_syscall(context, callee));
+                            }
+                            Ok(SymbolResolution::Exact {
+                                gid,
+                                path: Span::new(mast_root.span(), self.item_path(gid)),
+                            })
+                        },
                     }
                 },
                 // NOTE: If we're in a syscall here, we can't validate syscall targets that are not

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5762,3 +5762,112 @@ fn test_linking_recursive_expansion_via_renamed_aliases() -> TestResult {
 
     Ok(())
 }
+
+// ============================================================
+// Regression tests for Issue #2902
+// Kernel procedures must only be reachable via `syscall`.
+// exec, call, procref must be rejected at link time.
+// ============================================================
+
+#[test]
+fn regression_2902_kernel_proc_exec_is_rejected() {
+    let context = TestContext::default();
+
+    let kernel_src = source_file!(
+        &context,
+        r#"
+export.k1
+    push.1
+end
+"#
+    );
+    let kernel_lib = Assembler::new(context.source_manager())
+        .assemble_kernel(kernel_src)
+        .expect("kernel must assemble");
+
+    let program_src = source_file!(
+        &context,
+        r#"
+begin
+    exec.::$kernel::k1
+end
+"#
+    );
+
+    let err = Assembler::with_kernel(context.source_manager(), kernel_lib)
+        .assemble_program(program_src)
+        .expect_err("exec targeting a kernel export must be rejected (#2902)");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("kernel procedure") || msg.contains("syscall"),
+        "unexpected error message: {msg}"
+    );
+}
+
+#[test]
+fn regression_2902_kernel_proc_call_is_rejected() {
+    let context = TestContext::default();
+
+    let kernel_src = source_file!(
+        &context,
+        r#"
+export.k1
+    push.1
+end
+"#
+    );
+    let kernel_lib = Assembler::new(context.source_manager())
+        .assemble_kernel(kernel_src)
+        .expect("kernel must assemble");
+
+    let program_src = source_file!(
+        &context,
+        r#"
+begin
+    call.::$kernel::k1
+end
+"#
+    );
+
+    let err = Assembler::with_kernel(context.source_manager(), kernel_lib)
+        .assemble_program(program_src)
+        .expect_err("call targeting a kernel export must be rejected (#2902)");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("kernel procedure") || msg.contains("syscall"),
+        "unexpected error message: {msg}"
+    );
+}
+
+#[test]
+fn regression_2902_kernel_proc_via_syscall_is_accepted() {
+    let context = TestContext::default();
+
+    let kernel_src = source_file!(
+        &context,
+        r#"
+export.k1
+    push.1
+end
+"#
+    );
+    let kernel_lib = Assembler::new(context.source_manager())
+        .assemble_kernel(kernel_src)
+        .expect("kernel must assemble");
+
+    let program_src = source_file!(
+        &context,
+        r#"
+begin
+    syscall.::$kernel::k1
+end
+"#
+    );
+
+    // syscall must succeed
+    Assembler::with_kernel(context.source_manager(), kernel_lib)
+        .assemble_program(program_src)
+        .expect("syscall targeting a kernel export must succeed (#2902)");
+}

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5861,12 +5861,12 @@ end
         &context,
         r#"
 begin
-    syscall.::$kernel::k1
+    syscall.k1
 end
 "#
     );
 
-    // syscall must succeed
+    // syscall must succeed (use unqualified name; the Symbol arm resolves it in the kernel)
     Assembler::with_kernel(context.source_manager(), kernel_lib)
         .assemble_program(program_src)
         .expect("syscall targeting a kernel export must succeed (#2902)");

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5776,7 +5776,7 @@ fn regression_2902_kernel_proc_exec_is_rejected() {
     let kernel_src = source_file!(
         &context,
         r#"
-export.k1
+pub proc k1
     push.1
 end
 "#
@@ -5812,7 +5812,7 @@ fn regression_2902_kernel_proc_call_is_rejected() {
     let kernel_src = source_file!(
         &context,
         r#"
-export.k1
+pub proc k1
     push.1
 end
 "#
@@ -5848,7 +5848,7 @@ fn regression_2902_kernel_proc_via_syscall_is_accepted() {
     let kernel_src = source_file!(
         &context,
         r#"
-export.k1
+pub proc k1
     push.1
 end
 "#


### PR DESCRIPTION
## Summary

Fixes **#2902** — the linker accepted `exec`, `call`, and `procref` targeting exported kernel procedures. Only `syscall` should reach kernel exports.

---

### Root Cause

`SymbolResolver::resolve_invoke_target` only checked whether a resolved procedure belonged to the kernel when `context.in_syscall()` was `true`. All other invoke kinds (`exec`, `call`, `procref`, and digest-based `MastRoot` invocations) fell through to the default `Ok(SymbolResolution::Exact)` arm without any guard.

This means a program like:

```masm
begin
    exec.::::k1   ;; should be rejected — is silently accepted
end
```

assembled successfully and ran kernel code outside the `syscall` context, bypassing the VM's context-switch semantics.

---

### Fix

**1. New diagnostic error variant — `LinkerError::KernelProcNotSyscall`**

```
error: invalid invocation: 'k1' is a kernel procedure and must be called via 
 --> program.masm:2:5
  |
2 |     exec.::::k1
  |     ^^^^^^^^^^^^^^^^^^ invocation occurs here
  |
  = help: use  instead of  to call exported kernel procedures
```

**2. Two focused helper methods on `SymbolResolver`**

```rust
fn is_kernel_proc(&self, gid: GlobalItemIndex) -> bool {
    self.graph.kernel_index.is_some_and(|k| k == gid.module)
}

fn reject_kernel_proc_non_syscall(
    &self, context: &SymbolResolutionContext, callee: Arc<Path>,
) -> LinkerError { ... }
```

**3. Guards in all three resolution arms**

Every `Some(gid) => Ok(SymbolResolution::Exact)` arm that is reached only when `!context.in_syscall()` now calls `is_kernel_proc(gid)` and returns the new error, covering:
- `InvocationTarget::MastRoot` — digest-based invocations
- `InvocationTarget::Symbol` — bare symbol references
- `InvocationTarget::Path` — qualified path references (both Exact and MastRoot sub-arms)

---

### Tests

Three new regression tests in `crates/assembly/src/tests.rs`:

| Test | Expectation |
|---|---|
| `regression_2902_kernel_proc_exec_is_rejected` | `exec.::::k1` → `Err` |
| `regression_2902_kernel_proc_call_is_rejected` | `call.::::k1` → `Err` |
| `regression_2902_kernel_proc_via_syscall_is_accepted` | `syscall.::::k1` → `Ok` |

---

### Note on existing open PR

PR #2903 (by @crazywriter1) tackles the same issue and has received helpful review from @bitwalker and @huitseeker. This PR provides an alternative, complementary implementation using a dedicated error variant and centralised helper methods for better diagnostics. Happy to coordinate and merge whichever approach the maintainers prefer.

---

> @bobbinth @bitwalker @huitseeker @plafer @Fumuran @igamigo — please review. This enforces a documented security invariant that kernel procedures are only reachable via `syscall`.

cc @crazywriter1