### PR TITLE
test(assembly),deny: reduce merge drift from main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,7 +1367,7 @@ dependencies = [
  "num",
  "num-bigint",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha",
  "rstest",
  "serde",
@@ -1405,7 +1405,7 @@ dependencies = [
  "p3-miden-lifted-stark",
  "p3-symmetric",
  "p3-util",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha",
  "rand_core 0.9.5",
  "rand_hc",
@@ -1456,7 +1456,7 @@ dependencies = [
  "p3-field",
  "p3-goldilocks",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "subtle",
  "thiserror",
@@ -1955,7 +1955,7 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-util",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "tracing",
 ]
@@ -1976,7 +1976,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
 ]
 
@@ -2001,7 +2001,7 @@ dependencies = [
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "tracing",
 ]
@@ -2025,7 +2025,7 @@ dependencies = [
  "p3-field",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -2056,7 +2056,7 @@ dependencies = [
  "p3-miden-lmcs",
  "p3-miden-transcript",
  "p3-util",
- "rand 0.10.0",
+ "rand 0.10.1",
  "thiserror",
  "tracing",
 ]
@@ -2096,7 +2096,7 @@ dependencies = [
  "p3-miden-transcript",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "thiserror",
  "tracing",
@@ -2142,7 +2142,7 @@ dependencies = [
  "p3-symmetric",
  "p3-util",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde",
  "spin 0.10.0",
  "tracing",
@@ -2156,7 +2156,7 @@ checksum = "6dd56ae3a51ded1b77f7b1b21d0b157ae82b9d5ca8f2cba347c0b821fe771a79"
 dependencies = [
  "p3-field",
  "p3-symmetric",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -2169,7 +2169,7 @@ dependencies = [
  "p3-mds",
  "p3-symmetric",
  "p3-util",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -2415,7 +2415,7 @@ checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2470,9 +2470,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2480,9 +2480,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "rand_core 0.10.0",
 ]

--- a/crates/assembly/tests/fixtures/protocol/kernel/bin/main-alt.masm
+++ b/crates/assembly/tests/fixtures/protocol/kernel/bin/main-alt.masm
@@ -2,7 +2,7 @@
 # program to be executed, so we store that into procedure local memory, and then dyncall it
 @locals(4)
 proc invoke_user_script
-    loc_storew_be.0
+    loc_storew_le.0
     locaddr.0
     dyncall
 end

--- a/crates/assembly/tests/fixtures/protocol/kernel/bin/main.masm
+++ b/crates/assembly/tests/fixtures/protocol/kernel/bin/main.masm
@@ -2,7 +2,7 @@
 # program to be executed, so we store that into procedure local memory, and then dyncall it
 @locals(4)
 proc invoke_user_script
-    loc_storew_be.0
+    loc_storew_le.0
     locaddr.0
     dyncall
 end

--- a/crates/assembly/tests/fixtures/protocol/kernel/kernel/io.masm
+++ b/crates/assembly/tests/fixtures/protocol/kernel/kernel/io.masm
@@ -1,7 +1,7 @@
-const PRINTLN = 0
+const PRINTLN = event("sys.println")
 
 #! Prints the given null-terminated byte string to stdout, if debug tracing is enabled
 pub proc println(message: ptr<u8, addrspace(byte)>)
-    trace.PRINTLN
+    emit.PRINTLN
     drop
 end

--- a/crates/assembly/tests/fixtures/protocol/kernel/kernel/mod.masm
+++ b/crates/assembly/tests/fixtures/protocol/kernel/kernel/mod.masm
@@ -7,11 +7,11 @@ const PRINTLN_ADDR = SYSCALL_TABLE_ADDR + 2
 #! Initializes the kernel environment
 pub proc init
     procref.is_valid_syscall
-    mem_storew_be.SYSCALL_TABLE_ADDR
+    mem_storew_le.SYSCALL_TABLE_ADDR
     procref.$kernel::sys::panic
-    mem_storew_be.PANIC_ADDR
+    mem_storew_le.PANIC_ADDR
     procref.$kernel::io::println
-    mem_storew_be.PRINTLN_ADDR
+    mem_storew_le.PRINTLN_ADDR
 end
 
 #! Execute one of this kernel's syscalls
@@ -24,7 +24,7 @@ pub proc system_call
     # validate syscall id
     dup.0 mem_load.SYSCALL_TABLE_ADDR dynexec
     # invoke the syscall
-    add.SYSCALL_TABLE_ADDR mem_loadw_be dynexec
+    add.SYSCALL_TABLE_ADDR mem_loadw_le dynexec
 end
 
 proc is_valid_syscall

--- a/deny.toml
+++ b/deny.toml
@@ -49,9 +49,6 @@ deny = [
     #{ name = "ansi_term", version = "=0.11.0" },
 ]
 skip = [
-    # Allow duplicate anstream/anstyle-parse versions - clap uses 1.0.0, env_logger uses 0.6.*
-    { name = "anstream" },
-    { name = "anstyle-parse" },
     # Allow duplicate spin versions - transitively pulled by p3-dft and flume
     { name = "spin" },
     # Allow duplicate rand versions - miden-field uses 0.10, miden-vm uses 0.9


### PR DESCRIPTION
This is merge-prep for the upcoming `main` -> `next` reconciliation (see #2878). Another PR against main (#2984) takes care of the rest.

  Changes:
  - refresh the protocol kernel assembly fixtures to the current `next`-compatible shape
  - remove stale `anstream` / `anstyle-parse` skips from `deny.toml`

  Notes:
  - I intentionally did not port the `main`-only `exec.$kernel::init` fixture lines
  - I also did not port the extra `miden-core` workspace wiring from `main`, because that currently breaks the packaging test on `next`