### PR TITLE
fix(assembly): validate procedure roots during library deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fixed debug-only underflow in memory range-check trace generation when the first memory access is at `clk = 0` ([#2976](https://github.com/0xMiden/miden-vm/pull/2976)).
 - Replaced unsound `ptr::read` with safe unbox in panic recovery, removing UB from potential double-drop ([#2934](https://github.com/0xMiden/miden-vm/pull/2934)).
+- Library deserialization now rejects exports whose `MastNodeId` is not a procedure root, closing a silent-failure path ([#2933](https://github.com/0xMiden/miden-vm/pull/2933)).
 - Reverted `InvokeKind::ProcRef` back to `InvokeKind::Exec` in `visit_mut_procref` and added an explanatory comment (#2893).
 - Fixed the release dry-run publish cycle between `miden-air` and `miden-ace-codegen`, and preserved leaf-only DAG imports with explicit snapshots ([#2931](https://github.com/0xMiden/miden-vm/pull/2931)).
 - Fixed AEAD padding handling so encrypt does not overwrite memory next to the plaintext buffer and decrypt leaves the plaintext output tail untouched ([#3008](https://github.com/0xMiden/miden-vm/pull/3008)).

--- a/crates/assembly-syntax/src/library/mod.rs
+++ b/crates/assembly-syntax/src/library/mod.rs
@@ -648,6 +648,16 @@ impl Deserializable for Library {
             exports.insert(path, export);
         }
 
+        for export in exports.values() {
+            if let LibraryExport::Procedure(ProcedureExport { node, path, .. }) = export
+                && !mast_forest.is_procedure_root(*node)
+            {
+                return Err(DeserializationError::InvalidValue(format!(
+                    "invalid export: no procedure root for {path} procedure"
+                )));
+            }
+        }
+
         let digest =
             mast_forest.compute_nodes_commitment(exports.values().filter_map(|e| match e {
                 LibraryExport::Procedure(e) => Some(&e.node),

--- a/crates/assembly-syntax/src/library/mod.rs
+++ b/crates/assembly-syntax/src/library/mod.rs
@@ -648,23 +648,8 @@ impl Deserializable for Library {
             exports.insert(path, export);
         }
 
-        for export in exports.values() {
-            if let LibraryExport::Procedure(ProcedureExport { node, path, .. }) = export
-                && !mast_forest.is_procedure_root(*node)
-            {
-                return Err(DeserializationError::InvalidValue(format!(
-                    "invalid export: no procedure root for {path} procedure"
-                )));
-            }
-        }
-
-        let digest =
-            mast_forest.compute_nodes_commitment(exports.values().filter_map(|e| match e {
-                LibraryExport::Procedure(e) => Some(&e.node),
-                LibraryExport::Constant(_) | LibraryExport::Type(_) => None,
-            }));
-
-        Ok(Self { digest, exports, mast_forest })
+        Self::new(mast_forest, exports)
+            .map_err(|err| DeserializationError::InvalidValue(format!("{err}")))
     }
 }
 

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -411,6 +411,66 @@ fn library_serialization() -> Result<(), Report> {
     Ok(())
 }
 
+/// Verifies that deserializing a library rejects procedure exports whose `MastNodeId` is not a
+/// procedure root in the underlying MAST forest (issue #2831).
+#[test]
+fn library_deserialization_rejects_non_root_export() {
+    use miden_core::{
+        mast::{BasicBlockNodeBuilder, MastForestContributor},
+        serde::ByteWriter,
+    };
+
+    let context = TestContext::new();
+    let source = r#"
+        pub proc foo
+            add
+        end
+    "#;
+    let module = parse_module!(&context, "test::foo", source);
+
+    // Build a valid library.
+    let lib = Assembler::new(context.source_manager()).assemble_library([module]).unwrap();
+
+    // Clone the forest and add a non-root node.
+    let mut forest: MastForest = (**lib.mast_forest()).clone();
+    let builder = BasicBlockNodeBuilder::new(vec![Operation::Add], vec![]);
+    let non_root_id = builder.add_to_forest(&mut forest).unwrap();
+    assert!(
+        !forest.is_procedure_root(non_root_id),
+        "sanity check: new node should not be a root"
+    );
+
+    // Manually serialize a tampered library: forest + one export referencing the non-root node.
+    let mut tampered_bytes = Vec::new();
+    forest.write_into(&mut tampered_bytes);
+
+    // Number of exports.
+    1usize.write_into(&mut tampered_bytes);
+    // Tag: 0 = Procedure export.
+    0u8.write_into(&mut tampered_bytes);
+    // Fully qualified procedure path.
+    let path = PathBuf::new("::test::foo::foo").unwrap();
+    path.write_into(&mut tampered_bytes);
+    // MastNodeId of the non-root node.
+    u32::from(non_root_id).write_into(&mut tampered_bytes);
+    // No function signature.
+    tampered_bytes.write_bool(false);
+    // Empty attribute set.
+    miden_assembly_syntax::ast::AttributeSet::default().write_into(&mut tampered_bytes);
+
+    // Deserializing should fail because the export references a non-root node.
+    let result = Library::read_from_bytes(&tampered_bytes);
+    assert!(
+        result.is_err(),
+        "deserialization should reject exports referencing non-root nodes"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("no procedure root"),
+        "error should mention missing procedure root, got: {err_msg}"
+    );
+}
+
 #[test]
 fn get_module_by_path() -> Result<(), Report> {
     let context = TestContext::new();


### PR DESCRIPTION
## Description

This PR fixes an issue where \Library::read_from\ accepts procedure exports whose \MastNodeId\ is not a procedure root in the underlying MAST forest. This allows crafting a library with uncallable procedure exports, violating the invariant enforced by \Library::new()\.

This was identified as finding 19 in the audit report.

## Changes

### Fix
- Added a validation loop to the \Deserializable\ implementation for \Library\ (in \crates/assembly-syntax/src/library/mod.rs\) that checks each procedure export references a valid procedure root in the \MastForest\, matching the existing check in \Library::new()\.

### Test
- Added \library_deserialization_rejects_non_root_export\ test that constructs a tampered serialized library with an export pointing to a non-root node and verifies deserialization rejects it with an appropriate error message.

## Testing

- \cargo test -p miden-assembly library_deserialization_rejects_non_root_export\ passes
- \cargo test -p miden-assembly library_serialization\ still passes (no regression)
- Both \miden-assembly\ and \miden-assembly-syntax\ crates compile cleanly

Closes #2831