### PR TITLE
ci: Harden CI, signed-commit on maintainers, non-regression on next, workspace inheritance

### DIFF
--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -46,7 +46,7 @@ runs:
     # Install cargo-msrv for MSRV checks
     - name: Install cargo-msrv
       shell: bash
-      run: cargo install cargo-msrv
+      run: cargo install cargo-msrv --version 0.19.3 --locked
 
     # Keep your existing MSRV check
     - name: Check MSRV

--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -32,10 +32,13 @@ runs:
         fi
 
     - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      shell: bash
+      run: |
+        rustup update --no-self-update stable
+        rustup default stable
 
     - name: Cache Rust build artifacts
-      uses: WarpBuilds/rust-cache@v2
+      uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
 
     - name: Cleanup large tools for build space
       uses: ./.github/actions/cleanup-runner

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,7 +16,9 @@ jobs:
     name: Bench on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Bench for all features
         run: |
           rustup +stable update --no-self-update

--- a/.github/workflows/blake3-nonregression.yml
+++ b/.github/workflows/blake3-nonregression.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - next
   workflow_dispatch:
     inputs:
       baseline_ref:
@@ -59,7 +60,7 @@ jobs:
           rustup toolchain install "${toolchain}" --profile minimal --target wasm32-unknown-unknown
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Prepare benchmark directories
         id: dirs

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,10 +28,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - name: Build for no-std

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,19 +16,3 @@ on:
 jobs:
   changelog-reusable:
     uses: 0xMiden/.github/.github/workflows/changelog.yml@d34ae3cd29234c5aa4d3ab57635b30563471c3c3
-
-  changelog:
-    runs-on: ubuntu-latest
-    needs: changelog-reusable
-    if: always()
-    steps:
-      - name: Mirror reusable workflow result
-        env:
-          RESULT: ${{ needs.changelog-reusable.result }}
-        run: |
-          if [ "$RESULT" = "success" ] || [ "$RESULT" = "skipped" ]; then
-            exit 0
-          fi
-
-          echo "Reusable changelog workflow concluded with $RESULT" >&2
-          exit 1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   changelog-reusable:
-    uses: 0xMiden/.github/.github/workflows/changelog.yml@main
+    uses: 0xMiden/.github/.github/workflows/changelog.yml@d34ae3cd29234c5aa4d3ab57635b30563471c3c3
 
   changelog:
     runs-on: ubuntu-latest

--- a/.github/workflows/contribution-quality.yml
+++ b/.github/workflows/contribution-quality.yml
@@ -17,14 +17,15 @@ on:
         type: choice
         options: ["false", "true"]
 
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
+permissions: {}
 
 jobs:
   contribution-quality-reusable:
-    uses: 0xMiden/.github/.github/workflows/contribution-quality.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    uses: 0xMiden/.github/.github/workflows/contribution-quality.yml@d34ae3cd29234c5aa4d3ab57635b30563471c3c3
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
       force_all: ${{ github.event.inputs.force_all || 'false' }}

