### PR TITLE
refactor(assembly): remove push.a.b.c.d dot-delimited syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [BREAKING] Removed the deprecated unbound `TraceBuildInputs::new()` and `TraceBuildInputs::from_program()` constructors; use `execute_trace_inputs_sync()` or `execute_trace_inputs()` instead ([#2865](https://github.com/0xMiden/miden-vm/pull/2865)).
 - Added `prove_from_trace_sync(...)` for proving from pre-executed trace inputs ([#2865](https://github.com/0xMiden/miden-vm/pull/2865)).
 - Refactor trace generation to row-major format ([#2937](https://github.com/0xMiden/miden-vm/pull/2937)).
+- [BREAKING] Removed the `push.a.b.c.d` dot-delimited multi-value push syntax; use individual `push` instructions or word literals instead ([#2572](https://github.com/0xMiden/miden-vm/issues/2572)).
 
 ## 0.22.0 (2025-03-18)
 

--- a/crates/assembly-syntax/src/ast/instruction/print.rs
+++ b/crates/assembly-syntax/src/ast/instruction/print.rs
@@ -364,14 +364,12 @@ fn inst_with_felt_imm(name: &'static str, imm: &Immediate<crate::Felt>) -> Docum
 fn inst_with_pretty_felt_params(inst: &'static str, params: &[crate::Felt]) -> Document {
     use crate::prettier::*;
 
-    let single_line = text(inst)
-        + const_text(".")
-        + params
-            .iter()
-            .copied()
-            .map(display)
-            .reduce(|acc, doc| acc + const_text(".") + doc)
-            .unwrap_or_default();
+    let single_line = params
+        .iter()
+        .copied()
+        .map(|v| text(inst) + const_text(".") + display(v))
+        .reduce(|acc, doc| acc + const_text(" ") + doc)
+        .unwrap_or_default();
 
     let multi_line = params
         .iter()
@@ -410,7 +408,7 @@ mod tests {
             "{}",
             Instruction::PushFeltList(vec![Felt::new(3), Felt::new(4), Felt::new(8), Felt::new(9)])
         );
-        assert_eq!("push.3.4.8.9", instruction);
+        assert_eq!("push.3 push.4 push.8 push.9", instruction);
         let instruction = format!(
             "{}",
             Instruction::Push(Immediate::Value(miden_debug_types::Span::unknown(

--- a/crates/assembly-syntax/src/ast/tests.rs
+++ b/crates/assembly-syntax/src/ast/tests.rs
@@ -494,11 +494,11 @@ fn test_ast_parsing_program_push() -> Result<(), Report> {
         r#"
     begin
         push.10 push.500 push.70000 push.5000000000
-        push.5000000000.7000000000.9000000000.11000000000
-        push.5.7
-        push.500.700
-        push.70000.90000
-        push.5000000000.7000000000
+        push.5000000000 push.7000000000 push.9000000000 push.11000000000
+        push.5 push.7
+        push.500 push.700
+        push.70000 push.90000
+        push.5000000000 push.7000000000
 
         push.0x0000000000000000010000000000000002000000000000000300000000000000
     end"#
@@ -1266,7 +1266,7 @@ fn assert_parsing_line_unmatched_begin() {
         &context,
         "\
         begin
-          push.1.2
+          push.1 push.2
 
         add
         mul"
@@ -1315,7 +1315,7 @@ fn assert_parsing_line_invalid_op() {
     begin
         repeat.3
             push.1
-            push.0.1
+            push.0 push.1
         end
 
         # some comments
@@ -1331,7 +1331,7 @@ fn assert_parsing_line_invalid_op() {
         # to test if line is correct
 
         while.true
-            push.5.7
+            push.5 push.7
             u32wrapping_add
             loc_store.4
             push.0
@@ -1354,7 +1354,7 @@ fn assert_parsing_line_invalid_op() {
         "   :                     `-- found a identifier here",
         "29 |         end",
         "   `----",
-        r#" help: expected ".", or primitive opcode (e.g. "add"), or "end", or control flow opcode (e.g. "if.true")"#
+        r#" help: expected primitive opcode (e.g. "add"), or "end", or control flow opcode (e.g. "if.true")"#
     );
 }
 
@@ -1414,7 +1414,7 @@ proc add_n_times # [n, b, a]
     push.0
     u32gt
     if.true
-        push.0.1
+        push.0 push.1
         while.true  # [total, n, b, a]
             dup.3 dup.3
             u32wrapping_add3 # [total', n, b, a]
@@ -1434,7 +1434,7 @@ proc add_n_times # [n, b, a]
 end
 
 begin
-    push.1.1.DEFAULT_CONST
+    push.1 push.1 push.DEFAULT_CONST
     exec.add_n_times
     push.20
     assert_eq
@@ -1514,10 +1514,10 @@ const A = 0x0200000000000000030000000000000004000000000000000500000000000000
 const B = [2,3,4,5]
 begin
     push.0x0200000000000000030000000000000004000000000000000500000000000000
-    push.A.6
-    push.B.6
-    push.2.3.4.5
-    push.A.B
+    push.A push.6
+    push.B push.6
+    push.2 push.3 push.4 push.5
+    push.A push.B
 end
 ";
 

--- a/crates/assembly-syntax/src/parser/error.rs
+++ b/crates/assembly-syntax/src/parser/error.rs
@@ -247,16 +247,6 @@ pub enum ParsingError {
         #[label]
         span: SourceSpan,
     },
-    #[error(
-        "too many operands for `push`: tried to push {} elements, but only 16 can be pushed at one time",
-        count
-    )]
-    #[diagnostic()]
-    PushOverflow {
-        #[label]
-        span: SourceSpan,
-        count: usize,
-    },
     #[error("expected a fully-qualified module path, e.g. `std::u64`")]
     UnqualifiedImport {
         #[label]
@@ -390,7 +380,6 @@ impl PartialEq for ParsingError {
                 Self::ImmediateOutOfRange { range: l, .. },
                 Self::ImmediateOutOfRange { range: r, .. },
             ) => l == r,
-            (Self::PushOverflow { count: l, .. }, Self::PushOverflow { count: r, .. }) => l == r,
             (
                 Self::UnrecognizedToken { token: ltok, expected: lexpect, .. },
                 Self::UnrecognizedToken { token: rtok, expected: rexpect, .. },

--- a/crates/assembly-syntax/src/parser/grammar.lalrpop
+++ b/crates/assembly-syntax/src/parser/grammar.lalrpop
@@ -285,14 +285,6 @@ CommaDelimitedAllowTrailing<T>: Vec<T> = {
     }
 };
 
-// dot-delimited with at least one element
-#[inline]
-DotDelimited<T>: Vec<T> = {
-    <mut v:(<T> ".")*> <e:T> => {
-        v.push(e);
-        v
-    }
-};
 
 
 // TOP-LEVEL FORMS
@@ -1712,25 +1704,14 @@ Push: SmallOpsVec = {
         ))]
     },
 
-    <l:@L> "push" "." <values:DotDelimited<IntOrHexImm>> <r:@R> =>? {
-        let ops = values.into_iter().enumerate().map(|(i, imm)| {
-            let span = imm.span();
-            // Include the "push" token in the first item's span
-            let span = if i == 0 {
-                span!(source_id, l, span.end().to_u32())
-            } else {
-                span
-            };
-            Op::Inst(Span::new(span, match imm {
+    <l:@L> "push" "." <imm:IntOrHexImm> <r:@R> => {
+        smallvec![Op::Inst(Span::new(
+            span!(source_id, l, r),
+            match imm {
                 Immediate::Constant(name) => Instruction::Push(Immediate::Constant(name)),
                 Immediate::Value(value) => Instruction::Push(Immediate::Value(value.map(PushValue::Int)))
-            }))
-        }).collect::<SmallOpsVec>();
-        if ops.len() > 16 {
-            Err(ParseError::User { error: ParsingError::PushOverflow { span: span!(source_id, l, r), count: ops.len() } })
-        } else {
-            Ok(ops)
-        }
+            }
+        ))]
     }
 }
 

--- a/crates/assembly/README.md
+++ b/crates/assembly/README.md
@@ -91,8 +91,8 @@ the library, as shown next:
 use core::math::u64
 
 begin
-    push.1.0
-    push.2.0
+    push.1 push.0
+    push.2 push.0
     exec.u64::wrapping_add
 end
 ```
@@ -196,7 +196,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Assemble our program
     let program = assembler.assemble_program("
 begin
-    push.1.2
+    push.1 push.2
     syscall.foo
 end
 ")?;

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -440,11 +440,11 @@ fn get_proc_digest_by_name() -> Result<(), Report> {
 
     let testing_module_source = "
         pub proc foo
-            push.1.2 add drop
+            push.1 push.2 add drop
         end
 
         pub proc bar
-            push.5.6 sub drop
+            push.5 push.6 sub drop
         end
     ";
     let testing_module = parse_module!(&context, "test::names", testing_module_source);
@@ -503,11 +503,11 @@ fn simple_main_call() -> TestResult {
             &context,
             "\
         pub proc account_method_1
-            push.2.1 add
+            push.2 push.1 add
         end
 
         pub proc account_method_2
-            push.3.1 sub
+            push.3 push.1 sub
         end
         "
         ),
@@ -552,11 +552,11 @@ fn call_without_path() -> TestResult {
             &context,
             "\
     pub proc account_method_1
-        push.2.1 add
+        push.2 push.1 add
     end
 
     pub proc account_method_2
-        push.3.1 sub
+        push.3 push.1 sub
     end
     "
         ),
@@ -571,11 +571,11 @@ fn call_without_path() -> TestResult {
             &context,
             "\
     pub proc account_method_1
-        push.2.2 add
+        push.2 push.2 add
     end
 
     pub proc account_method_2
-        push.4.1 sub
+        push.4 push.1 sub
     end
     "
         ),
@@ -618,11 +618,11 @@ fn procref_call() -> TestResult {
             &context,
             "
         pub proc aaa
-            push.7.8
+            push.7 push.8
         end
 
         pub proc foo
-            push.1.2
+            push.1 push.2
         end"
         ),
     )?;
@@ -650,7 +650,7 @@ fn procref_call() -> TestResult {
 
         @locals(4)
         proc baz
-            push.3.4
+            push.3 push.4
         end
 
         begin
@@ -854,7 +854,7 @@ fn multiple_constants_push() -> TestResult {
         "const CONSTANT_1 = 21 \
     const CONSTANT_2 = 44 \
     begin \
-    push.CONSTANT_1.64.CONSTANT_2.72 \
+    push.CONSTANT_1 push.64 push.CONSTANT_2 push.72 \
     end"
     );
     let program = context.assemble(source)?;
@@ -2929,8 +2929,8 @@ fn module_alias() -> TestResult {
         use dummy::math::u64->bigint
 
         begin
-            push.1.0
-            push.2.0
+            push.1 push.0
+            push.2 push.0
             exec.bigint::checked_add
         end"
     );
@@ -2945,8 +2945,8 @@ fn module_alias() -> TestResult {
         use dummy::math::u64->bigint->invalidname
 
         begin
-            push.1.0
-            push.2.0
+            push.1 push.0
+            push.2 push.0
             exec.bigint->invalidname::checked_add
         end"
     );
@@ -3001,8 +3001,8 @@ fn module_alias_unused_import() -> TestResult {
         use dummy::math::u64->bigint
 
         begin
-            push.1.0
-            push.2.0
+            push.1 push.0
+            push.2 push.0
             exec.bigint::checked_add
         end"
     );
@@ -3035,8 +3035,8 @@ fn module_alias_unused_import() -> TestResult {
         use dummy::math::u64->bigint2
 
         begin
-            push.1.0
-            push.2.0
+            push.1 push.0
+            push.2 push.0
             exec.bigint::checked_add
             exec.bigint2::checked_add
         end"
@@ -4037,7 +4037,7 @@ fn test_reexported_proc_with_same_name_as_local_proc_diff_locals() {
 fn test_program_serde_simple() {
     let source = "
     begin
-        push.1.2
+        push.1 push.2
         add
         drop
     end
@@ -4060,7 +4060,7 @@ fn test_program_serde_with_decorators() {
     const EVENT_CONST = event(\"serde::evt\")
 
     proc foo
-        push.1.2 add
+        push.1 push.2 add
         debug.stack.8
     end
 
@@ -4329,7 +4329,7 @@ fn build_library_example() -> Arc<Library> {
 fn build_program_example() -> Arc<Program> {
     let source = "
     begin
-        push.1.2
+        push.1 push.2
         add
         drop
     end

--- a/crates/lib/core/asm/collections/smt.masm
+++ b/crates/lib/core/asm/collections/smt.masm
@@ -293,7 +293,7 @@ proc get_multi_leaf_value
         # => [val_ptr, x, x, R]
 
         # (2 cycles)
-        push.0.0
+        push.0 push.0
         # => [x, x, key_ptr, x, x, R]
 
         # (1 cycle)

--- a/crates/lib/core/asm/crypto/dsa/ecdsa_k256_keccak.masm
+++ b/crates/lib/core/asm/crypto/dsa/ecdsa_k256_keccak.masm
@@ -191,6 +191,6 @@ pub proc verify_prehash_impl
 
     # Create TAG = [ECDSA_VERIFY_EVENT, result, 0, 0] on stack
     # Stack positions 4-7 should have [event_id, result, 0, 0] for get_stack_word(4)
-    push.0.0 dup.6 push.ECDSA_VERIFY_EVENT swapw
+    push.0 push.0 dup.6 push.ECDSA_VERIFY_EVENT swapw
     # => [COMM, TAG, result]
 end

--- a/crates/lib/core/asm/crypto/dsa/eddsa_ed25519.masm
+++ b/crates/lib/core/asm/crypto/dsa/eddsa_ed25519.masm
@@ -257,6 +257,6 @@ pub proc verify_prehash_impl
 
     # Create TAG = [EDDSA_VERIFY_EVENT, result, 0, 0] on stack
     # Stack positions 4-7 should have [event_id, result, 0, 0] for get_stack_word(4)
-    push.0.0 dup.6 push.EDDSA_VERIFY_EVENT swapw
+    push.0 push.0 dup.6 push.EDDSA_VERIFY_EVENT swapw
     # => [COMM, TAG, result]
 end

--- a/crates/lib/core/asm/crypto/dsa/falcon512_poseidon2.masm
+++ b/crates/lib/core/asm/crypto/dsa/falcon512_poseidon2.masm
@@ -168,7 +168,7 @@ pub proc load_h_s2_and_product
     # 1) Set up the stack for loading the coefficients of the polynomials, evaluating and hashing them
 
     ## a) Set up the accumulator for `horner_eval_base` and the memory pointers
-    push.0.0
+    push.0 push.0
     locaddr.4
     movup.3
     # => [ptr, tau_inv_ptr, 0, 0, PK, ...]

--- a/crates/lib/core/asm/crypto/hashes/blake3.masm
+++ b/crates/lib/core/asm/crypto/hashes/blake3.masm
@@ -15,19 +15,19 @@
 #!
 #! Functionally this routine is equivalent to https://github.com/itzmeanjan/blake3/blob/f07d32e/include/blake3.hpp#!L1709-L1713
 proc initialize_2to1
-    push.0xA54FF53A.0x3C6EF372.0xBB67AE85.0x6A09E667
+    push.0xA54FF53A push.0x3C6EF372 push.0xBB67AE85 push.0x6A09E667
     movup.4
     mem_storew_be
     movup.5
     mem_storew_be
     dropw
 
-    push.0x5BE0CD19.0x1F83D9AB.0x9B05688C.0x510E527F
+    push.0x5BE0CD19 push.0x1F83D9AB push.0x9B05688C push.0x510E527F
     movup.4
     mem_storew_be
     dropw
 
-    push.11.64.0.0
+    push.11 push.64 push.0 push.0
     movup.4
     mem_storew_be
     dropw
@@ -51,19 +51,19 @@ end
 #! Functionally this routine is equivalent to https://github.com/itzmeanjan/blake3/blob/f07d32e/include/blake3.hpp#!L1709-L1713
 #! with only difference being value of BLOCK_LEN = 32
 proc initialize_1to1
-    push.0xA54FF53A.0x3C6EF372.0xBB67AE85.0x6A09E667
+    push.0xA54FF53A push.0x3C6EF372 push.0xBB67AE85 push.0x6A09E667
     movup.4
     mem_storew_be
     movup.5
     mem_storew_be
     dropw
 
-    push.0x5BE0CD19.0x1F83D9AB.0x9B05688C.0x510E527F
+    push.0x5BE0CD19 push.0x1F83D9AB push.0x9B05688C push.0x510E527F
     movup.4
     mem_storew_be
     dropw
 
-    push.11.32.0.0
+    push.11 push.32 push.0 push.0
     movup.4
     mem_storew_be
     dropw

--- a/crates/lib/core/asm/crypto/hashes/keccak256.masm
+++ b/crates/lib/core/asm/crypto/hashes/keccak256.masm
@@ -129,7 +129,7 @@ pub proc hash_bytes_impl
     # => [COMM, len_bytes, ...]
 
     # Prepare TAG = [KECCAK_HASH_BYTES_EVENT, len_bytes, 0, 0]
-    push.0.0 movup.6 push.KECCAK_HASH_BYTES_EVENT swapw
+    push.0 push.0 movup.6 push.KECCAK_HASH_BYTES_EVENT swapw
     # => [COMM, TAG, ...]
 
     # Reload digest limbs from locals

--- a/crates/lib/core/asm/crypto/hashes/poseidon2.masm
+++ b/crates/lib/core/asm/crypto/hashes/poseidon2.masm
@@ -139,7 +139,7 @@ pub proc hash_words
     # => [start_addr, end_addr, is_odd, ...]
 
     # prepare hasher state (14 cycles)
-    dup.2 mul.4 push.0.0.0 movup.3 padw padw
+    dup.2 mul.4 push.0 push.0 push.0 movup.3 padw padw
     # => [R0, R1, C, start_addr, end_addr, is_odd, ...]
 
     # (4 + 3 * words cycles)
@@ -216,7 +216,7 @@ pub proc prepare_hasher_state
     # => [capacity, ptr, end_pairs_addr, num_elements%8]
 
     # prepare hasher state for Poseidon2 permutation
-    push.0.0.0 movup.3 padw padw
+    push.0 push.0 push.0 movup.3 padw padw
     # => [R0, R1, C, ptr, end_pairs_addr, num_elements%8]
 end
 

--- a/crates/lib/core/asm/crypto/hashes/sha256.masm
+++ b/crates/lib/core/asm/crypto/hashes/sha256.masm
@@ -1521,8 +1521,8 @@ end
 #!
 #! SHA256 digest is represented in terms of eight 32 -bit words ( big endian byte order ).
 pub proc merge
-    push.0x5be0cd19.0x1f83d9ab.0x9b05688c.0x510e527f
-    push.0xa54ff53a.0x3c6ef372.0xbb67ae85.0x6a09e667
+    push.0x5be0cd19 push.0x1f83d9ab push.0x9b05688c push.0x510e527f
+    push.0xa54ff53a push.0x3c6ef372 push.0xbb67ae85 push.0x6a09e667
 
     exec.prepare_message_schedule_and_consume
     exec.consume_padding_message_schedule
@@ -1545,11 +1545,11 @@ end
 pub proc hash
     # apply padding, see padding rule in section 5.1.1 of
     # https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
-    push.256.0.0.0.0.0.0.2147483648
+    push.256 push.0 push.0 push.0 push.0 push.0 push.0 push.2147483648
     swapdw
 
-    push.0x5be0cd19.0x1f83d9ab.0x9b05688c.0x510e527f
-    push.0xa54ff53a.0x3c6ef372.0xbb67ae85.0x6a09e667
+    push.0x5be0cd19 push.0x1f83d9ab push.0x9b05688c push.0x510e527f
+    push.0xa54ff53a push.0x3c6ef372 push.0xbb67ae85 push.0x6a09e667
 
     exec.prepare_message_schedule_and_consume
 end
@@ -1605,8 +1605,8 @@ pub proc hash_bytes
     loc_load.12 mem_storew_be dropw
 
     # Sha256 init
-    push.0x5be0cd19.0x1f83d9ab.0x9b05688c.0x510e527f
-    push.0xa54ff53a.0x3c6ef372.0xbb67ae85.0x6a09e667
+    push.0x5be0cd19 push.0x1f83d9ab push.0x9b05688c push.0x510e527f
+    push.0xa54ff53a push.0x3c6ef372 push.0xbb67ae85 push.0x6a09e667
 
     # Consume sha256 blocks
     loc_load.28 u32assert neq.0

--- a/crates/lib/core/asm/crypto/hashes/sha512.masm
+++ b/crates/lib/core/asm/crypto/hashes/sha512.masm
@@ -73,7 +73,7 @@ pub proc hash_bytes_impl
     # => [COMM, len_bytes, ...]
 
     # Prepare TAG = [SHA512_HASH_BYTES_EVENT, len_bytes, 0, 0]
-    push.0.0 movup.6 push.SHA512_HASH_BYTES_EVENT swapw
+    push.0 push.0 movup.6 push.SHA512_HASH_BYTES_EVENT swapw
     # => [COMM, TAG, ...]
 
     # Reload digest limbs from locals

--- a/crates/lib/core/asm/mem.masm
+++ b/crates/lib/core/asm/mem.masm
@@ -167,7 +167,7 @@ pub proc pipe_words_to_memory
   # element to `len % 8` where `len` is the length of the hashed sequence. Since `len % 8`
   # is either equal to 0 or 4,  this is determined by the `needs_padding` flag multiplied
   # by 4. (7 cycles)
-  dup.2 mul.4 push.0.0.0
+  dup.2 mul.4 push.0 push.0 push.0
   movup.3
   # => [C, write_ptr, end_ptr, needs_padding, ...]
   # (C is the capacity word)

--- a/crates/lib/core/asm/pcs/fri/frie2f4.masm
+++ b/crates/lib/core/asm/pcs/fri/frie2f4.masm
@@ -225,7 +225,7 @@ pub proc verify_query_64
     # => [rem_ptr, rem_ptr, poe^(2^n), f_pos, ne0, ne1, rem_ptr, rem_ptr, x, x, x, x, x, x, x, x, ...]
 
     movup.2
-    push.0.0.0 movup.3 exec.constants::tmp2 mem_storew_le dropw
+    push.0 push.0 push.0 movup.3 exec.constants::tmp2 mem_storew_le dropw
     # => [rem_ptr, rem_ptr, f_pos, ne0, ne1, rem_ptr, rem_ptr, x, x, x, x, x, x, x, x, ...]
 
     push.0 exec.constants::tmp1 mem_loadw_le
@@ -284,7 +284,7 @@ pub proc verify_query_128
     # => [rem_ptr, rem_ptr, poe^(2^n), f_pos, ne0, ne1, rem_ptr, rem_ptr, x, x, x, x, x, x, x, x, ...]
 
     movup.2
-    push.0.0.0 movup.3 exec.constants::tmp2 mem_storew_le dropw
+    push.0 push.0 push.0 movup.3 exec.constants::tmp2 mem_storew_le dropw
     # => [rem_ptr, rem_ptr, f_pos, ne0, ne1, rem_ptr, rem_ptr, x, x, x, x, x, x, x, x, ...]
 
     push.0 exec.constants::tmp1 mem_loadw_le
@@ -349,7 +349,7 @@ proc verify_64
 
     # Save a word containing a fresh accumulator for Horner evaluating the remainder polynomial,
     # a pointer to the evaluation point and a pointer to the location of the polynomial.
-    push.0.0
+    push.0 push.0
     exec.constants::tmp2 exec.constants::get_remainder_poly_address
     exec.constants::tmp1 mem_storew_le
     movup.4
@@ -428,7 +428,7 @@ proc verify_128
 
     # Save a word containing a fresh accumulator for Horner evaluating the remainder polynomial,
     # a pointer to the evaluation point and a pointer to the location of the polynomial.
-    push.0.0
+    push.0 push.0
     exec.constants::tmp2 exec.constants::get_remainder_poly_address
     exec.constants::tmp1 mem_storew_le
     movup.4

--- a/crates/lib/core/asm/pcs/fri/helper.masm
+++ b/crates/lib/core/asm/pcs/fri/helper.masm
@@ -112,7 +112,7 @@ pub proc load_fri_layer_commitments
     # => [Y, ...] where `Y` is as "garbage" word
 
     # Address containing the first layer commitment
-    push.0.0
+    push.0 push.0
     exec.constants::fri_com_ptr
     exec.constants::get_num_fri_layers
     # => [num_layers, ptr_layer, y, y, Y, ...] where `y` are considered as "garbage" values

--- a/crates/lib/core/asm/stark/deep_queries.masm
+++ b/crates/lib/core/asm/stark/deep_queries.masm
@@ -128,7 +128,7 @@ pub proc prepare_stack_deep_queries_computation
 
     # Store pointers to alpha, memory region to store trace row for current query and a fresh
     # accumulator value i.e., (0, 0).
-    push.0.0
+    push.0 push.0
     exec.constants::deep_rand_alpha_nd_ptr
     exec.constants::current_trace_row_ptr
     exec.constants::tmp2 mem_storew_le

--- a/crates/lib/core/asm/stark/ood_frames.masm
+++ b/crates/lib/core/asm/stark/ood_frames.masm
@@ -41,7 +41,7 @@ pub proc load_and_horner_eval_ood_frames
     # => [alpha_0, alpha_1]
 
     # Save the random challenge
-    push.0.0 movup.3 movup.3
+    push.0 push.0 movup.3 movup.3
     exec.constants::deep_rand_alpha_nd_ptr mem_storew_le
     # => [Y]
 
@@ -51,7 +51,7 @@ pub proc load_and_horner_eval_ood_frames
 
     ### a) Set up the initial accumulator and the pointers to alpha and a pointer to some memory
     ###    region to which we save the OOD.
-    push.0.0
+    push.0 push.0
     exec.constants::deep_rand_alpha_nd_ptr
     exec.constants::ood_evaluations_ptr
     # => [ood_evaluations_ptr, deep_rand_alpha_ptr, 0, 0, Y]
@@ -76,13 +76,13 @@ pub proc load_and_horner_eval_ood_frames
     # => [ood_frame_ptr, alpha_ptr, acc0, acc1, Y, C, Y]
     movup.3 neg
     movup.3 neg
-    push.0.0
+    push.0 push.0
     movup.2
     movup.3
     swap.1
     exec.constants::ood_fixed_term_horner_evaluations_ptr mem_storew_le
     dropw
-    push.0.0
+    push.0 push.0
     movdn.3
     movdn.3
     # => [ood_frame_ptr, alpha_ptr, 0, 0, Y, C, Y]

--- a/crates/lib/core/asm/stark/random_coin.masm
+++ b/crates/lib/core/asm/stark/random_coin.masm
@@ -226,7 +226,7 @@ pub proc init_seed
     #    ^-- R2       ^-- C (INSTANCE_SEED)
 
     # Build R1 = [lth, 0, 0, 0] on top.
-    push.0.0.0
+    push.0 push.0 push.0
     exec.constants::get_trace_length_log
     #=> [lth, 0, 0, 0, 0, 0, 0, 0, C0, C1, C2, C3, ...]
     #    ^-- R1          ^-- R2     ^-- C (INSTANCE_SEED)
@@ -474,7 +474,7 @@ end
 pub proc generate_constraint_composition_coefficients
     # Sample alpha (constraint folding challenge).
     exec.sample_ext
-    push.0.0
+    push.0 push.0
     movup.3
     movup.3
     exec.constants::composition_coef_ptr

--- a/crates/lib/core/asm/stark/utils.masm
+++ b/crates/lib/core/asm/stark/utils.masm
@@ -136,7 +136,7 @@ pub proc set_up_auxiliary_inputs_ace
     # => [alpha0, alpha1, 0, 0, max_cycle_len_log, ...]
 
     movup.3 movup.3
-    push.0.0 exec.constants::z_ptr mem_loadw_le
+    push.0 push.0 exec.constants::z_ptr mem_loadw_le
     # => [z_n_0, z_n_1, z_0, z_1, alpha0, alpha1, max_cycle_len_log, ...]
 
     # Compute z_k = z^(N / max_cycle_len) via repeated squaring.
@@ -228,7 +228,7 @@ pub proc set_up_auxiliary_inputs_ace
     # ==================================================================
 
     # Compute s0 = offset^N
-    push.0.7
+    push.0 push.7
     exec.constants::get_trace_length
     exp.u32
     # => [s0, 0, ...]

--- a/crates/lib/core/asm/sys/vm/deep_queries.masm
+++ b/crates/lib/core/asm/sys/vm/deep_queries.masm
@@ -106,7 +106,7 @@ proc process_main_segment_execution_trace
 
     # Get commitment to main segment of the execution trace
     movdn.3 movdn.2
-    push.0.0
+    push.0 push.0
     exec.constants::main_trace_com_ptr mem_loadw_le
     #=>[MAIN_TRACE_TREE_ROOT, depth, index, query_ptr]
 

--- a/crates/lib/core/asm/sys/vm/mod.masm
+++ b/crates/lib/core/asm/sys/vm/mod.masm
@@ -91,7 +91,7 @@ pub proc verify_proof
     # --- Get constants -------------------------------------------------------
 
     # Push RELATION_DIGEST, then move log(trace_length) back to top.
-    push.RELATION_DIGEST_3.RELATION_DIGEST_2.RELATION_DIGEST_1.RELATION_DIGEST_0
+    push.RELATION_DIGEST_3 push.RELATION_DIGEST_2 push.RELATION_DIGEST_1 push.RELATION_DIGEST_0
     movup.4
     # => [log(trace_length), rd0, rd1, rd2, rd3]
 

--- a/crates/lib/core/asm/sys/vm/public_inputs.masm
+++ b/crates/lib/core/asm/sys/vm/public_inputs.masm
@@ -261,7 +261,7 @@ proc reduce_kernel_digests
     # Store number of kernel procedures digests at TMP1 as [num_ker, 0, 0, num_ker].
     # We keep only digests_ptr on the stack (dropping the counter word since we read
     # it back from TMP1 later).
-    push.0.0 dup.2
+    push.0 push.0 dup.2
     exec.constants::tmp1 mem_storew_le
     dropw
     # => [digests_ptr, ...]
@@ -287,7 +287,7 @@ proc reduce_kernel_digests
     # => [alpha0 + op_label, alpha1, beta0, beta1, digests_ptr, ...]
 
     # Push the `horner_eval_ext` accumulator
-    push.0.0
+    push.0 push.0
     # => [acc0, acc1, alpha0 + op_label, alpha1, beta0, beta1, digests_ptr, ...]
 
     # Push the pointer to the evaluation point beta
@@ -404,7 +404,7 @@ proc reduce_kernel_digests
     # Store the result at `digests_ptr` as `[prod0, prod1, 0, 0]`
     # Note that `digests_ptr` points to the group that we just reduced above and hence it is safe
     # to overwrite it with the result.
-    push.0.0
+    push.0 push.0
     movup.3
     movup.3
     # => [prod0, prod1, 0, 0, ...]

--- a/crates/lib/core/asm/word.masm
+++ b/crates/lib/core/asm/word.masm
@@ -115,7 +115,7 @@ pub proc gt(rhs: word, lhs: word) -> i1
     exec.arrange_words_adjacent_le
     # => [l_3, r_3, l_2, r_2, l_1, r_1, l_0, r_0]
 
-    push.1.0
+    push.1 push.0
     # => [is_lhs_less, continue, l_3, r_3, l_2, r_2, l_1, r_1, l_0, r_0]
 
     repeat.4
@@ -181,7 +181,7 @@ pub proc lt(rhs: word, lhs: word) -> i1
     exec.arrange_words_adjacent_le
     # => [l_3, r_3, l_2, r_2, l_1, r_1, l_0, r_0]
 
-    push.1.0
+    push.1 push.0
     # => [is_lhs_greater, continue, l_3, r_3, l_2, r_2, l_1, r_1, l_0, r_0]
 
     repeat.4

--- a/crates/lib/core/tests/collections/mmr.rs
+++ b/crates/lib/core/tests/collections/mmr.rs
@@ -496,9 +496,9 @@ fn test_mmr_pack() {
         use miden::core::collections::mmr
 
         begin
-            push.3.1000 mem_store  # num_leaves, 2 peaks
-            push.1.1004 mem_store  # peak1
-            push.2.1008 mem_store  # peak2
+            push.3 push.1000 mem_store  # num_leaves, 2 peaks
+            push.1 push.1004 mem_store  # peak1
+            push.2 push.1008 mem_store  # peak2
 
             push.1000 exec.mmr::pack
 
@@ -539,7 +539,7 @@ fn test_mmr_add_single() {
 
         begin
             push.{mmr_ptr} # the address of the mmr
-            push.4.3.2.1   # the new peak (stack order for [1,2,3,4])
+            push.4 push.3 push.2 push.1   # the new peak (stack order for [1,2,3,4])
             exec.mmr::add  # add the element
         end
     "
@@ -564,11 +564,11 @@ fn test_mmr_two() {
 
         begin
             push.{mmr_ptr} # first peak
-            push.4.3.2.1
+            push.4 push.3 push.2 push.1
             exec.mmr::add
 
             push.{mmr_ptr} # second peak
-            push.8.7.6.5
+            push.8 push.7 push.6 push.5
             exec.mmr::add
         end
     "
@@ -613,11 +613,11 @@ fn test_mmr_add_then_mtree_get() {
 
         begin
             push.{mmr_ptr}
-            push.{}.{}.{}.{}
+            push.{} push.{} push.{} push.{}
             exec.mmr::add
 
             push.{mmr_ptr}
-            push.{}.{}.{}.{}
+            push.{} push.{} push.{} push.{}
             exec.mmr::add
 
             push.{mmr_ptr}
@@ -656,13 +656,13 @@ fn test_add_mmr_large() {
         use miden::core::collections::mmr
 
         begin
-            push.{mmr_ptr}.0.0.0.1 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.2 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.3 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.4 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.5 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.6 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.7 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.1 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.2 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.3 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.4 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.5 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.6 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.7 exec.mmr::add
 
             push.{mmr_ptr} exec.mmr::pack
 
@@ -697,13 +697,13 @@ fn debug_mmr_peaks_vs_vm_memory() {
         use miden::core::collections::mmr
 
         begin
-            push.{mmr_ptr}.0.0.0.1 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.2 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.3 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.4 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.5 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.6 exec.mmr::add
-            push.{mmr_ptr}.0.0.0.7 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.1 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.2 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.3 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.4 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.5 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.6 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.7 exec.mmr::add
         end
     "
     );
@@ -785,7 +785,7 @@ fn test_mmr_large_add_roundtrip() {
 
         begin
             exec.mmr::unpack
-            push.{mmr_ptr}.0.0.0.8 exec.mmr::add
+            push.{mmr_ptr} push.0 push.0 push.0 push.8 exec.mmr::add
             push.{mmr_ptr} exec.mmr::pack
 
             swapw dropw

--- a/crates/lib/core/tests/crypto/ecdsa_k256_keccak.rs
+++ b/crates/lib/core/tests/crypto/ecdsa_k256_keccak.rs
@@ -58,7 +58,7 @@ fn test_ecdsa_verify_cases() {
                     {memory_stores}
 
                     # Call verify: [ptr_pk, ptr_digest, ptr_sig]
-                    push.{SIG_ADDR}.{DIGEST_ADDR}.{PK_ADDR}
+                    push.{SIG_ADDR} push.{DIGEST_ADDR} push.{PK_ADDR}
                     exec.ecdsa_k256_keccak::verify_prehash
                     # => [result, ...]
 
@@ -102,7 +102,7 @@ fn test_ecdsa_verify_impl_commitment() {
                 {memory_stores}
 
                 # Call verify_impl: [ptr_pk, ptr_digest, ptr_sig]
-                push.{SIG_ADDR}.{DIGEST_ADDR}.{PK_ADDR}
+                push.{SIG_ADDR} push.{DIGEST_ADDR} push.{PK_ADDR}
                 exec.ecdsa_k256_keccak::verify_prehash_impl
                 # => [COMM, TAG, result, ...]
 

--- a/crates/lib/core/tests/crypto/eddsa_ed25519.rs
+++ b/crates/lib/core/tests/crypto/eddsa_ed25519.rs
@@ -57,7 +57,7 @@ fn test_eddsa_verify_prehash_cases() {
             begin
                 {memory_stores}
 
-                push.{SIG_ADDR}.{K_DIGEST_ADDR}.{PK_ADDR}
+                push.{SIG_ADDR} push.{K_DIGEST_ADDR} push.{PK_ADDR}
                 exec.eddsa_ed25519::verify_prehash
 
                 exec.sys::truncate_stack
@@ -85,7 +85,7 @@ fn test_eddsa_verify_prehash_cases() {
             begin
                 {memory_stores}
 
-                push.{SIG_ADDR}.{K_DIGEST_ADDR}.{PK_ADDR}
+                push.{SIG_ADDR} push.{K_DIGEST_ADDR} push.{PK_ADDR}
                 exec.eddsa_ed25519::verify_prehash
 
                 exec.sys::truncate_stack
@@ -124,7 +124,7 @@ fn test_eddsa_verify_prehash_impl_commitment() {
             begin
                 {memory_stores}
 
-                push.{SIG_ADDR}.{K_DIGEST_ADDR}.{PK_ADDR}
+                push.{SIG_ADDR} push.{K_DIGEST_ADDR} push.{PK_ADDR}
                 exec.eddsa_ed25519::verify_prehash_impl
 
                 exec.sys::truncate_stack

--- a/crates/lib/core/tests/crypto/keccak256.rs
+++ b/crates/lib/core/tests/crypto/keccak256.rs
@@ -63,7 +63,7 @@ fn test_keccak_handler(input_u8: &[u8]) {
                 {memory_stores_source}
 
                 # Push handler inputs
-                push.{len_bytes}.{INPUT_MEMORY_ADDR}
+                push.{len_bytes} push.{INPUT_MEMORY_ADDR}
                 # => [ptr, len_bytes, ...]
 
                 emit.event("{KECCAK_HASH_BYTES_EVENT_NAME}")
@@ -108,7 +108,7 @@ fn test_keccak_hash_bytes_impl(input_u8: &[u8]) {
                 {memory_stores_source}
 
                 # Push wrapper inputs
-                push.{len_bytes}.{INPUT_MEMORY_ADDR}
+                push.{len_bytes} push.{INPUT_MEMORY_ADDR}
                 # => [ptr, len_bytes]
 
                 exec.keccak256::hash_bytes_impl
@@ -161,7 +161,7 @@ fn test_keccak_hash_bytes(input_u8: &[u8]) {
                 {memory_stores_source}
 
                 # Push wrapper inputs
-                push.{len_bytes}.{INPUT_MEMORY_ADDR}
+                push.{len_bytes} push.{INPUT_MEMORY_ADDR}
                 # => [ptr, len_bytes]
 
                 exec.keccak256::hash_bytes
@@ -328,7 +328,7 @@ fn run_keccak_with_max_hash_len(
         r#"
         begin
             {memory_stores}
-            push.{len_bytes_on_stack}.{INPUT_MEMORY_ADDR}
+            push.{len_bytes_on_stack} push.{INPUT_MEMORY_ADDR}
             emit.event("{KECCAK_HASH_BYTES_EVENT_NAME}")
             drop drop
         end

--- a/crates/lib/core/tests/crypto/poseidon2.rs
+++ b/crates/lib/core/tests/crypto/poseidon2.rs
@@ -89,7 +89,7 @@ fn test_single_iteration() {
 
     begin
         # insert 1 to memory
-        push.1.1000 mem_store
+        push.1 push.1000 mem_store
 
         # mem_stream state
         push.1000 padw padw padw
@@ -118,7 +118,7 @@ fn test_single_iteration() {
 
     begin
         # insert 1 to memory
-        push.1.1000 mem_store
+        push.1 push.1000 mem_store
 
         push.1008 # end address
         push.1000 # start address
@@ -149,7 +149,7 @@ fn test_hash_one_word() {
     use miden::core::crypto::hashes::poseidon2
 
     begin
-        push.1.1000 mem_store # push data to memory
+        push.1 push.1000 mem_store # push data to memory
 
         push.1004 # end address
         push.1000 # start address
@@ -167,13 +167,13 @@ fn test_hash_one_word() {
 #[test]
 fn test_hash_even_words() {
     // checks the hash of two words
-    // With mem_storew_le: push.D.C.B.A stores [A, B, C, D]
+    // With mem_storew_le: push.D push.C push.B push.A stores [A, B, C, D]
     let even_words = "
     use miden::core::crypto::hashes::poseidon2
 
     begin
-        push.0.1.0.0.1000 mem_storew_le dropw
-        push.1.0.0.0.1004 mem_storew_le dropw
+        push.0 push.1 push.0 push.0 push.1000 mem_storew_le dropw
+        push.1 push.0 push.0 push.0 push.1004 mem_storew_le dropw
 
         push.1008 # end address
         push.1000 # start address
@@ -185,7 +185,7 @@ fn test_hash_even_words() {
     end
     ";
 
-    // push.0.1.0.0 stores [0, 0, 1, 0], push.1.0.0.0 stores [0, 0, 0, 1]
+    // push.0 push.1 push.0 push.0 stores [0, 0, 1, 0], push.1 push.0 push.0 push.0 stores [0, 0, 0, 1]
     // Total input: [0, 0, 1, 0, 0, 0, 0, 1]
     #[rustfmt::skip]
     let even_hash: Vec<u64> = build_expected_hash(&[
@@ -204,9 +204,9 @@ fn test_hash_odd_words() {
     use miden::core::crypto::hashes::poseidon2
 
     begin
-        push.0.1.0.0.1000 mem_storew_le dropw
-        push.0.0.1.0.1004 mem_storew_le dropw
-        push.0.0.0.1.1008 mem_storew_le dropw
+        push.0 push.1 push.0 push.0 push.1000 mem_storew_le dropw
+        push.0 push.0 push.1 push.0 push.1004 mem_storew_le dropw
+        push.0 push.0 push.0 push.1 push.1008 mem_storew_le dropw
 
         push.1012 # end address
         push.1000 # start address
@@ -229,14 +229,14 @@ fn test_hash_odd_words() {
 
 #[test]
 fn test_absorb_double_words_from_memory() {
-    // With mem_storew_le: push.D.C.B.A stores [A, B, C, D]
+    // With mem_storew_le: push.D push.C push.B push.A stores [A, B, C, D]
     let even_words = "
     use miden::core::sys
     use miden::core::crypto::hashes::poseidon2
 
     begin
-        push.0.0.0.1.1000 mem_storew_le dropw
-        push.0.0.1.0.1004 mem_storew_le dropw
+        push.0 push.0 push.0 push.1 push.1000 mem_storew_le dropw
+        push.0 push.0 push.1 push.0 push.1004 mem_storew_le dropw
 
         push.1008      # end address
         push.1000      # start address
@@ -248,7 +248,7 @@ fn test_absorb_double_words_from_memory() {
     end
     ";
 
-    // push.0.0.0.1 stores [1, 0, 0, 0], push.0.0.1.0 stores [0, 1, 0, 0]
+    // push.0 push.0 push.0 push.1 stores [1, 0, 0, 0], push.0 push.0 push.1 push.0 stores [0, 1, 0, 0]
     #[rustfmt::skip]
     let mut even_hash: Vec<u64> = build_expected_perm(&[
         1, 0, 0, 0, // first word of the rate
@@ -266,17 +266,17 @@ fn test_absorb_double_words_from_memory() {
 #[test]
 fn test_hash_double_words() {
     // test the standard case
-    // With mem_storew_le: push.D.C.B.A stores [A, B, C, D]
+    // With mem_storew_le: push.D push.C push.B push.A stores [A, B, C, D]
     let double_words = "
     use miden::core::sys
     use miden::core::crypto::hashes::poseidon2
 
     begin
         # store four words (two double words) in memory
-        push.0.0.0.1.1000 mem_storew_le dropw
-        push.0.0.1.0.1004 mem_storew_le dropw
-        push.0.1.0.0.1008 mem_storew_le dropw
-        push.1.0.0.0.1012 mem_storew_le dropw
+        push.0 push.0 push.0 push.1 push.1000 mem_storew_le dropw
+        push.0 push.0 push.1 push.0 push.1004 mem_storew_le dropw
+        push.0 push.1 push.0 push.0 push.1008 mem_storew_le dropw
+        push.1 push.0 push.0 push.0 push.1012 mem_storew_le dropw
 
         push.1016      # end address
         push.1000      # start address
@@ -291,7 +291,7 @@ fn test_hash_double_words() {
     end
     ";
 
-    // push.0.0.0.1 stores [1,0,0,0], push.0.0.1.0 stores [0,1,0,0], etc.
+    // push.0 push.0 push.0 push.1 stores [1,0,0,0], push.0 push.0 push.1 push.0 stores [0,1,0,0], etc.
     // Total: [1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1]
     #[rustfmt::skip]
     let resulting_hash: Vec<u64> = build_expected_hash(&[
@@ -309,7 +309,7 @@ fn test_hash_double_words() {
     use miden::core::crypto::hashes::poseidon2
 
     begin
-        push.1000.1000 # start and end addresses
+        push.1000 push.1000 # start and end addresses
         # => [start_addr, end_addr]
 
         exec.poseidon2::hash_double_words
@@ -329,15 +329,15 @@ fn test_hash_double_words() {
 
 #[test]
 fn test_squeeze_digest() {
-    // With mem_storew_le: push.D.C.B.A stores [A, B, C, D]
+    // With mem_storew_le: push.D push.C push.B push.A stores [A, B, C, D]
     let even_words = "
     use miden::core::crypto::hashes::poseidon2
 
     begin
-        push.0.0.0.1.1000 mem_storew_le dropw
-        push.0.0.1.0.1004 mem_storew_le dropw
-        push.0.1.0.0.1008 mem_storew_le dropw
-        push.1.0.0.0.1012 mem_storew_le dropw
+        push.0 push.0 push.0 push.1 push.1000 mem_storew_le dropw
+        push.0 push.0 push.1 push.0 push.1004 mem_storew_le dropw
+        push.0 push.1 push.0 push.0 push.1008 mem_storew_le dropw
+        push.1 push.0 push.0 push.0 push.1012 mem_storew_le dropw
 
         push.1016      # end address
         push.1000      # start address
@@ -369,14 +369,14 @@ fn test_squeeze_digest() {
 
 #[test]
 fn test_copy_digest() {
-    // With mem_storew_le: push.D.C.B.A stores [A, B, C, D]
+    // With mem_storew_le: push.D push.C push.B push.A stores [A, B, C, D]
     let copy_digest = r#"
     use miden::core::sys
     use miden::core::crypto::hashes::poseidon2
 
     begin
-        push.1.0.0.0.1000 mem_storew_le dropw
-        push.0.1.0.0.1004 mem_storew_le dropw
+        push.1 push.0 push.0 push.0 push.1000 mem_storew_le dropw
+        push.0 push.1 push.0 push.0 push.1004 mem_storew_le dropw
 
         push.1008      # end address
         push.1000      # start address
@@ -401,7 +401,7 @@ fn test_copy_digest() {
     end
     "#;
 
-    // push.1.0.0.0 stores [0, 0, 0, 1], push.0.1.0.0 stores [0, 0, 1, 0]
+    // push.1 push.0 push.0 push.0 stores [0, 0, 0, 1], push.0 push.1 push.0 push.0 stores [0, 0, 1, 0]
     #[rustfmt::skip]
     let mut resulting_stack: Vec<u64> = build_expected_perm(&[
         0, 0, 0, 1, // first word of the rate
@@ -426,11 +426,11 @@ fn test_hash_elements() {
     use miden::core::crypto::hashes::poseidon2
 
     begin
-        push.4.3.2.1.1000 mem_storew_le dropw
-        push.0.0.0.5.1004 mem_storew_le dropw
+        push.4 push.3 push.2 push.1 push.1000 mem_storew_le dropw
+        push.0 push.0 push.0 push.5 push.1004 mem_storew_le dropw
         push.11
 
-        push.5.1000
+        push.5 push.1000
 
         exec.poseidon2::hash_elements
 
@@ -452,11 +452,11 @@ fn test_hash_elements() {
     use miden::core::crypto::hashes::poseidon2
 
     begin
-        push.4.3.2.1.1000 mem_storew_le dropw
-        push.8.7.6.5.1004 mem_storew_le dropw
+        push.4 push.3 push.2 push.1 push.1000 mem_storew_le dropw
+        push.8 push.7 push.6 push.5 push.1004 mem_storew_le dropw
         push.11
 
-        push.8.1000
+        push.8 push.1000
 
         exec.poseidon2::hash_elements
 
@@ -478,13 +478,13 @@ fn test_hash_elements() {
     use miden::core::crypto::hashes::poseidon2
 
     begin
-        push.4.3.2.1.1000 mem_storew_le dropw
-        push.8.7.6.5.1004 mem_storew_le dropw
-        push.12.11.10.9.1008 mem_storew_le dropw
-        push.16.15.14.13.1012 mem_storew_le dropw
+        push.4 push.3 push.2 push.1 push.1000 mem_storew_le dropw
+        push.8 push.7 push.6 push.5 push.1004 mem_storew_le dropw
+        push.12 push.11 push.10 push.9 push.1008 mem_storew_le dropw
+        push.16 push.15 push.14 push.13 push.1012 mem_storew_le dropw
         push.11
 
-        push.15.1000
+        push.15 push.1000
 
         exec.poseidon2::hash_elements
 

--- a/crates/lib/core/tests/crypto/sha512.rs
+++ b/crates/lib/core/tests/crypto/sha512.rs
@@ -47,7 +47,7 @@ fn test_sha512_handler(bytes: &[u8]) {
             begin
                 {memory_stores}
 
-                push.{len_bytes}.{INPUT_MEMORY_ADDR}
+                push.{len_bytes} push.{INPUT_MEMORY_ADDR}
 
                 emit.event("{SHA512_HASH_BYTES_EVENT_NAME}")
                 drop drop
@@ -81,7 +81,7 @@ fn test_sha512_hash_memory_impl(bytes: &[u8]) {
             begin
                 {memory_stores}
 
-                push.{len_bytes}.{INPUT_MEMORY_ADDR}
+                push.{len_bytes} push.{INPUT_MEMORY_ADDR}
                 exec.sha512::hash_bytes_impl
 
                 exec.sys::truncate_stack
@@ -130,7 +130,7 @@ fn test_sha512_hash_memory(bytes: &[u8]) {
             begin
                 {memory_stores}
 
-                push.{len_bytes}.{INPUT_MEMORY_ADDR}
+                push.{len_bytes} push.{INPUT_MEMORY_ADDR}
                 exec.sha512::hash_bytes
 
                 exec.sys::truncate_stack
@@ -177,7 +177,7 @@ fn test_sha512_hash_bytes_documented_stack_contract() {
             begin
                 {memory_stores}
 
-                push.{len_bytes}.{INPUT_MEMORY_ADDR}
+                push.{len_bytes} push.{INPUT_MEMORY_ADDR}
                 exec.sha512::hash_bytes
 
                 # drop the digest and ensure caller stack words are preserved
@@ -212,7 +212,7 @@ fn run_sha512_with_max_hash_len(
         r#"
         begin
             {memory_stores}
-            push.{len_bytes_on_stack}.{INPUT_MEMORY_ADDR}
+            push.{len_bytes_on_stack} push.{INPUT_MEMORY_ADDR}
             emit.event("{SHA512_HASH_BYTES_EVENT_NAME}")
             drop drop
         end

--- a/crates/lib/core/tests/mem/mod.rs
+++ b/crates/lib/core/tests/mem/mod.rs
@@ -14,13 +14,13 @@ fn test_memcopy_words() {
     use miden::core::mem
 
     begin
-        push.0.0.0.1.1000 mem_storew_be dropw
-        push.0.0.1.0.1004 mem_storew_be dropw
-        push.0.0.1.1.1008 mem_storew_be dropw
-        push.0.1.0.0.1012 mem_storew_be dropw
-        push.0.1.0.1.1016 mem_storew_be dropw
+        push.0 push.0 push.0 push.1 push.1000 mem_storew_be dropw
+        push.0 push.0 push.1 push.0 push.1004 mem_storew_be dropw
+        push.0 push.0 push.1 push.1 push.1008 mem_storew_be dropw
+        push.0 push.1 push.0 push.0 push.1012 mem_storew_be dropw
+        push.0 push.1 push.0 push.1 push.1016 mem_storew_be dropw
 
-        push.2000.1000.5 exec.mem::memcopy_words
+        push.2000 push.1000 push.5 exec.mem::memcopy_words
     end
     ";
 
@@ -130,13 +130,13 @@ fn test_memcopy_elements() {
     use miden::core::mem
 
     begin
-        push.1.2.3.4.1000 mem_storew_be dropw
-        push.5.6.7.8.1004 mem_storew_be dropw
-        push.9.10.11.12.1008 mem_storew_be dropw
-        push.13.14.15.16.1012 mem_storew_be dropw
-        push.17.18.19.20.1016 mem_storew_be dropw
+        push.1 push.2 push.3 push.4 push.1000 mem_storew_be dropw
+        push.5 push.6 push.7 push.8 push.1004 mem_storew_be dropw
+        push.9 push.10 push.11 push.12 push.1008 mem_storew_be dropw
+        push.13 push.14 push.15 push.16 push.1012 mem_storew_be dropw
+        push.17 push.18 push.19 push.20 push.1016 mem_storew_be dropw
 
-        push.2002.1001.18 exec.mem::memcopy_elements
+        push.2002 push.1001 push.18 exec.mem::memcopy_elements
     end
     ";
 

--- a/crates/lib/core/tests/stark/batch_query_gen.rs
+++ b/crates/lib/core/tests/stark/batch_query_gen.rs
@@ -34,15 +34,15 @@ fn setup_masm(sponge: &[u64; 12], output_len: u32, num_queries: u32, depth: u32)
     format!(
         r#"
     # Store R1 (rate word 1)
-    push.{r1_3}.{r1_2}.{r1_1}.{r1_0}
+    push.{r1_3} push.{r1_2} push.{r1_1} push.{r1_0}
     push.{R1_PTR} mem_storew_le dropw
 
     # Store R2 (rate word 2)
-    push.{r2_3}.{r2_2}.{r2_1}.{r2_0}
+    push.{r2_3} push.{r2_2} push.{r2_1} push.{r2_0}
     push.{R2_PTR} mem_storew_le dropw
 
     # Store C (capacity)
-    push.{c_3}.{c_2}.{c_1}.{c_0}
+    push.{c_3} push.{c_2} push.{c_1} push.{c_0}
     push.{C_PTR} mem_storew_le dropw
 
     # Random coin buffer state

--- a/crates/lib/core/tests/stark_asserts/mod.rs
+++ b/crates/lib/core/tests/stark_asserts/mod.rs
@@ -77,7 +77,7 @@ fn init_seed_trace_length_too_large_has_message() {
     let source = "
         use miden::core::stark::random_coin
         begin
-            push.0.0.0.0 push.32
+            push.0 push.0 push.0 push.0 push.32
             exec.random_coin::init_seed
         end
     ";
@@ -91,8 +91,8 @@ fn generate_aux_randomness_mismatch_has_message() {
         use miden::core::stark::constants
         use miden::core::stark::random_coin
         begin
-            push.11.22.33.44 exec.constants::r1_ptr mem_storew_be dropw
-            push.99.44.11.22 exec.constants::aux_rand_nd_ptr mem_storew_be dropw
+            push.11 push.22 push.33 push.44 exec.constants::r1_ptr mem_storew_be dropw
+            push.99 push.44 push.11 push.22 exec.constants::aux_rand_nd_ptr mem_storew_be dropw
             exec.random_coin::generate_aux_randomness
         end
     ";
@@ -113,7 +113,7 @@ fn check_pow_invalid_has_message() {
             push.16 exec.constants::set_query_pow_bits
             push.0  exec.constants::set_deep_pow_bits
             push.16 exec.constants::set_folding_pow_bits
-            push.0.0.0.0 push.10
+            push.0 push.0 push.0 push.0 push.10
             exec.random_coin::init_seed
             exec.random_coin::check_query_pow
         end

--- a/crates/lib/core/tests/sys/mod.rs
+++ b/crates/lib/core/tests/sys/mod.rs
@@ -51,7 +51,7 @@ fn reduce_kernel_digests_upper_bound() {
             push.0  exec.constants::set_query_pow_bits
             push.0  exec.constants::set_deep_pow_bits
             push.16 exec.constants::set_folding_pow_bits
-            push.0.0.0.0 push.10
+            push.0 push.0 push.0 push.0 push.10
             exec.random_coin::init_seed
             exec.public_inputs::process_public_inputs
         end

--- a/docs/src/user_docs/assembly/code_organization.md
+++ b/docs/src/user_docs/assembly/code_organization.md
@@ -263,8 +263,8 @@ const SAMPLE_WORD = [1,2,3,4]
 const SAMPLE_HEX_WORD = 0x0200000000000000030000000000000004000000000000000500000000000000
 
 begin
-    push.SAMPLE_WORD       # is equivalent to push.1.2.3.4
-    push.SAMPLE_HEX_WORD.6 # is equivalent to push.2.3.4.5.6
+    push.SAMPLE_WORD       # is equivalent to push.[1,2,3,4]
+    push.SAMPLE_HEX_WORD.6 # is equivalent to push.2 push.3 push.4 push.5 push.6
 end
 ```
 

--- a/docs/src/user_docs/assembly/cryptographic_operations.md
+++ b/docs/src/user_docs/assembly/cryptographic_operations.md
@@ -88,7 +88,7 @@ For more examples of how `hperm` instruction is used, please see `miden::core::c
 
 Both `hash` and `hmerge` instructions are actually "macro-instructions" which are implemented using `hperm` (and other) instructions. At assembly time, these are "expanded" into the following sequences of operations:
 
-- `hash`: `padw push.0.0.0.4 swapw.2 hperm dropw swapw dropw`.
+- `hash`: `padw push.0 push.0 push.0 push.4 swapw.2 hperm dropw swapw dropw`.
 - `hmerge`: `padw swapw.2 swapw hperm dropw swapw dropw`.
 
 ### Circuits and polynomials

--- a/docs/src/user_docs/assembly/instruction_reference.md
+++ b/docs/src/user_docs/assembly/instruction_reference.md
@@ -167,7 +167,7 @@ Instructions for moving data between the stack and other sources like program co
 
 | Instruction | Stack Input | Stack Output     | Cycles | Notes                                                                                                                                                                                                     |
 | ----------- | ----------- | ---------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `push.a...` | `[ ... ]`   | `[c, b, a, ...]` | 1-2    | Pushes up to 16 field elements (decimal or hex) onto the stack. Hex words (32 bytes) are little-endian; short hex values are big-endian. Example: `push.0x1234.0x5678` or `push.0x34120000...78560000...` |
+| `push.a` | `[ ... ]`   | `[a, ...]` | 1-2    | Pushes a single field element (decimal or hex) onto the stack. For multiple values, use separate instructions: `push.1 push.2 push.3`. |
 | `push.[a,b,c,d]` | `[ ... ]` | `[a, b, c, d, ...]` | 4 | Pushes a word (4 field elements) onto the stack. Element `a` ends up on top. Example: `push.[1,2,3,4]` results in `[1, 2, 3, 4, ...]`. |
 
 ### Environment Inputs

--- a/docs/src/user_docs/assembly/io_operations.md
+++ b/docs/src/user_docs/assembly/io_operations.md
@@ -16,18 +16,18 @@ Miden assembly provides a set of instructions for moving data between the operan
 
 | Instruction                                                                     | Stack_input | Stack_output                                         | Notes                                                                                                                                                                                               |
 | ------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| push._a_ <br /> - _(1-2 cycles)_ <br /> push._a_._b_ <br /> push._a_._b_._c_... | [ ... ]     | [a, ... ] <br /> [b, a, ... ] <br /> [c, b, a, ... ] | Pushes values $a$, $b$, $c$ etc. onto the stack. Up to $16$ values can be specified. All values must be valid field elements in decimal (e.g., $123$) or hexadecimal (e.g., $0x7b$) representation. |
+| push._a_ <br /> - _(1-2 cycles)_ | [ ... ]     | [a, ... ] | Pushes value $a$ onto the stack. The value must be a valid field element in decimal (e.g., $123$) or hexadecimal (e.g., $0x7b$) representation. Multiple values can be pushed using separate instructions (e.g., `push.1 push.2 push.3`). |
 | push.[_a_,_b_,_c_,_d_] <br /> - _(4 cycles)_                                     | [ ... ]     | [a, b, c, d, ... ]                                   | Pushes a word (4 field elements) onto the stack. The first element $a$ ends up on top of the stack. All values must be valid field elements in decimal or hexadecimal representation. |
 
-The value can be specified in hexadecimal form without periods between individual values as long as it describes a full word ($4$ field elements or $32$ bytes). Note that hexadecimal values separated by periods (short hexadecimal strings) are assumed to be in big-endian order, while the strings specifying whole words (long hexadecimal strings) are assumed to be in little-endian order. That is, the following are semantically equivalent:
+The value can be specified in hexadecimal form. Short hexadecimal values are assumed to be in big-endian order. A full word ($4$ field elements or $32$ bytes) can be pushed using the word literal syntax `push.[a,b,c,d]` or via a long hexadecimal string (little-endian order). That is, the following are semantically equivalent:
 
 ```
-push.0x00001234.0x00005678.0x00009012.0x0000abcd
-push.0x341200000000000078560000000000001290000000000000cdab000000000000
-push.4660.22136.36882.43981
+push.0x00001234 push.0x00005678 push.0x00009012 push.0x0000abcd
+push.[0x00001234, 0x00005678, 0x00009012, 0x0000abcd]
+push.4660 push.22136 push.36882 push.43981
 ```
 
-In both case the values must still encode valid field elements.
+In all cases the values must still encode valid field elements.
 
 #### Word literal syntax
 

--- a/miden-vm/masm-examples/debug/debug.masm
+++ b/miden-vm/masm-examples/debug/debug.masm
@@ -24,12 +24,12 @@ proc bar
 end
 
 begin
-    push.13.2
+    push.13 push.2
     mem_store
     debug.mem.2
-    push.104467440737.1
+    push.104467440737 push.1
     mem_store
-    push.1044674407370.10446744073.10446744073709.10446744073709.1000
+    push.1044674407370 push.10446744073 push.10446744073709 push.10446744073709 push.1000
     mem_storew_be
 
     debug.mem.1000

--- a/miden-vm/masm-examples/hashing/blake3_2to1/blake3_2to1.masm
+++ b/miden-vm/masm-examples/hashing/blake3_2to1/blake3_2to1.masm
@@ -8,7 +8,7 @@ begin
     # Check the correctness of the hashing result by comparing it with precomputed correct values.
     # This hash is a result of applying a blake3 hashing function to the binary value consisting of
     # only ones.
-    push.0xD9696D27.0xF209D66E.0xD0DFDEB9.0x7D5992E2.0x44DDA9CB.0xD6FFB5E5.0x8CD0CAA6.0xF0270FA9
+    push.0xD9696D27 push.0xF209D66E push.0xD0DFDEB9 push.0x7D5992E2 push.0x44DDA9CB push.0xD6FFB5E5 push.0x8CD0CAA6 push.0xF0270FA9
 
     # compare results
     movupw.2

--- a/miden-vm/masm-examples/hashing/sha256/sha256.masm
+++ b/miden-vm/masm-examples/hashing/sha256/sha256.masm
@@ -8,7 +8,7 @@ begin
     # Check the correctness of the hashing result by comparing it with precomputed correct values.
     # This hash is a result of applying a sha256 hashing function to the binary value consisting of
     # only ones.
-    push.0x85E1D1F7.0x8643E4A2.0x2DAD7274.0x1F764AAD.0xBA3EEB20.0xF1D30600.0x294E9E0D.0x8667E718
+    push.0x85E1D1F7 push.0x8643E4A2 push.0x2DAD7274 push.0x1F764AAD push.0xBA3EEB20 push.0xF1D30600 push.0x294E9E0D push.0x8667E718
 
     # compare results
     movupw.2

--- a/miden-vm/masm-examples/merkle_store/merkle_store.masm
+++ b/miden-vm/masm-examples/merkle_store/merkle_store.masm
@@ -3,7 +3,7 @@ begin
     push.[16822663461127792392, 13353258177390434098, 2416982434710942653, 7676447709976871076]
 
     # get value at depth = 2, index = 0 from the Partial Merkle Tree; this value should be 20
-    push.0.2
+    push.0 push.2
     mtree_get
     # check that returned value is equal to 20
     push.[20,0,0,0]
@@ -15,7 +15,7 @@ begin
     push.[11789474913582628944, 10542203670838121629, 14970381554615752019, 10887162719400902293]
 
     # get value at depth = 64, index = 1 from the Sparse Merkle Tree; this value should be 21
-    push.1.64
+    push.1 push.64
     mtree_get
     # check that returned value is equal to 21
     push.[21,0,0,0]
@@ -27,7 +27,7 @@ begin
     push.[937566728702260333, 10423322521195732810, 16243291006317403500, 12736773875258955401]
 
     # get value at depth = 2, index = 2 from the Merkle Tree; this value should be 22
-    push.2.2
+    push.2 push.2
     mtree_get
     # check that returned value is equal to 22
     push.[22,0,0,0]

--- a/miden-vm/masm-examples/nprime/nprime.masm
+++ b/miden-vm/masm-examples/nprime/nprime.masm
@@ -46,7 +46,7 @@ proc is_not_prime_should_continue
 
     # push return flags
     # [continue loop?, is prime?, prime, j, candidate, i, n, primes..]
-    push.0.1
+    push.0 push.1
 
     # a composite number have its smallest prime squared lesser than itself.
     # if the squared prime is bigger than the candidate, and provided we iterate
@@ -67,7 +67,7 @@ proc is_not_prime_should_continue
     if.true
         drop
         drop
-        push.1.0
+        push.1 push.0
     end
 
     # check mod only if should continue loop
@@ -84,7 +84,7 @@ proc is_not_prime_should_continue
         if.true
             drop
             drop
-            push.0.0
+            push.0 push.0
         end
     end
 

--- a/miden-vm/tests/integration/exec.rs
+++ b/miden-vm/tests/integration/exec.rs
@@ -13,7 +13,7 @@ use miden_vm::DefaultHost;
 fn advice_map_loaded_before_execution() {
     let source = "\
     begin
-        push.1.1.1.1
+        push.1 push.1 push.1 push.1
         adv.push_mapval
         dropw
     end";

--- a/miden-vm/tests/integration/flow_control/mod.rs
+++ b/miden-vm/tests/integration/flow_control/mod.rs
@@ -306,13 +306,13 @@ fn call_in_syscall() {
             loc_loadw_be.0 assertz assertz assertz assertz
 
             # Write to memory locals, which should not affect context 0 memory
-            push.5.6.7.8 loc_storew_be.0 dropw
+            push.5 push.6 push.7 push.8 loc_storew_be.0 dropw
 
             # Syscall back into context 0
             syscall.second_kernel_entry
 
             # Ensure that procedure locals were untouched
-            loc_loadw_be.0 push.5.6.7.8 assert_eqw
+            loc_loadw_be.0 push.5 push.6 push.7 push.8 assert_eqw
         end
 
         # CONTEXT 0 FUNCTIONS
@@ -325,7 +325,7 @@ fn call_in_syscall() {
 
             # Write to procedure locals. We will later ensure that this write didn't affect procedure locals
             # in first_kernel_entry.
-            push.9.10.11.12 loc_storew_be.0 dropw
+            push.9 push.10 push.11 push.12 loc_storew_be.0 dropw
         end
 
         @locals(4)
@@ -334,13 +334,13 @@ fn call_in_syscall() {
             loc_loadw_be.0 assertz assertz assertz assertz
 
             # Write to memory locals. We will ensure at the end that these values are still present
-            push.1.2.3.4 loc_storew_be.0 dropw
+            push.1 push.2 push.3 push.4 loc_storew_be.0 dropw
 
             # Call userland, which will syscall back into context 0
             call.userland
 
             # Ensure that procedure locals were untouched
-            loc_loadw_be.0 push.1.2.3.4 assert_eqw
+            loc_loadw_be.0 push.1 push.2 push.3 push.4 assert_eqw
         end
     ";
 
@@ -463,7 +463,7 @@ fn dynexec_with_procref() {
     use external::module
 
     proc foo
-        push.1.2
+        push.1 push.2
         u32wrapping_add
     end
 
@@ -624,7 +624,7 @@ fn procref() -> Result<(), Report> {
 
     @locals(4)
     pub proc foo
-        push.3.4
+        push.3 push.4
     end
     ";
 
@@ -651,7 +651,7 @@ fn procref() -> Result<(), Report> {
 
     @locals(4)
     proc foo
-        push.3.4
+        push.3 push.4
     end
 
     begin

--- a/miden-vm/tests/integration/operations/crypto_ops.rs
+++ b/miden-vm/tests/integration/operations/crypto_ops.rs
@@ -293,16 +293,16 @@ fn crypto_stream_basic() {
 
     let asm_op = "
         # Initialize memory with plaintext [1,2,3,4,5,6,7,8] at address 1000
-        push.1.2.3.4 push.1000 mem_storew_be dropw
-        push.5.6.7.8 push.1004 mem_storew_be dropw
+        push.1 push.2 push.3 push.4 push.1000 mem_storew_be dropw
+        push.5 push.6 push.7 push.8 push.1004 mem_storew_be dropw
 
         # Setup stack: [rate(8), capacity(4), src, dst]
         # Rate is keystream [1,2,3,4,5,6,7,8]
         push.2000           # dst_ptr
         push.1000           # src_ptr
         padw                # capacity
-        push.1.2.3.4        # rate[0-3]
-        push.5.6.7.8        # rate[4-7]
+        push.1 push.2 push.3 push.4        # rate[0-3]
+        push.5 push.6 push.7 push.8        # rate[4-7]
 
         crypto_stream
 
@@ -328,14 +328,14 @@ fn crypto_stream_basic() {
 #[test]
 fn crypto_stream_rejects_in_place() {
     let asm_op = "
-        push.1.2.3.4 push.1000 mem_storew_be dropw
-        push.5.6.7.8 push.1004 mem_storew_be dropw
+        push.1 push.2 push.3 push.4 push.1000 mem_storew_be dropw
+        push.5 push.6 push.7 push.8 push.1004 mem_storew_be dropw
 
         push.1000           # dst_ptr (in-place)
         push.1000           # src_ptr
         padw                # capacity
-        push.1.2.3.4        # rate[0-3]
-        push.5.6.7.8        # rate[4-7]
+        push.1 push.2 push.3 push.4        # rate[0-3]
+        push.5 push.6 push.7 push.8        # rate[4-7]
 
         crypto_stream
     ";
@@ -362,14 +362,14 @@ fn crypto_stream_rejects_partial_overlap() {
     // Test case 1: dst starts within src range (src=1000, dst=1004)
     // src: [1000..1008), dst: [1004..1012) - overlaps by 1 word
     let asm_op_case1 = "
-        push.1.2.3.4 push.1000 mem_storew_be dropw
-        push.5.6.7.8 push.1004 mem_storew_be dropw
+        push.1 push.2 push.3 push.4 push.1000 mem_storew_be dropw
+        push.5 push.6 push.7 push.8 push.1004 mem_storew_be dropw
 
         push.1004           # dst_ptr (partial overlap)
         push.1000           # src_ptr
         padw                # capacity
-        push.1.2.3.4        # rate[0-3]
-        push.5.6.7.8        # rate[4-7]
+        push.1 push.2 push.3 push.4        # rate[0-3]
+        push.5 push.6 push.7 push.8        # rate[4-7]
 
         crypto_stream
     ";
@@ -389,14 +389,14 @@ fn crypto_stream_rejects_partial_overlap() {
     // Test case 2: src starts within dst range (src=1004, dst=1000)
     // src: [1004..1012), dst: [1000..1008) - overlaps by 1 word
     let asm_op_case2 = "
-        push.1.2.3.4 push.1000 mem_storew_be dropw
-        push.5.6.7.8 push.1004 mem_storew_be dropw
+        push.1 push.2 push.3 push.4 push.1000 mem_storew_be dropw
+        push.5 push.6 push.7 push.8 push.1004 mem_storew_be dropw
 
         push.1000           # dst_ptr
         push.1004           # src_ptr (partial overlap)
         padw                # capacity
-        push.1.2.3.4        # rate[0-3]
-        push.5.6.7.8        # rate[4-7]
+        push.1 push.2 push.3 push.4        # rate[0-3]
+        push.5 push.6 push.7 push.8        # rate[4-7]
 
         crypto_stream
     ";
@@ -423,8 +423,8 @@ fn crypto_stream_rejects_src_range_overflow() {
         push.0               # dst_ptr (valid)
         push.4294967292      # src_ptr (u32::MAX - 3, aligned), src+8 overflows
         padw                 # capacity
-        push.1.2.3.4         # rate[0-3]
-        push.5.6.7.8         # rate[4-7]
+        push.1 push.2 push.3 push.4         # rate[0-3]
+        push.5 push.6 push.7 push.8         # rate[4-7]
 
         crypto_stream
     ";
@@ -449,8 +449,8 @@ fn crypto_stream_rejects_dst_range_overflow() {
         push.4294967292      # dst_ptr (u32::MAX - 3, aligned), dst+8 overflows
         push.0               # src_ptr (valid)
         padw                 # capacity
-        push.1.2.3.4         # rate[0-3]
-        push.5.6.7.8         # rate[4-7]
+        push.1 push.2 push.3 push.4         # rate[0-3]
+        push.5 push.6 push.7 push.8         # rate[4-7]
 
         crypto_stream
     ";
@@ -473,8 +473,8 @@ fn crypto_stream_rejects_unaligned_src() {
         push.2000           # dst_ptr (aligned)
         push.1002           # src_ptr (unaligned)
         padw                # capacity
-        push.1.2.3.4        # rate[0-3]
-        push.5.6.7.8        # rate[4-7]
+        push.1 push.2 push.3 push.4        # rate[0-3]
+        push.5 push.6 push.7 push.8        # rate[4-7]
 
         crypto_stream
     ";
@@ -497,8 +497,8 @@ fn crypto_stream_rejects_unaligned_dst() {
         push.2002           # dst_ptr (unaligned)
         push.1000           # src_ptr (aligned)
         padw                # capacity
-        push.1.2.3.4        # rate[0-3]
-        push.5.6.7.8        # rate[4-7]
+        push.1 push.2 push.3 push.4        # rate[0-3]
+        push.5 push.6 push.7 push.8        # rate[4-7]
 
         crypto_stream
     ";
@@ -520,15 +520,15 @@ fn crypto_stream_allows_adjacent_after() {
     // src: [1000..1008), dst: [1008..1016)
     let asm_op = "
         # Plaintext at src
-        push.1.2.3.4 push.1000 mem_storew_be dropw
-        push.5.6.7.8 push.1004 mem_storew_be dropw
+        push.1 push.2 push.3 push.4 push.1000 mem_storew_be dropw
+        push.5 push.6 push.7 push.8 push.1004 mem_storew_be dropw
 
         # Setup stack: [rate(8), capacity(4), src, dst]
         push.1008           # dst_ptr (adjacent after)
         push.1000           # src_ptr
         padw                # capacity
-        push.1.2.3.4        # rate[0-3]
-        push.5.6.7.8        # rate[4-7]
+        push.1 push.2 push.3 push.4        # rate[0-3]
+        push.5 push.6 push.7 push.8        # rate[4-7]
 
         crypto_stream
     ";
@@ -544,15 +544,15 @@ fn crypto_stream_allows_adjacent_before() {
     // src: [1008..1016), dst: [1000..1008)
     let asm_op = "
         # Plaintext at src
-        push.1.2.3.4 push.1008 mem_storew_be dropw
-        push.5.6.7.8 push.1012 mem_storew_be dropw
+        push.1 push.2 push.3 push.4 push.1008 mem_storew_be dropw
+        push.5 push.6 push.7 push.8 push.1012 mem_storew_be dropw
 
         # Setup stack: [rate(8), capacity(4), src, dst]
         push.1000           # dst_ptr (adjacent before)
         push.1008           # src_ptr
         padw                # capacity
-        push.1.2.3.4        # rate[0-3]
-        push.5.6.7.8        # rate[4-7]
+        push.1 push.2 push.3 push.4        # rate[0-3]
+        push.5 push.6 push.7 push.8        # rate[4-7]
 
         crypto_stream
     ";

--- a/miden-vm/tests/integration/operations/decorators/advice.rs
+++ b/miden-vm/tests/integration/operations/decorators/advice.rs
@@ -443,7 +443,7 @@ fn run_insert_mem_with_max_size(
         r#"begin
             {mem_stores}
             push.{end_addr} push.{start_addr}
-            push.1.2.3.4
+            push.1 push.2 push.3 push.4
             adv.insert_mem
             dropw drop drop
         end"#,

--- a/miden-vm/tests/integration/operations/io_ops/adv_ops.rs
+++ b/miden-vm/tests/integration/operations/io_ops/adv_ops.rs
@@ -73,7 +73,7 @@ fn adv_pipe() {
         {TRUNCATE_STACK_PROC}
 
         begin
-            push.12.11.10.9.8.7.6.5.4.3.2.1
+            push.12 push.11 push.10 push.9 push.8 push.7 push.6 push.5 push.4 push.3 push.2 push.1
             adv_pipe
 
             exec.truncate_stack
@@ -106,7 +106,7 @@ fn adv_pipe_with_hperm() {
         {TRUNCATE_STACK_PROC}
 
         begin
-            push.12.11.10.9.8.7.6.5.4.3.2.1
+            push.12 push.11 push.10 push.9 push.8 push.7 push.6 push.5 push.4 push.3 push.2 push.1
             adv_pipe hperm
 
             exec.truncate_stack

--- a/miden-vm/tests/integration/operations/io_ops/constant_ops.rs
+++ b/miden-vm/tests/integration/operations/io_ops/constant_ops.rs
@@ -29,13 +29,13 @@ fn push_one() {
 fn push_many() {
     let base_op = "push";
 
-    // --- multiple values with separators --------------------------------------------------------
-    let asm_op = format!("{base_op}.17.0x13.23");
+    // --- multiple values as individual push instructions ----------------------------------------
+    let asm_op = format!("{base_op}.17 {base_op}.0x13 {base_op}.23");
     let test = build_op_test!(asm_op);
     test.expect_stack(&[23, 19, 17]);
 
-    // --- push the maximum number of decimal values (16) -------------------------------------
-    let asm_op = format!("{base_op}.16.17.18.19.20.21.22.23.24.25.26.27.28.29.30.31");
+    // --- push 16 decimal values as individual push instructions --------------------------------
+    let asm_op = (16..32).map(|i| format!("{base_op}.{i}")).collect::<Vec<_>>().join(" ");
     let mut expected = Vec::with_capacity(16);
     for i in (16..32).rev() {
         expected.push(i);
@@ -44,8 +44,8 @@ fn push_many() {
     let test = build_op_test!(asm_op);
     test.expect_stack(&expected);
 
-    // --- push hexadecimal values with period separators between values ----------------------
-    let asm_op = format!("{base_op}.0x0A.0x64.0x03E8.0x2710.0x0186A0");
+    // --- push hexadecimal values as individual push instructions --------------------------------
+    let asm_op = format!("{base_op}.0x0A {base_op}.0x64 {base_op}.0x03E8 {base_op}.0x2710 {base_op}.0x0186A0");
     let mut expected = Vec::with_capacity(5);
     for i in (1..=5).rev() {
         expected.push(10_u64.pow(i));
@@ -54,8 +54,8 @@ fn push_many() {
     let test = build_op_test!(asm_op);
     test.expect_stack(&expected);
 
-    // --- push a mixture of decimal and single-element hexadecimal values --------------------
-    let asm_op = format!("{base_op}.2.4.8.0x10.0x20.0x40.128.0x0100");
+    // --- push a mixture of decimal and hexadecimal values --------------------------------------
+    let asm_op = format!("{base_op}.2 {base_op}.4 {base_op}.8 {base_op}.0x10 {base_op}.0x20 {base_op}.0x40 {base_op}.128 {base_op}.0x0100");
     let mut expected = Vec::with_capacity(8);
     for i in (1_u32..=8).rev() {
         expected.push(2_u64.pow(i));

--- a/miden-vm/tests/integration/operations/io_ops/mem_ops.rs
+++ b/miden-vm/tests/integration/operations/io_ops/mem_ops.rs
@@ -245,7 +245,7 @@ fn mem_stream() {
             push.4
             mem_storew_le
             dropw
-            push.12.11.10.9.8.7.6.5.4.3.2.1
+            push.12 push.11 push.10 push.9 push.8 push.7 push.6 push.5 push.4 push.3 push.2 push.1
             mem_stream
 
             exec.truncate_stack
@@ -278,7 +278,7 @@ fn mem_stream_with_hperm() {
             push.4
             mem_storew_le
             dropw
-            push.12.11.10.9.8.7.6.5.4.3.2.1
+            push.12 push.11 push.10 push.9 push.8 push.7 push.6 push.5 push.4 push.3 push.2 push.1
             mem_stream hperm
 
             exec.truncate_stack

--- a/processor/src/fast/tests/masm_consistency.rs
+++ b/processor/src/fast/tests/masm_consistency.rs
@@ -189,7 +189,7 @@ use super::*;
 // ---- horner ops --------------------------------
 #[case(None,
     "begin
-        push.1.2.3.4 mem_storew_le.40 dropw
+        push.1 push.2 push.3 push.4 mem_storew_le.40 dropw
         horner_eval_base
     end",
     vec![Felt::from_u32(16), Felt::from_u32(15), Felt::from_u32(14), Felt::from_u32(13), Felt::from_u32(12), Felt::from_u32(11), Felt::from_u32(10),
@@ -198,7 +198,7 @@ use super::*;
 )]
 #[case(None,
     "begin
-        push.1.2.3.4 mem_storew_le.40 dropw
+        push.1 push.2 push.3 push.4 mem_storew_le.40 dropw
         horner_eval_ext
         end",
     vec![Felt::from_u32(16), Felt::from_u32(15), Felt::from_u32(14), Felt::from_u32(13), Felt::from_u32(12), Felt::from_u32(11), Felt::from_u32(10),

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -260,9 +260,9 @@ fn test_diagnostic_failed_assertion() {
     // No error message
     let source = "
         begin
-            push.1.2
+            push.1 push.2
             assertz
-            push.3.4
+            push.3 push.4
         end";
 
     let build_test = build_test_by_mode!(true, source, &[1, 2]);
@@ -271,10 +271,10 @@ fn test_diagnostic_failed_assertion() {
         err,
         "  x assertion failed with error code: 0",
         regex!(r#",-\[test[\d]+:4:13\]"#),
-        " 3 |             push.1.2",
+        " 3 |             push.1 push.2",
         " 4 |             assertz",
         "   :             ^^^^^^^",
-        " 5 |             push.3.4",
+        " 5 |             push.3 push.4",
         "   `----",
         "  help: assertions validate program invariants. Review the assertion condition and ensure all prerequisites are met"
     );
@@ -282,9 +282,9 @@ fn test_diagnostic_failed_assertion() {
     // With error message
     let source = "
         begin
-            push.1.2
+            push.1 push.2
             assertz.err=\"some error message\"
-            push.3.4
+            push.3 push.4
         end";
 
     let build_test = build_test_by_mode!(true, source, &[1, 2]);
@@ -293,10 +293,10 @@ fn test_diagnostic_failed_assertion() {
         err,
         "  x assertion failed with error message: some error message",
         regex!(r#",-\[test[\d]+:4:13\]"#),
-        " 3 |             push.1.2",
+        " 3 |             push.1 push.2",
         " 4 |             assertz.err=\"some error message\"",
         "   :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
-        " 5 |             push.3.4",
+        " 5 |             push.3 push.4",
         "   `----",
         "  help: assertions validate program invariants. Review the assertion condition and ensure all prerequisites are met"
     );
@@ -305,9 +305,9 @@ fn test_diagnostic_failed_assertion() {
     let source = "
         const ERR_MSG = \"some error message\"
         begin
-            push.1.2
+            push.1 push.2
             assertz.err=ERR_MSG
-            push.3.4
+            push.3 push.4
         end";
 
     let build_test = build_test_by_mode!(true, source, &[1, 2]);
@@ -316,10 +316,10 @@ fn test_diagnostic_failed_assertion() {
         err,
         "  x assertion failed with error message: some error message",
         regex!(r#",-\[test[\d]+:5:13\]"#),
-        " 4 |             push.1.2",
+        " 4 |             push.1 push.2",
         " 5 |             assertz.err=ERR_MSG",
         "   :             ^^^^^^^^^^^^^^^^^^^",
-        " 6 |             push.3.4",
+        " 6 |             push.3 push.4",
         "   `----",
         "  help: assertions validate program invariants. Review the assertion condition and ensure all prerequisites are met"
     );

--- a/processor/tests/issue_2456_test.rs
+++ b/processor/tests/issue_2456_test.rs
@@ -15,7 +15,7 @@ fn test_issue_2456_statically_linked_library_call() {
 
     let test_module_source = "
         pub proc foo
-            push.3.4
+            push.3 push.4
             add
             swapw dropw
         end
@@ -33,7 +33,7 @@ fn test_issue_2456_statically_linked_library_call() {
         use test::module_1
 
         begin
-            push.1.2
+            push.1 push.2
             call.module_1::foo
             dropw dropw dropw dropw
         end


### PR DESCRIPTION
## Description

Removes the dot-delimited multi-value push syntax (e.g., `push.1.2.3.4`) from the MASM parser, as proposed in #2572.

Users should now use individual push instructions (`push.1 push.2 push.3 push.4`) or word literals (`push.[1,2,3,4]`).

## Changes

**Parser (grammar.lalrpop):**
- Removed the `DotDelimited` generic helper macro (only used by the push rule)
- Replaced the multi-value push rule with a single-value rule: `push.IMM`

**Error handling (error.rs):**
- Removed the `PushOverflow` error variant (no longer reachable since the parser only accepts one value)

**Display (print.rs):**
- Updated `PushFeltList` display to emit space-separated individual pushes (`push.3 push.4 push.8`) instead of dot-delimited (`push.3.4.8`)

**MASM files (26 files):**
- Converted all dot-delimited push patterns to individual push instructions

**Test files (~24 files):**
- Updated all static string literals in Rust tests
- Updated programmatic format-string generators (e.g., `format!("push.{}.{}", a, b)` to `format!("push.{} push.{}", a, b)`)
- Rewrote the `push_many` integration test to use the new syntax

## Testing

- All assembly-syntax tests pass (104)
- All assembly tests pass (180)
- All processor tests pass (1488)
- All core-lib tests pass (326)
- All integration tests pass (350)
- Clippy clean (zero warnings)

Closes #2572
