### PR TITLE
ci: add a daily job to report unused crates

### DIFF
--- a/.github/templates/UNUSED_DEPS_ISSUE.md
+++ b/.github/templates/UNUSED_DEPS_ISSUE.md
@@ -1,0 +1,13 @@
+---
+title: Unused dependency check failed
+labels: ci, dependencies
+---
+
+The scheduled unused dependency check reported one or more dependencies that are not used in the
+feature and target combinations covered by `.github/workflows/unused-deps.yml`.
+
+Please review the failing workflow run in the Actions tab and either:
+
+- remove the dependency if it is genuinely unused, or
+- add a documented `cargo-udeps` ignore entry if the dependency is only used by cfg-gated code,
+  generated code, or doctests that `cargo-udeps` cannot see.

--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -1,0 +1,41 @@
+# Runs unused dependency check for crate consumers.
+name: Unused dependency check
+
+permissions:
+  contents: read
+  issues: write
+
+on:
+  schedule:
+    # Run daily at 00:00 UTC
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  unused-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-udeps
+      # Normally running cargo-udeps requires use of a nightly compiler.
+      # In order to have a more stable and less noisy experience, we instead
+      # use the stable toolchain and enable nightly features via RUSTC_BOOTSTRAP.
+      - name: Run cargo-udeps
+        id: udeps
+        run: |
+          set -euo pipefail
+          # `miden-vm` has optional CLI dependencies behind non-default features,
+          # so check the workspace default targets separately from that package.
+          RUSTC_BOOTSTRAP=1 cargo udeps --workspace --all-targets --exclude miden-vm
+          RUSTC_BOOTSTRAP=1 cargo udeps -p miden-vm --all-targets --all-features
+      - uses: JasonEtco/create-an-issue@v2
+        if: ${{ failure() && steps.udeps.outcome == 'failure' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          update_existing: true
+          filename: .github/templates/UNUSED_DEPS_ISSUE.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,7 +1652,6 @@ dependencies = [
  "loom",
  "once_cell",
  "parking_lot",
- "proptest",
 ]
 
 [[package]]

--- a/crates/assembly/Cargo.toml
+++ b/crates/assembly/Cargo.toml
@@ -44,3 +44,7 @@ miden-assembly = { path = ".", default-features = false, features = ["testing"] 
 miden-mast-package = { workspace = true, features = ["arbitrary"] }
 insta = { workspace = true }
 proptest = { workspace = true, features = ["std"] }
+
+[package.metadata.cargo-udeps.ignore]
+# Self-reference to dev-dependency is a false positive: enables "testing" feature for tests
+development = ["miden-assembly"]

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -35,8 +35,13 @@ toml = { version = "1.0", default-features = false, features = ["serde", "parse"
 [dev-dependencies]
 miden-core.workspace = true
 miden-test-serde-macros.workspace = true
+# serde_json is used by miden-test-serde-macros generated code
 serde_json.workspace = true
 toml = { version = "1.0", default-features = false, features = ["std", "serde", "parse"] }
+
+[package.metadata.cargo-udeps.ignore]
+# These are only referenced by generated test code when the `arbitrary` feature is enabled.
+development = ["miden-test-serde-macros", "serde_json"]
 
 [lints.rust]
 # This is needed until this warning appears in stable when this is commented out. Currently, it

--- a/crates/test-serde-macros/Cargo.toml
+++ b/crates/test-serde-macros/Cargo.toml
@@ -20,9 +20,16 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { workspace = true, features = ["derive", "extra-traits", "full"] }
+# Used in generated test code
 proptest.workspace = true
 proptest-derive.workspace = true
 
 [dev-dependencies]
 proptest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+
+[package.metadata.cargo-udeps.ignore]
+# Dependencies used in generated proc-macro code are false positives
+normal = ["proptest", "proptest-derive"]
+# Dev-dependencies are only exercised by doctests for the generated examples
+development = ["proptest", "serde"]

--- a/crates/utils-sync/Cargo.toml
+++ b/crates/utils-sync/Cargo.toml
@@ -20,15 +20,22 @@ std = ["dep:parking_lot"]
 
 [dependencies]
 lock_api = { version = "0.4", features = ["arc_lock"] }
+# Used in no-std builds for OnceLockCompat
 once_cell = { version = "1.21", default-features = false, features = ["alloc", "race"] }
 parking_lot = { version = "0.12", optional = true }
 
+[target.'cfg(loom)'.dependencies]
+# loom is only used in tests via cfg(loom)
+loom = "0.7"
+
 [dev-dependencies]
 loom = "0.7"
-proptest.workspace = true
 
-[target.'cfg(loom)'.dependencies]
-loom = "0.7"
+[package.metadata.cargo-udeps.ignore]
+# once_cell is used in no-std builds via OnceLockCompat
+# loom is cfg-gated and only compiled when tests are run with `--cfg loom`
+normal = ["once_cell", "loom"]
+development = ["loom"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -74,6 +74,7 @@ miden-crypto.workspace = true
 miden-debug-types.workspace = true
 miden-processor.workspace = true
 miden-prover.workspace = true
+# Used directly in CLI verify.rs and utils.rs
 miden-mast-package.workspace = true
 miden-core-lib.workspace = true
 miden-verifier.workspace = true


### PR DESCRIPTION
This adds a daily GitHub Actions job that looks for crates listed in Cargo.toml but not used by the code.

The workspace check skips `miden-vm`, and `miden-vm` is checked in a second step with all features enabled. This avoids false positives from crates that are only used by optional CLI code.

The change also fixes the Cargo metadata used by `cargo-udeps`, restores the missing `miden-project` test macro dependency, and adds the issue template used when the daily check  fails.