### PR TITLE
ci: add workflow to verify all PR commits are signed

### DIFF
--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -1,0 +1,79 @@
+# Verifies that all commits in a PR are signed (GPG or SSH).
+# Posts a comment with remediation steps if unsigned commits are found.
+
+name: signed commits
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request_target:
+    branches:
+      - main
+      - next
+    types: [opened, reopened, synchronize]
+
+jobs:
+  check-signed-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for unsigned commits
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const commits = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 250
+            });
+
+            const unsigned = commits.data.filter(c => !c.commit.verification.verified);
+
+            if (unsigned.length === 0) {
+              core.setOutput('unsigned', '');
+              core.info('All commits are signed.');
+              return;
+            }
+
+            const lines = unsigned.map(c =>
+              `- \`${c.sha.slice(0, 8)}\` ${c.commit.message.split('\n')[0]}`
+            );
+
+            core.setOutput('unsigned', lines.join('\n'));
+            core.setOutput('pr_number', String(prNumber));
+            core.setFailed(
+              `Found ${unsigned.length} unsigned commit(s) in this PR. ` +
+              'All commits must be signed (GPG or SSH).'
+            );
+
+      - name: Comment with remediation steps
+        if: failure() && steps.check.outputs.unsigned != ''
+        uses: actions/github-script@v7
+        env:
+          UNSIGNED: ${{ steps.check.outputs.unsigned }}
+          PRNUM: ${{ steps.check.outputs.pr_number }}
+        with:
+          script: |
+            const issue_number = parseInt(process.env.PRNUM, 10);
+            const unsignedList = process.env.UNSIGNED;
+
+            const body = [
+              'This PR contains unsigned commits. All commits must be cryptographically signed (GPG or SSH).',
+              '',
+              'Unsigned commits:',
+              unsignedList,
+              '',
+              'For instructions on setting up commit signing and re-signing existing commits, see:',
+              'https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits'
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              body
+            });


### PR DESCRIPTION
Checks each commit in a PR via the GitHub API for signature verification. Fails the check and posts a remediation comment when unsigned commits are found.
