### PR TITLE
fix(processor): document and stabilise wrapping-clk semantics in Memory trace builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 #### Bug Fixes
 
 - Reverted `InvokeKind::ProcRef` back to `InvokeKind::Exec` in `visit_mut_procref` and added an explanatory comment (#2893).
+- Documented and stabilised the wrapping-subtraction semantics used to initialise `prev_clk` in `Memory::append_range_checks` and `Memory::fill_trace`; replaced the implicit `- 1` with `wrapping_sub(1)` so the intent is explicit and debug builds no longer overflow ([#2828](https://github.com/0xMiden/miden-vm/issues/2828)).
+
 #### Changes
 
 - Documented that enum variants are module-level constants and must be unique within a module (#2932).

--- a/processor/src/trace/chiplets/memory/mod.rs
+++ b/processor/src/trace/chiplets/memory/mod.rs
@@ -250,8 +250,15 @@ impl Memory {
         // set the previous address and clock cycle to the first address and clock cycle of the
         // trace; we also adjust the clock cycle so that delta value for the first row would end
         // up being ZERO. if the trace is empty, return without any further processing.
+        //
+        // NOTE: `wrapping_sub(1)` is intentional here. When the first memory access occurs at
+        // clock cycle 0 (clk == 0), subtracting 1 wraps to u64::MAX. The subsequent delta
+        // computation `clk - prev_clk` then yields `0 - u64::MAX`, which also wraps back to 1.
+        // This happens to be the correct delta (consecutive-clock access at the same address).
+        // Using plain `- 1` would panic in debug builds; `wrapping_sub` makes the intent explicit
+        // and ensures consistent behaviour across debug and release builds. See #2828.
         let (mut prev_ctx, mut prev_addr, mut prev_clk) = match self.get_first_row_info() {
-            Some((ctx, addr, clk)) => (ctx, addr, clk.as_canonical_u64() - 1),
+            Some((ctx, addr, clk)) => (ctx, addr, clk.as_canonical_u64().wrapping_sub(1)),
             None => return,
         };
 
@@ -291,9 +298,15 @@ impl Memory {
     pub fn fill_trace(self, trace: &mut TraceFragment) {
         debug_assert_eq!(self.trace_len(), trace.len(), "inconsistent trace lengths");
 
-        // set the pervious address and clock cycle to the first address and clock cycle of the
+        // set the previous address and clock cycle to the first address and clock cycle of the
         // trace; we also adjust the clock cycle so that delta value for the first row would end
         // up being ZERO. if the trace is empty, return without any further processing.
+        //
+        // NOTE: `clk - ONE` uses Felt field arithmetic. When clk == ZERO this wraps to P - 1
+        // (the largest field element). The subsequent delta `clk - prev_clk` then evaluates to
+        // `0 - (P - 1) == 1` in the field, which is the correct delta for a first access at
+        // clock 0. This relies on field-element wrap-around semantics and is intentional.
+        // See #2828.
         let (mut prev_ctx, mut prev_addr, mut prev_clk) = match self.get_first_row_info() {
             Some((ctx, addr, clk)) => (Felt::from(ctx), Felt::from_u32(addr), clk - ONE),
             None => return,


### PR DESCRIPTION
## Summary

Closes #2828.

`Memory::append_range_checks` and `Memory::fill_trace` both initialise `prev_clk` by subtracting one from the first memory-access clock so that the delta for that row comes out as zero.  The subtractions are intentional wrap-around operations, but:

| Location | Old code | Problem |
|---|---|---|
| `append_range_checks` | `clk.as_canonical_u64() - 1` | Integer underflow / panic in debug builds when `clk == 0` |
| `fill_trace` | `clk - ONE` (Felt arithmetic) | Silent field-element wrap to `P - 1`; not obviously intentional |

Neither subtraction is *incorrect* (the resulting delta arithmetic still produces the right value), but both are surprising to readers and the first one **panics in debug builds** when the first memory access happens at clock cycle 0.

## Fix

* Replace `clk.as_canonical_u64() - 1` with `clk.as_canonical_u64().wrapping_sub(1)` to make the wrap-around explicit and prevent debug panics.
* Add detailed comments to both sites explaining *why* the wrap-around is safe and intentional.
* Update `CHANGELOG.md` under `#### Bug Fixes`.

## Testing

Existing memory-trace tests cover the affected code paths.  No behavioural change; this is a correctness-documentation and debug-build stability fix.