--- a/.github/workflows/contribution-quality.yml
+++ b/.github/workflows/contribution-quality.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    uses: 0xMiden/.github/.github/workflows/contribution-quality.yml@d34ae3cd29234c5aa4d3ab57635b30563471c3c3
+    uses: 0xMiden/.github/.github/workflows/contribution-quality.yml@38552ca595c5773dd361cdc479f349ef75831386
     with:
       pr_number: ${{ github.event.inputs.pr_number || '' }}
       force_all: ${{ github.event.inputs.force_all || 'false' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,13 +32,15 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Generate documentation
         run: |
@@ -75,10 +77,10 @@ jobs:
           touch _site/.nojekyll
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./_site
 
       - name: Deploy documentation
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -41,11 +41,14 @@ jobs:
           - package_deserialize
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: dtolnay/rust-toolchain@nightly
-      - uses: Swatinem/rust-cache@v2
+      - name: Install Rust toolchain
+        run: rustup update --no-self-update nightly
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
       - name: Run fuzz target (smoke test)

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -20,20 +20,22 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set fail-fast flag depending on trigger
         id: flags
         run: |
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "fail_fast=false" >> $GITHUB_OUTPUT
+            echo "fail_fast=false" >> "$GITHUB_OUTPUT"
           else
-            echo "fail_fast=${{ inputs.fail-fast }}" >> $GITHUB_OUTPUT
+            echo "fail_fast=${{ inputs.fail-fast }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2.0.2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           fail: ${{ steps.flags.outputs.fail_fast }}
           args: |
@@ -51,7 +53,7 @@ jobs:
 
       - name: Open issue on failure (only if fail-fast is false)
         if: steps.lychee.outputs.exit_code != 0 && steps.flags.outputs.fail_fast != 'true'
-        uses: peter-evans/create-issue-from-file@v5
+        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,11 +32,11 @@ jobs:
         with:
           persist-credentials: false
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@b51e10a30e12f8d30315761119b1445be295e8b6 # cargo-binstall
+        uses: taiki-e/install-action@c1596c3b5e0949d3aaac0490d189c853cc35deb2 # cargo-binstall
       - name: Install workspace inheritance checker
         run: cargo binstall --no-confirm cargo-workspace-inheritance-check@1.2.0
       - name: Check workspace inheritance
-        run: cargo workspace-inheritance-check --promotion-failure
+        run: cargo workspace-inheritance-check --promotion-threshold 2 --promotion-failure
 
   clippy:
     name: clippy nightly on ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,11 @@ jobs:
     name: cargo-deny on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: taiki-e/install-action@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          tool: cargo-deny
+          persist-credentials: false
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --version 0.19.1 --locked
       - name: Check dependencies with cargo-deny
         run: cargo deny check
 
@@ -27,7 +28,9 @@ jobs:
     name: clippy nightly on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - name: Clippy
@@ -40,7 +43,9 @@ jobs:
     name: rustfmt check nightly on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - name: Rustfmt
@@ -53,7 +58,9 @@ jobs:
     name: doc stable on ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
       - name: Build docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,20 @@ jobs:
       - name: Check dependencies with cargo-deny
         run: cargo deny check
 
+  workspace-inheritance:
+    name: workspace inheritance on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@b51e10a30e12f8d30315761119b1445be295e8b6 # cargo-binstall
+      - name: Install workspace inheritance checker
+        run: cargo binstall --no-confirm cargo-workspace-inheritance-check@1.2.0
+      - name: Check workspace inheritance
+        run: cargo workspace-inheritance-check --promotion-failure
+
   clippy:
     name: clippy nightly on ubuntu-latest
     runs-on: ubuntu-latest

--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -27,6 +27,11 @@ jobs:
             const login = (context.payload.pull_request.user?.login || '').toLowerCase();
             let permission = 'none';
             try {
+              // Signed-commit checks only apply to maintainers.
+              // GitHub repo roles are too broad here because most access
+              // comes from org team permissions, so this probe reads the
+              // PR author's effective repo write access and decides who
+              // should be asked to sign commits.
               const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/signed-commits.yml
+++ b/.github/workflows/signed-commits.yml
@@ -3,9 +3,7 @@
 
 name: signed commits
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 on:
   pull_request_target:
@@ -17,10 +15,38 @@ on:
 jobs:
   check-signed-commits:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
+      - name: Resolve author permission
+        id: perm
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const login = (context.payload.pull_request.user?.login || '').toLowerCase();
+            let permission = 'none';
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: login,
+              });
+              permission = (data.permission || 'none').toLowerCase();
+            } catch (error) {
+              if (error.status !== 404) {
+                core.warning(`Failed to resolve collaborator permission for ${login}: ${error.message}`);
+              }
+            }
+
+            const enforce = ['admin', 'maintain', 'write'].includes(permission);
+            core.info(`author=${login} permission=${permission} enforce=${enforce}`);
+            core.setOutput('enforce', enforce ? 'true' : 'false');
+
       - name: Check for unsigned commits
+        if: steps.perm.outputs.enforce == 'true'
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const prNumber = context.payload.pull_request.number;
@@ -51,8 +77,8 @@ jobs:
             );
 
       - name: Comment with remediation steps
