### PR TITLE
ci: tune warpbuild runners and taiki install pins

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,4 +2,4 @@
 # blake3 non-regression workflow.
 self-hosted-runner:
   labels:
-    - warp-ubuntu-latest-x64-4x
+    - warp-ubuntu-latest-x64-8x

--- a/.github/workflows/blake3-nonregression.yml
+++ b/.github/workflows/blake3-nonregression.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   benchmark:
     name: Benchmark baseline vs current
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: warp-ubuntu-latest-x64-8x
     timeout-minutes: 180
     permissions:
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,8 +31,13 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+      # Do not pin taiki-e's moving tool shortcut tags by hash. Pin a released
+      # install-action commit and set tool explicitly, or zizmor's
+      # impostor-commit audit can flag stale shortcut-tag hashes.
       - name: Install cargo-binstall
-        uses: taiki-e/install-action@c1596c3b5e0949d3aaac0490d189c853cc35deb2 # cargo-binstall
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-binstall
       - name: Install workspace inheritance checker
         run: cargo binstall --no-confirm cargo-workspace-inheritance-check@1.2.0
       - name: Check workspace inheritance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,21 @@ permissions:
 
 jobs:
   test:
-    name: test on warp-ubuntu-latest-x64-4x
-    runs-on: warp-ubuntu-latest-x64-4x
+    name: test on warpbuild
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - name: Cleanup large tools for build space
         uses: ./.github/actions/cleanup-runner
-      - uses: taiki-e/install-action@dd81e62c198605dea8507fed3fb6834da354ded4 # nextest
+      # Do not pin taiki-e's moving tool shortcut tags by hash. Pin a released
+      # install-action commit and set tool explicitly, or zizmor's
+      # impostor-commit audit can flag stale shortcut-tag hashes.
+      - name: Install nextest
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-nextest
       - uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
         with:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
@@ -32,7 +38,7 @@ jobs:
 
   doc-tests:
     name: doc-tests
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -49,7 +55,7 @@ jobs:
 
   check-core-lib-docs:
     name: check core library docs
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: warp-ubuntu-latest-x64-8x
     needs: [test, doc-tests]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -106,7 +112,7 @@ jobs:
 
   run-examples:
     name: run masm examples
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -123,7 +129,7 @@ jobs:
 
   check-features:
     name: check all feature combinations
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: warp-ubuntu-latest-x64-8x
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -135,7 +141,11 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/next' }}
       - name: Install rust
         run: rustup update --no-self-update
+      # Keep this on a released install-action commit with an explicit tool; see
+      # the nextest install above for the zizmor/tool-shortcut rationale.
       - name: Install cargo-hack
-        uses: taiki-e/install-action@36052feccaae5f79088f0d62a11f9bac2a9e2ec0 # cargo-hack
+        uses: taiki-e/install-action@055f5df8c3f65ea01cd41e9dc855becd88953486 # v2.75.18
+        with:
+          tool: cargo-hack
       - name: Check all feature combinations
         run: make check-features

--- a/.github/workflows/workspace-dry-run.yml
+++ b/.github/workflows/workspace-dry-run.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   release-dry-run:
     if: ${{ github.repository_owner == '0xMiden' }}
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: warp-ubuntu-latest-x64-8x
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   publish:
     if: ${{ github.repository_owner == '0xMiden' }}
-    runs-on: warp-ubuntu-latest-x64-4x
+    runs-on: warp-ubuntu-latest-x64-8x
     environment: release  # Optional: for enhanced security
 
     steps:


### PR DESCRIPTION
This moves the WarpBuild jobs from warp-ubuntu-latest-x64-4x to warp-ubuntu-latest-x64-8x.

It also renames the visible test job from the full runner label to test on warpbuild, so future runner size changes do not rename the required check.

The zizmor failure came from pinning taiki-e’s moving tool shortcut tags by hash. Those tags move on each release, so old hashes can later look like impostor commits. This now pins a released install-action commit and sets the tool name with tool:.

actionlint.yaml was updated only to allow the new custom runner label. It does not run actionlint on WarpBuild.