### PR TITLE
fix: merge procedure names with concrete-over-placeholder priority and deterministic tie-breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Fixes
 - Rejected non-syscall references to exported kernel procedures in the linker ([#2902](https://github.com/0xMiden/miden-vm/issues/2902)).
 - Reverted the `MainTrace` typed row storage change that caused a large `blake3_1to1` trace-building regression ([#2949](https://github.com/0xMiden/miden-vm/pull/2949)).
+- Fixed `MastForest::merge` to transfer procedure names, prefer concrete root metadata over external placeholders, and choose the lexicographically smallest name when two concrete roots disagree ([#2982](https://github.com/0xMiden/miden-vm/issues/2982)).
 #### Bug Fixes
 
 - Replaced unsound `ptr::read` with safe unbox in panic recovery, removing UB from potential double-drop ([#2934](https://github.com/0xMiden/miden-vm/pull/2934)).

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -1,6 +1,7 @@
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 
 use crate::{
+    LexicographicWord,
     crypto::hash::Blake3Digest,
     mast::{
         DecoratorId, MastForest, MastForestContributor, MastForestError, MastNode, MastNodeBuilder,
@@ -158,6 +159,8 @@ impl MastForestMerger {
             self.merge_roots(forest_idx, forest)?;
         }
 
+        self.merge_procedure_names(&forests);
+
         Ok(())
     }
 
@@ -280,6 +283,59 @@ impl MastForestMerger {
         }
 
         Ok(())
+    }
+
+    /// Merges procedure names from all input forests into the merged forest.
+    ///
+    /// The merge uses the following priority rules:
+    ///
+    /// 1. A name from a concrete (non-external) root always wins over a name from an external
+    ///    (placeholder) root for the same digest.
+    /// 2. When two concrete roots provide different names for the same digest, the
+    ///    lexicographically smallest name is chosen for determinism.
+    /// 3. A placeholder name is used as a fallback when no concrete root provides a name for that
+    ///    digest.
+    /// 4. When two placeholders provide different names, the lexicographically smallest name is
+    ///    chosen for determinism.
+    fn merge_procedure_names(&mut self, forests: &[&MastForest]) {
+        // For each digest, track the best name found so far and whether it came from a concrete
+        // root.
+        let mut best_names: BTreeMap<LexicographicWord, (Arc<str>, bool)> = BTreeMap::new();
+
+        for forest in forests {
+            for (digest, name) in forest.debug_info.procedure_names() {
+                let is_concrete = forest
+                    .find_procedure_root(digest)
+                    .map(|root_id| !forest[root_id].is_external())
+                    .unwrap_or(true);
+
+                let key = LexicographicWord::from(digest);
+
+                match best_names.get(&key) {
+                    Some((existing_name, existing_is_concrete)) => {
+                        let should_replace = match (is_concrete, *existing_is_concrete) {
+                            // Concrete always beats placeholder.
+                            (true, false) => true,
+                            // Placeholder never beats concrete.
+                            (false, true) => false,
+                            // Same kind: pick lexicographically smallest for determinism.
+                            _ => name.as_ref() < existing_name.as_ref(),
+                        };
+
+                        if should_replace {
+                            best_names.insert(key, (name.clone(), is_concrete));
+                        }
+                    },
+                    None => {
+                        best_names.insert(key, (name.clone(), is_concrete));
+                    },
+                }
+            }
+        }
+
+        for (digest, (name, _)) in best_names {
+            self.mast_forest.debug_info.insert_procedure_name(digest.into_inner(), name);
+        }
     }
 
     // HELPERS

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -1,3 +1,5 @@
+use alloc::sync::Arc;
+
 use super::*;
 use crate::{
     Felt, ONE, Word,
@@ -1113,4 +1115,104 @@ fn mast_forest_merge_op_indexed_decorators_preservation() {
         merged.decorators().len(),
         "Every decorator in merged forest should be referenced at least once (no orphans)"
     );
+}
+
+/// Tests that a concrete root's procedure name wins over an external placeholder's name for the
+/// same digest.
+///
+/// Forest A: External(foo_digest) with name "foo_placeholder"
+/// Forest B: Block(foo) with name "foo_concrete"
+///
+/// The merged forest should have "foo_concrete" regardless of merge order.
+#[test]
+fn mast_forest_merge_concrete_name_wins_over_placeholder() {
+    let foo_block = block_foo().build().unwrap();
+    let foo_digest = foo_block.digest();
+
+    // Forest A: external placeholder with a name
+    let mut forest_a = MastForest::new();
+    let id_ext = ExternalNodeBuilder::new(foo_digest).add_to_forest(&mut forest_a).unwrap();
+    forest_a.make_root(id_ext);
+    forest_a
+        .debug_info
+        .insert_procedure_name(foo_digest, Arc::from("foo_placeholder"));
+
+    // Forest B: concrete block with a name
+    let mut forest_b = MastForest::new();
+    let id_foo = block_foo().add_to_forest(&mut forest_b).unwrap();
+    forest_b.make_root(id_foo);
+    forest_b.debug_info.insert_procedure_name(foo_digest, Arc::from("foo_concrete"));
+
+    // Merge A+B: concrete should win
+    let (merged_ab, _) = MastForest::merge([&forest_a, &forest_b]).unwrap();
+    assert_eq!(merged_ab.procedure_name(&foo_digest), Some("foo_concrete"));
+
+    // Merge B+A: concrete should still win
+    let (merged_ba, _) = MastForest::merge([&forest_b, &forest_a]).unwrap();
+    assert_eq!(merged_ba.procedure_name(&foo_digest), Some("foo_concrete"));
+}
+
+/// Tests that a placeholder name is used as fallback when the concrete root has no name.
+///
+/// Forest A: External(foo_digest) with name "foo_fallback"
+/// Forest B: Block(foo) with no procedure name
+///
+/// The merged forest should use "foo_fallback" since the concrete root provides no name.
+#[test]
+fn mast_forest_merge_placeholder_name_as_fallback() {
+    let foo_block = block_foo().build().unwrap();
+    let foo_digest = foo_block.digest();
+
+    // Forest A: external placeholder with a name
+    let mut forest_a = MastForest::new();
+    let id_ext = ExternalNodeBuilder::new(foo_digest).add_to_forest(&mut forest_a).unwrap();
+    forest_a.make_root(id_ext);
+    forest_a.debug_info.insert_procedure_name(foo_digest, Arc::from("foo_fallback"));
+
+    // Forest B: concrete block without a name
+    let mut forest_b = MastForest::new();
+    let id_foo = block_foo().add_to_forest(&mut forest_b).unwrap();
+    forest_b.make_root(id_foo);
+    // No procedure name inserted for forest B
+
+    // Merge A+B: placeholder should serve as fallback
+    let (merged_ab, _) = MastForest::merge([&forest_a, &forest_b]).unwrap();
+    assert_eq!(merged_ab.procedure_name(&foo_digest), Some("foo_fallback"));
+
+    // Merge B+A: same result
+    let (merged_ba, _) = MastForest::merge([&forest_b, &forest_a]).unwrap();
+    assert_eq!(merged_ba.procedure_name(&foo_digest), Some("foo_fallback"));
+}
+
+/// Tests deterministic procedure name selection when two concrete roots provide different names
+/// for the same digest.
+///
+/// Forest A: Block(foo) with name "beta_name"
+/// Forest B: Block(foo) with name "alpha_name"
+///
+/// The lexicographically smallest name ("alpha_name") should be chosen regardless of merge order.
+#[test]
+fn mast_forest_merge_deterministic_procedure_names() {
+    let foo_block = block_foo().build().unwrap();
+    let foo_digest = foo_block.digest();
+
+    // Forest A: concrete block with a name
+    let mut forest_a = MastForest::new();
+    let id_foo_a = block_foo().add_to_forest(&mut forest_a).unwrap();
+    forest_a.make_root(id_foo_a);
+    forest_a.debug_info.insert_procedure_name(foo_digest, Arc::from("beta_name"));
+
+    // Forest B: same concrete block with a different name
+    let mut forest_b = MastForest::new();
+    let id_foo_b = block_foo().add_to_forest(&mut forest_b).unwrap();
+    forest_b.make_root(id_foo_b);
+    forest_b.debug_info.insert_procedure_name(foo_digest, Arc::from("alpha_name"));
+
+    // Merge A+B: lexicographically smallest should win
+    let (merged_ab, _) = MastForest::merge([&forest_a, &forest_b]).unwrap();
+    assert_eq!(merged_ab.procedure_name(&foo_digest), Some("alpha_name"));
+
+    // Merge B+A: same result (deterministic)
+    let (merged_ba, _) = MastForest::merge([&forest_b, &forest_a]).unwrap();
+    assert_eq!(merged_ba.procedure_name(&foo_digest), Some("alpha_name"));
 }


### PR DESCRIPTION
## Summary

Adds procedure name merging to `MastForest::merge` with two rules from [#2982](https://github.com/0xMiden/miden-vm/issues/2982):

1. **Concrete wins over placeholder**: metadata from an external placeholder root no longer overrides metadata from the concrete root it points to. The concrete name wins; the placeholder name serves as fallback only when the concrete root has no name.
2. **Deterministic tie-breaking**: when two concrete roots provide different names for the same digest, the lexicographically smallest name is chosen so the result does not depend on merge order.

## Rationale

Issue #2982 identified that `MastForest::merge` does not merge procedure names at all, which means debug metadata is silently dropped during forest merging. This causes lost diagnostics information when multiple forests are combined. The fix ensures procedure names survive merging with sensible priority rules: concrete definitions take precedence over placeholders, and deterministic tie-breaking guarantees reproducible results regardless of input order.

## Changes

- **`core/src/mast/merger/mod.rs`**: added `merge_procedure_names()` that collects procedure names from all input forests, classifies each as concrete or placeholder based on whether the source root is external, then picks the winning name per the priority rules above. Called at the end of `merge_inner()`.
- **`core/src/mast/merger/tests.rs`**: three new tests:
  - `mast_forest_merge_concrete_name_wins_over_placeholder` -- concrete name beats placeholder in both merge orders
  - `mast_forest_merge_placeholder_name_as_fallback` -- placeholder name preserved when concrete root has no name
  - `mast_forest_merge_deterministic_procedure_names` -- same result regardless of merge order when two concrete roots disagree

## Test plan

- `cargo test -p miden-core mast_forest_merge_concrete_name_wins_over_placeholder` -- verifies concrete names win over placeholder names in both merge orders
- `cargo test -p miden-core mast_forest_merge_placeholder_name_as_fallback` -- verifies placeholder name is preserved when no concrete name exists
- `cargo test -p miden-core mast_forest_merge_deterministic_procedure_names` -- verifies deterministic output regardless of merge order
- All existing merger tests continue to pass (`cargo test -p miden-core mast_forest_merge`)

Closes #2982