### PR TITLE
refactor: rename ModuleInfo to ModuleDescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Documented non-overlap requirement for `memcopy_words`, `memcopy_elements`, and AEAD encrypt/decrypt procedures ([#2941](https://github.com/0xMiden/miden-vm/pull/2941)).
 - Added chainable `Test` builders for common test setup in `miden-utils-testing` ([#2957](https://github.com/0xMiden/miden-vm/pull/2957)).
 - Speed-up AUX range check trace generation by changing divisors to a flat Vec layout ([#2966](https://github.com/0xMiden/miden-vm/pull/2966)).
+- [BREAKING] Renamed `ModuleInfo` to `ModuleDescriptor` and `module_infos()` to `module_descriptors()` across the assembly crates ([#2928](https://github.com/0xMiden/miden-vm/issues/2928)).
 ## 0.22.1
 
 #### Enhancements

--- a/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
@@ -24,7 +24,7 @@ pub trait SymbolTable {
     fn symbols(&self, source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter;
 }
 
-impl SymbolTable for &crate::library::ModuleInfo {
+impl SymbolTable for &crate::library::ModuleDescriptor {
     type SymbolIter = alloc::vec::IntoIter<LocalSymbol>;
 
     fn symbols(&self, _source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter {

--- a/crates/assembly-syntax/src/library/mod.rs
+++ b/crates/assembly-syntax/src/library/mod.rs
@@ -18,7 +18,7 @@ use crate::ast::{AttributeSet, Ident, Path, PathBuf, ProcedureName};
 mod error;
 mod module;
 
-pub use module::{ConstantInfo, ItemInfo, ModuleInfo, ProcedureInfo, TypeInfo};
+pub use module::{ConstantInfo, ItemInfo, ModuleDescriptor, ProcedureInfo, TypeInfo};
 pub use semver::{Error as VersionError, Version};
 
 pub use self::error::LibraryError;
@@ -362,16 +362,16 @@ impl Library {
 
 /// Conversions
 impl Library {
-    /// Returns an iterator over the module infos of the library.
-    pub fn module_infos(&self) -> impl Iterator<Item = ModuleInfo> {
-        let mut modules_by_path: BTreeMap<Arc<Path>, ModuleInfo> = BTreeMap::new();
+    /// Returns an iterator over the module descriptors of the library.
+    pub fn module_descriptors(&self) -> impl Iterator<Item = ModuleDescriptor> {
+        let mut modules_by_path: BTreeMap<Arc<Path>, ModuleDescriptor> = BTreeMap::new();
 
         for export in self.exports.values() {
             let module_name =
                 Arc::from(export.path().parent().unwrap().to_path_buf().into_boxed_path());
             let module = modules_by_path
                 .entry(Arc::clone(&module_name))
-                .or_insert_with(|| ModuleInfo::new(module_name, None));
+                .or_insert_with(|| ModuleDescriptor::new(module_name, None));
             match export {
                 LibraryExport::Procedure(ProcedureExport { node, path, signature, attributes }) => {
                     let proc_digest = self.mast_forest[*node].digest();
@@ -463,7 +463,7 @@ pub struct KernelLibrary {
     #[cfg_attr(feature = "serde", serde(skip))]
     kernel: Kernel,
     #[cfg_attr(feature = "serde", serde(skip))]
-    kernel_info: ModuleInfo,
+    kernel_descriptor: ModuleDescriptor,
     library: Arc<Library>,
 }
 
@@ -496,8 +496,8 @@ impl KernelLibrary {
     }
 
     /// Destructures this kernel library into individual parts.
-    pub fn into_parts(self) -> (Kernel, ModuleInfo, Arc<MastForest>) {
-        (self.kernel, self.kernel_info, self.library.mast_forest().clone())
+    pub fn into_parts(self) -> (Kernel, ModuleDescriptor, Arc<MastForest>) {
+        (self.kernel, self.kernel_descriptor, self.library.mast_forest().clone())
     }
 }
 
@@ -508,7 +508,7 @@ impl TryFrom<Arc<Library>> for KernelLibrary {
         let kernel_path = Arc::from(Path::kernel_path().to_path_buf().into_boxed_path());
         let mut proc_digests = Vec::with_capacity(library.exports.len());
 
-        let mut kernel_module = ModuleInfo::new(Arc::clone(&kernel_path), None);
+        let mut kernel_module = ModuleDescriptor::new(Arc::clone(&kernel_path), None);
 
         for export in library.exports.values() {
             match export {
@@ -557,7 +557,7 @@ impl TryFrom<Arc<Library>> for KernelLibrary {
 
         Ok(Self {
             kernel,
-            kernel_info: kernel_module,
+            kernel_descriptor: kernel_module,
             library,
         })
     }
@@ -754,7 +754,7 @@ impl<'de> serde::Deserialize<'de> for Library {
 /// NOTE: Serialization of libraries is likely to be deprecated in a future release
 impl Serializable for KernelLibrary {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let Self { kernel: _, kernel_info: _, library } = self;
+        let Self { kernel: _, kernel_descriptor: _, library } = self;
 
         library.write_into(target);
     }

--- a/crates/assembly-syntax/src/library/module.rs
+++ b/crates/assembly-syntax/src/library/module.rs
@@ -8,11 +8,11 @@ use crate::{
     ast::{self, AttributeSet, ConstantValue, Ident, ItemIndex, ProcedureName},
 };
 
-// MODULE INFO
+// MODULE DESCRIPTOR
 // ================================================================================================
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ModuleInfo {
+pub struct ModuleDescriptor {
     path: Arc<Path>,
     /// When specified, multiple modules with the same name can be present, so long as they are
     /// disambiguated by version.
@@ -20,8 +20,9 @@ pub struct ModuleInfo {
     items: Vec<ItemInfo>,
 }
 
-impl ModuleInfo {
-    /// Returns a new [`ModuleInfo`] instantiated by library path and optional semantic version.
+impl ModuleDescriptor {
+    /// Returns a new [`ModuleDescriptor`] instantiated by library path and optional semantic
+    /// version.
     ///
     /// The semantic version is optional, as currently the assembler allows assembling artifacts
     /// without providing one.
@@ -130,7 +131,7 @@ impl ModuleInfo {
     }
 }
 
-impl Index<ItemIndex> for ModuleInfo {
+impl Index<ItemIndex> for ModuleDescriptor {
     type Output = ItemInfo;
 
     fn index(&self, index: ItemIndex) -> &Self::Output {

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -354,7 +354,7 @@ impl Assembler {
                     )));
                 }
 
-                let kernel_module = package.kernel_module_info()?;
+                let kernel_module = package.kernel_module_descriptor()?;
                 let kernel = package.to_kernel()?;
                 self.linker.link_with_kernel(kernel, kernel_module)?;
                 Ok(())

--- a/crates/assembly/src/linker/library.rs
+++ b/crates/assembly/src/linker/library.rs
@@ -1,6 +1,6 @@
 use alloc::{sync::Arc, vec::Vec};
 
-use miden_assembly_syntax::{Library, library::ModuleInfo};
+use miden_assembly_syntax::{Library, library::ModuleDescriptor};
 use miden_core::mast::MastForest;
 use miden_mast_package::Package;
 use miden_project::Linkage;
@@ -14,7 +14,7 @@ pub struct LinkLibrary {
     /// The MAST of this library
     pub mast: Arc<MastForest>,
     /// Metadata about the modules and symbols available in the linked forest
-    pub module_infos: Vec<ModuleInfo>,
+    pub module_descriptors: Vec<ModuleDescriptor>,
     /// How to link against this library
     pub linkage: Linkage,
 }
@@ -23,9 +23,9 @@ impl LinkLibrary {
     /// Construct a [LinkLibrary] from a [miden_mast_package::Package]
     pub fn from_package(package: Arc<Package>) -> Self {
         let mast = package.mast.mast_forest().clone();
-        let module_infos = package
+        let module_descriptors = package
             .mast
-            .module_infos()
+            .module_descriptors()
             .map(|mut mi| {
                 mi.set_version(package.version.clone());
                 mi
@@ -33,17 +33,17 @@ impl LinkLibrary {
             .collect();
         Self {
             mast,
-            module_infos,
+            module_descriptors,
             linkage: Linkage::Dynamic,
         }
     }
 
     pub(crate) fn from_library(library: &Library) -> Self {
         let mast = library.mast_forest().clone();
-        let module_infos = library.module_infos().collect();
+        let module_descriptors = library.module_descriptors().collect();
         Self {
             mast,
-            module_infos,
+            module_descriptors,
             linkage: Linkage::Dynamic,
         }
     }

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -56,7 +56,7 @@ use miden_assembly_syntax::{
         Module, ModuleIndex, Path, SymbolResolution, Visibility, types,
     },
     debuginfo::{SourceManager, SourceSpan, Span, Spanned},
-    library::{ItemInfo, ModuleInfo},
+    library::{ItemInfo, ModuleDescriptor},
 };
 use miden_core::{Word, advice::AdviceMap, program::Kernel};
 use miden_project::Linkage;
@@ -164,7 +164,7 @@ impl Linker {
         match self.libraries.entry(library.mast.commitment()) {
             Entry::Vacant(entry) => {
                 entry.insert(library.clone());
-                self.link_assembled_modules(library.module_infos)
+                self.link_assembled_modules(library.module_descriptors)
             },
             Entry::Occupied(mut entry) => {
                 let prev = entry.get_mut();
@@ -186,7 +186,7 @@ impl Linker {
     /// [`Self::link_library`] if you wish to statically link a set of assembled modules.
     pub fn link_assembled_modules(
         &mut self,
-        modules: impl IntoIterator<Item = ModuleInfo>,
+        modules: impl IntoIterator<Item = ModuleDescriptor>,
     ) -> Result<(), LinkerError> {
         for module in modules {
             self.link_assembled_module(module)?;
@@ -201,7 +201,7 @@ impl Linker {
     /// [`Self::link_library`] if you wish to statically link `module`.
     pub fn link_assembled_module(
         &mut self,
-        module: ModuleInfo,
+        module: ModuleDescriptor,
     ) -> Result<ModuleIndex, LinkerError> {
         log::debug!(target: "linker", "adding pre-assembled module {} to module graph", module.path());
 
@@ -339,7 +339,7 @@ impl Linker {
     pub(super) fn with_kernel(
         source_manager: Arc<dyn SourceManager>,
         kernel: Kernel,
-        kernel_module: ModuleInfo,
+        kernel_module: ModuleDescriptor,
     ) -> Self {
         assert!(!kernel.is_empty());
         assert!(
@@ -369,7 +369,7 @@ impl Linker {
     pub(super) fn link_with_kernel(
         &mut self,
         kernel: Kernel,
-        kernel_module: ModuleInfo,
+        kernel_module: ModuleDescriptor,
     ) -> Result<(), LinkerError> {
         assert!(self.kernel.is_empty());
         assert!(!kernel.is_empty());

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -426,10 +426,10 @@ fn get_module_by_path() -> Result<(), Report> {
         .assemble_library(modules.iter().cloned())
         .unwrap();
 
-    let foo_module_info = bundle.module_infos().next().unwrap();
-    assert_eq!(foo_module_info.path(), &PathBuf::new("::test::foo").unwrap());
+    let foo_module_descriptor = bundle.module_descriptors().next().unwrap();
+    assert_eq!(foo_module_descriptor.path(), &PathBuf::new("::test::foo").unwrap());
 
-    let (_, foo_proc) = foo_module_info.procedures().next().unwrap();
+    let (_, foo_proc) = foo_module_descriptor.procedures().next().unwrap();
     assert_eq!(foo_proc.name, ProcedureName::new("foo").unwrap());
 
     Ok(())

--- a/crates/lib/core/src/lib.rs
+++ b/crates/lib/core/src/lib.rs
@@ -176,7 +176,7 @@ mod tests {
     fn test_compile() {
         let path = Path::new("::miden::core::math::u64::overflowing_add");
         let core_lib = CoreLibrary::default();
-        let exists = core_lib.0.module_infos().any(|module| {
+        let exists = core_lib.0.module_descriptors().any(|module| {
             module.procedures().any(|(_, proc)| &module.path().join(&proc.name) == path)
         });
 

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -15,7 +15,7 @@ use alloc::{
 };
 
 use miden_assembly_syntax::{
-    KernelLibrary, Library, Report, ast::QualifiedProcedureName, library::ModuleInfo,
+    KernelLibrary, Library, Report, ast::QualifiedProcedureName, library::ModuleDescriptor,
 };
 use miden_core::{Word, program::Kernel, serde::Deserializable};
 #[cfg(feature = "serde")]
@@ -122,10 +122,11 @@ impl Package {
         matches!(self.kind, TargetType::Kernel)
     }
 
-    /// Get the [ModuleInfo] corresponding to the kernel module, if this package contains the kernel
-    pub fn kernel_module_info(&self) -> Result<ModuleInfo, Report> {
+    /// Get the [ModuleDescriptor] corresponding to the kernel module, if this package contains
+    /// the kernel
+    pub fn kernel_module_descriptor(&self) -> Result<ModuleDescriptor, Report> {
         self.mast
-            .module_infos()
+            .module_descriptors()
             .find(|mi| mi.path().is_kernel_path())
             .ok_or_else(|| Report::msg("invalid kernel package: does not contain kernel module"))
     }
@@ -341,7 +342,7 @@ impl Package {
 
         let module = self
             .mast
-            .module_infos()
+            .module_descriptors()
             .find(|info| info.path() == entrypoint.namespace())
             .ok_or_else(|| {
                 Report::msg(format!(

--- a/miden-vm/tests/integration/flow_control/mod.rs
+++ b/miden-vm/tests/integration/flow_control/mod.rs
@@ -604,9 +604,9 @@ fn procref() -> Result<(), Report> {
             .assemble_library([module])
             .unwrap();
 
-        let module_info = library.module_infos().next().unwrap();
+        let module_descriptor = library.module_descriptors().next().unwrap();
 
-        module_info.procedure_digests().collect()
+        module_descriptor.procedure_digests().collect()
     };
 
     let source = "


### PR DESCRIPTION
## Summary

Renames `ModuleInfo` to `ModuleDescriptor` across the assembly crates, as discussed in #2928.

## Rationale

The name `ModuleInfo` is generic and does not clearly convey the role of the type, which describes a module's path, version, and exported items. `ModuleDescriptor` better communicates that it is a descriptor of a module's interface rather than an opaque info bag. This was requested by @bobbinth in #2928 with a preference for `descriptor` or `metadata`.

## Changes

### Type rename
- `ModuleInfo` -> `ModuleDescriptor` (struct, impls, trait impls)

### Method renames
- `Library::module_infos()` -> `Library::module_descriptors()`
- `Package::kernel_module_info()` -> `Package::kernel_module_descriptor()`

### Field renames
- `KernelLibrary::kernel_info` -> `KernelLibrary::kernel_descriptor`
- `LinkLibrary::module_infos` -> `LinkLibrary::module_descriptors`

### Files changed (11)
- `crates/assembly-syntax/src/library/module.rs` - struct definition and impls
- `crates/assembly-syntax/src/library/mod.rs` - re-export, `KernelLibrary` field, `Library::module_descriptors()`
- `crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs` - `SymbolTable` trait impl
- `crates/assembly/src/linker/library.rs` - `LinkLibrary` struct and constructors
- `crates/assembly/src/linker/mod.rs` - linker method signatures
- `crates/assembly/src/assembler.rs` - kernel module descriptor call site
- `crates/assembly/src/tests.rs` - test variable names
- `crates/mast-package/src/package/mod.rs` - import and method rename
- `crates/lib/core/src/lib.rs` - call site update
- `miden-vm/tests/integration/flow_control/mod.rs` - test variable names
- `CHANGELOG.md` - breaking change entry

## Test plan

1. `cargo check -p miden-assembly-syntax -p miden-assembly -p miden-mast-package` - all three crates compile cleanly
2. `cargo test -p miden-assembly-syntax -p miden-mast-package` - all 25 tests pass
3. `cargo clippy -p miden-assembly-syntax -p miden-assembly -p miden-mast-package -- -D warnings` - no warnings
4. `git grep ModuleInfo -- '*.rs'` returns zero matches, confirming a complete rename

Closes #2928