### PR TITLE
trace generation: follow-up refactoring + couple perf improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@
 - Collapsed the kernel ROM chiplet to one row per digest with a LogUp multiplicity, eliminating duplicate-callsite rows ([#2962](https://github.com/0xMiden/miden-vm/pull/2962)).
 - Made all internal `core::math` procedures natively little-endian ([#3084](https://github.com/0xMiden/miden-vm/pull/3084)).
 - [BREAKING] Updated the Miden crypto stack to `miden-crypto` 0.25, and switched SMT leaf hashing to use Poseidon2 domain separation so masm-side leaf digests match `SmtLeaf::hash()` ([#3095](https://github.com/0xMiden/miden-vm/pull/3095)).
+- Follow-up refactoring + couple perf improvements on trace generation ([#2953](https://github.com/0xMiden/miden-vm/pull/2953)).
+
 
 ## 0.22.1
 

--- a/air/src/trace/main_trace.rs
+++ b/air/src/trace/main_trace.rs
@@ -12,8 +12,8 @@ use miden_core::{
 
 use super::{
     CHIPLETS_OFFSET, CHIPLETS_WIDTH, CLK_COL_IDX, CTX_COL_IDX, DECODER_TRACE_OFFSET,
-    DECODER_TRACE_WIDTH, FN_HASH_OFFSET, PADDED_TRACE_WIDTH, RANGE_CHECK_TRACE_OFFSET,
-    RANGE_CHECK_TRACE_WIDTH, RowIndex, STACK_TRACE_OFFSET, STACK_TRACE_WIDTH,
+    DECODER_TRACE_WIDTH, FN_HASH_OFFSET, RANGE_CHECK_TRACE_OFFSET, RANGE_CHECK_TRACE_WIDTH,
+    RowIndex, STACK_TRACE_OFFSET, STACK_TRACE_WIDTH, TRACE_WIDTH,
     chiplets::{
         BITWISE_A_COL_IDX, BITWISE_B_COL_IDX, BITWISE_OUTPUT_COL_IDX, HASHER_DIRECTION_BIT_COL_IDX,
         HASHER_IS_BOUNDARY_COL_IDX, HASHER_MRUPDATE_ID_COL_IDX, HASHER_NODE_INDEX_COL_IDX,
@@ -181,7 +181,7 @@ impl MainTrace {
                 num_rows,
             } => {
                 assert!(r < *num_rows, "main trace row index in bounds");
-                assert!(col < PADDED_TRACE_WIDTH, "main trace column index in bounds");
+                assert!(col < TRACE_WIDTH, "main trace column index in bounds");
 
                 if col < CORE_WIDTH {
                     core_rm[r * CORE_WIDTH + col]
@@ -215,7 +215,7 @@ impl MainTrace {
     #[inline]
     pub fn width(&self) -> usize {
         match &self.storage {
-            TraceStorage::Parts { .. } => PADDED_TRACE_WIDTH,
+            TraceStorage::Parts { .. } => TRACE_WIDTH,
             TraceStorage::RowMajor(matrix) => matrix.width(),
             TraceStorage::Transposed { num_cols, .. } => *num_cols,
         }
@@ -233,9 +233,8 @@ impl MainTrace {
                 num_rows,
             } => {
                 let h = *num_rows;
-                let w = PADDED_TRACE_WIDTH;
+                let w = TRACE_WIDTH;
                 let cw = CHIPLETS_WIDTH;
-                let num_pad = PADDED_TRACE_WIDTH - CORE_WIDTH - 2 - cw;
 
                 let total = h * w;
                 let mut data = Vec::with_capacity(total);
@@ -256,9 +255,6 @@ impl MainTrace {
                         dst[CORE_WIDTH + 1] = range_checker_cols[1][row];
                         dst[CORE_WIDTH + 2..CORE_WIDTH + 2 + cw]
                             .copy_from_slice(&chiplets_rm[row * cw..(row + 1) * cw]);
-                        for p in 0..num_pad {
-                            dst[CORE_WIDTH + 2 + cw + p] = ZERO;
-                        }
                     }
                 };
 
@@ -277,133 +273,6 @@ impl MainTrace {
                 }
 
                 RowMajorMatrix::new(data, w)
-            },
-        }
-    }
-
-    /// Like [`to_row_major`](Self::to_row_major) but only the first `target_width` columns.
-    pub fn to_row_major_stripped(&self, target_width: usize) -> RowMajorMatrix<Felt> {
-        match &self.storage {
-            TraceStorage::RowMajor(matrix) => {
-                let h = matrix.height();
-                let w = matrix.width();
-                debug_assert!(target_width <= w);
-                if target_width == w {
-                    return matrix.clone();
-                }
-                let total = h * target_width;
-                let mut data = Vec::with_capacity(total);
-                // SAFETY: the loop below writes exactly `h * target_width` elements.
-                #[allow(clippy::uninit_vec)]
-                unsafe {
-                    data.set_len(total);
-                }
-
-                #[cfg(not(feature = "concurrent"))]
-                for row in 0..h {
-                    let src = matrix.row_slice(row).expect("row index in bounds");
-                    data[row * target_width..(row + 1) * target_width]
-                        .copy_from_slice(&src[..target_width]);
-                }
-
-                #[cfg(feature = "concurrent")]
-                {
-                    use miden_crypto::parallel::*;
-                    let rows_per_chunk = ROW_MAJOR_CHUNK_SIZE;
-                    data.par_chunks_mut(rows_per_chunk * target_width).enumerate().for_each(
-                        |(chunk_idx, chunk)| {
-                            let chunk_rows = chunk.len() / target_width;
-                            for i in 0..chunk_rows {
-                                let row = chunk_idx * rows_per_chunk + i;
-                                let src = matrix.row_slice(row).expect("row index in bounds");
-                                chunk[i * target_width..(i + 1) * target_width]
-                                    .copy_from_slice(&src[..target_width]);
-                            }
-                        },
-                    );
-                }
-
-                RowMajorMatrix::new(data, target_width)
-            },
-            TraceStorage::Transposed { .. } => {
-                let full = self.to_row_major();
-                if target_width == full.width() {
-                    return full;
-                }
-                let h = full.height();
-                let total = h * target_width;
-                let mut data = Vec::with_capacity(total);
-                // SAFETY: the loop below writes exactly `h * target_width` elements.
-                #[allow(clippy::uninit_vec)]
-                unsafe {
-                    data.set_len(total);
-                }
-                for row in 0..h {
-                    let src = full.row_slice(row).expect("row index in bounds");
-                    data[row * target_width..(row + 1) * target_width]
-                        .copy_from_slice(&src[..target_width]);
-                }
-                RowMajorMatrix::new(data, target_width)
-            },
-            TraceStorage::Parts {
-                core_rm,
-                chiplets_rm,
-                range_checker_cols,
-                num_rows,
-            } => {
-                let h = *num_rows;
-                let cw = CHIPLETS_WIDTH;
-                debug_assert!(target_width >= CORE_WIDTH);
-                let nc_needed = target_width - CORE_WIDTH;
-
-                let total = h * target_width;
-                let mut data = Vec::with_capacity(total);
-                // SAFETY: the loop below writes exactly `h * target_width` elements.
-                #[allow(clippy::uninit_vec)]
-                unsafe {
-                    data.set_len(total);
-                }
-
-                let fill_rows = |chunk: &mut [Felt], start_row: usize| {
-                    let chunk_rows = chunk.len() / target_width;
-                    for i in 0..chunk_rows {
-                        let row = start_row + i;
-                        let dst = &mut chunk[i * target_width..(i + 1) * target_width];
-                        dst[..CORE_WIDTH]
-                            .copy_from_slice(&core_rm[row * CORE_WIDTH..(row + 1) * CORE_WIDTH]);
-                        let nc_dst = &mut dst[CORE_WIDTH..];
-                        let mut nc_pos = 0;
-                        for col in &range_checker_cols[..RANGE_CHECK_TRACE_WIDTH.min(nc_needed)] {
-                            nc_dst[nc_pos] = col[row];
-                            nc_pos += 1;
-                        }
-                        if nc_pos < nc_needed {
-                            let chip_cols = (nc_needed - nc_pos).min(cw);
-                            nc_dst[nc_pos..nc_pos + chip_cols]
-                                .copy_from_slice(&chiplets_rm[row * cw..row * cw + chip_cols]);
-                            nc_pos += chip_cols;
-                        }
-                        for dst in &mut dst[nc_pos..nc_needed] {
-                            *dst = ZERO;
-                        }
-                    }
-                };
-
-                #[cfg(not(feature = "concurrent"))]
-                fill_rows(&mut data, 0);
-
-                #[cfg(feature = "concurrent")]
-                {
-                    use miden_crypto::parallel::*;
-                    let rows_per_chunk = ROW_MAJOR_CHUNK_SIZE;
-                    data.par_chunks_mut(rows_per_chunk * target_width).enumerate().for_each(
-                        |(chunk_idx, chunk)| {
-                            fill_rows(chunk, chunk_idx * rows_per_chunk);
-                        },
-                    );
-                }
-
-                RowMajorMatrix::new(data, target_width)
             },
         }
     }

--- a/air/src/trace/main_trace.rs
+++ b/air/src/trace/main_trace.rs
@@ -189,10 +189,8 @@ impl MainTrace {
                     let nc = col - CORE_WIDTH;
                     if nc < RANGE_CHECK_TRACE_WIDTH {
                         range_checker_cols[nc][r]
-                    } else if nc < RANGE_CHECK_TRACE_WIDTH + CHIPLETS_WIDTH {
-                        chiplets_rm[r * CHIPLETS_WIDTH + (nc - RANGE_CHECK_TRACE_WIDTH)]
                     } else {
-                        ZERO
+                        chiplets_rm[r * CHIPLETS_WIDTH + (nc - RANGE_CHECK_TRACE_WIDTH)]
                     }
                 }
             },
@@ -308,9 +306,6 @@ impl MainTrace {
                 row[CORE_WIDTH + 2..CORE_WIDTH + 2 + CHIPLETS_WIDTH].copy_from_slice(
                     &chiplets_rm[row_idx * CHIPLETS_WIDTH..(row_idx + 1) * CHIPLETS_WIDTH],
                 );
-                for dst in &mut row[CORE_WIDTH + 2 + CHIPLETS_WIDTH..w] {
-                    *dst = ZERO;
-                }
             },
             TraceStorage::Transposed { matrix, num_cols, .. } => {
                 for (col_idx, cell) in row[..*num_cols].iter_mut().enumerate() {
@@ -327,17 +322,16 @@ impl MainTrace {
             TraceStorage::Parts {
                 core_rm, chiplets_rm, range_checker_cols, ..
             } => {
+                assert!(col_idx < TRACE_WIDTH, "main trace column index in bounds");
                 if col_idx < CORE_WIDTH {
                     (0..h).map(|r| core_rm[r * CORE_WIDTH + col_idx]).collect()
                 } else {
                     let nc = col_idx - CORE_WIDTH;
-                    if nc < 2 {
+                    if nc < RANGE_CHECK_TRACE_WIDTH {
                         range_checker_cols[nc].clone()
-                    } else if nc < 2 + CHIPLETS_WIDTH {
-                        let cc = nc - 2;
-                        (0..h).map(|r| chiplets_rm[r * CHIPLETS_WIDTH + cc]).collect()
                     } else {
-                        vec![ZERO; h]
+                        let cc = nc - RANGE_CHECK_TRACE_WIDTH;
+                        (0..h).map(|r| chiplets_rm[r * CHIPLETS_WIDTH + cc]).collect()
                     }
                 }
             },

--- a/air/src/trace/mod.rs
+++ b/air/src/trace/mod.rs
@@ -1,6 +1,5 @@
 use core::ops::Range;
 
-use chiplets::hasher::RATE_LEN;
 use miden_core::utils::range;
 
 pub mod chiplets;
@@ -120,7 +119,6 @@ pub const CHIPLET_S3_COL_IDX: usize = CHIPLET_SELECTORS_RANGE.start + 3;
 pub const CHIPLET_S4_COL_IDX: usize = CHIPLET_SELECTORS_RANGE.start + 4;
 
 pub const TRACE_WIDTH: usize = CHIPLETS_OFFSET + CHIPLETS_WIDTH;
-pub const PADDED_TRACE_WIDTH: usize = TRACE_WIDTH.next_multiple_of(RATE_LEN);
 
 // AUXILIARY COLUMNS LAYOUT
 // ------------------------------------------------------------------------------------------------

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -5,7 +5,7 @@ use core::ops::Range;
 use miden_air::{
     AirWitness, ProcessorAir, PublicInputs, debug,
     trace::{
-        DECODER_TRACE_OFFSET, MainTrace, PADDED_TRACE_WIDTH, TRACE_WIDTH,
+        DECODER_TRACE_OFFSET, MainTrace, TRACE_WIDTH,
         decoder::{NUM_USER_OP_HELPERS, USER_OP_HELPERS_OFFSET},
     },
 };
@@ -16,7 +16,7 @@ use crate::{
     fast::ExecutionOutput,
     field::QuadFelt,
     precompile::{PrecompileRequest, PrecompileTranscript, PrecompileTranscriptDigest},
-    utils::RowMajorMatrix,
+    utils::{Matrix, RowMajorMatrix},
 };
 
 pub(crate) mod utils;
@@ -350,19 +350,10 @@ impl ExecutionTrace {
     }
 
     /// Returns the main trace as a row-major matrix for proving.
-    ///
-    /// Only includes the first [`TRACE_WIDTH`] columns (excluding padding columns added for
-    /// Poseidon2 rate alignment), which is the width expected by the AIR.
-    // TODO: the padding columns can be removed once we use the lifted-stark's virtual trace
-    // alignment, which pads to the required rate width without materializing extra columns.
     pub fn to_row_major_matrix(&self) -> RowMajorMatrix<Felt> {
-        let stored_w = self.main_trace.width();
-        if stored_w == TRACE_WIDTH {
-            return self.main_trace.to_row_major();
-        }
-
-        assert_eq!(stored_w, PADDED_TRACE_WIDTH);
-        self.main_trace.to_row_major_stripped(TRACE_WIDTH)
+        let row_major = self.main_trace.to_row_major();
+        debug_assert_eq!(row_major.width(), TRACE_WIDTH);
+        row_major
     }
 
     // HELPER METHODS
@@ -377,15 +368,10 @@ impl ExecutionTrace {
     // --------------------------------------------------------------------------------------------
     #[cfg(feature = "std")]
     pub fn print(&self) {
-        use miden_air::trace::TRACE_WIDTH;
-
-        let mut row = [ZERO; PADDED_TRACE_WIDTH];
+        let mut row = [ZERO; TRACE_WIDTH];
         for i in 0..self.length() {
             self.main_trace.read_row_into(i, &mut row);
-            std::println!(
-                "{:?}",
-                row.iter().take(TRACE_WIDTH).map(Felt::as_canonical_u64).collect::<Vec<_>>()
-            );
+            std::println!("{:?}", row.map(|v| v.as_canonical_u64()));
         }
     }
 

--- a/processor/src/trace/parallel/mod.rs
+++ b/processor/src/trace/parallel/mod.rs
@@ -649,11 +649,15 @@ fn pad_core_row_major(core_trace_data: &mut Vec<Felt>, main_trace_len: usize) {
 
     // Pad CLK trace - fill with index values
 
-    core_trace_data.reserve(num_padding_rows * w);
-    for idx in 0..num_padding_rows {
-        template[CLK_COL_IDX] = Felt::from_u32((total_program_rows + idx) as u32);
-        core_trace_data.extend_from_slice(&template);
-    }
+    let pad_start = total_program_rows * w;
+    core_trace_data.resize(pad_start + num_padding_rows * w, ZERO);
+    core_trace_data[pad_start..]
+        .par_chunks_mut(w)
+        .enumerate()
+        .for_each(|(idx, row)| {
+            row.copy_from_slice(&template);
+            row[CLK_COL_IDX] = Felt::from_u32((total_program_rows + idx) as u32);
+        });
 }
 
 /// Uses the provided `CoreTraceFragmentContext` to build and return a `ReplayProcessor` and

--- a/processor/src/trace/range/mod.rs
+++ b/processor/src/trace/range/mod.rs
@@ -96,7 +96,7 @@ impl RangeChecker {
         // }
         self.cycle_lookups
             .entry(clk)
-            .and_modify(|entry| entry.append(&mut values.to_vec()))
+            .and_modify(|entry| entry.extend_from_slice(values))
             .or_insert_with(|| values.to_vec());
     }
 


### PR DESCRIPTION
## Describe your changes

Follow-up of #2937, consisting in:

- making `chiplets` and `core` traces `RowMajorMatrix`
- remove binary search for `last_program_row`
- precomputing the transposed main trace for aux builder
- parallelize trace row padding
- remove padding column
- some couple other tweaks

### Performance

Output of 
```bash
$ make exec-info
$ MIDEN_LOG=info ./target/optimized/miden-vm prove ./miden-vm/masm-examples/hashing/blake3_1to1/blake3_1to1.masm --release
 ```
 
 averaged over 5 runs, against `next` and this branch:

| Step | `next` | this branch | delta | Note |
|--------|--------|--------|--------|------|
| `build_trace` | 90.3 ms | 86.8 ms | -3.5 ms | _mostly from padding change_ |
| `to_row_major_matrix` | 18.4 ms | 17.6 ms | -0.8 ms | _noise_ |
| `build_aux_trace` | 155 ms | 124 ms | -31 ms | _mostly from precomputed transpose_ |
| total trace gen. | 263.7 ms | 228.4 ms | -35.3 ms (-13.4%) |

Fixes #2847