### PR TITLE
test: reduce proptest cases in VM operation hotspots

### DIFF
--- a/miden-vm/tests/integration/operations/field_ops.rs
+++ b/miden-vm/tests/integration/operations/field_ops.rs
@@ -742,6 +742,7 @@ fn gte() {
 // ================================================================================================
 
 proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
     #[test]
     fn add_proptest(a in any::<u64>(), b in any::<u64>()) {
         let asm_op = "add";

--- a/miden-vm/tests/integration/operations/stack_ops.rs
+++ b/miden-vm/tests/integration/operations/stack_ops.rs
@@ -433,6 +433,7 @@ fn cdropw() {
 }
 
 proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
 
     #[test]
     fn drop_proptest(test_values in prop::collection::vec(any::<u64>(), MIN_STACK_DEPTH)) {

--- a/miden-vm/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden-vm/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -685,6 +685,7 @@ fn u32divmod_fail() {
 // U32 OPERATIONS TESTS - RANDOMIZED - ARITHMETIC OPERATIONS
 // ================================================================================================
 proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
     #[test]
     fn u32unchecked_add_proptest(a in any::<u32>(), b in any::<u32>()) {
         let wrapping_asm_op = "u32wrapping_add";


### PR DESCRIPTION
This change cuts the case count to 100 in the three VM operation `proptest!` blocks that dominate runtime: field arithmetic, u32 arithmetic, and stack ops.

The baseline data is concentrated enough that this is the right first cut. These 33 tests used about 464s of CPU time out of about 1200s total proptest CPU time, or roughly 39% of the total. The biggest outliers were sub_proptest at 42s, u32div_proptest at 25s, u32mod_proptest at 23s, and the stack ops block at about 254s total.

The coverage tradeoff here is deliberate and bounded. Each touched test still runs 100 randomized samples per run, and the change is limited to the known hotspots instead of weakening proptests across the workspace.
