### PR TITLE
fix(core): preserve asm-op mappings in MastForest::merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 #### Fixes
 
 - Fixed stale `ReplayProcessor` doc comment links to `ExecutionTracer` after module-structure refactors.
+- Preserved `AssemblyOp` source mappings when merging `MastForest`s, preventing source-location loss after node deduplication.
 
 ## 0.22.1 (2026-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [BREAKING] Bounded the live advice map by total field elements during execution; advice-provider setup now returns an error when initial advice exceeds this limit ([#3085](https://github.com/0xMiden/miden-vm/pull/3085)).
 - Rejected empty kernel packages before linking so malformed dependency metadata returns a structured package error instead of reaching the linker's non-empty-kernel assertion ([#3082](https://github.com/0xMiden/miden-vm/pull/3082)).
 - [BREAKING] Fixed project artifact reuse to ignore unrelated manifest fields, rejected private cross-module imports, and kept signature-only type imports live ([#3091](https://github.com/0xMiden/miden-vm/pull/3091)).
+- Preserved `AssemblyOp` source mappings when merging `MastForest`s, preventing source-location loss after node deduplication.
 
 #### Changes
 
@@ -83,7 +84,6 @@
 #### Fixes
 
 - Fixed stale `ReplayProcessor` doc comment links to `ExecutionTracer` after module-structure refactors.
-- Preserved `AssemblyOp` source mappings when merging `MastForest`s, preventing source-location loss after node deduplication.
 
 ## 0.22.1 (2026-04-07)
 

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -1,4 +1,11 @@
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::{
+    collections::{BTreeMap, btree_map::Entry},
+    string::String,
+    vec::Vec,
+};
+use core::cmp::Ordering;
+
+use miden_debug_types::Location;
 
 use crate::{
     crypto::hash::Blake3Digest,
@@ -7,12 +14,15 @@ use crate::{
         MastNode, MastNodeBuilder, MastNodeFingerprint, MastNodeId, MultiMastForestIteratorItem,
         MultiMastForestNodeIter,
     },
+    operations::AssemblyOp,
     serde::Serializable,
     utils::{DenseIdMap, IndexVec},
 };
 
 #[cfg(test)]
 mod tests;
+
+type AssemblyOpKey = (Option<Location>, String, u8, String);
 
 /// A type that allows merging [`MastForest`]s.
 ///
@@ -27,6 +37,8 @@ pub(crate) struct MastForestMerger {
     node_id_by_hash: BTreeMap<MastNodeFingerprint, MastNodeId>,
     hash_by_node_id: IndexVec<MastNodeId, MastNodeFingerprint>,
     decorators_by_hash: BTreeMap<Blake3Digest<32>, DecoratorId>,
+    asm_op_id_by_value: BTreeMap<AssemblyOpKey, AsmOpId>,
+    asm_op_value_by_id: BTreeMap<AsmOpId, AssemblyOpKey>,
     /// Mappings from old decorator and node ids to their new ids.
     ///
     /// Any decorator in `mast_forest` is present as the target of some mapping in this map.
@@ -35,6 +47,10 @@ pub(crate) struct MastForestMerger {
     ///
     /// Any `MastNodeId` in `mast_forest` is present as the target of some mapping in this map.
     node_id_mappings: Vec<DenseIdMap<MastNodeId, MastNodeId>>,
+    /// AssemblyOp mappings to register after all nodes have been merged.
+    ///
+    /// This is keyed by merged node id and stores `(num_operations, [(op_idx, asm_op_id)])`.
+    pending_asm_op_mappings: BTreeMap<MastNodeId, (usize, Vec<(usize, AsmOpId)>)>,
 }
 
 impl MastForestMerger {
@@ -65,9 +81,12 @@ impl MastForestMerger {
             node_id_by_hash: BTreeMap::new(),
             hash_by_node_id: IndexVec::new(),
             decorators_by_hash: BTreeMap::new(),
+            asm_op_id_by_value: BTreeMap::new(),
+            asm_op_value_by_id: BTreeMap::new(),
             mast_forest: MastForest::new(),
             decorator_id_mappings,
             node_id_mappings,
+            pending_asm_op_mappings: BTreeMap::new(),
         };
 
         merger.merge_inner(forests.clone())?;
@@ -81,13 +100,14 @@ impl MastForestMerger {
 
     /// Merges all `forests` into self.
     ///
-    /// It does this in three steps:
+    /// It does this in six steps:
     ///
     /// 1. Merge all advice maps, checking for key collisions.
     /// 2. Merge all decorators, which is a case of deduplication and creating a decorator id
     ///    mapping which contains how existing [`DecoratorId`]s map to [`DecoratorId`]s in the
     ///    merged forest.
-    /// 3. Merge all nodes of forests.
+    /// 3. Merge all error codes.
+    /// 4. Merge all nodes of forests.
     ///    - Similar to decorators, node indices might move during merging, so the merger keeps a
     ///      node id mapping as it merges nodes.
     ///    - This is a depth-first traversal over all forests to ensure all children are processed
@@ -109,7 +129,11 @@ impl MastForestMerger {
     ///        `replacement` node. Now we can simply add a mapping from the external node to the
     ///        `replacement` node in our node id mapping which means all nodes that referenced the
     ///        external node will point to the `replacement` instead.
-    /// 4. Finally, we merge all roots of all forests. Here we map the existing root indices to
+    /// 5. Merge all AssemblyOp source mappings for merged nodes.
+    ///    - AssemblyOps are deduplicated by value and remapped to merged ids.
+    ///    - Op-indexed source mappings are registered after node merge, when all node remappings
+    ///      are known.
+    /// 6. Finally, we merge all roots of all forests. Here we map the existing root indices to
     ///    their potentially new indices in the merged forest and add them to the forest,
     ///    deduplicating in the process, too.
     fn merge_inner(&mut self, forests: Vec<&MastForest>) -> Result<(), MastForestError> {
@@ -148,6 +172,12 @@ impl MastForestMerger {
                         .get(replacement_mast_node_id)
                         .expect("every merged node id should be mapped");
 
+                    self.merge_node_asm_ops(
+                        forests[replaced_forest_idx],
+                        replaced_mast_node_id,
+                        mapped_replacement,
+                    )?;
+
                     // SAFETY: The iterator only yields valid forest indices, so it is safe to index
                     // directly.
                     self.node_id_mappings[replaced_forest_idx]
@@ -155,6 +185,8 @@ impl MastForestMerger {
                 },
             }
         }
+
+        self.register_asm_op_mappings();
 
         for (forest_idx, forest) in forests.iter().enumerate() {
             self.merge_roots(forest_idx, forest)?;
@@ -239,17 +271,14 @@ impl MastForestMerger {
         // blocks from different forests are not collapsed.
         let debug_var_data =
             serialize_debug_var_content_for_node(original_forests[forest_idx], merging_id);
-        let asm_op_data =
-            serialize_asm_op_content_for_node(original_forests[forest_idx], merging_id);
-        let node_fingerprint = base_fingerprint
-            .augment_with_data(&debug_var_data)
-            .augment_with_data(&asm_op_data);
+        let node_fingerprint = base_fingerprint.augment_with_data(&debug_var_data);
 
-        match self.lookup_node_by_fingerprint(&node_fingerprint) {
+        let mapped_node_id = match self.lookup_node_by_fingerprint(&node_fingerprint) {
             Some(matching_node_id) => {
                 // If a node with a matching fingerprint exists, then the merging node is a
                 // duplicate and we remap it to the existing node.
                 self.node_id_mappings[forest_idx].insert(merging_id, matching_node_id);
+                matching_node_id
             },
             None => {
                 // If no node with a matching fingerprint exists, then the merging node is
@@ -271,8 +300,11 @@ impl MastForestMerger {
                     returned_id, new_node_id,
                     "hash_by_node_id push() should return the same node IDs as node_id_by_hash"
                 );
+                new_node_id
             },
-        }
+        };
+
+        self.merge_node_asm_ops(original_forests[forest_idx], merging_id, mapped_node_id)?;
 
         Ok(())
     }
@@ -296,12 +328,12 @@ impl MastForestMerger {
         Ok(())
     }
 
-    /// Transfers procedure names, asm ops, and debug vars from the source forests
-    /// into the merged forest, remapping all IDs along the way.
+    /// Transfers procedure names and debug vars from the source forests into the merged forest,
+    /// remapping all IDs along the way.
     ///
-    /// Procedure names are merged separately by digest. Per-node asm-op and debug-var
-    /// metadata are remapped by node ID, and when two source nodes map to the same merged
-    /// node (dedup), the first forest's per-node metadata wins.
+    /// Procedure names are merged separately by digest. Per-node debug-var metadata is remapped by
+    /// node ID, and when two source nodes map to the same merged node (dedup), the first forest's
+    /// per-node metadata wins.
     fn merge_debug_metadata(&mut self, forests: &[&MastForest]) -> Result<(), MastForestError> {
         // Procedure names are keyed by digest. First name wins so that a later
         // forest cannot silently rename an already-registered procedure.
@@ -313,21 +345,12 @@ impl MastForestMerger {
             }
         }
 
-        // Collect per-node asm-op and debug-var registrations across all forests.
+        // Collect per-node debug-var registrations across all forests.
         // BTreeMap gives us sorted-by-node-id iteration, which the CSR requires.
-        let mut asm_entries: BTreeMap<MastNodeId, Vec<(usize, AsmOpId)>> = BTreeMap::new();
         let mut dbg_entries: BTreeMap<MastNodeId, Vec<(usize, DebugVarId)>> = BTreeMap::new();
 
         for (forest_idx, forest) in forests.iter().enumerate() {
-            // Copy AssemblyOp objects and build old→new AsmOpId remapping.
-            let mut asm_id_map: BTreeMap<AsmOpId, AsmOpId> = BTreeMap::new();
-            for (raw, asm_op) in forest.debug_info.asm_ops().iter().enumerate() {
-                let old_id = AsmOpId::new(raw as u32);
-                let new_id = self.mast_forest.debug_info.add_asm_op(asm_op.clone())?;
-                asm_id_map.insert(old_id, new_id);
-            }
-
-            // Copy DebugVarInfo objects and build old→new DebugVarId remapping.
+            // Copy DebugVarInfo objects and build old-to-new DebugVarId remapping.
             let mut dbg_id_map: BTreeMap<DebugVarId, DebugVarId> = BTreeMap::new();
             for (raw, dvar) in forest.debug_info.debug_vars().iter().enumerate() {
                 let old_id = DebugVarId::from(raw as u32);
@@ -343,16 +366,7 @@ impl MastForestMerger {
                     None => continue,
                 };
 
-                if let alloc::collections::btree_map::Entry::Vacant(e) = asm_entries.entry(new_id) {
-                    let ops = forest.debug_info.asm_ops_for_node(old_id);
-                    if !ops.is_empty() {
-                        let remapped =
-                            ops.into_iter().map(|(idx, id)| (idx, asm_id_map[&id])).collect();
-                        e.insert(remapped);
-                    }
-                }
-
-                if let alloc::collections::btree_map::Entry::Vacant(e) = dbg_entries.entry(new_id) {
+                if let Entry::Vacant(e) = dbg_entries.entry(new_id) {
                     let vars = forest.debug_info.debug_vars_for_node(old_id);
                     if !vars.is_empty() {
                         let remapped =
@@ -364,17 +378,6 @@ impl MastForestMerger {
         }
 
         // Register in node-ID order (CSR sequential constraint).
-        for (node_id, entries) in asm_entries {
-            let num_ops = match &self.mast_forest[node_id] {
-                MastNode::Block(block) => block.num_operations() as usize,
-                _ => entries.iter().map(|(idx, _)| idx + 1).max().unwrap_or(0),
-            };
-            self.mast_forest
-                .debug_info
-                .register_asm_ops(node_id, num_ops, entries)
-                .map_err(|_| MastForestError::TooManyNodes)?;
-        }
-
         for (node_id, entries) in dbg_entries {
             self.mast_forest
                 .debug_info
@@ -392,6 +395,285 @@ impl MastForestMerger {
     /// fingerprint, if any.
     fn lookup_node_by_fingerprint(&self, fingerprint: &MastNodeFingerprint) -> Option<MastNodeId> {
         self.node_id_by_hash.get(fingerprint).copied()
+    }
+
+    /// Merges AssemblyOp source mappings for a single node.
+    ///
+    /// For basic blocks we preserve op-indexed source mapping transitions. For non-basic-block
+    /// nodes we preserve all sparse transitions as stored in debug info.
+    fn merge_node_asm_ops(
+        &mut self,
+        source_forest: &MastForest,
+        source_node_id: MastNodeId,
+        merged_node_id: MastNodeId,
+    ) -> Result<(), MastForestError> {
+        let (num_operations, asm_ops) = match &source_forest[source_node_id] {
+            MastNode::Block(block) => {
+                let num_operations = block.num_operations() as usize;
+                let mut asm_ops = Vec::new();
+                let mut previous_asm_op: Option<AssemblyOpKey> = None;
+
+                for op_idx in 0..num_operations {
+                    let asm_op =
+                        source_forest.debug_info.asm_op_for_operation(source_node_id, op_idx);
+                    let asm_op_key = asm_op.map(Self::asm_op_key);
+
+                    if asm_op_key == previous_asm_op {
+                        continue;
+                    }
+
+                    if let Some(asm_op) = asm_op {
+                        let merged_asm_op_id = self.intern_asm_op(asm_op)?;
+                        asm_ops.push((op_idx, merged_asm_op_id));
+                    }
+
+                    previous_asm_op = asm_op_key;
+                }
+
+                (num_operations, asm_ops)
+            },
+            _ => {
+                let source_asm_ops = source_forest.debug_info.asm_ops_for_node(source_node_id);
+                if source_asm_ops.is_empty() {
+                    return Ok(());
+                }
+
+                let mut asm_ops = Vec::with_capacity(source_asm_ops.len());
+                for (op_idx, asm_op_id) in source_asm_ops.iter().copied() {
+                    let asm_op = source_forest
+                        .debug_info
+                        .asm_op(asm_op_id)
+                        .expect("asm-op mapping should reference a valid assembly op");
+                    let merged_asm_op_id = self.intern_asm_op(asm_op)?;
+                    asm_ops.push((op_idx, merged_asm_op_id));
+                }
+
+                let num_operations =
+                    source_asm_ops.last().map(|(op_idx, _)| op_idx + 1).unwrap_or(0);
+
+                (num_operations, asm_ops)
+            },
+        };
+
+        if asm_ops.is_empty() {
+            return Ok(());
+        }
+
+        self.merge_pending_asm_op_mapping(merged_node_id, num_operations, asm_ops);
+
+        Ok(())
+    }
+
+    /// Adds or merges asm-op mappings for a merged node.
+    ///
+    /// Nodes can be visited multiple times due to deduplication across input forests. In that case,
+    /// we merge compatible mappings and resolve conflicts deterministically, favoring the richer
+    /// source mapping.
+    fn merge_pending_asm_op_mapping(
+        &mut self,
+        merged_node_id: MastNodeId,
+        num_operations: usize,
+        asm_ops: Vec<(usize, AsmOpId)>,
+    ) {
+        match self.pending_asm_op_mappings.entry(merged_node_id) {
+            Entry::Vacant(entry) => {
+                entry.insert((num_operations, asm_ops));
+            },
+            Entry::Occupied(mut entry) => {
+                let (existing_num_operations, existing_asm_ops) = entry.get_mut();
+                let merged_num_operations =
+                    core::cmp::max(*existing_num_operations, num_operations);
+                let merged_asm_ops = Self::merge_asm_op_mappings(
+                    merged_num_operations,
+                    existing_asm_ops,
+                    &asm_ops,
+                    &self.asm_op_value_by_id,
+                );
+                *existing_num_operations = merged_num_operations;
+                *existing_asm_ops = merged_asm_ops;
+            },
+        }
+    }
+
+    /// Merges two sparse asm-op mappings for the same node.
+    ///
+    /// Compatible entries are unified. Conflicts are resolved deterministically by preferring the
+    /// richer mapping.
+    fn merge_asm_op_mappings(
+        num_operations: usize,
+        lhs: &[(usize, AsmOpId)],
+        rhs: &[(usize, AsmOpId)],
+        asm_op_value_by_id: &BTreeMap<AsmOpId, AssemblyOpKey>,
+    ) -> Vec<(usize, AsmOpId)> {
+        let lhs_expanded = Self::expand_asm_op_mapping(num_operations, lhs);
+        let rhs_expanded = Self::expand_asm_op_mapping(num_operations, rhs);
+        let preference = Self::compare_asm_op_mapping_specificity(num_operations, lhs, rhs);
+
+        if preference.is_eq()
+            && Self::has_conflicting_asm_op_assignments(&lhs_expanded, &rhs_expanded)
+        {
+            return match Self::compare_asm_op_mapping_value_key(lhs, rhs, asm_op_value_by_id) {
+                Ordering::Greater | Ordering::Equal => lhs.to_vec(),
+                Ordering::Less => rhs.to_vec(),
+            };
+        }
+
+        let mut merged = Vec::with_capacity(num_operations);
+        for op_idx in 0..num_operations {
+            let merged_asm_op = match (lhs_expanded[op_idx], rhs_expanded[op_idx]) {
+                (Some(lhs_asm_op), Some(rhs_asm_op)) if lhs_asm_op == rhs_asm_op => {
+                    Some(lhs_asm_op)
+                },
+                (Some(lhs_asm_op), Some(rhs_asm_op)) => Some(match preference {
+                    Ordering::Greater => lhs_asm_op,
+                    Ordering::Less => rhs_asm_op,
+                    Ordering::Equal => lhs_asm_op,
+                }),
+                (Some(asm_op), None) | (None, Some(asm_op)) => Some(asm_op),
+                (None, None) => None,
+            };
+            merged.push(merged_asm_op);
+        }
+
+        Self::compress_asm_op_mapping(&merged)
+    }
+
+    fn has_conflicting_asm_op_assignments(
+        lhs_expanded: &[Option<AsmOpId>],
+        rhs_expanded: &[Option<AsmOpId>],
+    ) -> bool {
+        lhs_expanded.iter().zip(rhs_expanded.iter()).any(|(lhs_entry, rhs_entry)| {
+            match (lhs_entry, rhs_entry) {
+                (Some(lhs_asm_op), Some(rhs_asm_op)) => lhs_asm_op != rhs_asm_op,
+                _ => false,
+            }
+        })
+    }
+
+    fn compare_asm_op_mapping_value_key(
+        lhs: &[(usize, AsmOpId)],
+        rhs: &[(usize, AsmOpId)],
+        asm_op_value_by_id: &BTreeMap<AsmOpId, AssemblyOpKey>,
+    ) -> Ordering {
+        for ((lhs_op_idx, lhs_asm_op), (rhs_op_idx, rhs_asm_op)) in lhs.iter().zip(rhs.iter()) {
+            let op_idx_cmp = lhs_op_idx.cmp(rhs_op_idx);
+            if !op_idx_cmp.is_eq() {
+                return op_idx_cmp;
+            }
+
+            let lhs_key = asm_op_value_by_id
+                .get(lhs_asm_op)
+                .expect("asm-op id should resolve to a value key");
+            let rhs_key = asm_op_value_by_id
+                .get(rhs_asm_op)
+                .expect("asm-op id should resolve to a value key");
+            let key_cmp = lhs_key.cmp(rhs_key);
+            if !key_cmp.is_eq() {
+                return key_cmp;
+            }
+        }
+
+        lhs.len().cmp(&rhs.len())
+    }
+
+    /// Expands sparse mapping transitions into per-operation mapping.
+    fn expand_asm_op_mapping(
+        num_operations: usize,
+        asm_ops: &[(usize, AsmOpId)],
+    ) -> Vec<Option<AsmOpId>> {
+        let mut expanded = vec![None; num_operations];
+        for (i, (start_op_idx, asm_op_id)) in asm_ops.iter().copied().enumerate() {
+            if start_op_idx >= num_operations {
+                break;
+            }
+            let end_op_idx =
+                asm_ops.get(i + 1).map(|(op_idx, _)| *op_idx).unwrap_or(num_operations);
+            expanded[start_op_idx..end_op_idx].fill(Some(asm_op_id));
+        }
+        expanded
+    }
+
+    /// Compresses per-operation mapping into sparse transition points.
+    fn compress_asm_op_mapping(asm_ops: &[Option<AsmOpId>]) -> Vec<(usize, AsmOpId)> {
+        let mut compressed = Vec::new();
+        let mut previous_asm_op = None;
+
+        for (op_idx, asm_op) in asm_ops.iter().copied().enumerate() {
+            if asm_op == previous_asm_op {
+                continue;
+            }
+
+            if let Some(asm_op) = asm_op {
+                compressed.push((op_idx, asm_op));
+            }
+            previous_asm_op = asm_op;
+        }
+
+        compressed
+    }
+
+    /// Compares mapping richness for deterministic conflict resolution.
+    ///
+    /// Richer mapping means:
+    /// 1. More transition points.
+    /// 2. If tied, larger covered suffix of operations.
+    fn compare_asm_op_mapping_specificity(
+        num_operations: usize,
+        lhs: &[(usize, AsmOpId)],
+        rhs: &[(usize, AsmOpId)],
+    ) -> Ordering {
+        let transitions_cmp = lhs.len().cmp(&rhs.len());
+        if !transitions_cmp.is_eq() {
+            return transitions_cmp;
+        }
+
+        let coverage = |mapping: &[(usize, AsmOpId)]| {
+            mapping
+                .first()
+                .map(|(op_idx, _)| num_operations.saturating_sub(*op_idx))
+                .unwrap_or(0)
+        };
+        let coverage_cmp = coverage(lhs).cmp(&coverage(rhs));
+        if !coverage_cmp.is_eq() {
+            return coverage_cmp;
+        }
+
+        Ordering::Equal
+    }
+
+    /// Registers all merged asm-op mappings into the merged forest.
+    fn register_asm_op_mappings(&mut self) {
+        for (node_id, (num_operations, asm_ops)) in
+            core::mem::take(&mut self.pending_asm_op_mappings)
+        {
+            self.mast_forest
+                .debug_info
+                .register_asm_ops(node_id, num_operations, asm_ops)
+                .expect("asm-op mappings should be registered in increasing node id order");
+        }
+    }
+
+    /// Adds the provided AssemblyOp to the merged forest if not present and returns its ID.
+    fn intern_asm_op(&mut self, asm_op: &AssemblyOp) -> Result<AsmOpId, MastForestError> {
+        let key = Self::asm_op_key(asm_op);
+        if let Some(existing_id) = self.asm_op_id_by_value.get(&key) {
+            return Ok(*existing_id);
+        }
+
+        let asm_op_id = self.mast_forest.debug_info.add_asm_op(asm_op.clone())?;
+        self.asm_op_id_by_value.insert(key.clone(), asm_op_id);
+        self.asm_op_value_by_id.insert(asm_op_id, key);
+
+        Ok(asm_op_id)
+    }
+
+    fn asm_op_key(asm_op: &AssemblyOp) -> AssemblyOpKey {
+        (
+            asm_op.location().cloned(),
+            String::from(asm_op.context_name()),
+            asm_op.num_cycles(),
+            String::from(asm_op.op()),
+        )
     }
 
     /// Builds a new node with remapped children and decorators using the provided mappings.
@@ -427,38 +709,6 @@ fn serialize_debug_var_content_for_node(forest: &MastForest, node_id: MastNodeId
         data.extend_from_slice(&op_idx.to_le_bytes());
         if let Some(info) = forest.debug_info().debug_var(var_id) {
             info.write_into(&mut data);
-        }
-    }
-    data
-}
-
-/// Serializes the actual asm-op content for a node, producing a stable byte
-/// sequence suitable for fingerprint augmentation.
-///
-/// This ensures that nodes with identical structure but different source-mapping
-/// metadata do not collapse during merge.
-fn serialize_asm_op_content_for_node(forest: &MastForest, node_id: MastNodeId) -> Vec<u8> {
-    let entries = forest.debug_info().asm_ops_for_node(node_id);
-    if entries.is_empty() {
-        return Vec::new();
-    }
-
-    let mut data = Vec::new();
-    for (op_idx, asm_op_id) in entries {
-        data.extend_from_slice(&op_idx.to_le_bytes());
-        if let Some(asm_op) = forest.debug_info().asm_op(asm_op_id) {
-            asm_op.context_name().write_into(&mut data);
-            asm_op.op().write_into(&mut data);
-            asm_op.num_cycles().write_into(&mut data);
-            match asm_op.location() {
-                Some(location) => {
-                    data.push(1);
-                    location.uri.write_into(&mut data);
-                    data.extend_from_slice(&u32::from(location.start).to_le_bytes());
-                    data.extend_from_slice(&u32::from(location.end).to_le_bytes());
-                },
-                None => data.push(0),
-            }
         }
     }
     data

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -271,7 +271,12 @@ impl MastForestMerger {
         // blocks from different forests are not collapsed.
         let debug_var_data =
             serialize_debug_var_content_for_node(original_forests[forest_idx], merging_id);
-        let node_fingerprint = base_fingerprint.augment_with_data(&debug_var_data);
+        let asm_op_data =
+            serialize_asm_op_content_for_node(original_forests[forest_idx], merging_id);
+        let node_fingerprint =
+            augment_fingerprint_with_metadata(base_fingerprint, b"debug-vars", &debug_var_data);
+        let node_fingerprint =
+            augment_fingerprint_with_metadata(node_fingerprint, b"asm-ops", &asm_op_data);
 
         let mapped_node_id = match self.lookup_node_by_fingerprint(&node_fingerprint) {
             Some(matching_node_id) => {
@@ -712,6 +717,89 @@ fn serialize_debug_var_content_for_node(forest: &MastForest, node_id: MastNodeId
         }
     }
     data
+}
+
+fn augment_fingerprint_with_metadata(
+    fingerprint: MastNodeFingerprint,
+    tag: &[u8],
+    payload: &[u8],
+) -> MastNodeFingerprint {
+    if payload.is_empty() {
+        return fingerprint;
+    }
+
+    let mut data = Vec::new();
+    data.extend_from_slice(&(tag.len() as u32).to_le_bytes());
+    data.extend_from_slice(tag);
+    data.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+    data.extend_from_slice(payload);
+
+    fingerprint.augment_with_data(&data)
+}
+
+/// Serializes the actual asm-op content for a node, producing a stable byte sequence suitable for
+/// fingerprint augmentation.
+///
+/// This ensures that nodes with identical structure but different source-mapping metadata do not
+/// collapse during merge.
+fn serialize_asm_op_content_for_node(forest: &MastForest, node_id: MastNodeId) -> Vec<u8> {
+    let mut data = Vec::new();
+
+    match &forest[node_id] {
+        MastNode::Block(block) => {
+            let num_operations = block.num_operations() as usize;
+            let mut previous_asm_op: Option<AssemblyOpKey> = None;
+
+            for op_idx in 0..num_operations {
+                let asm_op = forest.debug_info().asm_op_for_operation(node_id, op_idx);
+                let asm_op_key = asm_op.map(MastForestMerger::asm_op_key);
+
+                if asm_op_key == previous_asm_op {
+                    continue;
+                }
+
+                if let Some(asm_op) = asm_op {
+                    data.extend_from_slice(&op_idx.to_le_bytes());
+                    serialize_asm_op_content(asm_op, &mut data);
+                }
+
+                previous_asm_op = asm_op_key;
+            }
+        },
+        _ => {
+            let entries = forest.debug_info().asm_ops_for_node(node_id);
+            if entries.is_empty() {
+                return data;
+            }
+
+            let num_operations = entries.last().map(|(op_idx, _)| op_idx + 1).unwrap_or(0);
+            data.extend_from_slice(&num_operations.to_le_bytes());
+
+            for (op_idx, asm_op_id) in entries {
+                data.extend_from_slice(&op_idx.to_le_bytes());
+                if let Some(asm_op) = forest.debug_info().asm_op(asm_op_id) {
+                    serialize_asm_op_content(asm_op, &mut data);
+                }
+            }
+        },
+    }
+
+    data
+}
+
+fn serialize_asm_op_content(asm_op: &AssemblyOp, data: &mut Vec<u8>) {
+    asm_op.context_name().write_into(data);
+    asm_op.op().write_into(data);
+    asm_op.num_cycles().write_into(data);
+    match asm_op.location() {
+        Some(location) => {
+            data.push(1);
+            location.uri.write_into(data);
+            data.extend_from_slice(&u32::from(location.start).to_le_bytes());
+            data.extend_from_slice(&u32::from(location.end).to_le_bytes());
+        },
+        None => data.push(0),
+    }
 }
 
 // MAST FOREST ROOT MAP

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -186,7 +186,7 @@ impl MastForestMerger {
             }
         }
 
-        self.register_asm_op_mappings();
+        self.register_asm_op_mappings()?;
 
         for (forest_idx, forest) in forests.iter().enumerate() {
             self.merge_roots(forest_idx, forest)?;
@@ -481,10 +481,12 @@ impl MastForestMerger {
         let lhs_expanded = Self::expand_asm_op_mapping(num_operations, lhs);
         let rhs_expanded = Self::expand_asm_op_mapping(num_operations, rhs);
         let preference = Self::compare_asm_op_mapping_specificity(num_operations, lhs, rhs);
+        let has_conflicting_assignments =
+            lhs_expanded.iter().zip(&rhs_expanded).any(|(lhs_entry, rhs_entry)| {
+                matches!((lhs_entry, rhs_entry), (Some(lhs_asm_op), Some(rhs_asm_op)) if lhs_asm_op != rhs_asm_op)
+            });
 
-        if preference.is_eq()
-            && Self::has_conflicting_asm_op_assignments(&lhs_expanded, &rhs_expanded)
-        {
+        if preference.is_eq() && has_conflicting_assignments {
             return match Self::compare_asm_op_mapping_value_key(lhs, rhs, asm_op_value_by_id) {
                 Ordering::Greater | Ordering::Equal => lhs.to_vec(),
                 Ordering::Less => rhs.to_vec(),
@@ -514,42 +516,19 @@ impl MastForestMerger {
         Self::compress_asm_op_mapping(&merged, &preserved_transition_points)
     }
 
-    fn has_conflicting_asm_op_assignments(
-        lhs_expanded: &[Option<AsmOpId>],
-        rhs_expanded: &[Option<AsmOpId>],
-    ) -> bool {
-        lhs_expanded.iter().zip(rhs_expanded.iter()).any(|(lhs_entry, rhs_entry)| {
-            match (lhs_entry, rhs_entry) {
-                (Some(lhs_asm_op), Some(rhs_asm_op)) => lhs_asm_op != rhs_asm_op,
-                _ => false,
-            }
-        })
-    }
-
     fn compare_asm_op_mapping_value_key(
         lhs: &[(usize, AsmOpId)],
         rhs: &[(usize, AsmOpId)],
         asm_op_value_by_id: &BTreeMap<AsmOpId, AssemblyOpKey>,
     ) -> Ordering {
-        for ((lhs_op_idx, lhs_asm_op), (rhs_op_idx, rhs_asm_op)) in lhs.iter().zip(rhs.iter()) {
-            let op_idx_cmp = lhs_op_idx.cmp(rhs_op_idx);
-            if !op_idx_cmp.is_eq() {
-                return op_idx_cmp;
-            }
+        let value_key = |(op_idx, asm_op): &(usize, AsmOpId)| {
+            (
+                *op_idx,
+                asm_op_value_by_id.get(asm_op).expect("asm-op id should resolve to a value key"),
+            )
+        };
 
-            let lhs_key = asm_op_value_by_id
-                .get(lhs_asm_op)
-                .expect("asm-op id should resolve to a value key");
-            let rhs_key = asm_op_value_by_id
-                .get(rhs_asm_op)
-                .expect("asm-op id should resolve to a value key");
-            let key_cmp = lhs_key.cmp(rhs_key);
-            if !key_cmp.is_eq() {
-                return key_cmp;
-            }
-        }
-
-        lhs.len().cmp(&rhs.len())
+        lhs.iter().map(value_key).cmp(rhs.iter().map(value_key))
     }
 
     /// Expands sparse mapping transitions into per-operation mapping.
@@ -621,15 +600,17 @@ impl MastForestMerger {
     }
 
     /// Registers all merged asm-op mappings into the merged forest.
-    fn register_asm_op_mappings(&mut self) {
+    fn register_asm_op_mappings(&mut self) -> Result<(), MastForestError> {
         for (node_id, (num_operations, asm_ops)) in
             core::mem::take(&mut self.pending_asm_op_mappings)
         {
             self.mast_forest
                 .debug_info
                 .register_asm_ops(node_id, num_operations, asm_ops)
-                .expect("asm-op mappings should be registered in increasing node id order");
+                .map_err(MastForestError::AssemblyOpError)?;
         }
+
+        Ok(())
     }
 
     /// Adds the provided AssemblyOp to the merged forest if not present and returns its ID.

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -1,5 +1,5 @@
 use alloc::{
-    collections::{BTreeMap, btree_map::Entry},
+    collections::{BTreeMap, BTreeSet, btree_map::Entry},
     string::String,
     vec::Vec,
 };
@@ -412,56 +412,24 @@ impl MastForestMerger {
         source_node_id: MastNodeId,
         merged_node_id: MastNodeId,
     ) -> Result<(), MastForestError> {
-        let (num_operations, asm_ops) = match &source_forest[source_node_id] {
-            MastNode::Block(block) => {
-                let num_operations = block.num_operations() as usize;
-                let mut asm_ops = Vec::new();
-                let mut previous_asm_op: Option<AssemblyOpKey> = None;
+        let source_asm_ops = source_forest.debug_info.asm_ops_for_node(source_node_id);
+        if source_asm_ops.is_empty() {
+            return Ok(());
+        }
 
-                for op_idx in 0..num_operations {
-                    let asm_op =
-                        source_forest.debug_info.asm_op_for_operation(source_node_id, op_idx);
-                    let asm_op_key = asm_op.map(Self::asm_op_key);
-
-                    if asm_op_key == previous_asm_op {
-                        continue;
-                    }
-
-                    if let Some(asm_op) = asm_op {
-                        let merged_asm_op_id = self.intern_asm_op(asm_op)?;
-                        asm_ops.push((op_idx, merged_asm_op_id));
-                    }
-
-                    previous_asm_op = asm_op_key;
-                }
-
-                (num_operations, asm_ops)
-            },
-            _ => {
-                let source_asm_ops = source_forest.debug_info.asm_ops_for_node(source_node_id);
-                if source_asm_ops.is_empty() {
-                    return Ok(());
-                }
-
-                let mut asm_ops = Vec::with_capacity(source_asm_ops.len());
-                for (op_idx, asm_op_id) in source_asm_ops.iter().copied() {
-                    let asm_op = source_forest
-                        .debug_info
-                        .asm_op(asm_op_id)
-                        .expect("asm-op mapping should reference a valid assembly op");
-                    let merged_asm_op_id = self.intern_asm_op(asm_op)?;
-                    asm_ops.push((op_idx, merged_asm_op_id));
-                }
-
-                let num_operations =
-                    source_asm_ops.last().map(|(op_idx, _)| op_idx + 1).unwrap_or(0);
-
-                (num_operations, asm_ops)
-            },
+        let num_operations = match &source_forest[source_node_id] {
+            MastNode::Block(block) => block.num_operations() as usize,
+            _ => source_asm_ops.last().map(|(op_idx, _)| op_idx + 1).unwrap_or(0),
         };
 
-        if asm_ops.is_empty() {
-            return Ok(());
+        let mut asm_ops = Vec::with_capacity(source_asm_ops.len());
+        for (op_idx, asm_op_id) in source_asm_ops.iter().copied() {
+            let asm_op = source_forest
+                .debug_info
+                .asm_op(asm_op_id)
+                .expect("asm-op mapping should reference a valid assembly op");
+            let merged_asm_op_id = self.intern_asm_op(asm_op)?;
+            asm_ops.push((op_idx, merged_asm_op_id));
         }
 
         self.merge_pending_asm_op_mapping(merged_node_id, num_operations, asm_ops);
@@ -540,7 +508,10 @@ impl MastForestMerger {
             merged.push(merged_asm_op);
         }
 
-        Self::compress_asm_op_mapping(&merged)
+        let preserved_transition_points =
+            lhs.iter().chain(rhs.iter()).map(|(op_idx, _)| *op_idx).collect::<BTreeSet<_>>();
+
+        Self::compress_asm_op_mapping(&merged, &preserved_transition_points)
     }
 
     fn has_conflicting_asm_op_assignments(
@@ -599,12 +570,15 @@ impl MastForestMerger {
     }
 
     /// Compresses per-operation mapping into sparse transition points.
-    fn compress_asm_op_mapping(asm_ops: &[Option<AsmOpId>]) -> Vec<(usize, AsmOpId)> {
+    fn compress_asm_op_mapping(
+        asm_ops: &[Option<AsmOpId>],
+        preserved_transition_points: &BTreeSet<usize>,
+    ) -> Vec<(usize, AsmOpId)> {
         let mut compressed = Vec::new();
         let mut previous_asm_op = None;
 
         for (op_idx, asm_op) in asm_ops.iter().copied().enumerate() {
-            if asm_op == previous_asm_op {
+            if asm_op == previous_asm_op && !preserved_transition_points.contains(&op_idx) {
                 continue;
             }
 
@@ -743,45 +717,23 @@ fn augment_fingerprint_with_metadata(
 /// This ensures that nodes with identical structure but different source-mapping metadata do not
 /// collapse during merge.
 fn serialize_asm_op_content_for_node(forest: &MastForest, node_id: MastNodeId) -> Vec<u8> {
+    let entries = forest.debug_info().asm_ops_for_node(node_id);
+    if entries.is_empty() {
+        return Vec::new();
+    }
+
     let mut data = Vec::new();
 
-    match &forest[node_id] {
-        MastNode::Block(block) => {
-            let num_operations = block.num_operations() as usize;
-            let mut previous_asm_op: Option<AssemblyOpKey> = None;
+    if !matches!(forest[node_id], MastNode::Block(_)) {
+        let num_operations = entries.last().map(|(op_idx, _)| op_idx + 1).unwrap_or(0);
+        data.extend_from_slice(&num_operations.to_le_bytes());
+    }
 
-            for op_idx in 0..num_operations {
-                let asm_op = forest.debug_info().asm_op_for_operation(node_id, op_idx);
-                let asm_op_key = asm_op.map(MastForestMerger::asm_op_key);
-
-                if asm_op_key == previous_asm_op {
-                    continue;
-                }
-
-                if let Some(asm_op) = asm_op {
-                    data.extend_from_slice(&op_idx.to_le_bytes());
-                    serialize_asm_op_content(asm_op, &mut data);
-                }
-
-                previous_asm_op = asm_op_key;
-            }
-        },
-        _ => {
-            let entries = forest.debug_info().asm_ops_for_node(node_id);
-            if entries.is_empty() {
-                return data;
-            }
-
-            let num_operations = entries.last().map(|(op_idx, _)| op_idx + 1).unwrap_or(0);
-            data.extend_from_slice(&num_operations.to_le_bytes());
-
-            for (op_idx, asm_op_id) in entries {
-                data.extend_from_slice(&op_idx.to_le_bytes());
-                if let Some(asm_op) = forest.debug_info().asm_op(asm_op_id) {
-                    serialize_asm_op_content(asm_op, &mut data);
-                }
-            }
-        },
+    for (op_idx, asm_op_id) in entries {
+        data.extend_from_slice(&op_idx.to_le_bytes());
+        if let Some(asm_op) = forest.debug_info().asm_op(asm_op_id) {
+            serialize_asm_op_content(asm_op, &mut data);
+        }
     }
 
     data

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -816,6 +816,46 @@ fn mast_forest_merge_multiple_external_nodes_with_decorator() {
     }
 }
 
+#[test]
+fn mast_forest_merge_preserves_asm_op_mappings_from_external_replacement() {
+    let mut forest_with_external = MastForest::new();
+    let foo_digest = block_foo().build().unwrap().digest();
+    let external_id = ExternalNodeBuilder::new(foo_digest)
+        .add_to_forest(&mut forest_with_external)
+        .unwrap();
+    forest_with_external.make_root(external_id);
+
+    let external_asm_op = AssemblyOp::new(None, "proc::caller".into(), 1, "call.foo".into());
+    let external_asm_op_id = forest_with_external
+        .debug_info_mut()
+        .add_asm_op(external_asm_op.clone())
+        .unwrap();
+    forest_with_external
+        .debug_info_mut()
+        .register_asm_ops(external_id, 1, vec![(0, external_asm_op_id)])
+        .unwrap();
+
+    let mut forest_with_block = MastForest::new();
+    let block_id = block_foo().add_to_forest(&mut forest_with_block).unwrap();
+    forest_with_block.make_root(block_id);
+
+    let (merged_ext_then_block, root_maps_ext_then_block) =
+        MastForest::merge([&forest_with_external, &forest_with_block]).unwrap();
+    let mapped_external_root = root_maps_ext_then_block.map_root(0, &external_id).unwrap();
+    assert_eq!(
+        merged_ext_then_block.get_assembly_op(mapped_external_root, None),
+        Some(&external_asm_op),
+    );
+
+    let (merged_block_then_ext, root_maps_block_then_ext) =
+        MastForest::merge([&forest_with_block, &forest_with_external]).unwrap();
+    let mapped_external_root = root_maps_block_then_ext.map_root(1, &external_id).unwrap();
+    assert_eq!(
+        merged_block_then_ext.get_assembly_op(mapped_external_root, None),
+        Some(&external_asm_op),
+    );
+}
+
 /// Tests that dependencies between External nodes are correctly resolved.
 ///
 /// [External(foo), Call(0) = qux]

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -1180,6 +1180,45 @@ fn mast_forest_merge_op_indexed_decorators_preservation() {
     );
 }
 
+#[test]
+fn mast_forest_merge_preserves_asm_op_mappings_for_deduplicated_nodes() {
+    let mut forest_without_asm = MastForest::new();
+    let without_asm_block_id = block_foo().add_to_forest(&mut forest_without_asm).unwrap();
+    forest_without_asm.make_root(without_asm_block_id);
+
+    let mut forest_with_asm = MastForest::new();
+    let with_asm_block_id = block_foo().add_to_forest(&mut forest_with_asm).unwrap();
+    forest_with_asm.make_root(with_asm_block_id);
+
+    let asm_op = AssemblyOp::new(None, "proc::foo".into(), 1, "mul".into());
+    let asm_op_id = forest_with_asm.debug_info_mut().add_asm_op(asm_op.clone()).unwrap();
+    forest_with_asm
+        .debug_info_mut()
+        .register_asm_ops(with_asm_block_id, 2, vec![(0, asm_op_id)])
+        .unwrap();
+
+    // Mapping from the second forest must be preserved even when the node was already deduped
+    // after merging the first forest.
+    let (merged_without_then_with, root_maps_without_then_with) =
+        MastForest::merge([&forest_without_asm, &forest_with_asm]).unwrap();
+    let mapped_with_asm_root = root_maps_without_then_with.map_root(1, &with_asm_block_id).unwrap();
+
+    assert_eq!(
+        merged_without_then_with.get_assembly_op(mapped_with_asm_root, Some(0)),
+        Some(&asm_op),
+    );
+
+    // Reverse order should behave identically.
+    let (merged_with_then_without, root_maps_with_then_without) =
+        MastForest::merge([&forest_with_asm, &forest_without_asm]).unwrap();
+    let mapped_with_asm_root = root_maps_with_then_without.map_root(0, &with_asm_block_id).unwrap();
+
+    assert_eq!(
+        merged_with_then_without.get_assembly_op(mapped_with_asm_root, Some(0)),
+        Some(&asm_op),
+    );
+}
+
 /// Merging two forests preserves procedure names, asm ops, and debug vars
 /// with correct node-ID remapping.
 #[test]

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -1,4 +1,4 @@
-use alloc::sync::Arc;
+use alloc::{string::String, sync::Arc};
 
 use super::*;
 use crate::{
@@ -1269,6 +1269,111 @@ fn mast_forest_merge_prefers_richer_asm_op_mappings_for_deduplicated_nodes() {
     assert_eq!(
         merged_rich_then_coarse.get_assembly_op(mapped_rich_root, Some(1)),
         Some(&asm_add)
+    );
+}
+
+#[test]
+fn mast_forest_merge_preserves_sparse_non_block_asm_op_mappings() {
+    let mut forest_without_asm = MastForest::new();
+    let without_asm_callee_id = block_foo().add_to_forest(&mut forest_without_asm).unwrap();
+    let without_asm_call_id = CallNodeBuilder::new(without_asm_callee_id)
+        .add_to_forest(&mut forest_without_asm)
+        .unwrap();
+    forest_without_asm.make_root(without_asm_call_id);
+
+    let mut forest_with_asm = MastForest::new();
+    let with_asm_callee_id = block_foo().add_to_forest(&mut forest_with_asm).unwrap();
+    let with_asm_call_id = CallNodeBuilder::new(with_asm_callee_id)
+        .add_to_forest(&mut forest_with_asm)
+        .unwrap();
+    forest_with_asm.make_root(with_asm_call_id);
+
+    let asm_enter = AssemblyOp::new(None, "proc::caller".into(), 1, "call.enter".into());
+    let asm_exit = AssemblyOp::new(None, "proc::caller".into(), 1, "call.exit".into());
+    let asm_enter_id = forest_with_asm.debug_info_mut().add_asm_op(asm_enter.clone()).unwrap();
+    let asm_exit_id = forest_with_asm.debug_info_mut().add_asm_op(asm_exit.clone()).unwrap();
+    forest_with_asm
+        .debug_info_mut()
+        .register_asm_ops(with_asm_call_id, 4, vec![(1, asm_enter_id), (3, asm_exit_id)])
+        .unwrap();
+
+    let (merged_without_then_with, root_maps_without_then_with) =
+        MastForest::merge([&forest_without_asm, &forest_with_asm]).unwrap();
+    let mapped_call = root_maps_without_then_with.map_root(1, &with_asm_call_id).unwrap();
+    assert_eq!(merged_without_then_with.get_assembly_op(mapped_call, Some(0)), None);
+    assert_eq!(merged_without_then_with.get_assembly_op(mapped_call, Some(1)), Some(&asm_enter));
+    assert_eq!(merged_without_then_with.get_assembly_op(mapped_call, Some(2)), Some(&asm_enter));
+    assert_eq!(merged_without_then_with.get_assembly_op(mapped_call, Some(3)), Some(&asm_exit));
+
+    let (merged_with_then_without, root_maps_with_then_without) =
+        MastForest::merge([&forest_with_asm, &forest_without_asm]).unwrap();
+    let mapped_call = root_maps_with_then_without.map_root(0, &with_asm_call_id).unwrap();
+    assert_eq!(merged_with_then_without.get_assembly_op(mapped_call, Some(0)), None);
+    assert_eq!(merged_with_then_without.get_assembly_op(mapped_call, Some(1)), Some(&asm_enter));
+    assert_eq!(merged_with_then_without.get_assembly_op(mapped_call, Some(2)), Some(&asm_enter));
+    assert_eq!(merged_with_then_without.get_assembly_op(mapped_call, Some(3)), Some(&asm_exit));
+}
+
+#[test]
+fn mast_forest_merge_equal_richness_asm_op_conflicts_choose_whole_mapping() {
+    let mut forest_lhs = MastForest::new();
+    let lhs_block_id = block_foo().add_to_forest(&mut forest_lhs).unwrap();
+    forest_lhs.make_root(lhs_block_id);
+
+    let mut forest_rhs = MastForest::new();
+    let rhs_block_id = block_foo().add_to_forest(&mut forest_rhs).unwrap();
+    forest_rhs.make_root(rhs_block_id);
+
+    let asm_shared = AssemblyOp::new(None, "proc::foo".into(), 1, "shared".into());
+    let asm_lhs_only = AssemblyOp::new(None, "proc::foo".into(), 1, "lhs-only".into());
+    let asm_rhs_only = AssemblyOp::new(None, "proc::foo".into(), 1, "rhs-only".into());
+
+    let lhs_shared_id = forest_lhs.debug_info_mut().add_asm_op(asm_shared.clone()).unwrap();
+    let lhs_only_id = forest_lhs.debug_info_mut().add_asm_op(asm_lhs_only.clone()).unwrap();
+    forest_lhs
+        .debug_info_mut()
+        .register_asm_ops(lhs_block_id, 2, vec![(0, lhs_shared_id), (1, lhs_only_id)])
+        .unwrap();
+
+    let rhs_only_id = forest_rhs.debug_info_mut().add_asm_op(asm_rhs_only.clone()).unwrap();
+    let rhs_shared_id = forest_rhs.debug_info_mut().add_asm_op(asm_shared.clone()).unwrap();
+    forest_rhs
+        .debug_info_mut()
+        .register_asm_ops(rhs_block_id, 2, vec![(0, rhs_only_id), (1, rhs_shared_id)])
+        .unwrap();
+
+    let selected_mapping = |forest: &MastForest, node_id| {
+        (
+            forest.get_assembly_op(node_id, Some(0)).map(|asm_op| String::from(asm_op.op())),
+            forest.get_assembly_op(node_id, Some(1)).map(|asm_op| String::from(asm_op.op())),
+        )
+    };
+
+    let (merged_lhs_then_rhs, root_maps_lhs_then_rhs) =
+        MastForest::merge([&forest_lhs, &forest_rhs]).unwrap();
+    let mapped_lhs_block = root_maps_lhs_then_rhs.map_root(0, &lhs_block_id).unwrap();
+    let mapping_lhs_then_rhs = selected_mapping(&merged_lhs_then_rhs, mapped_lhs_block);
+
+    let (merged_rhs_then_lhs, root_maps_rhs_then_lhs) =
+        MastForest::merge([&forest_rhs, &forest_lhs]).unwrap();
+    let mapped_lhs_block = root_maps_rhs_then_lhs.map_root(1, &lhs_block_id).unwrap();
+    let mapping_rhs_then_lhs = selected_mapping(&merged_rhs_then_lhs, mapped_lhs_block);
+
+    assert_eq!(
+        mapping_lhs_then_rhs, mapping_rhs_then_lhs,
+        "equal-richness conflicts should resolve deterministically independent of merge order"
+    );
+
+    let lhs_mapping = (Some(String::from("shared")), Some(String::from("lhs-only")));
+    let rhs_mapping = (Some(String::from("rhs-only")), Some(String::from("shared")));
+    assert!(
+        mapping_lhs_then_rhs == lhs_mapping || mapping_lhs_then_rhs == rhs_mapping,
+        "merged mapping should match one full input mapping"
+    );
+    assert_ne!(
+        mapping_lhs_then_rhs,
+        (Some(String::from("shared")), Some(String::from("shared"))),
+        "merged mapping should not synthesize a mixed mapping"
     );
 }
 

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -1260,6 +1260,42 @@ fn mast_forest_merge_preserves_asm_op_mappings_for_deduplicated_nodes() {
 }
 
 #[test]
+fn mast_forest_merge_keeps_same_blocks_with_different_asm_ops_distinct() {
+    let mut forest_lhs = MastForest::new();
+    let lhs_block_id = block_foo().add_to_forest(&mut forest_lhs).unwrap();
+    forest_lhs.make_root(lhs_block_id);
+
+    let lhs_asm_op = AssemblyOp::new(None, "proc::foo".into(), 1, "lhs-op".into());
+    let lhs_asm_op_id = forest_lhs.debug_info_mut().add_asm_op(lhs_asm_op.clone()).unwrap();
+    forest_lhs
+        .debug_info_mut()
+        .register_asm_ops(lhs_block_id, 2, vec![(0, lhs_asm_op_id)])
+        .unwrap();
+
+    let mut forest_rhs = MastForest::new();
+    let rhs_block_id = block_foo().add_to_forest(&mut forest_rhs).unwrap();
+    forest_rhs.make_root(rhs_block_id);
+
+    let rhs_asm_op = AssemblyOp::new(None, "proc::foo".into(), 1, "rhs-op".into());
+    let rhs_asm_op_id = forest_rhs.debug_info_mut().add_asm_op(rhs_asm_op.clone()).unwrap();
+    forest_rhs
+        .debug_info_mut()
+        .register_asm_ops(rhs_block_id, 2, vec![(0, rhs_asm_op_id)])
+        .unwrap();
+
+    let (merged, root_maps) = MastForest::merge([&forest_lhs, &forest_rhs]).unwrap();
+    let mapped_lhs_block = root_maps.map_root(0, &lhs_block_id).unwrap();
+    let mapped_rhs_block = root_maps.map_root(1, &rhs_block_id).unwrap();
+
+    assert_ne!(
+        mapped_lhs_block, mapped_rhs_block,
+        "identical blocks with different asm-op content must not collapse"
+    );
+    assert_eq!(merged.get_assembly_op(mapped_lhs_block, Some(0)), Some(&lhs_asm_op));
+    assert_eq!(merged.get_assembly_op(mapped_rhs_block, Some(0)), Some(&rhs_asm_op));
+}
+
+#[test]
 fn mast_forest_merge_prefers_richer_asm_op_mappings_for_deduplicated_nodes() {
     let mut forest_coarse = MastForest::new();
     let coarse_block_id = block_foo().add_to_forest(&mut forest_coarse).unwrap();
@@ -1369,14 +1405,14 @@ fn mast_forest_merge_equal_richness_asm_op_conflicts_choose_whole_mapping() {
     let asm_rhs_only = AssemblyOp::new(None, "proc::foo".into(), 1, "rhs-only".into());
 
     let lhs_shared_id = forest_lhs.debug_info_mut().add_asm_op(asm_shared.clone()).unwrap();
-    let lhs_only_id = forest_lhs.debug_info_mut().add_asm_op(asm_lhs_only.clone()).unwrap();
+    let lhs_only_id = forest_lhs.debug_info_mut().add_asm_op(asm_lhs_only).unwrap();
     forest_lhs
         .debug_info_mut()
         .register_asm_ops(lhs_block_id, 2, vec![(0, lhs_shared_id), (1, lhs_only_id)])
         .unwrap();
 
-    let rhs_only_id = forest_rhs.debug_info_mut().add_asm_op(asm_rhs_only.clone()).unwrap();
-    let rhs_shared_id = forest_rhs.debug_info_mut().add_asm_op(asm_shared.clone()).unwrap();
+    let rhs_only_id = forest_rhs.debug_info_mut().add_asm_op(asm_rhs_only).unwrap();
+    let rhs_shared_id = forest_rhs.debug_info_mut().add_asm_op(asm_shared).unwrap();
     forest_rhs
         .debug_info_mut()
         .register_asm_ops(rhs_block_id, 2, vec![(0, rhs_only_id), (1, rhs_shared_id)])

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -1219,6 +1219,59 @@ fn mast_forest_merge_preserves_asm_op_mappings_for_deduplicated_nodes() {
     );
 }
 
+#[test]
+fn mast_forest_merge_prefers_richer_asm_op_mappings_for_deduplicated_nodes() {
+    let mut forest_coarse = MastForest::new();
+    let coarse_block_id = block_foo().add_to_forest(&mut forest_coarse).unwrap();
+    forest_coarse.make_root(coarse_block_id);
+
+    let mut forest_rich = MastForest::new();
+    let rich_block_id = block_foo().add_to_forest(&mut forest_rich).unwrap();
+    forest_rich.make_root(rich_block_id);
+
+    let asm_mul = AssemblyOp::new(None, "proc::foo".into(), 1, "mul".into());
+    let asm_add = AssemblyOp::new(None, "proc::foo".into(), 1, "add".into());
+
+    let coarse_mul_id = forest_coarse.debug_info_mut().add_asm_op(asm_mul.clone()).unwrap();
+    forest_coarse
+        .debug_info_mut()
+        .register_asm_ops(coarse_block_id, 2, vec![(0, coarse_mul_id)])
+        .unwrap();
+
+    let rich_mul_id = forest_rich.debug_info_mut().add_asm_op(asm_mul.clone()).unwrap();
+    let rich_add_id = forest_rich.debug_info_mut().add_asm_op(asm_add.clone()).unwrap();
+    forest_rich
+        .debug_info_mut()
+        .register_asm_ops(rich_block_id, 2, vec![(0, rich_mul_id), (1, rich_add_id)])
+        .unwrap();
+
+    // Coarse + rich should keep the richer mapping at op 1.
+    let (merged_coarse_then_rich, root_maps_coarse_then_rich) =
+        MastForest::merge([&forest_coarse, &forest_rich]).unwrap();
+    let mapped_rich_root = root_maps_coarse_then_rich.map_root(1, &rich_block_id).unwrap();
+    assert_eq!(
+        merged_coarse_then_rich.get_assembly_op(mapped_rich_root, Some(0)),
+        Some(&asm_mul)
+    );
+    assert_eq!(
+        merged_coarse_then_rich.get_assembly_op(mapped_rich_root, Some(1)),
+        Some(&asm_add)
+    );
+
+    // Rich + coarse should be identical.
+    let (merged_rich_then_coarse, root_maps_rich_then_coarse) =
+        MastForest::merge([&forest_rich, &forest_coarse]).unwrap();
+    let mapped_rich_root = root_maps_rich_then_coarse.map_root(0, &rich_block_id).unwrap();
+    assert_eq!(
+        merged_rich_then_coarse.get_assembly_op(mapped_rich_root, Some(0)),
+        Some(&asm_mul)
+    );
+    assert_eq!(
+        merged_rich_then_coarse.get_assembly_op(mapped_rich_root, Some(1)),
+        Some(&asm_add)
+    );
+}
+
 /// Merging two forests preserves procedure names, asm ops, and debug vars
 /// with correct node-ID remapping.
 #[test]

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -1260,6 +1260,44 @@ fn mast_forest_merge_preserves_asm_op_mappings_for_deduplicated_nodes() {
 }
 
 #[test]
+fn mast_forest_merge_preserves_explicit_adjacent_asm_op_transitions() {
+    let mut forest_lhs = MastForest::new();
+    let lhs_block_id = block_foo().add_to_forest(&mut forest_lhs).unwrap();
+    forest_lhs.make_root(lhs_block_id);
+
+    let lhs_asm_op = AssemblyOp::new(None, "proc::foo".into(), 1, "mul".into());
+    let lhs_asm_op_id = forest_lhs.debug_info_mut().add_asm_op(lhs_asm_op).unwrap();
+    forest_lhs
+        .debug_info_mut()
+        .register_asm_ops(lhs_block_id, 2, vec![(0, lhs_asm_op_id), (1, lhs_asm_op_id)])
+        .unwrap();
+
+    let mut forest_rhs = MastForest::new();
+    let rhs_block_id = block_foo().add_to_forest(&mut forest_rhs).unwrap();
+    forest_rhs.make_root(rhs_block_id);
+
+    let rhs_asm_op = AssemblyOp::new(None, "proc::foo".into(), 1, "mul".into());
+    let rhs_asm_op_id = forest_rhs.debug_info_mut().add_asm_op(rhs_asm_op).unwrap();
+    forest_rhs
+        .debug_info_mut()
+        .register_asm_ops(rhs_block_id, 2, vec![(0, rhs_asm_op_id), (1, rhs_asm_op_id)])
+        .unwrap();
+
+    let (merged, root_maps) = MastForest::merge([&forest_lhs, &forest_rhs]).unwrap();
+    let mapped_lhs_root = root_maps.map_root(0, &lhs_block_id).unwrap();
+    let mapped_rhs_root = root_maps.map_root(1, &rhs_block_id).unwrap();
+    assert_eq!(mapped_lhs_root, mapped_rhs_root);
+
+    let mapped_with_asm_root = mapped_lhs_root;
+    let merged_entries = merged.debug_info().asm_ops_for_node(mapped_with_asm_root);
+
+    assert_eq!(merged_entries.len(), 2);
+    assert_eq!(merged_entries[0].0, 0);
+    assert_eq!(merged_entries[1].0, 1);
+    assert_eq!(merged_entries[0].1, merged_entries[1].1);
+}
+
+#[test]
 fn mast_forest_merge_keeps_same_blocks_with_different_asm_ops_distinct() {
     let mut forest_lhs = MastForest::new();
     let lhs_block_id = block_foo().add_to_forest(&mut forest_lhs).unwrap();

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, sync::Arc};
+use alloc::{collections::BTreeMap, string::String, sync::Arc};
 
 use super::*;
 use crate::{
@@ -34,6 +34,26 @@ fn block_qux() -> BasicBlockNodeBuilder {
         vec![Operation::Swap, Operation::Push(ONE), Operation::Eq],
         Vec::new(),
     )
+}
+
+fn register_asm_ops_for_node(
+    forest: &mut MastForest,
+    node_id: MastNodeId,
+    num_operations: usize,
+    asm_ops: &[(usize, AssemblyOp)],
+) -> Vec<AsmOpId> {
+    let mut registered = Vec::with_capacity(asm_ops.len());
+    for (op_idx, asm_op) in asm_ops {
+        let asm_op_id = forest.debug_info_mut().add_asm_op(asm_op.clone()).unwrap();
+        registered.push((*op_idx, asm_op_id));
+    }
+
+    forest
+        .debug_info_mut()
+        .register_asm_ops(node_id, num_operations, registered.clone())
+        .unwrap();
+
+    registered.into_iter().map(|(_, asm_op_id)| asm_op_id).collect()
 }
 
 fn loop_with_decorators(
@@ -1231,11 +1251,7 @@ fn mast_forest_merge_preserves_asm_op_mappings_for_deduplicated_nodes() {
     forest_with_asm.make_root(with_asm_block_id);
 
     let asm_op = AssemblyOp::new(None, "proc::foo".into(), 1, "mul".into());
-    let asm_op_id = forest_with_asm.debug_info_mut().add_asm_op(asm_op.clone()).unwrap();
-    forest_with_asm
-        .debug_info_mut()
-        .register_asm_ops(with_asm_block_id, 2, vec![(0, asm_op_id)])
-        .unwrap();
+    register_asm_ops_for_node(&mut forest_with_asm, with_asm_block_id, 2, &[(0, asm_op.clone())]);
 
     // Mapping from the second forest must be preserved even when the node was already deduped
     // after merging the first forest.
@@ -1260,28 +1276,50 @@ fn mast_forest_merge_preserves_asm_op_mappings_for_deduplicated_nodes() {
 }
 
 #[test]
+fn mast_forest_merge_returns_error_for_out_of_bounds_asm_op_mapping() {
+    let mut forest = MastForest::new();
+    let block_id = block_foo().add_to_forest(&mut forest).unwrap();
+    forest.make_root(block_id);
+
+    let asm_op = AssemblyOp::new(None, "proc::foo".into(), 1, "out-of-bounds".into());
+    let asm_op_id = forest.debug_info_mut().add_asm_op(asm_op).unwrap();
+    forest
+        .debug_info_mut()
+        .register_asm_ops(block_id, 3, vec![(2, asm_op_id)])
+        .unwrap();
+
+    let err = MastForest::merge([&forest]).unwrap_err();
+    assert_matches!(
+        err,
+        MastForestError::AssemblyOpError(crate::mast::AsmOpIndexError::OpIndexOutOfBounds(2, 2))
+    );
+}
+
+#[test]
 fn mast_forest_merge_preserves_explicit_adjacent_asm_op_transitions() {
     let mut forest_lhs = MastForest::new();
     let lhs_block_id = block_foo().add_to_forest(&mut forest_lhs).unwrap();
     forest_lhs.make_root(lhs_block_id);
 
     let lhs_asm_op = AssemblyOp::new(None, "proc::foo".into(), 1, "mul".into());
-    let lhs_asm_op_id = forest_lhs.debug_info_mut().add_asm_op(lhs_asm_op).unwrap();
-    forest_lhs
-        .debug_info_mut()
-        .register_asm_ops(lhs_block_id, 2, vec![(0, lhs_asm_op_id), (1, lhs_asm_op_id)])
-        .unwrap();
+    register_asm_ops_for_node(
+        &mut forest_lhs,
+        lhs_block_id,
+        2,
+        &[(0, lhs_asm_op.clone()), (1, lhs_asm_op)],
+    );
 
     let mut forest_rhs = MastForest::new();
     let rhs_block_id = block_foo().add_to_forest(&mut forest_rhs).unwrap();
     forest_rhs.make_root(rhs_block_id);
 
     let rhs_asm_op = AssemblyOp::new(None, "proc::foo".into(), 1, "mul".into());
-    let rhs_asm_op_id = forest_rhs.debug_info_mut().add_asm_op(rhs_asm_op).unwrap();
-    forest_rhs
-        .debug_info_mut()
-        .register_asm_ops(rhs_block_id, 2, vec![(0, rhs_asm_op_id), (1, rhs_asm_op_id)])
-        .unwrap();
+    register_asm_ops_for_node(
+        &mut forest_rhs,
+        rhs_block_id,
+        2,
+        &[(0, rhs_asm_op.clone()), (1, rhs_asm_op)],
+    );
 
     let (merged, root_maps) = MastForest::merge([&forest_lhs, &forest_rhs]).unwrap();
     let mapped_lhs_root = root_maps.map_root(0, &lhs_block_id).unwrap();
@@ -1304,22 +1342,14 @@ fn mast_forest_merge_keeps_same_blocks_with_different_asm_ops_distinct() {
     forest_lhs.make_root(lhs_block_id);
 
     let lhs_asm_op = AssemblyOp::new(None, "proc::foo".into(), 1, "lhs-op".into());
-    let lhs_asm_op_id = forest_lhs.debug_info_mut().add_asm_op(lhs_asm_op.clone()).unwrap();
-    forest_lhs
-        .debug_info_mut()
-        .register_asm_ops(lhs_block_id, 2, vec![(0, lhs_asm_op_id)])
-        .unwrap();
+    register_asm_ops_for_node(&mut forest_lhs, lhs_block_id, 2, &[(0, lhs_asm_op.clone())]);
 
     let mut forest_rhs = MastForest::new();
     let rhs_block_id = block_foo().add_to_forest(&mut forest_rhs).unwrap();
     forest_rhs.make_root(rhs_block_id);
 
     let rhs_asm_op = AssemblyOp::new(None, "proc::foo".into(), 1, "rhs-op".into());
-    let rhs_asm_op_id = forest_rhs.debug_info_mut().add_asm_op(rhs_asm_op.clone()).unwrap();
-    forest_rhs
-        .debug_info_mut()
-        .register_asm_ops(rhs_block_id, 2, vec![(0, rhs_asm_op_id)])
-        .unwrap();
+    register_asm_ops_for_node(&mut forest_rhs, rhs_block_id, 2, &[(0, rhs_asm_op.clone())]);
 
     let (merged, root_maps) = MastForest::merge([&forest_lhs, &forest_rhs]).unwrap();
     let mapped_lhs_block = root_maps.map_root(0, &lhs_block_id).unwrap();
@@ -1334,55 +1364,23 @@ fn mast_forest_merge_keeps_same_blocks_with_different_asm_ops_distinct() {
 }
 
 #[test]
-fn mast_forest_merge_prefers_richer_asm_op_mappings_for_deduplicated_nodes() {
-    let mut forest_coarse = MastForest::new();
-    let coarse_block_id = block_foo().add_to_forest(&mut forest_coarse).unwrap();
-    forest_coarse.make_root(coarse_block_id);
+fn merge_asm_op_mappings_prefers_richer_mapping() {
+    let asm_mul = AsmOpId::new(0);
+    let asm_add = AsmOpId::new(1);
+    let coarse = vec![(0, asm_mul)];
+    let rich = vec![(0, asm_mul), (1, asm_add)];
+    let asm_op_value_by_id = BTreeMap::from([
+        (asm_mul, (None, String::from("proc::foo"), 1, String::from("mul"))),
+        (asm_add, (None, String::from("proc::foo"), 1, String::from("add"))),
+    ]);
 
-    let mut forest_rich = MastForest::new();
-    let rich_block_id = block_foo().add_to_forest(&mut forest_rich).unwrap();
-    forest_rich.make_root(rich_block_id);
-
-    let asm_mul = AssemblyOp::new(None, "proc::foo".into(), 1, "mul".into());
-    let asm_add = AssemblyOp::new(None, "proc::foo".into(), 1, "add".into());
-
-    let coarse_mul_id = forest_coarse.debug_info_mut().add_asm_op(asm_mul.clone()).unwrap();
-    forest_coarse
-        .debug_info_mut()
-        .register_asm_ops(coarse_block_id, 2, vec![(0, coarse_mul_id)])
-        .unwrap();
-
-    let rich_mul_id = forest_rich.debug_info_mut().add_asm_op(asm_mul.clone()).unwrap();
-    let rich_add_id = forest_rich.debug_info_mut().add_asm_op(asm_add.clone()).unwrap();
-    forest_rich
-        .debug_info_mut()
-        .register_asm_ops(rich_block_id, 2, vec![(0, rich_mul_id), (1, rich_add_id)])
-        .unwrap();
-
-    // Coarse + rich should keep the richer mapping at op 1.
-    let (merged_coarse_then_rich, root_maps_coarse_then_rich) =
-        MastForest::merge([&forest_coarse, &forest_rich]).unwrap();
-    let mapped_rich_root = root_maps_coarse_then_rich.map_root(1, &rich_block_id).unwrap();
     assert_eq!(
-        merged_coarse_then_rich.get_assembly_op(mapped_rich_root, Some(0)),
-        Some(&asm_mul)
+        MastForestMerger::merge_asm_op_mappings(2, &coarse, &rich, &asm_op_value_by_id),
+        rich
     );
     assert_eq!(
-        merged_coarse_then_rich.get_assembly_op(mapped_rich_root, Some(1)),
-        Some(&asm_add)
-    );
-
-    // Rich + coarse should be identical.
-    let (merged_rich_then_coarse, root_maps_rich_then_coarse) =
-        MastForest::merge([&forest_rich, &forest_coarse]).unwrap();
-    let mapped_rich_root = root_maps_rich_then_coarse.map_root(0, &rich_block_id).unwrap();
-    assert_eq!(
-        merged_rich_then_coarse.get_assembly_op(mapped_rich_root, Some(0)),
-        Some(&asm_mul)
-    );
-    assert_eq!(
-        merged_rich_then_coarse.get_assembly_op(mapped_rich_root, Some(1)),
-        Some(&asm_add)
+        MastForestMerger::merge_asm_op_mappings(2, &rich, &coarse, &asm_op_value_by_id),
+        rich
     );
 }
 
@@ -1404,12 +1402,12 @@ fn mast_forest_merge_preserves_sparse_non_block_asm_op_mappings() {
 
     let asm_enter = AssemblyOp::new(None, "proc::caller".into(), 1, "call.enter".into());
     let asm_exit = AssemblyOp::new(None, "proc::caller".into(), 1, "call.exit".into());
-    let asm_enter_id = forest_with_asm.debug_info_mut().add_asm_op(asm_enter.clone()).unwrap();
-    let asm_exit_id = forest_with_asm.debug_info_mut().add_asm_op(asm_exit.clone()).unwrap();
-    forest_with_asm
-        .debug_info_mut()
-        .register_asm_ops(with_asm_call_id, 4, vec![(1, asm_enter_id), (3, asm_exit_id)])
-        .unwrap();
+    register_asm_ops_for_node(
+        &mut forest_with_asm,
+        with_asm_call_id,
+        4,
+        &[(1, asm_enter.clone()), (3, asm_exit.clone())],
+    );
 
     let (merged_without_then_with, root_maps_without_then_with) =
         MastForest::merge([&forest_without_asm, &forest_with_asm]).unwrap();
@@ -1429,64 +1427,34 @@ fn mast_forest_merge_preserves_sparse_non_block_asm_op_mappings() {
 }
 
 #[test]
-fn mast_forest_merge_equal_richness_asm_op_conflicts_choose_whole_mapping() {
-    let mut forest_lhs = MastForest::new();
-    let lhs_block_id = block_foo().add_to_forest(&mut forest_lhs).unwrap();
-    forest_lhs.make_root(lhs_block_id);
+fn merge_asm_op_mappings_equal_richness_conflicts_choose_whole_mapping() {
+    let asm_shared = AsmOpId::new(0);
+    let asm_lhs_only = AsmOpId::new(1);
+    let asm_rhs_only = AsmOpId::new(2);
+    let lhs = vec![(0, asm_shared), (1, asm_lhs_only)];
+    let rhs = vec![(0, asm_rhs_only), (1, asm_shared)];
+    let asm_op_value_by_id = BTreeMap::from([
+        (asm_shared, (None, String::from("proc::foo"), 1, String::from("shared"))),
+        (asm_lhs_only, (None, String::from("proc::foo"), 1, String::from("lhs-only"))),
+        (asm_rhs_only, (None, String::from("proc::foo"), 1, String::from("rhs-only"))),
+    ]);
 
-    let mut forest_rhs = MastForest::new();
-    let rhs_block_id = block_foo().add_to_forest(&mut forest_rhs).unwrap();
-    forest_rhs.make_root(rhs_block_id);
-
-    let asm_shared = AssemblyOp::new(None, "proc::foo".into(), 1, "shared".into());
-    let asm_lhs_only = AssemblyOp::new(None, "proc::foo".into(), 1, "lhs-only".into());
-    let asm_rhs_only = AssemblyOp::new(None, "proc::foo".into(), 1, "rhs-only".into());
-
-    let lhs_shared_id = forest_lhs.debug_info_mut().add_asm_op(asm_shared.clone()).unwrap();
-    let lhs_only_id = forest_lhs.debug_info_mut().add_asm_op(asm_lhs_only).unwrap();
-    forest_lhs
-        .debug_info_mut()
-        .register_asm_ops(lhs_block_id, 2, vec![(0, lhs_shared_id), (1, lhs_only_id)])
-        .unwrap();
-
-    let rhs_only_id = forest_rhs.debug_info_mut().add_asm_op(asm_rhs_only).unwrap();
-    let rhs_shared_id = forest_rhs.debug_info_mut().add_asm_op(asm_shared).unwrap();
-    forest_rhs
-        .debug_info_mut()
-        .register_asm_ops(rhs_block_id, 2, vec![(0, rhs_only_id), (1, rhs_shared_id)])
-        .unwrap();
-
-    let selected_mapping = |forest: &MastForest, node_id| {
-        (
-            forest.get_assembly_op(node_id, Some(0)).map(|asm_op| String::from(asm_op.op())),
-            forest.get_assembly_op(node_id, Some(1)).map(|asm_op| String::from(asm_op.op())),
-        )
-    };
-
-    let (merged_lhs_then_rhs, root_maps_lhs_then_rhs) =
-        MastForest::merge([&forest_lhs, &forest_rhs]).unwrap();
-    let mapped_lhs_block = root_maps_lhs_then_rhs.map_root(0, &lhs_block_id).unwrap();
-    let mapping_lhs_then_rhs = selected_mapping(&merged_lhs_then_rhs, mapped_lhs_block);
-
-    let (merged_rhs_then_lhs, root_maps_rhs_then_lhs) =
-        MastForest::merge([&forest_rhs, &forest_lhs]).unwrap();
-    let mapped_lhs_block = root_maps_rhs_then_lhs.map_root(1, &lhs_block_id).unwrap();
-    let mapping_rhs_then_lhs = selected_mapping(&merged_rhs_then_lhs, mapped_lhs_block);
+    let mapping_lhs_then_rhs =
+        MastForestMerger::merge_asm_op_mappings(2, &lhs, &rhs, &asm_op_value_by_id);
+    let mapping_rhs_then_lhs =
+        MastForestMerger::merge_asm_op_mappings(2, &rhs, &lhs, &asm_op_value_by_id);
 
     assert_eq!(
         mapping_lhs_then_rhs, mapping_rhs_then_lhs,
         "equal-richness conflicts should resolve deterministically independent of merge order"
     );
-
-    let lhs_mapping = (Some(String::from("shared")), Some(String::from("lhs-only")));
-    let rhs_mapping = (Some(String::from("rhs-only")), Some(String::from("shared")));
     assert!(
-        mapping_lhs_then_rhs == lhs_mapping || mapping_lhs_then_rhs == rhs_mapping,
+        mapping_lhs_then_rhs == lhs || mapping_lhs_then_rhs == rhs,
         "merged mapping should match one full input mapping"
     );
     assert_ne!(
         mapping_lhs_then_rhs,
-        (Some(String::from("shared")), Some(String::from("shared"))),
+        vec![(0, asm_shared), (1, asm_shared)],
         "merged mapping should not synthesize a mixed mapping"
     );
 }

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -1315,6 +1315,8 @@ pub enum MastForestError {
     AdviceMapKeyCollisionOnMerge(Word),
     #[error("decorator storage error: {0}")]
     DecoratorError(DecoratorIndexError),
+    #[error("assembly op storage error: {0}")]
+    AssemblyOpError(AsmOpIndexError),
     #[error("digest is required for deserialization")]
     DigestRequiredForDeserialization,
     #[error("invalid batch in basic block node {0:?}: {1}")]


### PR DESCRIPTION
Preserve and remap AssemblyOp source mappings during MastForest::merge, preventing debug source locations from being lost after forest deduplication and link-time merge.