-        if: failure() && steps.check.outputs.unsigned != ''
-        uses: actions/github-script@v7
+        if: failure() && steps.perm.outputs.enforce == 'true' && steps.check.outputs.unsigned != ''
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           UNSIGNED: ${{ steps.check.outputs.unsigned }}
           PRNUM: ${{ steps.check.outputs.pr_number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,13 @@ jobs:
     name: test on warp-ubuntu-latest-x64-4x
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: taiki-e/install-action@nextest
-      - uses: WarpBuilds/rust-cache@v2
+      - uses: taiki-e/install-action@e9fe1d0c24b9415d0c0be1429c063ba3e3a8b277 # nextest
+      - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install rust
@@ -32,10 +34,12 @@ jobs:
     name: doc-tests
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: WarpBuilds/rust-cache@v2
+      - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install rust
@@ -48,10 +52,12 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-4x
     needs: [test, doc-tests]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: WarpBuilds/rust-cache@v2
+      - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install rust
@@ -100,10 +106,12 @@ jobs:
     name: run masm examples
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: WarpBuilds/rust-cache@v2
+      - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install rust
@@ -115,15 +123,17 @@ jobs:
     name: check all feature combinations
     runs-on: warp-ubuntu-latest-x64-4x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: WarpBuilds/rust-cache@v2
+      - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install rust
         run: rustup update --no-self-update
       - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
+        uses: taiki-e/install-action@f5d11b430651d1f6ce680bbd182b55307055de52 # cargo-hack
       - name: Check all feature combinations
         run: make check-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,10 +91,12 @@ jobs:
     name: check recursive constraint artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install rust

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: taiki-e/install-action@e9fe1d0c24b9415d0c0be1429c063ba3e3a8b277 # nextest
+      - uses: taiki-e/install-action@dd81e62c198605dea8507fed3fb6834da354ded4 # nextest
       - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
@@ -134,6 +134,6 @@ jobs:
       - name: Install rust
         run: rustup update --no-self-update
       - name: Install cargo-hack
-        uses: taiki-e/install-action@f5d11b430651d1f6ce680bbd182b55307055de52 # cargo-hack
+        uses: taiki-e/install-action@36052feccaae5f79088f0d62a11f9bac2a9e2ec0 # cargo-hack
       - name: Check all feature combinations
         run: make check-features

--- a/.github/workflows/workspace-dry-run.yml
+++ b/.github/workflows/workspace-dry-run.yml
@@ -21,9 +21,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Dry-run workspace release
         uses: ./.github/actions/workspace-release

--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -16,13 +16,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: main
+          persist-credentials: false
 
       - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth
 
       - name: Publish workspace crates

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [main, next]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "zizmor.yml"
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "zizmor.yml"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
+          config: zizmor.yml
+          version: 1.23.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,11 +89,9 @@ log             = { version = "0.4", default-features = false }
 paste           = { version = "1.0", default-features = false }
 proptest        = { version = "1.8", default-features = false, features = ["no_std", "alloc"] }
 proptest-derive = { version = "0.7", default-features = false }
-rand            = { version = "0.9", default-features = false }
 serde           = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }
 serde_json      = { version = "1.0", default-features = false, features = ["alloc"] }
 serde-untagged  = {version = "0.1" }
-semver          = { version = "1.0", default-features = false }
 smallvec        = { version = "1.15", default-features = false, features = ["union", "const_generics", "const_new"] }
 syn             = "1.0"
 tempfile        = { version = "3.18", default-features = false }
@@ -103,40 +101,15 @@ tracing         = { version = "0.1", default-features = false, features = ["attr
 
 # WASM support
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
-aho-corasick = { version = "1.1", default-features = false }
-assert_cmd = "2.1"
-clap = "4.5"
-escargot = "0.5"
-fs-err = "3.1"
-hex = "0.4"
-lalrpop = { version = "0.22", default-features = false }
-lalrpop-util = { version = "0.22", default-features = false }
-lock_api = "0.4"
 loom = "0.7"
-memchr = { version = "2.7", default-features = false }
 miette = { package = "miden-miette", version = "8.0", default-features = false }
-num = "0.4"
 num-bigint = "0.4"
-num-derive = { version = "0.4", default-features = false }
-num-traits = { version = "0.2", default-features = false }
-once_cell = { version = "1.21", default-features = false }
-parking_lot = "0.12"
-predicates = "3.1"
 pretty_assertions = { version = "1.4", default-features = false }
 proc-macro2 = "1.0"
-pubgrub = "0.3"
 quote = "1.0"
 rand_chacha = { version = "0.9", default-features = false }
-rayon = { version = "1.10", default-features = false }
-regex = { version = "1.12", default-features = false }
 rstest = "0.26"
-rustc_version = "0.4"
-serde_spanned = { version = "1.0", default-features = false }
-test-case = "3.2"
 toml = { version = "1.0", default-features = false }
-tracing-forest = "0.2"
-tracing-subscriber = "0.3"
-walkdir = "2.5"
 
 [workspace.lints.rust]
 unexpected_cfgs = { check-cfg = ['cfg(fuzzing)'], level = "warn" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,40 @@ tracing         = { version = "0.1", default-features = false, features = ["attr
 
 # WASM support
 getrandom = { version = "0.2", default-features = false, features = ["js"] }
+aho-corasick = { version = "1.1", default-features = false }
+assert_cmd = "2.1"
+clap = "4.5"
+escargot = "0.5"
+fs-err = "3.1"
+hex = "0.4"
+lalrpop = { version = "0.22", default-features = false }
+lalrpop-util = { version = "0.22", default-features = false }
+lock_api = "0.4"
+loom = "0.7"
+memchr = { version = "2.7", default-features = false }
+miette = { package = "miden-miette", version = "8.0", default-features = false }
+num = "0.4"
+num-bigint = "0.4"
+num-derive = { version = "0.4", default-features = false }
+num-traits = { version = "0.2", default-features = false }
+once_cell = { version = "1.21", default-features = false }
+parking_lot = "0.12"
+predicates = "3.1"
+pretty_assertions = { version = "1.4", default-features = false }
+proc-macro2 = "1.0"
+pubgrub = "0.3"
+quote = "1.0"
+rand_chacha = { version = "0.9", default-features = false }
+rayon = { version = "1.10", default-features = false }
+regex = { version = "1.12", default-features = false }
+rstest = "0.26"
+rustc_version = "0.4"
+serde_spanned = { version = "1.0", default-features = false }
+test-case = "3.2"
+toml = { version = "1.0", default-features = false }
+tracing-forest = "0.2"
+tracing-subscriber = "0.3"
+walkdir = "2.5"
 
 [workspace.lints.rust]
 unexpected_cfgs = { check-cfg = ['cfg(fuzzing)'], level = "warn" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,8 +55,8 @@ miden-utils-sync.workspace = true
 # External dependencies
 derive_more.workspace = true
 itertools.workspace = true
-num-derive = { version = "0.4", default-features = false }
-num-traits = { version = "0.2", default-features = false }
+num-derive = { workspace = true }
+num-traits = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
@@ -67,6 +67,6 @@ criterion = { workspace = true }
 insta.workspace = true
 miden-test-serde-macros.workspace = true
 proptest.workspace = true
-rstest = { version = "0.26" }
+rstest = { workspace = true }
 serde_json = { workspace = true }
 miden-utils-testing.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -55,8 +55,8 @@ miden-utils-sync.workspace = true
 # External dependencies
 derive_more.workspace = true
 itertools.workspace = true
-num-derive = { workspace = true }
-num-traits = { workspace = true }
+num-derive = { version = "0.4", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -43,14 +43,14 @@ miden-utils-diagnostics.workspace = true
 midenc-hir-type = { workspace = true, features = ["serde"] }
 
 # External dependencies
-aho-corasick = { workspace = true }
+aho-corasick = { version = "1.1", default-features = false }
 env_logger = { workspace = true, optional = true }
-lalrpop-util = { workspace = true }
+lalrpop-util = { version = "0.22", default-features = false }
 log.workspace = true
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
-regex = { workspace = true, features = ["unicode", "perf"] }
-semver = { workspace = true }
+regex = { version = "1.12", default-features = false, features = ["unicode", "perf"] }
+semver = { version = "1.0", default-features = false }
 serde = { workspace = true, optional = true }
 smallvec.workspace = true
 thiserror.workspace = true
@@ -63,5 +63,5 @@ pretty_assertions = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 
 [build-dependencies]
-lalrpop = { workspace = true }
-rustc_version = { workspace = true }
+lalrpop = { version = "0.22", default-features = false }
+rustc_version = "0.4"

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -43,14 +43,14 @@ miden-utils-diagnostics.workspace = true
 midenc-hir-type = { workspace = true, features = ["serde"] }
 
 # External dependencies
-aho-corasick = { version = "1.1", default-features = false }
+aho-corasick = { workspace = true }
 env_logger = { workspace = true, optional = true }
-lalrpop-util = { version = "0.22", default-features = false }
+lalrpop-util = { workspace = true }
 log.workspace = true
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
-regex = { version = "1.12", default-features = false, features = ["unicode", "perf"] }
-semver = { version = "1.0", default-features = false }
+regex = { workspace = true, features = ["unicode", "perf"] }
+semver = { workspace = true }
 serde = { workspace = true, optional = true }
 smallvec.workspace = true
 thiserror.workspace = true
@@ -59,9 +59,9 @@ thiserror.workspace = true
 env_logger.workspace = true
 miden-test-serde-macros.workspace = true
 proptest.workspace = true
-pretty_assertions = "1.4"
+pretty_assertions = { workspace = true }
 serde_json = { workspace = true }
 
 [build-dependencies]
-lalrpop = { version = "0.22", default-features = false }
-rustc_version = "0.4"
+lalrpop = { workspace = true }
+rustc_version = { workspace = true }

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -59,7 +59,7 @@ thiserror.workspace = true
 env_logger.workspace = true
 miden-test-serde-macros.workspace = true
 proptest.workspace = true
-pretty_assertions = { workspace = true }
+pretty_assertions = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 
 [build-dependencies]

--- a/crates/debug-types/Cargo.toml
+++ b/crates/debug-types/Cargo.toml
@@ -34,9 +34,9 @@ miden-utils-sync.workspace = true
 miden-utils-indexing.workspace = true
 
 # External dependencies
-memchr = { version = "2.7", default-features = false }
-miette = { package = "miden-miette", version = "8.0", default-features = false, features = ["fancy-no-syscall", "derive"] }
+memchr = { workspace = true }
+miette = { workspace = true, features = ["fancy-no-syscall", "derive"] }
 paste.workspace = true
 serde = { workspace = true, optional = true }
-serde_spanned = { version = "1.0", optional = true, default-features = false }
+serde_spanned = { workspace = true, optional = true }
 thiserror.workspace = true

--- a/crates/debug-types/Cargo.toml
+++ b/crates/debug-types/Cargo.toml
@@ -34,9 +34,9 @@ miden-utils-sync.workspace = true
 miden-utils-indexing.workspace = true
 
 # External dependencies
-memchr = { workspace = true }
+memchr = { version = "2.7", default-features = false }
 miette = { workspace = true, features = ["fancy-no-syscall", "derive"] }
 paste.workspace = true
 serde = { workspace = true, optional = true }
-serde_spanned = { workspace = true, optional = true }
+serde_spanned = { version = "1.0", optional = true, default-features = false }
 thiserror.workspace = true

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -51,10 +51,10 @@ miden-processor = { workspace = true, features = ["testing"] }
 miden-prover.workspace = true
 miden-utils-testing.workspace = true
 miden-verifier.workspace = true
-num = { workspace = true }
+num = { version = "0.4" }
 num-bigint = { workspace = true }
 pretty_assertions = { workspace = true, features = ["std"] }
-rand = { workspace = true }
+rand = { version = "0.9", default-features = false }
 rand_chacha = { workspace = true }
 rstest = { workspace = true }
 bincode.workspace = true
@@ -63,7 +63,7 @@ serde_json.workspace = true
 
 [build-dependencies]
 env_logger.workspace = true
-fs-err = { workspace = true }
+fs-err = { version = "3.1" }
 miden-assembly = { workspace = true, features = ["std"] }
 miden-package-registry = { workspace = true, features = ["resolver"] }
 

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -45,25 +45,25 @@ thiserror.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
-miden-ace-codegen = { path = "../../ace-codegen" }
+miden-ace-codegen.workspace = true
 miden-air.workspace = true
 miden-processor = { workspace = true, features = ["testing"] }
 miden-prover.workspace = true
 miden-utils-testing.workspace = true
 miden-verifier.workspace = true
-num = { version = "0.4" }
-num-bigint = { version = "0.4" }
-pretty_assertions = { version = "1.4" }
-rand = { version = "0.9", default-features = false }
-rand_chacha = { version = "0.9", default-features = false }
-rstest = { version = "0.26" }
+num = { workspace = true }
+num-bigint = { workspace = true }
+pretty_assertions = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
+rstest = { workspace = true }
 bincode.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
 [build-dependencies]
 env_logger.workspace = true
-fs-err = { version = "3.1" }
+fs-err = { workspace = true }
 miden-assembly = { workspace = true, features = ["std"] }
 miden-package-registry = { workspace = true, features = ["resolver"] }
 

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -53,7 +53,7 @@ miden-utils-testing.workspace = true
 miden-verifier.workspace = true
 num = { workspace = true }
 num-bigint = { workspace = true }
-pretty_assertions = { workspace = true }
+pretty_assertions = { workspace = true, features = ["std"] }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rstest = { workspace = true }

--- a/crates/package-registry/Cargo.toml
+++ b/crates/package-registry/Cargo.toml
@@ -23,7 +23,7 @@ serde = ["dep:serde", "miden-assembly-syntax/serde", "miden-core/serde", "miden-
 miden-assembly-syntax.workspace = true
 miden-core.workspace = true
 miden-mast-package.workspace = true
-pubgrub = { workspace = true, optional = true }
+pubgrub = { version = "0.3", optional = true }
 serde = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
 thiserror.workspace = true

--- a/crates/package-registry/Cargo.toml
+++ b/crates/package-registry/Cargo.toml
@@ -23,7 +23,7 @@ serde = ["dep:serde", "miden-assembly-syntax/serde", "miden-core/serde", "miden-
 miden-assembly-syntax.workspace = true
 miden-core.workspace = true
 miden-mast-package.workspace = true
-pubgrub = { version = "0.3", optional = true }
+pubgrub = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
 thiserror.workspace = true

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -30,7 +30,7 @@ proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde-untagged = { workspace = true, optional = true }
 thiserror.workspace = true
-toml = { version = "1.0", default-features = false }
+toml = { workspace = true }
 
 [dev-dependencies]
 miden-core.workspace = true
@@ -38,7 +38,7 @@ miden-mast-package = { workspace = true, features = ["arbitrary"] }
 miden-test-serde-macros.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
-toml = { version = "1.0", default-features = false, features = ["std", "serde", "parse"] }
+toml = { workspace = true, features = ["std", "serde", "parse"] }
 
 [lints.rust]
 # This is needed until this warning appears in stable when this is commented out. Currently, it

--- a/crates/test-serde-macros/Cargo.toml
+++ b/crates/test-serde-macros/Cargo.toml
@@ -17,8 +17,8 @@ edition.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 syn = { workspace = true, features = ["derive", "extra-traits", "full"] }
 proptest.workspace = true
 proptest-derive.workspace = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -31,7 +31,7 @@ miden-crypto.workspace = true
 miden-processor = { workspace = true, features = ["testing"] }
 miden-prover.workspace = true
 miden-verifier.workspace = true
-test-case = { workspace = true }
+test-case = "3.2"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 pretty_assertions = { workspace = true, default-features = false, features = [

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -40,5 +40,5 @@ pretty_assertions = { workspace = true, default-features = false, features = [
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 env_logger.workspace = true
-pretty_assertions = { workspace = true, default-features = true }
+pretty_assertions = { workspace = true, features = ["std"] }
 proptest.workspace = true

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -31,14 +31,14 @@ miden-crypto.workspace = true
 miden-processor = { workspace = true, features = ["testing"] }
 miden-prover.workspace = true
 miden-verifier.workspace = true
-test-case = "3.2"
+test-case = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-pretty_assertions = { version = "1.4", default-features = false, features = [
+pretty_assertions = { workspace = true, default-features = false, features = [
     "alloc",
 ] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 env_logger.workspace = true
-pretty_assertions = "1.4"
+pretty_assertions = { workspace = true, default-features = true }
 proptest.workspace = true

--- a/crates/utils-core-derive/Cargo.toml
+++ b/crates/utils-core-derive/Cargo.toml
@@ -16,6 +16,6 @@ edition.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
 syn = { workspace = true, features = ["derive", "extra-traits", "full"] }

--- a/crates/utils-diagnostics/Cargo.toml
+++ b/crates/utils-diagnostics/Cargo.toml
@@ -20,7 +20,7 @@ std = ["miette/fancy-no-syscall", "miette/std", "miden-crypto/std", "miden-debug
 
 [dependencies]
 miden-debug-types.workspace = true
-miette = { package = "miden-miette", version = "8.0", default-features = false, features = [
+miette = { workspace = true, features = [
     "fancy-no-syscall",
     "derive",
 ] }

--- a/crates/utils-sync/Cargo.toml
+++ b/crates/utils-sync/Cargo.toml
@@ -19,16 +19,16 @@ default = ["std"]
 std = ["dep:parking_lot"]
 
 [dependencies]
-lock_api = { version = "0.4", features = ["arc_lock"] }
-once_cell = { version = "1.21", default-features = false, features = ["alloc", "race"] }
-parking_lot = { version = "0.12", optional = true }
+lock_api = { workspace = true, features = ["arc_lock"] }
+once_cell = { workspace = true, features = ["alloc", "race"] }
+parking_lot = { workspace = true, optional = true }
 
 [dev-dependencies]
-loom = "0.7"
+loom = { workspace = true }
 proptest.workspace = true
 
 [target.'cfg(loom)'.dependencies]
-loom = "0.7"
+loom.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/crates/utils-sync/Cargo.toml
+++ b/crates/utils-sync/Cargo.toml
@@ -19,9 +19,9 @@ default = ["std"]
 std = ["dep:parking_lot"]
 
 [dependencies]
-lock_api = { workspace = true, features = ["arc_lock"] }
-once_cell = { workspace = true, features = ["alloc", "race"] }
-parking_lot = { workspace = true, optional = true }
+lock_api = { version = "0.4", features = ["arc_lock"] }
+once_cell = { version = "1.21", default-features = false, features = ["alloc", "race"] }
+parking_lot = { version = "0.12", optional = true }
 
 [dev-dependencies]
 loom = { workspace = true }

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -79,24 +79,24 @@ miden-core-lib.workspace = true
 miden-verifier.workspace = true
 
 # External dependencies
-clap = { version = "4.5", features = ["derive"], optional = true }
-hex = { version = "0.4", optional = true }
+clap = { workspace = true, features = ["derive"], optional = true }
+hex = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tracing.workspace = true
-tracing-subscriber = { version = "0.3", optional = true, features = ["std", "env-filter"] }
-tracing-forest = { version = "0.2", optional = true, features = ["ansi", "smallvec"] }
+tracing-subscriber = { workspace = true, features = ["std", "env-filter"], optional = true }
+tracing-forest = { workspace = true, features = ["ansi", "smallvec"], optional = true }
 
 [dev-dependencies]
-assert_cmd = { version = "2.1" }
-bincode = { version = "1.3" }
+assert_cmd = { workspace = true }
+bincode = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
-escargot = { version = "0.5" }
+escargot = { workspace = true }
 miden-processor = { workspace = true, features = ["testing"] }
 miden-utils-testing.workspace = true
-num-bigint = { version = "0.4" }
-predicates = { version = "3.1" }
-pretty_assertions = { version = "1.4" }
+num-bigint = { workspace = true }
+predicates = { workspace = true }
+pretty_assertions = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
-rand_chacha = { version = "0.9" }
-walkdir = { version = "2.5" }
+rand_chacha = { workspace = true }
+walkdir = { workspace = true }

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -96,7 +96,7 @@ miden-processor = { workspace = true, features = ["testing"] }
 miden-utils-testing.workspace = true
 num-bigint = { workspace = true }
 predicates = { workspace = true }
-pretty_assertions = { workspace = true }
+pretty_assertions = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 rand_chacha = { workspace = true }
 walkdir = { workspace = true }

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -79,24 +79,24 @@ miden-core-lib.workspace = true
 miden-verifier.workspace = true
 
 # External dependencies
-clap = { workspace = true, features = ["derive"], optional = true }
-hex = { workspace = true, optional = true }
+clap = { version = "4.5", features = ["derive"], optional = true }
+hex = { version = "0.4", optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tracing.workspace = true
-tracing-subscriber = { workspace = true, features = ["std", "env-filter"], optional = true }
-tracing-forest = { workspace = true, features = ["ansi", "smallvec"], optional = true }
+tracing-subscriber = { version = "0.3", optional = true, features = ["std", "env-filter"] }
+tracing-forest = { version = "0.2", optional = true, features = ["ansi", "smallvec"] }
 
 [dev-dependencies]
-assert_cmd = { workspace = true }
+assert_cmd = { version = "2.1" }
 bincode = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
-escargot = { workspace = true }
+escargot = { version = "0.5" }
 miden-processor = { workspace = true, features = ["testing"] }
 miden-utils-testing.workspace = true
 num-bigint = { workspace = true }
-predicates = { workspace = true }
+predicates = { version = "3.1" }
 pretty_assertions = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 rand_chacha = { workspace = true }
-walkdir = { workspace = true }
+walkdir = { version = "2.5" }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -42,7 +42,7 @@ miden-utils-indexing.workspace = true
 # External dependencies
 itertools.workspace = true
 paste.workspace = true
-rayon = { version = "1.10", default-features = false }
+rayon = { workspace = true }
 tracing.workspace = true
 thiserror.workspace = true
 
@@ -50,7 +50,7 @@ thiserror.workspace = true
 miden-assembly = { workspace = true, features = ["testing"] }
 miden-utils-testing.workspace = true
 insta.workspace = true
-pretty_assertions = { version = "1.4" }
+pretty_assertions = { workspace = true }
 proptest.workspace = true
-rstest = { version = "0.26" }
+rstest = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -50,7 +50,7 @@ thiserror.workspace = true
 miden-assembly = { workspace = true, features = ["testing"] }
 miden-utils-testing.workspace = true
 insta.workspace = true
-pretty_assertions = { workspace = true }
+pretty_assertions = { workspace = true, features = ["std"] }
 proptest.workspace = true
 rstest = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -42,7 +42,7 @@ miden-utils-indexing.workspace = true
 # External dependencies
 itertools.workspace = true
 paste.workspace = true
-rayon = { workspace = true }
+rayon = { version = "1.10", default-features = false }
 tracing.workspace = true
 thiserror.workspace = true
 

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      - contribution-quality.yml
+      - signed-commits.yml
+  secrets-outside-env:
+    ignore:
+      - trigger-deploy-docs.yml


### PR DESCRIPTION
Tightens the repo’s GitHub Actions setup and keeps current workflow behavior the same (mostly).

- The Blake3 non-regression workflow now runs on pushes to next as well as main.
- The CI hardening pins external actions and reusable workflows to commit SHAs, sets persist-credentials: false on checkout steps, and narrows write permissions to the jobs that need them.
- A new [zizmor](https://github.com/zizmorcore/zizmor) workflow checks GitHub Actions changes. It is configured to allow the two `pull_request_target` workflows that need to comment on PRs.
- a new [cargo-workspace-inheritance-check](https://github.com/RomarQ/cargo-workspace-inheritance-check) ensures versioning doesn't drift between crates and workspace.
- The workspace release action now installs `cargo-msrv` at a fixed version with `--locked`.
- The signed-commit check now applies only to PR authors who already have write-level access to the repo.
- Removes the duplicated changelog check.