### PR TITLE
ci: enable stricter clippy lint set

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -40,9 +40,12 @@ xclippy = [
     "-Wclippy::mut_mut",
     "-Wclippy::mutex_integer",
     "-Wclippy::needless_borrow",
+    "-Wclippy::needless_collect",
     "-Wclippy::needless_continue",
     "-Wclippy::path_buf_push_overwrite",
     "-Wclippy::rc_mutex",
+    "-Wclippy::redundant_clone",
+    "-Wclippy::redundant_closure_for_method_calls",
     "-Wclippy::ref_option_ref",
     "-Wclippy::rest_pat_in_fully_bound_structs",
     "-Wclippy::same_functions_in_if_condition",
@@ -50,6 +53,8 @@ xclippy = [
     "-Wclippy::string_add_assign",
     "-Wclippy::todo",
     "-Wclippy::trait_duplication_in_bounds",
+    "-Wclippy::trivially_copy_pass_by_ref",
+    "-Wclippy::uninlined_format_args",
     "-Wclippy::unnested_or_patterns",
     "-Wclippy::useless_transmute",
     "-Wclippy::verbose_file_reads",
@@ -59,6 +64,7 @@ xclippy = [
     "-Wtrivial_numeric_casts",
     "-Wunexpected_cfgs",
     "-Wunused_lifetimes",
+    "-Wunused_qualifications",
     # The following lints are disabled because they trigger warnings:
     # -Wclippy::checked_conversions        (12 warnings)
     # -Wclippy::debug_assert_with_mut_call (3 warnings)
@@ -125,9 +131,12 @@ xclippy-fix = [
     "-Wclippy::mut_mut",
     "-Wclippy::mutex_integer",
     "-Wclippy::needless_borrow",
+    "-Wclippy::needless_collect",
     "-Wclippy::needless_continue",
     "-Wclippy::path_buf_push_overwrite",
     "-Wclippy::rc_mutex",
+    "-Wclippy::redundant_clone",
+    "-Wclippy::redundant_closure_for_method_calls",
     "-Wclippy::ref_option_ref",
     "-Wclippy::rest_pat_in_fully_bound_structs",
     "-Wclippy::same_functions_in_if_condition",
@@ -135,6 +144,8 @@ xclippy-fix = [
     "-Wclippy::string_add_assign",
     "-Wclippy::todo",
     "-Wclippy::trait_duplication_in_bounds",
+    "-Wclippy::trivially_copy_pass_by_ref",
+    "-Wclippy::uninlined_format_args",
     "-Wclippy::unnested_or_patterns",
     "-Wclippy::useless_transmute",
     "-Wclippy::verbose_file_reads",
@@ -144,6 +155,7 @@ xclippy-fix = [
     "-Wtrivial_numeric_casts",
     "-Wunexpected_cfgs",
     "-Wunused_lifetimes",
+    "-Wunused_qualifications",
 ]
 
 [target.wasm32-unknown-unknown]

--- a/air/src/config.rs
+++ b/air/src/config.rs
@@ -330,8 +330,7 @@ mod tests {
             .chain(circuit_commitment.iter().copied())
             .collect();
         let digest = Poseidon2::hash_elements(&input);
-        let expected: Vec<u64> =
-            digest.as_elements().iter().map(|f| f.as_canonical_u64()).collect();
+        let expected: Vec<u64> = digest.as_elements().iter().map(Felt::as_canonical_u64).collect();
 
         let snapshot = format!(
             "num_inputs: {}\nnum_eval_gates: {}\nrelation_digest: {:?}",
@@ -341,8 +340,7 @@ mod tests {
         );
         insta::assert_snapshot!(snapshot);
 
-        let actual: Vec<u64> =
-            super::RELATION_DIGEST.iter().map(|f| f.as_canonical_u64()).collect();
+        let actual: Vec<u64> = super::RELATION_DIGEST.iter().map(Felt::as_canonical_u64).collect();
         assert_eq!(
             actual, expected,
             "RELATION_DIGEST in config.rs is stale. Regenerate with: {REGEN_HINT}"

--- a/air/src/constraints/chiplets/ace.rs
+++ b/air/src/constraints/chiplets/ace.rs
@@ -92,7 +92,7 @@ pub fn enforce_ace_constraints_all_rows<AB>(
     // ==========================================================================
     {
         // Last row of ACE chiplet cannot be section start
-        builder.when(ace_last.clone()).assert_zero(s_start);
+        builder.when(ace_last).assert_zero(s_start);
 
         // Prevent consecutive section starts within ACE chiplet
         builder.when(ace_transition.clone()).when(s_start).assert_zero(s_start_next);
@@ -146,7 +146,7 @@ pub fn enforce_ace_constraints_all_rows<AB>(
     // Enforce: f_read * (f_read' * n_eval' + f_eval' * id0' - n_eval) = 0
     let selected: AB::Expr = f_read_next * next.read().num_eval + f_eval_next * next.id_0;
     builder
-        .when(ace_transition.clone())
+        .when(ace_transition)
         .when(f_read.clone())
         .assert_eq(selected, local.read().num_eval);
 
@@ -156,7 +156,7 @@ pub fn enforce_ace_constraints_all_rows<AB>(
 
     // EVAL block: op ternary validity and arithmetic operation result.
     {
-        let builder = &mut builder.when(ace_flag.clone() * f_eval);
+        let builder = &mut builder.when(ace_flag * f_eval);
         let op: AB::Expr = local.eval_op.into();
 
         let op_square = op.square();

--- a/air/src/constraints/chiplets/bus/chiplets.rs
+++ b/air/src/constraints/chiplets/bus/chiplets.rs
@@ -215,33 +215,33 @@ pub fn enforce_chiplets_bus_constraint<AB>(
     let one_ef = AB::ExprEF::ONE;
 
     // Request multiplier = sum(flag * value) + (1 - sum(flags))
-    let requests: AB::ExprEF = v_hperm * f_hperm.clone()
-        + v_mpverify * f_mpverify.clone()
-        + v_mrupdate * f_mrupdate.clone()
-        + v_join * f_join.clone()
-        + v_split * f_split.clone()
-        + v_loop * f_loop.clone()
-        + v_call * f_call.clone()
-        + v_dyn * f_dyn.clone()
-        + v_dyncall * f_dyncall.clone()
-        + v_syscall * f_syscall.clone()
-        + v_span * f_span.clone()
-        + v_respan * f_respan.clone()
-        + v_end * f_end.clone()
-        + v_mload * f_mload.clone()
-        + v_mstore * f_mstore.clone()
-        + v_mloadw * f_mloadw.clone()
-        + v_mstorew * f_mstorew.clone()
-        + v_hornerbase * f_hornerbase.clone()
-        + v_hornerext * f_hornerext.clone()
-        + v_mstream * f_mstream.clone()
-        + v_pipe * f_pipe.clone()
-        + v_cryptostream * f_cryptostream.clone()
-        + v_u32and * f_u32and.clone()
-        + v_u32xor * f_u32xor.clone()
-        + v_evalcircuit * f_evalcircuit.clone()
-        + v_logprecompile * f_logprecompile.clone()
-        + (one_ef.clone() - request_flag_sum);
+    let requests: AB::ExprEF = v_hperm * f_hperm
+        + v_mpverify * f_mpverify
+        + v_mrupdate * f_mrupdate
+        + v_join * f_join
+        + v_split * f_split
+        + v_loop * f_loop
+        + v_call * f_call
+        + v_dyn * f_dyn
+        + v_dyncall * f_dyncall
+        + v_syscall * f_syscall
+        + v_span * f_span
+        + v_respan * f_respan
+        + v_end * f_end
+        + v_mload * f_mload
+        + v_mstore * f_mstore
+        + v_mloadw * f_mloadw
+        + v_mstorew * f_mstorew
+        + v_hornerbase * f_hornerbase
+        + v_hornerext * f_hornerext
+        + v_mstream * f_mstream
+        + v_pipe * f_pipe
+        + v_cryptostream * f_cryptostream
+        + v_u32and * f_u32and
+        + v_u32xor * f_u32xor
+        + v_evalcircuit * f_evalcircuit
+        + v_logprecompile * f_logprecompile
+        + (one_ef - request_flag_sum);
 
     // =========================================================================
     // COMPUTE RESPONSE MULTIPLIER
@@ -352,8 +352,8 @@ fn compute_bitwise_response<AB: MidenAirBuilder>(
     // label = (1 - sel) * AND_LABEL + sel * XOR_LABEL
     let sel: AB::Expr = local.chiplets[bw_offset].into();
     let one_minus_sel = AB::Expr::ONE - sel.clone();
-    let label = one_minus_sel * AB::Expr::from(BITWISE_AND_LABEL)
-        + sel.clone() * AB::Expr::from(BITWISE_XOR_LABEL);
+    let label =
+        one_minus_sel * AB::Expr::from(BITWISE_AND_LABEL) + sel * AB::Expr::from(BITWISE_XOR_LABEL);
 
     // Bitwise chiplet data columns (offset by bw_offset + bitwise internal indices)
     let a: AB::Expr = local.chiplets[bw_offset + bitwise::A_COL_IDX].into();
@@ -498,7 +498,7 @@ fn compute_mstream_request<AB: MidenAirBuilder>(
         [
             label,
             ctx,
-            addr + four.clone(),
+            addr + four,
             clk,
             word2[0].clone(),
             word2[1].clone(),
@@ -557,7 +557,7 @@ fn compute_pipe_request<AB: MidenAirBuilder>(
         [
             label,
             ctx,
-            addr + four.clone(),
+            addr + four,
             clk,
             word2[0].clone(),
             word2[1].clone(),
@@ -739,7 +739,7 @@ fn compute_memory_response<AB: MidenAirBuilder>(
         (one.clone() - is_word.clone()) * write_element_label + is_word.clone() * write_word_label;
     let read_label =
         (one.clone() - is_word.clone()) * read_element_label + is_word.clone() * read_word_label;
-    let label = (one.clone() - is_read.clone()) * write_label + is_read.clone() * read_label;
+    let label = (one.clone() - is_read.clone()) * write_label + is_read * read_label;
 
     // Get value columns (v0, v1, v2, v3)
     let v0: AB::Expr = local.chiplets[mem_offset + memory::V_COL_RANGE.start].into();
@@ -754,10 +754,10 @@ fn compute_memory_response<AB: MidenAirBuilder>(
         v0.clone() * (one.clone() - idx0.clone()) * (one.clone() - idx1.clone())
             + v1.clone() * idx0.clone() * (one.clone() - idx1.clone())
             + v2.clone() * (one.clone() - idx0.clone()) * idx1.clone()
-            + v3.clone() * idx0.clone() * idx1.clone();
+            + v3.clone() * idx0 * idx1;
 
     // For word access, all v0..v3 are used
-    let is_element = one.clone() - is_word.clone();
+    let is_element = one - is_word.clone();
 
     // Element access: include the selected element in the last slot.
     let element_msg = challenges.encode(
@@ -853,8 +853,7 @@ fn compute_hasher_response<AB: MidenAirBuilder>(
         (one.clone() - s0.clone()) * (one.clone() - s1.clone()) * (one.clone() - s2.clone());
 
     // SOUT output with is_boundary=1 only (HPERM return)
-    let f_sout_final =
-        (one.clone() - s0.clone()) * (one.clone() - s1.clone()) * s2.clone() * is_boundary;
+    let f_sout_final = (one.clone() - s0) * (one.clone() - s1) * s2 * is_boundary;
 
     // --- Message values ---
 
@@ -894,7 +893,7 @@ fn compute_hasher_response<AB: MidenAirBuilder>(
         (one.clone() - bit.clone()) * state[0].clone() + bit.clone() * state[4].clone(),
         (one.clone() - bit.clone()) * state[1].clone() + bit.clone() * state[5].clone(),
         (one.clone() - bit.clone()) * state[2].clone() + bit.clone() * state[6].clone(),
-        (one.clone() - bit.clone()) * state[3].clone() + bit.clone() * state[7].clone(),
+        (one - bit.clone()) * state[3].clone() + bit * state[7].clone(),
     ];
     let v_mp = compute_hasher_word_message::<AB>(
         challenges,
@@ -924,7 +923,7 @@ fn compute_hasher_response<AB: MidenAirBuilder>(
         challenges,
         label_hout,
         addr_next.clone(),
-        node_index.clone(),
+        node_index,
         &digest,
     );
 
@@ -1301,7 +1300,7 @@ enum ControlBlockOp {
 
 impl ControlBlockOp {
     /// Returns the opcode value for this control block operation.
-    fn opcode(&self) -> u8 {
+    fn opcode(self) -> u8 {
         match self {
             ControlBlockOp::Join => opcodes::JOIN,
             ControlBlockOp::Split => opcodes::SPLIT,
@@ -1647,7 +1646,7 @@ fn compute_mpverify_request<AB: MidenAirBuilder>(
         challenges,
         input_label,
         helper_0.clone(),
-        node_index.clone(),
+        node_index,
         &node_value,
     );
 

--- a/air/src/constraints/chiplets/bus/hash_kernel.rs
+++ b/air/src/constraints/chiplets/bus/hash_kernel.rs
@@ -106,10 +106,10 @@ pub fn enforce_hash_kernel_constraint<AB>(
     // f_mu = s0 * s1 * s2
     let f_mu: AB::Expr = controller_flag.clone() * ctrl.f_mu();
     // f_mv = s0 * s1 * !s2
-    let f_mv: AB::Expr = controller_flag.clone() * ctrl.f_mv();
+    let f_mv: AB::Expr = controller_flag * ctrl.f_mv();
 
     // Direction bit b = input_node_index - 2 * output_node_index (next row is the paired output).
-    let b: AB::Expr = node_index.clone() - node_index_next.clone().double();
+    let b: AB::Expr = node_index.clone() - node_index_next.double();
     let is_b_zero = one.clone() - b.clone();
     let is_b_one = b;
 
@@ -156,7 +156,7 @@ pub fn enforce_hash_kernel_constraint<AB>(
 
         let offset1: AB::Expr = AB::Expr::from(ACE_INSTRUCTION_ID1_OFFSET);
         let offset2: AB::Expr = AB::Expr::from(ACE_INSTRUCTION_ID2_OFFSET);
-        let element = id_1 + id_2 * offset1 + (eval_op + one.clone()) * offset2;
+        let element = id_1 + id_2 * offset1 + (eval_op + one) * offset2;
         let label: AB::Expr = AB::Expr::from(Felt::from_u8(MEMORY_READ_ELEMENT_LABEL));
 
         challenges.encode(bus_types::CHIPLETS_BUS, [label, ace_ctx, ace_ptr, ace_clk, element])

--- a/air/src/constraints/chiplets/bus/wiring.rs
+++ b/air/src/constraints/chiplets/bus/wiring.rs
@@ -187,9 +187,8 @@ where
     // EVAL: m0 * w1 * w2 - w0 * w2 - w0 * w1
     let read_terms =
         wire_1.clone() * wire_2.clone() * m0.clone() + wire_0.clone() * wire_2.clone() * m1;
-    let eval_terms = wire_1.clone() * wire_2.clone() * m0
-        - wire_0.clone() * wire_2.clone()
-        - wire_0.clone() * wire_1.clone();
+    let eval_terms =
+        wire_1.clone() * wire_2.clone() * m0 - wire_0.clone() * wire_2 - wire_0 * wire_1;
 
     let n_ace = read_terms * is_read + eval_terms * is_eval;
 

--- a/air/src/constraints/chiplets/hasher_control/flags.rs
+++ b/air/src/constraints/chiplets/hasher_control/flags.rs
@@ -101,14 +101,14 @@ impl<E: PrimeCharacteristicRing + Clone> ControllerFlags<E> {
         let s0: E = cols.s0.into();
         let s1: E = cols.s1.into();
         let s2: E = cols.s2.into();
-        let not_s0 = s0.clone().not();
-        let not_s1 = s1.clone().not();
-        let not_s2 = s2.clone().not();
+        let not_s0 = s0.not();
+        let not_s1 = s1.not();
+        let not_s2 = s2.not();
 
         let is_input = s0.clone();
         let is_output = not_s0.clone() * not_s1.clone();
         let is_padding = not_s0 * s1.clone();
-        let is_sponge_input = s0.clone() * not_s1.clone() * not_s2.clone();
+        let is_sponge_input = s0.clone() * not_s1 * not_s2.clone();
         let is_merkle_input = s0 * (s1.clone() + s2.clone() - s1 * s2.clone());
         let is_hout = is_output.clone() * not_s2;
         let is_sout = is_output.clone() * s2;
@@ -117,15 +117,14 @@ impl<E: PrimeCharacteristicRing + Clone> ControllerFlags<E> {
         let s0n: E = cols_next.s0.into();
         let s1n: E = cols_next.s1.into();
         let s2n: E = cols_next.s2.into();
-        let not_s0n = s0n.clone().not();
-        let not_s1n = s1n.clone().not();
-        let not_s2n = s2n.clone().not();
+        let not_s0n = s0n.not();
+        let not_s1n = s1n.not();
+        let not_s2n = s2n.not();
 
         let is_output_next = not_s0n.clone() * not_s1n.clone();
         let is_padding_next = not_s0n * s1n.clone();
         let is_sponge_input_next = s0n.clone() * not_s1n * not_s2n.clone();
-        let is_merkle_input_next =
-            s0n.clone() * (s1n.clone() + s2n.clone() - s1n.clone() * s2n.clone());
+        let is_merkle_input_next = s0n.clone() * (s1n.clone() + s2n.clone() - s1n.clone() * s2n);
         let is_mv_input_next = s0n * s1n * not_s2n;
 
         Self {

--- a/air/src/constraints/chiplets/hasher_control/mod.rs
+++ b/air/src/constraints/chiplets/hasher_control/mod.rs
@@ -361,7 +361,7 @@ pub fn enforce_controller_constraints<AB>(
     // Intermediate SOUT rows (non-boundary) are unconstrained here.
     builder
         .when(chiplet.is_active.clone())
-        .when(rows.is_sout.clone())
+        .when(rows.is_sout)
         .when(cols.is_boundary)
         .assert_zero(cols.direction_bit);
 }

--- a/air/src/constraints/chiplets/permutation/state.rs
+++ b/air/src/constraints/chiplets/permutation/state.rs
@@ -211,16 +211,16 @@ fn apply_matmul_external<E: PrimeCharacteristicRing>(state: &[E; STATE_WIDTH]) -
 
 /// Applies the 4x4 matrix M4 used in Poseidon2's external linear layer.
 fn matmul_m4<E: PrimeCharacteristicRing>(input: [E; 4]) -> [E; 4] {
-    let [a, b, c, d] = input.clone();
+    let [a, b, c, d] = input;
 
-    let t0 = a.clone() + b.clone();
-    let t1 = c.clone() + d.clone();
+    let t0 = a + b.clone();
+    let t1 = c + d.clone();
     let t2 = b.double() + t1.clone(); // 2b + t1
     let t3 = d.double() + t0.clone(); // 2d + t0
     let t4 = t1.double().double() + t3.clone(); // 4*t1 + t3
     let t5 = t0.double().double() + t2.clone(); // 4*t0 + t2
 
-    let out0 = t3.clone() + t5.clone();
+    let out0 = t3 + t5.clone();
     let out1 = t5;
     let out2 = t2 + t4.clone();
     let out3 = t4;

--- a/air/src/constraints/chiplets/selectors.rs
+++ b/air/src/constraints/chiplets/selectors.rs
@@ -142,7 +142,7 @@ where
 
     // Virtual s0 = 1 - (s_ctrl + s_perm): same semantics as old chiplets[0].
     // 0 on controller and perm rows, 1 on non-hasher rows.
-    let s0: AB::Expr = s_ctrl_or_s_perm.clone().not();
+    let s0: AB::Expr = s_ctrl_or_s_perm.not();
 
     // =========================================================================
     // TRI-STATE SELECTOR CONSTRAINTS
@@ -152,7 +152,7 @@ where
     // sum is also boolean, so they cannot both be 1 simultaneously).
     builder.assert_bool(s_ctrl.clone());
     builder.assert_bool(s_perm.clone());
-    builder.assert_bool(s_ctrl_or_s_perm.clone());
+    builder.assert_bool(s_ctrl_or_s_perm);
 
     // Transition rules: enforce the trace ordering ctrl...ctrl, perm...perm, s0...s0.
     {
@@ -160,7 +160,7 @@ where
 
         // A controller row must be followed by another controller or permutation row.
         // s_ctrl * (1 - (s_ctrl' + s_perm')) = 0.
-        builder.when(s_ctrl.clone()).assert_one(s_ctrl_or_s_perm_next.clone());
+        builder.when(s_ctrl.clone()).assert_one(s_ctrl_or_s_perm_next);
 
         // A permutation row cannot be followed by a controller row.
         // s_perm * s_ctrl' = 0.
@@ -215,10 +215,10 @@ where
         let builder = &mut builder.when_last_row();
         builder.assert_zero(s_ctrl.clone());
         builder.assert_zero(s_perm.clone());
-        builder.assert_one(s1.clone());
-        builder.assert_one(s2.clone());
-        builder.assert_one(s3.clone());
-        builder.assert_one(s4.clone());
+        builder.assert_one(s1);
+        builder.assert_one(s2);
+        builder.assert_one(s3);
+        builder.assert_one(s4);
     }
 
     // =========================================================================
@@ -238,7 +238,7 @@ where
     // is_last = s_ctrl * (1 - s_ctrl') (deg 2)
     let ctrl_is_active = s_ctrl.clone();
     let ctrl_is_transition = is_transition_flag.clone() * s_ctrl.clone() * s_ctrl_next.clone();
-    let ctrl_is_last = s_ctrl.clone() * s_ctrl_next.clone().not();
+    let ctrl_is_last = s_ctrl * s_ctrl_next.not();
     let ctrl_next_is_first = AB::Expr::ZERO; // controller is first section
 
     // --- Permutation flags (direct physical selector s_perm) ---
@@ -248,8 +248,8 @@ where
     // next_is_first = ctrl_is_last * s_perm' (deg 3)
     let perm_is_active = s_perm.clone();
     let perm_is_transition = is_transition_flag.clone() * s_perm.clone() * s_perm_next.clone();
-    let perm_is_last = s_perm.clone() * s_perm_next.clone().not();
-    let perm_next_is_first = ctrl_is_last.clone() * s_perm_next.clone();
+    let perm_is_last = s_perm * s_perm_next.not();
+    let perm_next_is_first = ctrl_is_last.clone() * s_perm_next;
 
     // --- Remaining chiplet active flags (subtraction trick: prefix - prefix * s_n) ---
     let is_bitwise = s0.clone() - s01.clone();
@@ -276,9 +276,9 @@ where
     // s_perm')` factor because the tri-state transition rule already enforces
     // `s0 = 1 → s_ctrl' = 0 ∧ s_perm' = 0`, so on valid traces that factor is
     // always 1 whenever the prefix is active.
-    let bitwise_transition = is_transition_flag.clone() * s0.clone() * not_s1_next;
-    let memory_transition = is_transition_flag.clone() * s01.clone() * not_s2_next;
-    let ace_transition = is_transition_flag.clone() * s012.clone() * not_s3_next;
+    let bitwise_transition = is_transition_flag.clone() * s0 * not_s1_next;
+    let memory_transition = is_transition_flag.clone() * s01 * not_s2_next;
+    let ace_transition = is_transition_flag.clone() * s012 * not_s3_next;
     let kernel_rom_transition = is_transition_flag * s0123 * not_s4_next;
 
     ChipletSelectors {

--- a/air/src/constraints/decoder/bus.rs
+++ b/air/src/constraints/decoder/bus.rs
@@ -277,7 +277,7 @@ pub fn enforce_block_stack_table_constraint<AB>(
     let v_join = msg_simple.clone() * is_join.clone();
     let v_split = msg_simple.clone() * is_split.clone();
     let v_span = msg_simple.clone() * is_span.clone();
-    let v_dyn = msg_simple.clone() * is_dyn.clone();
+    let v_dyn = msg_simple * is_dyn.clone();
 
     // LOOP: insert(addr', addr, s0, 0, 0, 0, 0, 0, 0, 0)
     let msg_loop = encoders.simple(&addr_next, &addr_local, &s0);
@@ -313,15 +313,15 @@ pub fn enforce_block_stack_table_constraint<AB>(
     let v_dyncall = msg_dyncall * is_dyncall.clone();
 
     // Sum of insertion flags
-    let insert_flag_sum = is_join.clone()
-        + is_split.clone()
-        + is_span.clone()
-        + is_dyn.clone()
-        + is_loop.clone()
+    let insert_flag_sum = is_join
+        + is_split
+        + is_span
+        + is_dyn
+        + is_loop
         + is_respan.clone()
-        + is_call.clone()
-        + is_syscall.clone()
-        + is_dyncall.clone();
+        + is_call
+        + is_syscall
+        + is_dyncall;
 
     // Total insertion contribution
     let insertion_sum =
@@ -364,7 +364,7 @@ pub fn enforce_block_stack_table_constraint<AB>(
     let u_end = u_end_simple + u_end_call;
 
     // Sum of removal flags
-    let remove_flag_sum = is_end.clone() + is_respan.clone();
+    let remove_flag_sum = is_end + is_respan;
 
     // Total removal contribution
     let removal_sum = u_end + u_respan;
@@ -525,10 +525,10 @@ pub fn enforce_block_hash_table_constraint<AB>(
     // SPLIT: Insert selected child based on s0
     // If s0=1: left child (h0-h3), else right child (h4-h7)
     let not_s0 = s0.not();
-    let split_h0 = s0.clone() * h0.clone() + not_s0.clone() * h4.clone();
-    let split_h1 = s0.clone() * h1.clone() + not_s0.clone() * h5.clone();
-    let split_h2 = s0.clone() * h2.clone() + not_s0.clone() * h6.clone();
-    let split_h3 = s0.clone() * h3.clone() + not_s0 * h7.clone();
+    let split_h0 = s0.clone() * h0.clone() + not_s0.clone() * h4;
+    let split_h1 = s0.clone() * h1.clone() + not_s0.clone() * h5;
+    let split_h2 = s0.clone() * h2.clone() + not_s0.clone() * h6;
+    let split_h3 = s0.clone() * h3.clone() + not_s0 * h7;
     let msg_split = encoder.encode(
         &parent_id,
         [&split_h0, &split_h1, &split_h2, &split_h3],
@@ -541,7 +541,7 @@ pub fn enforce_block_hash_table_constraint<AB>(
     let msg_loop =
         encoder.encode(&parent_id, [&h0, &h1, &h2, &h3], &AB::Expr::ZERO, &AB::Expr::ONE);
     // When s0=1: insert msg_loop; when s0=0: multiply by 1 (no insertion)
-    let v_loop = (msg_loop * s0.clone() + (AB::ExprEF::ONE - s0.clone())) * is_loop.clone();
+    let v_loop = (msg_loop * s0.clone() + (AB::ExprEF::ONE - s0)) * is_loop.clone();
 
     // REPEAT: Insert loop body
     let msg_repeat =
@@ -557,14 +557,8 @@ pub fn enforce_block_hash_table_constraint<AB>(
     let v_syscall = msg_call_like * is_syscall.clone();
 
     // Sum of insertion flags
-    let insert_flag_sum = is_join.clone()
-        + is_split.clone()
-        + is_loop.clone()
-        + is_repeat.clone()
-        + is_dyn.clone()
-        + is_dyncall.clone()
-        + is_call.clone()
-        + is_syscall.clone();
+    let insert_flag_sum =
+        is_join + is_split + is_loop + is_repeat + is_dyn + is_dyncall + is_call + is_syscall;
 
     // Response side
     let response = v_join
@@ -731,7 +725,7 @@ pub fn enforce_op_group_table_constraint<AB>(
     let f_g8 = c0.clone();
     let not_c0 = c0.not();
     let f_g4 = not_c0.clone() * c1.clone() * c2.not();
-    let f_g2 = not_c0 * c1.not() * c2.clone();
+    let f_g2 = not_c0 * c1.not() * c2;
 
     // =========================================================================
     // RESPONSE (insertions during SPAN/RESPAN)
@@ -757,7 +751,7 @@ pub fn enforce_op_group_table_constraint<AB>(
     // decoder constraints enforce (1 - f_span_respan) * (c0 + c1 + c2) = 0, so all batch
     // flags are zero outside SPAN/RESPAN rows. This keeps the max degree at 9 and matches
     // the sum-form bus expansion used in air-script.
-    let response = (v_1.clone() * f_g2.clone())
+    let response = (v_1 * f_g2.clone())
         + (prod_3 * f_g4.clone())
         + (prod_7 * f_g8.clone())
         + (AB::ExprEF::ONE - (f_g2 + f_g4 + f_g8));

--- a/air/src/constraints/decoder/mod.rs
+++ b/air/src/constraints/decoder/mod.rs
@@ -440,8 +440,8 @@ pub fn enforce_main<AB>(
         let groups_1 = not_bc0 * bc1 * bc2;
 
         // Combined flags for the cascading lane-zeroing constraints.
-        let groups_1_or_2 = groups_1.clone() + groups_2.clone();
-        let groups_1_or_2_or_4 = groups_1_or_2.clone() + groups_4.clone();
+        let groups_1_or_2 = groups_1.clone() + groups_2;
+        let groups_1_or_2_or_4 = groups_1_or_2.clone() + groups_4;
 
         let span_or_respan = op_flags.span() + op_flags.respan();
 

--- a/air/src/constraints/op_flags/mod.rs
+++ b/air/src/constraints/op_flags/mod.rs
@@ -362,7 +362,7 @@ where
             // +MOVUP3|MOVDN3  — permute s0..s3
             movup_or_movdn[1].clone(),
             // +ADVPOPW|EXPACC — overwrite s0..s3 in place
-            advpopw_or_expacc.clone(),
+            advpopw_or_expacc,
             // +SWAPW2|SWAPW3  — swap s0..s3 with s8+ (leaves at depth 8)
             swapw2_or_swapw3.clone(),
             // +EXT2MUL        — ext field multiply on s0..s3
@@ -387,7 +387,7 @@ where
 
         let no_shift_depth12
             // +SWAPW2|SWAPW3 — pair re-enters (both leave depths 12+ untouched)
-            = swapw2_or_swapw3.clone()
+            = swapw2_or_swapw3
             // +HPERM         — Poseidon2 permutation on s0..s11
             + op5(opcodes::HPERM)
             // –SWAPW3        — SWAPW3 swaps s0..s3 with s12..s15, so s12+ still changes

--- a/air/src/constraints/op_flags/tests.rs
+++ b/air/src/constraints/op_flags/tests.rs
@@ -187,33 +187,21 @@ fn degree_7_op_flags() {
         // Check degree 7 flags: exactly one should be ONE
         for (i, &flag) in op_flags.degree7_op_flags.iter().enumerate() {
             if i == expected_idx {
-                assert_eq!(flag, ONE, "Degree 7 flag {} should be ONE for opcode {}", i, opcode);
+                assert_eq!(flag, ONE, "Degree 7 flag {i} should be ONE for opcode {opcode}");
             } else {
-                assert_eq!(flag, ZERO, "Degree 7 flag {} should be ZERO for opcode {}", i, opcode);
+                assert_eq!(flag, ZERO, "Degree 7 flag {i} should be ZERO for opcode {opcode}");
             }
         }
 
         // All other degree flags should be ZERO
         for (i, &flag) in op_flags.degree6_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 6 flag {} should be ZERO for degree 7 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 6 flag {i} should be ZERO for degree 7 opcode {opcode}");
         }
         for (i, &flag) in op_flags.degree5_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 5 flag {} should be ZERO for degree 7 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 5 flag {i} should be ZERO for degree 7 opcode {opcode}");
         }
         for (i, &flag) in op_flags.degree4_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 4 flag {} should be ZERO for degree 7 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 4 flag {i} should be ZERO for degree 7 opcode {opcode}");
         }
     }
 }
@@ -233,33 +221,21 @@ fn degree_6_op_flags() {
         // Check degree 6 flags
         for (i, &flag) in op_flags.degree6_op_flags.iter().enumerate() {
             if i == expected_idx {
-                assert_eq!(flag, ONE, "Degree 6 flag {} should be ONE for opcode {}", i, opcode);
+                assert_eq!(flag, ONE, "Degree 6 flag {i} should be ONE for opcode {opcode}");
             } else {
-                assert_eq!(flag, ZERO, "Degree 6 flag {} should be ZERO for opcode {}", i, opcode);
+                assert_eq!(flag, ZERO, "Degree 6 flag {i} should be ZERO for opcode {opcode}");
             }
         }
 
         // All other degree flags should be ZERO
         for (i, &flag) in op_flags.degree7_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 7 flag {} should be ZERO for degree 6 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 7 flag {i} should be ZERO for degree 6 opcode {opcode}");
         }
         for (i, &flag) in op_flags.degree5_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 5 flag {} should be ZERO for degree 6 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 5 flag {i} should be ZERO for degree 6 opcode {opcode}");
         }
         for (i, &flag) in op_flags.degree4_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 4 flag {} should be ZERO for degree 6 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 4 flag {i} should be ZERO for degree 6 opcode {opcode}");
         }
     }
 }
@@ -278,33 +254,21 @@ fn degree_5_op_flags() {
         // Check degree 5 flags
         for (i, &flag) in op_flags.degree5_op_flags.iter().enumerate() {
             if i == expected_idx {
-                assert_eq!(flag, ONE, "Degree 5 flag {} should be ONE for opcode {}", i, opcode);
+                assert_eq!(flag, ONE, "Degree 5 flag {i} should be ONE for opcode {opcode}");
             } else {
-                assert_eq!(flag, ZERO, "Degree 5 flag {} should be ZERO for opcode {}", i, opcode);
+                assert_eq!(flag, ZERO, "Degree 5 flag {i} should be ZERO for opcode {opcode}");
             }
         }
 
         // All other degree flags should be ZERO
         for (i, &flag) in op_flags.degree7_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 7 flag {} should be ZERO for degree 5 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 7 flag {i} should be ZERO for degree 5 opcode {opcode}");
         }
         for (i, &flag) in op_flags.degree6_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 6 flag {} should be ZERO for degree 5 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 6 flag {i} should be ZERO for degree 5 opcode {opcode}");
         }
         for (i, &flag) in op_flags.degree4_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 4 flag {} should be ZERO for degree 5 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 4 flag {i} should be ZERO for degree 5 opcode {opcode}");
         }
     }
 }
@@ -321,16 +285,16 @@ fn optimized_flags_match_naive() {
         let op_flags = op_flags_for_opcode(opcode);
 
         for (i, &flag) in op_flags.degree7_op_flags.iter().enumerate() {
-            assert_eq!(flag, deg7[i], "degree7 flag mismatch at index {}", i);
+            assert_eq!(flag, deg7[i], "degree7 flag mismatch at index {i}");
         }
         for (i, &flag) in op_flags.degree6_op_flags.iter().enumerate() {
-            assert_eq!(flag, deg6[i], "degree6 flag mismatch at index {}", i);
+            assert_eq!(flag, deg6[i], "degree6 flag mismatch at index {i}");
         }
         for (i, &flag) in op_flags.degree5_op_flags.iter().enumerate() {
-            assert_eq!(flag, deg5[i], "degree5 flag mismatch at index {}", i);
+            assert_eq!(flag, deg5[i], "degree5 flag mismatch at index {i}");
         }
         for (i, &flag) in op_flags.degree4_op_flags.iter().enumerate() {
-            assert_eq!(flag, deg4[i], "degree4 flag mismatch at index {}", i);
+            assert_eq!(flag, deg4[i], "degree4 flag mismatch at index {i}");
         }
 
         let (left_shift_flag, right_shift_flag, control_flow) =
@@ -357,33 +321,21 @@ fn degree_4_op_flags() {
         // Check degree 4 flags
         for (i, &flag) in op_flags.degree4_op_flags.iter().enumerate() {
             if i == expected_idx {
-                assert_eq!(flag, ONE, "Degree 4 flag {} should be ONE for opcode {}", i, opcode);
+                assert_eq!(flag, ONE, "Degree 4 flag {i} should be ONE for opcode {opcode}");
             } else {
-                assert_eq!(flag, ZERO, "Degree 4 flag {} should be ZERO for opcode {}", i, opcode);
+                assert_eq!(flag, ZERO, "Degree 4 flag {i} should be ZERO for opcode {opcode}");
             }
         }
 
         // All other degree flags should be ZERO
         for (i, &flag) in op_flags.degree7_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 7 flag {} should be ZERO for degree 4 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 7 flag {i} should be ZERO for degree 4 opcode {opcode}");
         }
         for (i, &flag) in op_flags.degree6_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 6 flag {} should be ZERO for degree 4 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 6 flag {i} should be ZERO for degree 4 opcode {opcode}");
         }
         for (i, &flag) in op_flags.degree5_op_flags.iter().enumerate() {
-            assert_eq!(
-                flag, ZERO,
-                "Degree 5 flag {} should be ZERO for degree 4 opcode {}",
-                i, opcode
-            );
+            assert_eq!(flag, ZERO, "Degree 5 flag {i} should be ZERO for degree 4 opcode {opcode}");
         }
     }
 }
@@ -406,9 +358,7 @@ fn composite_no_shift_flags() {
             assert_eq!(
                 op_flags.no_shift_at(i),
                 ONE,
-                "no_shift_at({}) should be ONE for opcode {:?}",
-                i,
-                opcode
+                "no_shift_at({i}) should be ONE for opcode {opcode:?}"
             );
         }
 
@@ -426,7 +376,7 @@ fn composite_incr_flags() {
     // Position 0 changes, positions 1-15 don't
     assert_eq!(op_flags.no_shift_at(0), ZERO);
     for i in 1..16 {
-        assert_eq!(op_flags.no_shift_at(i), ONE, "no_shift_at({}) should be ONE for INCR", i);
+        assert_eq!(op_flags.no_shift_at(i), ONE, "no_shift_at({i}) should be ONE for INCR");
     }
 
     assert_eq!(op_flags.right_shift(), ZERO);
@@ -441,7 +391,7 @@ fn composite_swap_flags() {
     assert_eq!(op_flags.no_shift_at(0), ZERO);
     assert_eq!(op_flags.no_shift_at(1), ZERO);
     for i in 2..16 {
-        assert_eq!(op_flags.no_shift_at(i), ONE, "no_shift_at({}) should be ONE for SWAP", i);
+        assert_eq!(op_flags.no_shift_at(i), ONE, "no_shift_at({i}) should be ONE for SWAP");
     }
 
     assert_eq!(op_flags.right_shift(), ZERO);
@@ -454,10 +404,10 @@ fn composite_hperm_flags() {
     let op_flags = op_flags_for_opcode(opcodes::HPERM.into());
 
     for i in 0..12 {
-        assert_eq!(op_flags.no_shift_at(i), ZERO, "no_shift_at({}) should be ZERO for HPERM", i);
+        assert_eq!(op_flags.no_shift_at(i), ZERO, "no_shift_at({i}) should be ZERO for HPERM");
     }
     for i in 12..16 {
-        assert_eq!(op_flags.no_shift_at(i), ONE, "no_shift_at({}) should be ONE for HPERM", i);
+        assert_eq!(op_flags.no_shift_at(i), ONE, "no_shift_at({i}) should be ONE for HPERM");
     }
 
     assert_eq!(op_flags.right_shift(), ZERO);
@@ -472,7 +422,7 @@ fn composite_loop_left_shift() {
     assert_eq!(op_flags.left_shift_at(0), ZERO);
     // LOOP shifts the stack left
     for i in 1..16 {
-        assert_eq!(op_flags.left_shift_at(i), ONE, "left_shift_at({}) should be ONE for LOOP", i);
+        assert_eq!(op_flags.left_shift_at(i), ONE, "left_shift_at({i}) should be ONE for LOOP");
     }
     for i in 0..16 {
         assert_eq!(op_flags.no_shift_at(i), ZERO);
@@ -492,7 +442,7 @@ fn composite_and_left_shift() {
     assert_eq!(op_flags.left_shift_at(0), ZERO);
     assert_eq!(op_flags.left_shift_at(1), ZERO);
     for i in 2..16 {
-        assert_eq!(op_flags.left_shift_at(i), ONE, "left_shift_at({}) should be ONE for AND", i);
+        assert_eq!(op_flags.left_shift_at(i), ONE, "left_shift_at({i}) should be ONE for AND");
     }
 
     assert_eq!(op_flags.left_shift(), ONE);
@@ -506,7 +456,7 @@ fn composite_dup1_right_shift() {
 
     // DUP1 shifts the entire stack right
     for i in 0..=15 {
-        assert_eq!(op_flags.right_shift_at(i), ONE, "right_shift_at({}) should be ONE for DUP1", i);
+        assert_eq!(op_flags.right_shift_at(i), ONE, "right_shift_at({i}) should be ONE for DUP1");
     }
     for i in 0..16 {
         assert_eq!(op_flags.no_shift_at(i), ZERO);
@@ -523,7 +473,7 @@ fn composite_push_right_shift() {
 
     // PUSH shifts the entire stack right
     for i in 0..=15 {
-        assert_eq!(op_flags.right_shift_at(i), ONE, "right_shift_at({}) should be ONE for PUSH", i);
+        assert_eq!(op_flags.right_shift_at(i), ONE, "right_shift_at({i}) should be ONE for PUSH");
     }
 
     assert_eq!(op_flags.right_shift(), ONE);
@@ -540,8 +490,7 @@ fn composite_end_flags() {
         assert_eq!(
             op_flags.no_shift_at(i),
             ONE,
-            "no_shift_at({}) should be ONE for END (no loop)",
-            i
+            "no_shift_at({i}) should be ONE for END (no loop)"
         );
     }
     assert_eq!(op_flags.left_shift(), ZERO);
@@ -557,16 +506,14 @@ fn composite_end_flags() {
         assert_eq!(
             op_flags_loop.no_shift_at(i),
             ZERO,
-            "no_shift_at({}) should be ZERO for END (with loop)",
-            i
+            "no_shift_at({i}) should be ZERO for END (with loop)"
         );
     }
     for i in 1..16 {
         assert_eq!(
             op_flags_loop.left_shift_at(i),
             ONE,
-            "left_shift_at({}) should be ONE for END (with loop)",
-            i
+            "left_shift_at({i}) should be ONE for END (with loop)"
         );
     }
     assert_eq!(op_flags_loop.left_shift(), ONE);
@@ -580,10 +527,10 @@ fn composite_swapw2_flags() {
 
     // Positions 4-7 and 12-15 should be no_shift (words that stay in place)
     for i in [0, 1, 2, 3, 8, 9, 10, 11] {
-        assert_eq!(op_flags.no_shift_at(i), ZERO, "no_shift_at({}) should be ZERO for SWAPW2", i);
+        assert_eq!(op_flags.no_shift_at(i), ZERO, "no_shift_at({i}) should be ZERO for SWAPW2");
     }
     for i in [4, 5, 6, 7, 12, 13, 14, 15] {
-        assert_eq!(op_flags.no_shift_at(i), ONE, "no_shift_at({}) should be ONE for SWAPW2", i);
+        assert_eq!(op_flags.no_shift_at(i), ONE, "no_shift_at({i}) should be ONE for SWAPW2");
     }
 
     assert_eq!(op_flags.right_shift(), ZERO);
@@ -625,7 +572,7 @@ fn control_flow_flag() {
 
     for op in non_cf_ops {
         let op_flags = op_flags_for_opcode(op.op_code().into());
-        assert_eq!(op_flags.control_flow(), ZERO, "control_flow should be ZERO for {:?}", op);
+        assert_eq!(op_flags.control_flow(), ZERO, "control_flow should be ZERO for {op:?}");
     }
 }
 
@@ -669,7 +616,7 @@ fn u32_rc_op_flag() {
 
     for op in u32_ops {
         let op_flags = op_flags_for_opcode(op.op_code().into());
-        assert_eq!(op_flags.u32_rc_op, ONE, "u32_rc_op should be ONE for {:?}", op);
+        assert_eq!(op_flags.u32_rc_op, ONE, "u32_rc_op should be ONE for {op:?}");
     }
 
     // Non-u32 operations
@@ -681,6 +628,6 @@ fn u32_rc_op_flag() {
 
     for op in non_u32_ops {
         let op_flags = op_flags_for_opcode(op.op_code().into());
-        assert_eq!(op_flags.u32_rc_op, ZERO, "u32_rc_op should be ZERO for {:?}", op);
+        assert_eq!(op_flags.u32_rc_op, ZERO, "u32_rc_op should be ZERO for {op:?}");
     }
 }

--- a/air/src/constraints/stack/bus.rs
+++ b/air/src/constraints/stack/bus.rs
@@ -116,9 +116,8 @@ pub fn enforce_bus<AB>(
     let request_flag_sum: AB::Expr = left_flag.clone() + dyncall_flag.clone();
 
     // Request: left_flag * left_value + dyncall_flag * dyncall_value + (1 - sum(flags))
-    let request: AB::ExprEF = request_row_left * left_flag.clone()
-        + request_row_dyncall * dyncall_flag.clone()
-        + request_flag_sum.not();
+    let request: AB::ExprEF =
+        request_row_left * left_flag + request_row_dyncall * dyncall_flag + request_flag_sum.not();
 
     // -------------------------------------------------------------------------
     // Main running product constraint

--- a/air/src/constraints/stack/stack_arith/mod.rs
+++ b/air/src/constraints/stack/stack_arith/mod.rs
@@ -169,10 +169,10 @@ pub fn enforce_main<AB>(
     let ext_b0 = s0.clone();
     let ext_b1 = s1.clone();
     let ext_a0 = s2.clone();
-    let ext_a1 = s3.clone();
+    let ext_a1 = s3;
     let ext_d0 = s0_next.clone();
     let ext_d1 = s1_next.clone();
-    let ext_c0 = s2_next.clone();
+    let ext_c0 = s2_next;
     let ext_c1 = s3_next;
     let ext_a0_b0 = ext_a0.clone() * ext_b0.clone();
     let ext_a1_b1 = ext_a1.clone() * ext_b1.clone();
@@ -191,7 +191,7 @@ pub fn enforce_main<AB>(
     // U32 ops
     // -------------------------------------------------------------------------
     // U32 limbs: v_lo = h1*2^16 + h0, v_hi = h3*2^16 + h2.
-    let u32_v_lo = uop_h1 * TWO_POW_16 + uop_h0.clone();
+    let u32_v_lo = uop_h1 * TWO_POW_16 + uop_h0;
     let u32_v_hi = uop_h3.clone() * TWO_POW_16 + uop_h2.clone();
     let u32_v48 = uop_h2 * TWO_POW_32 + u32_v_lo.clone();
     let u32_v64 = uop_h3 * TWO_POW_48 + u32_v48.clone();

--- a/core/src/events/mod.rs
+++ b/core/src/events/mod.rs
@@ -80,7 +80,7 @@ impl EventId {
 
 impl Display for EventId {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        core::fmt::Display::fmt(&self.0, f)
+        Display::fmt(&self.0, f)
     }
 }
 
@@ -206,7 +206,7 @@ impl proptest::prelude::Arbitrary for EventName {
             Just(EventName::new("user::custom::event")),
             // Dynamic strings (Cow::Owned)
             any::<(u32, u32)>()
-                .prop_map(|(a, b)| EventName::from_string(format!("dynamic::event::{}::{}", a, b))),
+                .prop_map(|(a, b)| EventName::from_string(format!("dynamic::event::{a}::{b}"))),
         ]
         .boxed()
     }
@@ -241,7 +241,7 @@ mod tests {
         // EventName constructors and conversions
         let name1 = EventName::new("static::event");
         assert_eq!(name1.as_str(), "static::event");
-        assert_eq!(format!("{}", name1), "static::event");
+        assert_eq!(format!("{name1}"), "static::event");
 
         let name2 = EventName::from_string("dynamic::event".to_string());
         assert_eq!(name2.as_str(), "dynamic::event");

--- a/core/src/mast/debuginfo/asm_op_storage.rs
+++ b/core/src/mast/debuginfo/asm_op_storage.rs
@@ -260,7 +260,7 @@ impl OpToAsmOpId {
         let result = Self { inner };
 
         result.validate_csr(asm_op_count).map_err(|e| {
-            DeserializationError::InvalidValue(format!("OpToAsmOpId validation failed: {}", e))
+            DeserializationError::InvalidValue(format!("OpToAsmOpId validation failed: {e}"))
         })?;
 
         Ok(result)
@@ -666,7 +666,7 @@ mod tests {
     fn test_serialization_roundtrip_empty() {
         let storage = OpToAsmOpId::new();
 
-        let mut bytes = alloc::vec::Vec::new();
+        let mut bytes = Vec::new();
         storage.write_into(&mut bytes);
 
         let mut reader = SliceReader::new(&bytes);
@@ -693,7 +693,7 @@ mod tests {
             .add_asm_ops_for_node(test_node_id(2), 2, vec![(1, test_asm_op_id(2))])
             .unwrap();
 
-        let mut bytes = alloc::vec::Vec::new();
+        let mut bytes = Vec::new();
         storage.write_into(&mut bytes);
 
         let mut reader = SliceReader::new(&bytes);
@@ -727,7 +727,7 @@ mod tests {
     #[test]
     fn test_debug_impl() {
         let storage = OpToAsmOpId::new();
-        let debug_str = alloc::format!("{:?}", storage);
+        let debug_str = alloc::format!("{storage:?}");
         assert!(debug_str.contains("OpToAsmOpId"));
     }
 }

--- a/core/src/mast/debuginfo/debug_var_storage.rs
+++ b/core/src/mast/debuginfo/debug_var_storage.rs
@@ -38,8 +38,7 @@ impl DebugVarId {
             Ok(Self(value))
         } else {
             Err(DeserializationError::InvalidValue(format!(
-                "DebugVarId {} exceeds bound {}",
-                value, bound
+                "DebugVarId {value} exceeds bound {bound}"
             )))
         }
     }

--- a/core/src/mast/debuginfo/decorator_storage.rs
+++ b/core/src/mast/debuginfo/decorator_storage.rs
@@ -468,7 +468,7 @@ impl OpToDecoratorIds {
         node: MastNodeId,
         operation: usize,
     ) -> Result<usize, DecoratorIndexError> {
-        self.decorator_ids_for_operation(node, operation).map(|slice| slice.len())
+        self.decorator_ids_for_operation(node, operation).map(<[DecoratorId]>::len)
     }
 
     /// Get all decorator IDs for a specific operation within a node.

--- a/core/src/mast/debuginfo/decorator_storage/tests.rs
+++ b/core/src/mast/debuginfo/decorator_storage/tests.rs
@@ -201,7 +201,7 @@ fn test_empty_nodes_basic_functionality() {
 #[test]
 fn test_debug_impl() {
     let storage = OpToDecoratorIds::new();
-    let debug_str = format!("{:?}", storage);
+    let debug_str = format!("{storage:?}");
     assert!(debug_str.contains("OpToDecoratorIds"));
 }
 
@@ -222,8 +222,8 @@ fn test_clone_and_equality() {
     node_indptr_for_op_idx.push(3).expect("test setup: IndexVec capacity exceeded");
 
     let storage1 = OpToDecoratorIds::from_components(
-        decorator_indices.clone(),
-        op_indptr_for_dec_idx.clone(),
+        decorator_indices,
+        op_indptr_for_dec_idx,
         node_indptr_for_op_idx.clone(),
     )
     .unwrap();
@@ -500,8 +500,7 @@ fn test_csr_and_coo_produce_same_elements() {
     ];
 
     // Build COO representation as a HashMap for easy lookup during verification
-    let mut coo_map: alloc::collections::BTreeMap<(MastNodeId, usize), Vec<DecoratorId>> =
-        alloc::collections::BTreeMap::new();
+    let mut coo_map: BTreeMap<(MastNodeId, usize), Vec<DecoratorId>> = BTreeMap::new();
     for (node, op_idx, decorator_id) in &coo_data {
         coo_map.entry((*node, *op_idx)).or_default().push(*decorator_id);
     }
@@ -562,8 +561,7 @@ fn test_csr_and_coo_produce_same_elements() {
             // They should be the same
             assert_eq!(
                 csr_decorator_ids, coo_decorator_ids,
-                "CSR and COO should produce the same decorator IDs for node {:?}, op {}",
-                node_id, op_idx
+                "CSR and COO should produce the same decorator IDs for node {node_id:?}, op {op_idx}"
             );
         }
     }
@@ -590,8 +588,7 @@ fn test_csr_and_coo_produce_same_elements() {
 
         assert_eq!(
             csr_flat, expected_flat,
-            "Flattened CSR and COO should produce the same elements for node {:?}",
-            node_id
+            "Flattened CSR and COO should produce the same elements for node {node_id:?}"
         );
     }
 }
@@ -707,7 +704,7 @@ fn test_sparse_case_manual() {
     let result =
         OpToDecoratorIds::from_components(decorator_ids, op_indptr_for_dec_ids, node_indptr);
 
-    assert!(result.is_ok(), "Single node with decorator should validate: {:?}", result);
+    assert!(result.is_ok(), "Single node with decorator should validate: {result:?}");
 }
 
 #[test]
@@ -725,8 +722,7 @@ fn test_sparse_case_two_nodes() {
 
     assert!(
         result.is_ok(),
-        "Two nodes (one with decorator, one empty) should validate: {:?}",
-        result
+        "Two nodes (one with decorator, one empty) should validate: {result:?}"
     );
 }
 
@@ -750,7 +746,7 @@ fn test_sparse_debuginfo_round_trip() {
     node_indptr_for_op_idx.push(4).unwrap(); // node 5
 
     let op_storage = OpToDecoratorIds::from_components(
-        decorator_ids.clone(),
+        decorator_ids,
         op_indptr_for_dec_ids,
         node_indptr_for_op_idx,
     )

--- a/core/src/mast/debuginfo/mod.rs
+++ b/core/src/mast/debuginfo/mod.rs
@@ -322,7 +322,7 @@ impl DebugInfo {
         &mut self,
         node_id: MastNodeId,
         decorators_info: Vec<(usize, DecoratorId)>,
-    ) -> Result<(), crate::mast::debuginfo::decorator_storage::DecoratorIndexError> {
+    ) -> Result<(), DecoratorIndexError> {
         self.op_decorator_storage.add_decorator_info_for_node(node_id, decorators_info)
     }
 
@@ -431,7 +431,7 @@ impl DebugInfo {
         &mut self,
         node_id: MastNodeId,
         debug_vars_info: Vec<(usize, DebugVarId)>,
-    ) -> Result<(), crate::mast::debuginfo::decorator_storage::DecoratorIndexError> {
+    ) -> Result<(), DecoratorIndexError> {
         self.op_debug_var_storage.add_debug_var_info_for_node(node_id, debug_vars_info)
     }
 
@@ -475,7 +475,7 @@ impl DebugInfo {
 
     /// Returns the procedure name for the given MAST root digest, if present.
     pub fn procedure_name(&self, digest: &Word) -> Option<&str> {
-        self.procedure_names.get(&LexicographicWord::from(*digest)).map(|s| s.as_ref())
+        self.procedure_names.get(&LexicographicWord::from(*digest)).map(AsRef::as_ref)
     }
 
     /// Returns an iterator over all (digest, name) pairs.
@@ -681,7 +681,7 @@ impl Deserializable for DebugInfo {
         };
 
         debug_info.validate().map_err(|e| {
-            DeserializationError::InvalidValue(format!("DebugInfo validation failed: {}", e))
+            DeserializationError::InvalidValue(format!("DebugInfo validation failed: {e}"))
         })?;
 
         Ok(debug_info)

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -531,7 +531,7 @@ fn mast_forest_merge_external_node_reference_with_decorator() {
     let trace = Decorator::Trace(1);
 
     // Build Forest A
-    let deco = forest_a.add_decorator(trace.clone()).unwrap();
+    let deco = forest_a.add_decorator(trace).unwrap();
 
     let foo_node_a = block_foo_with_decorators(&[deco], &[]);
     let foo_node_digest = block_foo_with_decorators(&[deco], &[]).build().unwrap().digest();
@@ -554,10 +554,14 @@ fn mast_forest_merge_external_node_reference_with_decorator() {
     .enumerate()
     {
         let id_foo_a_digest = forest_a[id_foo_a].digest();
-        let digests: Vec<_> = merged.nodes().iter().map(|node| node.digest()).collect();
-
         assert_eq!(merged.nodes.len(), 1);
-        assert!(digests.contains(&id_foo_a_digest));
+        assert!(
+            merged
+                .nodes()
+                .iter()
+                .map(MastNodeExt::digest)
+                .any(|digest| digest == id_foo_a_digest)
+        );
 
         if idx == 0 {
             assert_root_mapping(&root_maps, vec![&forest_a.roots, &forest_b.roots], &merged.roots)
@@ -590,8 +594,8 @@ fn mast_forest_merge_external_node_with_decorator() {
     let trace2 = Decorator::Trace(2);
 
     // Build Forest A
-    let deco1 = forest_a.add_decorator(trace1.clone()).unwrap();
-    let deco2 = forest_a.add_decorator(trace2.clone()).unwrap();
+    let deco1 = forest_a.add_decorator(trace1).unwrap();
+    let deco2 = forest_a.add_decorator(trace2).unwrap();
 
     let external_node_a =
         external_with_decorators(block_foo().build().unwrap().digest(), &[deco1], &[deco2]);
@@ -615,10 +619,14 @@ fn mast_forest_merge_external_node_with_decorator() {
         assert_eq!(merged.nodes.len(), 1);
 
         let id_foo_b_digest = forest_b[id_foo_b].digest();
-        let digests: Vec<_> = merged.nodes().iter().map(|node| node.digest()).collect();
-
         // Block foo should be unmodified.
-        assert!(digests.contains(&id_foo_b_digest));
+        assert!(
+            merged
+                .nodes()
+                .iter()
+                .map(MastNodeExt::digest)
+                .any(|digest| digest == id_foo_b_digest)
+        );
 
         if idx == 0 {
             assert_root_mapping(&root_maps, vec![&forest_a.roots, &forest_b.roots], &merged.roots)
@@ -651,7 +659,7 @@ fn mast_forest_merge_external_node_and_referenced_node_have_decorators() {
     let trace2 = Decorator::Trace(2);
 
     // Build Forest A
-    let deco1_a = forest_a.add_decorator(trace1.clone()).unwrap();
+    let deco1_a = forest_a.add_decorator(trace1).unwrap();
 
     let external_node_a =
         external_with_decorators(block_foo().build().unwrap().digest(), &[deco1_a], &[]);
@@ -661,7 +669,7 @@ fn mast_forest_merge_external_node_and_referenced_node_have_decorators() {
 
     // Build Forest B
     let mut forest_b = MastForest::new();
-    let deco2_b = forest_b.add_decorator(trace2.clone()).unwrap();
+    let deco2_b = forest_b.add_decorator(trace2).unwrap();
 
     let foo_node_b = block_foo_with_decorators(&[deco2_b], &[]);
     let id_foo_b = foo_node_b.add_to_forest(&mut forest_b).unwrap();
@@ -678,10 +686,14 @@ fn mast_forest_merge_external_node_and_referenced_node_have_decorators() {
         assert_eq!(merged.nodes.len(), 1);
 
         let id_foo_b_digest = forest_b[id_foo_b].digest();
-        let digests: Vec<_> = merged.nodes().iter().map(|node| node.digest()).collect();
-
         // Block foo should be unmodified.
-        assert!(digests.contains(&id_foo_b_digest));
+        assert!(
+            merged
+                .nodes()
+                .iter()
+                .map(MastNodeExt::digest)
+                .any(|digest| digest == id_foo_b_digest)
+        );
 
         if idx == 0 {
             assert_root_mapping(&root_maps, vec![&forest_a.roots, &forest_b.roots], &merged.roots)
@@ -717,7 +729,7 @@ fn mast_forest_merge_multiple_external_nodes_with_decorator() {
 
     // Build Forest A
     let deco1_a = forest_a.add_decorator(trace1.clone()).unwrap();
-    let deco2_a = forest_a.add_decorator(trace2.clone()).unwrap();
+    let deco2_a = forest_a.add_decorator(trace2).unwrap();
 
     let external_node_a =
         external_with_decorators(block_foo().build().unwrap().digest(), &[deco1_a], &[deco2_a]);
@@ -748,10 +760,14 @@ fn mast_forest_merge_multiple_external_nodes_with_decorator() {
         assert_eq!(merged.nodes.len(), 1);
 
         let id_foo_b_digest = forest_b[id_foo_b].digest();
-        let digests: Vec<_> = merged.nodes().iter().map(|node| node.digest()).collect();
-
         // Block foo should be unmodified.
-        assert!(digests.contains(&id_foo_b_digest));
+        assert!(
+            merged
+                .nodes()
+                .iter()
+                .map(MastNodeExt::digest)
+                .any(|digest| digest == id_foo_b_digest)
+        );
 
         if idx == 0 {
             assert_root_mapping(&root_maps, vec![&forest_a.roots, &forest_b.roots], &merged.roots)
@@ -800,7 +816,7 @@ fn mast_forest_merge_external_dependencies() {
     ]
     .into_iter()
     {
-        let digests = merged.nodes().iter().map(|node| node.digest()).collect::<Vec<_>>();
+        let digests = merged.nodes().iter().map(MastNodeExt::digest).collect::<Vec<_>>();
         assert_eq!(merged.nodes().len(), 3);
         assert!(digests.contains(&forest_b[id_ext_b].digest()));
         assert!(digests.contains(&forest_b[id_call_b].digest()));
@@ -822,8 +838,8 @@ fn mast_forest_merge_invalid_decorator_index() {
 
     // Build Forest A
     let mut forest_a = MastForest::new();
-    let deco1_a = forest_a.add_decorator(trace1.clone()).unwrap();
-    let deco2_a = forest_a.add_decorator(trace2.clone()).unwrap();
+    let deco1_a = forest_a.add_decorator(trace1).unwrap();
+    let deco2_a = forest_a.add_decorator(trace2).unwrap();
     let id_bar_a = block_bar().add_to_forest(&mut forest_a).unwrap();
 
     forest_a.make_root(id_bar_a);
@@ -876,7 +892,7 @@ fn mast_forest_merge_advice_maps_collision() {
     forest_a.make_root(id_call_a);
     let key_a = Word::new([Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)]);
     let value_a = vec![ONE, ONE];
-    forest_a.advice_map_mut().insert(key_a, value_a.clone());
+    forest_a.advice_map_mut().insert(key_a, value_a);
 
     let mut forest_b = MastForest::new();
     let id_bar = block_bar().add_to_forest(&mut forest_b).unwrap();
@@ -885,7 +901,7 @@ fn mast_forest_merge_advice_maps_collision() {
     // The key collides with key_a in the forest_a.
     let key_b = key_a;
     let value_b = vec![Felt::new(2), Felt::new(2)];
-    forest_b.advice_map_mut().insert(key_b, value_b.clone());
+    forest_b.advice_map_mut().insert(key_b, value_b);
 
     let err = MastForest::merge([&forest_a, &forest_b]).unwrap_err();
     assert_matches!(err, MastForestError::AdviceMapKeyCollisionOnMerge(_));
@@ -914,7 +930,7 @@ fn mast_forest_merge_op_indexed_decorators_preservation() {
     // Create a block with multiple operations and op-indexed decorators
     let ops_a = vec![Operation::Add, Operation::Mul, Operation::Or];
     let block_id_a = BasicBlockNodeBuilder::new(
-        ops_a.clone(),
+        ops_a,
         vec![(0, op0_a), (1, op1_a)], // Op-indexed decorators
     )
     .with_before_enter(vec![before_enter_a, shared_deco_a]) // Use shared decorator
@@ -937,7 +953,7 @@ fn mast_forest_merge_op_indexed_decorators_preservation() {
 
     let ops_b = vec![Operation::Add, Operation::Mul, Operation::Or];
     let block_id_b = BasicBlockNodeBuilder::new(
-        ops_b.clone(),
+        ops_b,
         vec![(0, op0_b), (2, op2_b)], // Op-indexed decorators at different positions
     )
     .with_before_enter(vec![before_enter_b, shared_deco_b]) // Use shared decorator
@@ -999,7 +1015,7 @@ fn mast_forest_merge_op_indexed_decorators_preservation() {
     );
 
     // Count how many times each decorator appears in the merged forest
-    let mut decorator_ref_counts = alloc::collections::BTreeMap::new();
+    let mut decorator_ref_counts = BTreeMap::new();
 
     // Check all nodes for decorator references
     for node in &merged.nodes {
@@ -1025,8 +1041,7 @@ fn mast_forest_merge_op_indexed_decorators_preservation() {
         let ref_count = decorator_ref_counts.get(&deco_id).unwrap_or(&0);
         if ref_count == &0 {
             panic!(
-                "Decorator at index {} (value: {:?}) is not referenced anywhere in the merged forest (orphan)",
-                i, decorator
+                "Decorator at index {i} (value: {decorator:?}) is not referenced anywhere in the merged forest (orphan)"
             );
         }
     }
@@ -1042,7 +1057,7 @@ fn mast_forest_merge_op_indexed_decorators_preservation() {
         );
 
         // Check op-indexed decorators at correct positions
-        let indexed_decs: alloc::collections::BTreeMap<usize, DecoratorId> =
+        let indexed_decs: BTreeMap<usize, DecoratorId> =
             block_a.indexed_decorator_iter(&merged).collect();
 
         assert_eq!(
@@ -1078,7 +1093,7 @@ fn mast_forest_merge_op_indexed_decorators_preservation() {
         );
 
         // Check op-indexed decorators at correct positions
-        let indexed_decs: alloc::collections::BTreeMap<usize, DecoratorId> =
+        let indexed_decs: BTreeMap<usize, DecoratorId> =
             block_b.indexed_decorator_iter(&merged).collect();
 
         assert_eq!(

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -1095,8 +1095,7 @@ impl DecoratorId {
             Ok(Self(value))
         } else {
             Err(DeserializationError::InvalidValue(format!(
-                "Invalid deserialized MAST decorator id '{}', but allows only {} decorators",
-                value, bound,
+                "Invalid deserialized MAST decorator id '{value}', but allows only {bound} decorators",
             )))
         }
     }
@@ -1245,7 +1244,7 @@ pub enum MastForestError {
 // by delegating to the existing miden-crypto serialization which already handles
 // the conversion between linked and owned decorator formats.
 #[cfg(feature = "serde")]
-impl serde::Serialize for MastForest {
+impl Serialize for MastForest {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -1257,7 +1256,7 @@ impl serde::Serialize for MastForest {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for MastForest {
+impl<'de> Deserialize<'de> for MastForest {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/core/src/mast/node/basic_block_node/arbitrary.rs
+++ b/core/src/mast/node/basic_block_node/arbitrary.rs
@@ -318,10 +318,7 @@ impl Arbitrary for MastForest {
         // Generate nodes in a way that respects topological ordering
         (
             // Generate basic blocks first (they have no dependencies)
-            prop::collection::vec(
-                any_with::<BasicBlockNode>(bb_params.clone()),
-                1..=*params.blocks.end(),
-            ),
+            prop::collection::vec(any_with::<BasicBlockNode>(bb_params), 1..=*params.blocks.end()),
             // Generate decorators
             prop::collection::vec(
                 any::<Decorator>(),

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -349,13 +349,13 @@ impl BasicBlockNode {
 
     /// Returns an iterator over the operations in the order in which they appear in the program.
     pub fn operations(&self) -> impl Iterator<Item = &Operation> {
-        self.op_batches.iter().flat_map(|batch| batch.ops())
+        self.op_batches.iter().flat_map(OpBatch::ops)
     }
 
     /// Returns an iterator over the un-padded operations in the order in which they
     /// appear in the program.
     pub fn raw_operations(&self) -> impl Iterator<Item = &Operation> {
-        self.op_batches.iter().flat_map(|batch| batch.raw_ops())
+        self.op_batches.iter().flat_map(OpBatch::raw_ops)
     }
 
     /// Returns the total number of operations and decorators in this basic block.
@@ -483,15 +483,11 @@ impl BasicBlockNode {
             if batch_idx + 1 < self.op_batches.len() {
                 if num_groups != BATCH_SIZE {
                     return Err(format!(
-                        "Batch {}: {} groups is not full batch size {}",
-                        batch_idx, num_groups, BATCH_SIZE
+                        "Batch {batch_idx}: {num_groups} groups is not full batch size {BATCH_SIZE}"
                     ));
                 }
             } else if !num_groups.is_power_of_two() {
-                return Err(format!(
-                    "Batch {}: {} groups is not power of two",
-                    batch_idx, num_groups
-                ));
+                return Err(format!("Batch {batch_idx}: {num_groups} groups is not power of two"));
             }
         }
         Ok(())
@@ -527,8 +523,7 @@ impl BasicBlockNode {
                     for (op_idx, op) in group_ops.iter().enumerate() {
                         if op.imm_value().is_some() {
                             return Err(format!(
-                                "Batch {}, group {}: operation at index {} requires immediate value, but this is the last group in batch",
-                                batch_idx, group_idx, op_idx
+                                "Batch {batch_idx}, group {group_idx}: operation at index {op_idx} requires immediate value, but this is the last group in batch"
                             ));
                         }
                     }
@@ -538,8 +533,7 @@ impl BasicBlockNode {
                         && last_op.imm_value().is_some()
                     {
                         return Err(format!(
-                            "Batch {}, group {}: ends with operation requiring immediate value",
-                            batch_idx, group_idx
+                            "Batch {batch_idx}, group {group_idx}: ends with operation requiring immediate value"
                         ));
                     }
                 }
@@ -602,8 +596,7 @@ impl BasicBlockNode {
 
                 if group_size > GROUP_SIZE {
                     return Err(format!(
-                        "Batch {}, group {}: contains {} operations, exceeds maximum {}",
-                        batch_idx, group_idx, group_size, GROUP_SIZE
+                        "Batch {batch_idx}, group {group_idx}: contains {group_size} operations, exceeds maximum {GROUP_SIZE}"
                     ));
                 }
             }
@@ -641,8 +634,7 @@ impl BasicBlockNode {
                 }
                 if groups[group_idx] != Felt::new(group_value) {
                     return Err(format!(
-                        "Batch {}, group {}: committed opcode group does not match operations",
-                        batch_idx, group_idx
+                        "Batch {batch_idx}, group {group_idx}: committed opcode group does not match operations"
                     ));
                 }
 
@@ -653,13 +645,12 @@ impl BasicBlockNode {
                     BATCH_SIZE,
                     Some(num_groups),
                 )
-                .map_err(|err| format!("Batch {}: {}", batch_idx, err))?;
+                .map_err(|err| format!("Batch {batch_idx}: {err}"))?;
 
                 for (imm_group_idx, imm_value) in placements {
                     if groups[imm_group_idx] != imm_value {
                         return Err(format!(
-                            "Batch {}: push immediate value mismatch at index {}",
-                            batch_idx, imm_group_idx
+                            "Batch {batch_idx}: push immediate value mismatch at index {imm_group_idx}"
                         ));
                     }
                     immediate_slots[imm_group_idx] = true;
@@ -672,8 +663,7 @@ impl BasicBlockNode {
                     && groups[group_idx] != ZERO
                 {
                     return Err(format!(
-                        "Batch {}, group {}: empty group must be zero",
-                        batch_idx, group_idx
+                        "Batch {batch_idx}, group {group_idx}: empty group must be zero"
                     ));
                 }
             }
@@ -689,7 +679,7 @@ impl BasicBlockNode {
         for (batch_idx, batch) in self.op_batches.iter().enumerate() {
             batch
                 .validate_padding_semantics()
-                .map_err(|err| format!("Batch {}: {}", batch_idx, err))?;
+                .map_err(|err| format!("Batch {batch_idx}: {err}"))?;
         }
 
         Ok(())
@@ -810,13 +800,12 @@ impl MastNodeExt for BasicBlockNode {
             let forest_node = &forest.nodes[*id];
             let forest_node_ptr = match forest_node {
                 MastNode::Block(block_node) => block_node as *const BasicBlockNode as *const (),
-                _ => panic!("Node type mismatch at {:?}", id),
+                _ => panic!("Node type mismatch at {id:?}"),
             };
             let self_as_void = self_ptr as *const ();
             debug_assert_eq!(
                 self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {:?} to be self",
-                id
+                "Node pointer mismatch: expected node at {id:?} to be self"
             );
         }
     }
@@ -842,7 +831,7 @@ impl PrettyPrint for BasicBlockNodePrettyPrint<'_> {
                     OperationOrDecorator::Operation(op) => op.render(),
                     OperationOrDecorator::Decorator(decorator_id) => {
                         self.mast_forest.decorator_by_id(decorator_id)
-                            .map(|decorator| decorator.render())
+                            .map(PrettyPrint::render)
                             .unwrap_or_else(|| const_text("<invalid_decorator_id>"))
                     },
                 })
@@ -870,7 +859,7 @@ impl PrettyPrint for BasicBlockNodePrettyPrint<'_> {
                         OperationOrDecorator::Operation(op) => op.render(),
                         OperationOrDecorator::Decorator(decorator_id) => {
                             self.mast_forest.decorator_by_id(decorator_id)
-                                .map(|decorator| decorator.render())
+                                .map(PrettyPrint::render)
                                 .unwrap_or_else(|| const_text("<invalid_decorator_id>"))
                         },
                     })
@@ -1679,7 +1668,7 @@ impl MastForestContributor for BasicBlockNodeBuilder {
 
         // Collect assert operation data
         let mut assert_data = Vec::new();
-        for (op_idx, op) in op_batches.iter().flat_map(|batch| batch.ops()).enumerate() {
+        for (op_idx, op) in op_batches.iter().flat_map(OpBatch::ops).enumerate() {
             if let Operation::U32assert2(inner_value)
             | Operation::Assert(inner_value)
             | Operation::MpVerify(inner_value) = op
@@ -1701,9 +1690,9 @@ impl MastForestContributor for BasicBlockNodeBuilder {
         // Create iterator of slices from all collected data
         let decorator_bytes_iter = before_enter_bytes
             .iter()
-            .map(|bytes| bytes.as_slice())
+            .map(<[u8; 32]>::as_slice)
             .chain(core::iter::once(op_decorator_data.as_slice()))
-            .chain(after_exit_bytes.iter().map(|bytes| bytes.as_slice()))
+            .chain(after_exit_bytes.iter().map(<[u8; 32]>::as_slice))
             .chain(core::iter::once(assert_data.as_slice()));
 
         if self.before_enter.is_empty()
@@ -1749,7 +1738,7 @@ impl MastForestContributor for BasicBlockNodeBuilder {
 
 #[cfg(any(test, feature = "arbitrary"))]
 impl proptest::prelude::Arbitrary for BasicBlockNodeBuilder {
-    type Parameters = super::arbitrary::BasicBlockNodeParams;
+    type Parameters = arbitrary::BasicBlockNodeParams;
     type Strategy = proptest::strategy::BoxedStrategy<Self>;
 
     fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {

--- a/core/src/mast/node/basic_block_node/op_batch.rs
+++ b/core/src/mast/node/basic_block_node/op_batch.rs
@@ -53,7 +53,7 @@ impl OpBatch {
     /// of operations in the batch may be larger than the number of operations reported by this
     /// method.
     pub fn raw_ops(&self) -> impl Iterator<Item = &Operation> {
-        debug_assert!(self.num_groups == 0 || self.indptr[self.num_groups] != 0, "{:?}", self);
+        debug_assert!(self.num_groups == 0 || self.indptr[self.num_groups] != 0, "{self:?}");
         (0..self.num_groups).flat_map(|group_idx| {
             let padded = self.padding[group_idx];
             let start_idx = self.indptr[group_idx];
@@ -131,7 +131,7 @@ impl OpBatch {
             let is_padded = *self
                 .padding
                 .get(group_idx)
-                .ok_or_else(|| format!("group {}: missing padding metadata", group_idx))?;
+                .ok_or_else(|| format!("group {group_idx}: missing padding metadata"))?;
             if !is_padded {
                 continue;
             }
@@ -139,27 +139,27 @@ impl OpBatch {
             let group_start = *self
                 .indptr
                 .get(group_idx)
-                .ok_or_else(|| format!("group {}: missing indptr start", group_idx))?;
+                .ok_or_else(|| format!("group {group_idx}: missing indptr start"))?;
             let group_end = *self
                 .indptr
                 .get(group_idx + 1)
-                .ok_or_else(|| format!("group {}: missing indptr end", group_idx))?;
+                .ok_or_else(|| format!("group {group_idx}: missing indptr end"))?;
 
             if group_start == group_end {
-                return Err(format!("group {}: empty group cannot be marked as padded", group_idx));
+                return Err(format!("group {group_idx}: empty group cannot be marked as padded"));
             }
             if group_start > group_end {
-                return Err(format!("group {}: invalid group bounds", group_idx));
+                return Err(format!("group {group_idx}: invalid group bounds"));
             }
 
             let last_op_idx = group_end - 1;
             let last_op = self
                 .ops
                 .get(last_op_idx)
-                .ok_or_else(|| format!("group {}: invalid group bounds", group_idx))?;
+                .ok_or_else(|| format!("group {group_idx}: invalid group bounds"))?;
 
             if *last_op != Operation::Noop {
-                return Err(format!("group {}: padded group must end with NOOP", group_idx));
+                return Err(format!("group {group_idx}: padded group must end with NOOP"));
             }
         }
 
@@ -336,14 +336,12 @@ pub(crate) fn collect_immediate_placements(
                 && next_group_idx >= num_groups
             {
                 return Err(format!(
-                    "push immediate index {} exceeds num_groups {}",
-                    next_group_idx, num_groups
+                    "push immediate index {next_group_idx} exceeds num_groups {num_groups}"
                 ));
             }
             if indptr[next_group_idx] != indptr[next_group_idx + 1] {
                 return Err(format!(
-                    "push immediate overlaps operation group at index {}",
-                    next_group_idx
+                    "push immediate overlaps operation group at index {next_group_idx}"
                 ));
             }
             placements.push((next_group_idx, imm));

--- a/core/src/mast/node/basic_block_node/tests.rs
+++ b/core/src/mast/node/basic_block_node/tests.rs
@@ -14,7 +14,7 @@ use crate::{
 fn batch_ops_1() {
     // --- one operation ----------------------------------------------------------------------
     let ops = vec![Operation::Add];
-    let (batches, hash) = super::batch_and_hash_ops(&ops);
+    let (batches, hash) = batch_and_hash_ops(&ops);
     insta::assert_debug_snapshot!(batches);
     insta::assert_debug_snapshot!(build_group_chunks(&batches).collect::<Vec<_>>());
 
@@ -28,7 +28,7 @@ fn batch_ops_1() {
 fn batch_ops_2() {
     // --- two operations ---------------------------------------------------------------------
     let ops = vec![Operation::Add, Operation::Mul];
-    let (batches, hash) = super::batch_and_hash_ops(&ops);
+    let (batches, hash) = batch_and_hash_ops(&ops);
     insta::assert_debug_snapshot!(batches);
     insta::assert_debug_snapshot!(build_group_chunks(&batches).collect::<Vec<_>>());
 
@@ -42,7 +42,7 @@ fn batch_ops_2() {
 fn batch_ops_3() {
     // --- one group with one immediate value -------------------------------------------------
     let ops = vec![Operation::Add, Operation::Push(Felt::new(12345678))];
-    let (batches, hash) = super::batch_and_hash_ops(&ops);
+    let (batches, hash) = batch_and_hash_ops(&ops);
     insta::assert_debug_snapshot!(batches);
     insta::assert_debug_snapshot!(build_group_chunks(&batches).collect::<Vec<_>>());
 
@@ -66,7 +66,7 @@ fn batch_ops_4() {
         Operation::Push(Felt::new(7)),
         Operation::Add,
     ];
-    let (batches, hash) = super::batch_and_hash_ops(&ops);
+    let (batches, hash) = batch_and_hash_ops(&ops);
     insta::assert_debug_snapshot!(batches);
     insta::assert_debug_snapshot!(build_group_chunks(&batches).collect::<Vec<_>>());
 
@@ -99,7 +99,7 @@ fn batch_ops_5() {
         Operation::Add,
         Operation::Push(Felt::new(7)),
     ];
-    let (batches, hash) = super::batch_and_hash_ops(&ops);
+    let (batches, hash) = batch_and_hash_ops(&ops);
     insta::assert_debug_snapshot!(batches);
     insta::assert_debug_snapshot!(build_group_chunks(&batches).collect::<Vec<_>>());
 
@@ -137,7 +137,7 @@ fn batch_ops_6() {
         Operation::Add,
     ];
 
-    let (batches, hash) = super::batch_and_hash_ops(&ops);
+    let (batches, hash) = batch_and_hash_ops(&ops);
     insta::assert_debug_snapshot!(batches);
     insta::assert_debug_snapshot!(build_group_chunks(&batches).collect::<Vec<_>>());
 
@@ -169,7 +169,7 @@ fn batch_ops_7() {
         Operation::Add,
         Operation::Push(Felt::new(11)),
     ];
-    let (batches, hash) = super::batch_and_hash_ops(&ops);
+    let (batches, hash) = batch_and_hash_ops(&ops);
     insta::assert_debug_snapshot!(batches);
     insta::assert_debug_snapshot!(build_group_chunks(&batches).collect::<Vec<_>>());
 
@@ -201,7 +201,7 @@ fn batch_ops_8() {
         Operation::Push(ONE),
         Operation::Push(Felt::new(2)),
     ];
-    let (batches, hash) = super::batch_and_hash_ops(&ops);
+    let (batches, hash) = batch_and_hash_ops(&ops);
     insta::assert_debug_snapshot!(batches);
     insta::assert_debug_snapshot!(build_group_chunks(&batches).collect::<Vec<_>>());
 
@@ -244,7 +244,7 @@ fn batch_ops_9() {
         Operation::Pad,
     ];
 
-    let (batches, hash) = super::batch_and_hash_ops(&ops);
+    let (batches, hash) = batch_and_hash_ops(&ops);
     insta::assert_debug_snapshot!(batches);
     insta::assert_debug_snapshot!(build_group_chunks(&batches).collect::<Vec<_>>());
 
@@ -280,13 +280,14 @@ fn operation_or_decorator_iterator() {
     ];
 
     // Convert raw decorators to decorator list by adding them to the forest first
-    let decorator_list: Vec<(usize, crate::mast::DecoratorId)> = decorators
+    let decorator_list: Vec<(usize, DecoratorId)> = decorators
         .into_iter()
-        .map(|(idx, decorator)| -> Result<(usize, crate::mast::DecoratorId), crate::mast::MastForestError> {
+        .map(|(idx, decorator)| -> Result<(usize, DecoratorId), MastForestError> {
             let decorator_id = mast_forest.add_decorator(decorator)?;
             Ok((idx, decorator_id))
         })
-        .collect::<Result<Vec<_>, _>>().unwrap();
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
 
     let node_id = BasicBlockNodeBuilder::new(operations, decorator_list)
         .add_to_forest(&mut mast_forest)
@@ -326,7 +327,7 @@ fn build_group(ops: &[Operation]) -> Felt {
 }
 
 fn build_group_chunks(batches: &[OpBatch]) -> impl Iterator<Item = &[Operation]> {
-    batches.iter().flat_map(|opbatch| opbatch.group_chunks())
+    batches.iter().flat_map(OpBatch::group_chunks)
 }
 
 fn basic_block_from_batch(batch: OpBatch) -> BasicBlockNode {
@@ -359,7 +360,7 @@ proptest! {
     /// - Operations are correctly distributed across batches and groups.
     #[test]
     fn test_batch_creation_invariants(ops in op_non_control_sequence_strategy(50)) {
-        let (batches, _) = super::batch_and_hash_ops(&ops);
+        let (batches, _) = batch_and_hash_ops(&ops);
 
         // A basic block contains one or more batches
         assert!(!batches.is_empty(), "There should be at least one batch");
@@ -387,8 +388,7 @@ proptest! {
             for chunk in batch.group_chunks() {
                     let count = chunk.len();
                     assert!(chunk.len() <= GROUP_SIZE,
-                        "Group {:?} in batch has {} operations, which exceeds the maximum of {}",
-                        chunk, count, GROUP_SIZE);
+                        "Group {chunk:?} in batch has {count} operations, which exceeds the maximum of {GROUP_SIZE}");
             }
         }
     }
@@ -399,7 +399,7 @@ proptest! {
     /// - If no groups available, both operation and immediate move to next batch
     #[test]
     fn test_immediate_value_placement(ops in op_non_control_sequence_strategy(50)) {
-        let (batches, _) = super::batch_and_hash_ops(&ops);
+        let (batches, _) = batch_and_hash_ops(&ops);
 
         for batch in batches {
             let mut op_idx_in_group = 0;
@@ -629,12 +629,12 @@ proptest! {
         let mut dummy_forest = MastForest::new();
 
         // Convert decorators to use forest's decorator IDs
-        let forest_decorators: Vec<(usize, crate::mast::DecoratorId)> = decs
+        let forest_decorators: Vec<(usize, DecoratorId)> = decs
             .iter()
             .map(|(idx, decorator_id)| (*idx, *decorator_id))
             .collect();
 
-        let node_id = BasicBlockNodeBuilder::new(ops.clone(), forest_decorators)
+        let node_id = BasicBlockNodeBuilder::new(ops, forest_decorators)
             .add_to_forest(&mut dummy_forest)
             .unwrap();
         let block = dummy_forest.get_node_by_id(node_id).unwrap().unwrap_basic_block();
@@ -661,9 +661,9 @@ fn test_mast_node_error_context_decorators_iterates_all_decorators() {
     let op_deco = Decorator::Trace(2);
     let after_exit_deco = Decorator::Trace(3);
 
-    let before_enter_id = forest.add_decorator(before_enter_deco.clone()).unwrap();
-    let op_id = forest.add_decorator(op_deco.clone()).unwrap();
-    let after_exit_id = forest.add_decorator(after_exit_deco.clone()).unwrap();
+    let before_enter_id = forest.add_decorator(before_enter_deco).unwrap();
+    let op_id = forest.add_decorator(op_deco).unwrap();
+    let after_exit_id = forest.add_decorator(after_exit_deco).unwrap();
 
     // Create a basic block with all types of decorators using add_to_forest
     let node_id = BasicBlockNodeBuilder::new(operations, vec![(1, op_id)])
@@ -700,10 +700,10 @@ fn test_indexed_decorator_iter_excludes_before_enter_after_exit() {
     let op_deco2 = Decorator::Trace(3);
     let after_exit_deco = Decorator::Trace(4);
 
-    let before_enter_id = forest.add_decorator(before_enter_deco.clone()).unwrap();
-    let op_id1 = forest.add_decorator(op_deco1.clone()).unwrap();
-    let op_id2 = forest.add_decorator(op_deco2.clone()).unwrap();
-    let after_exit_id = forest.add_decorator(after_exit_deco.clone()).unwrap();
+    let before_enter_id = forest.add_decorator(before_enter_deco).unwrap();
+    let op_id1 = forest.add_decorator(op_deco1).unwrap();
+    let op_id2 = forest.add_decorator(op_deco2).unwrap();
+    let after_exit_id = forest.add_decorator(after_exit_deco).unwrap();
 
     // Create a basic block with all types of decorators using add_to_forest
     let node_id = BasicBlockNodeBuilder::new(operations, vec![(0, op_id1), (1, op_id2)])
@@ -743,8 +743,8 @@ fn test_decorator_positions() {
     let trace_deco = Decorator::Trace(42);
     let debug_deco = Decorator::Trace(999);
 
-    let trace_id = forest.add_decorator(trace_deco.clone()).unwrap();
-    let debug_id = forest.add_decorator(debug_deco.clone()).unwrap();
+    let trace_id = forest.add_decorator(trace_deco).unwrap();
+    let debug_id = forest.add_decorator(debug_deco).unwrap();
 
     // Create a basic block with complex operations
     let operations = vec![
@@ -756,12 +756,11 @@ fn test_decorator_positions() {
     ];
 
     // Create a basic block with complex operations using add_to_forest
-    let node_id =
-        BasicBlockNodeBuilder::new(operations.clone(), vec![(2, trace_id), (4, debug_id)])
-            .with_before_enter(vec![trace_id, debug_id])
-            .with_after_exit(vec![trace_id])
-            .add_to_forest(&mut forest)
-            .unwrap();
+    let node_id = BasicBlockNodeBuilder::new(operations, vec![(2, trace_id), (4, debug_id)])
+        .with_before_enter(vec![trace_id, debug_id])
+        .with_after_exit(vec![trace_id])
+        .add_to_forest(&mut forest)
+        .unwrap();
 
     let block = forest.get_node_by_id(node_id).unwrap().unwrap_basic_block();
 
@@ -807,7 +806,7 @@ proptest! {
         // Build BasicBlockNode using linked storage (this applies padding)
         let mut forest = MastForest::new();
         // Convert decorators to use forest's decorator IDs
-        let forest_decorators: Vec<(usize, crate::mast::DecoratorId)> = decorators
+        let forest_decorators: Vec<(usize, DecoratorId)> = decorators
             .iter()
             .map(|(idx, decorator_id)| (*idx, *decorator_id))
             .collect();
@@ -815,7 +814,7 @@ proptest! {
             .add_to_forest(&mut forest)
             .unwrap();
         let block = forest.get_node_by_id(node_id).unwrap().unwrap_basic_block();
-        let padded_ops = block.op_batches().iter().flat_map(|batch| batch.ops()).collect::<Vec<_>>();
+        let padded_ops = block.op_batches().iter().flat_map(OpBatch::ops).collect::<Vec<_>>();
 
         // Build both prefix arrays
         let raw2pad = RawToPaddedPrefix::new(block.op_batches());
@@ -874,7 +873,7 @@ proptest! {
         // Build BasicBlockNode using linked storage
         let mut forest = MastForest::new();
         // Convert decorators to use forest's decorator IDs
-        let forest_decorators: Vec<(usize, crate::mast::DecoratorId)> = decorators
+        let forest_decorators: Vec<(usize, DecoratorId)> = decorators
             .iter()
             .map(|(idx, decorator_id)| (*idx, *decorator_id))
             .collect();

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -276,13 +276,12 @@ impl MastNodeExt for CallNode {
             let forest_node = &forest.nodes[id];
             let forest_node_ptr = match forest_node {
                 MastNode::Call(call_node) => call_node as *const CallNode as *const (),
-                _ => panic!("Node type mismatch at {:?}", id),
+                _ => panic!("Node type mismatch at {id:?}"),
             };
             let self_as_void = self_ptr as *const ();
             debug_assert_eq!(
                 self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {:?} to be self",
-                id
+                "Node pointer mismatch: expected node at {id:?} to be self"
             );
         }
     }
@@ -453,10 +452,7 @@ impl MastForestContributor for CallNodeBuilder {
                     CallNode::CALL_DOMAIN
                 };
 
-                crate::chiplets::hasher::merge_in_domain(
-                    &[callee_digest, miden_crypto::Word::default()],
-                    domain,
-                )
+                hasher::merge_in_domain(&[callee_digest, Word::default()], domain)
             },
         )
     }
@@ -489,7 +485,7 @@ impl MastForestContributor for CallNodeBuilder {
         self.after_exit.extend(decorators);
     }
 
-    fn with_digest(mut self, digest: crate::Word) -> Self {
+    fn with_digest(mut self, digest: Word) -> Self {
         self.digest = Some(digest);
         self
     }

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -143,8 +143,8 @@ impl DynNodePrettyPrint<'_> {
     }
 }
 
-impl crate::prettier::PrettyPrint for DynNodePrettyPrint<'_> {
-    fn render(&self) -> crate::prettier::Document {
+impl PrettyPrint for DynNodePrettyPrint<'_> {
+    fn render(&self) -> Document {
         let dyn_text = if self.node.is_dyncall() {
             const_text("dyncall")
         } else {
@@ -254,13 +254,12 @@ impl MastNodeExt for DynNode {
             let forest_node = &forest.nodes[id];
             let forest_node_ptr = match forest_node {
                 MastNode::Dyn(dyn_node) => dyn_node as *const DynNode as *const (),
-                _ => panic!("Node type mismatch at {:?}", id),
+                _ => panic!("Node type mismatch at {id:?}"),
             };
             let self_as_void = self_ptr as *const ();
             debug_assert_eq!(
                 self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {:?} to be self",
-                id
+                "Node pointer mismatch: expected node at {id:?} to be self"
             );
         }
     }
@@ -426,7 +425,7 @@ impl MastForestContributor for DynNodeBuilder {
         self.after_exit.extend(decorators);
     }
 
-    fn with_digest(mut self, digest: crate::Word) -> Self {
+    fn with_digest(mut self, digest: Word) -> Self {
         self.digest = Some(digest);
         self
     }

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -104,8 +104,8 @@ impl ExternalNodePrettyPrint<'_> {
     }
 }
 
-impl crate::prettier::PrettyPrint for ExternalNodePrettyPrint<'_> {
-    fn render(&self) -> crate::prettier::Document {
+impl PrettyPrint for ExternalNodePrettyPrint<'_> {
+    fn render(&self) -> Document {
         let external = const_text("external")
             + const_text(".")
             + text(self.node.digest.as_bytes().to_hex_with_prefix());
@@ -208,13 +208,12 @@ impl MastNodeExt for ExternalNode {
                 crate::mast::MastNode::External(external) => {
                     external as *const ExternalNode as *const ()
                 },
-                _ => panic!("Node type mismatch at {:?}", id),
+                _ => panic!("Node type mismatch at {id:?}"),
             };
             let self_as_void = self_ptr as *const ();
             debug_assert_eq!(
                 self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {:?} to be self",
-                id
+                "Node pointer mismatch: expected node at {id:?} to be self"
             );
         }
     }
@@ -340,7 +339,7 @@ impl MastForestContributor for ExternalNodeBuilder {
         self.after_exit.extend(decorators);
     }
 
-    fn with_digest(mut self, digest: crate::Word) -> Self {
+    fn with_digest(mut self, digest: Word) -> Self {
         self.digest = digest;
         self
     }
@@ -390,12 +389,7 @@ impl proptest::prelude::Arbitrary for ExternalNodeBuilder {
 
         (
             any::<[u64; 4]>().prop_map(|[a, b, c, d]| {
-                miden_crypto::Word::new([
-                    miden_crypto::Felt::new(a),
-                    miden_crypto::Felt::new(b),
-                    miden_crypto::Felt::new(c),
-                    miden_crypto::Felt::new(d),
-                ])
+                Word::new([Felt::new(a), Felt::new(b), Felt::new(c), Felt::new(d)])
             }),
             proptest::collection::vec(
                 super::arbitrary::decorator_id_strategy(params.max_decorator_id_u32),

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -260,13 +260,12 @@ impl MastNodeExt for JoinNode {
             let forest_node = &forest.nodes[id];
             let forest_node_ptr = match forest_node {
                 MastNode::Join(join_node) => join_node as *const JoinNode as *const (),
-                _ => panic!("Node type mismatch at {:?}", id),
+                _ => panic!("Node type mismatch at {id:?}"),
             };
             let self_as_void = self_ptr as *const ();
             debug_assert_eq!(
                 self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {:?} to be self",
-                id
+                "Node pointer mismatch: expected node at {id:?} to be self"
             );
         }
     }
@@ -416,10 +415,7 @@ impl MastForestContributor for JoinNodeBuilder {
                 let left_child_hash = forest[self.children[0]].digest();
                 let right_child_hash = forest[self.children[1]].digest();
 
-                crate::chiplets::hasher::merge_in_domain(
-                    &[left_child_hash, right_child_hash],
-                    JoinNode::DOMAIN,
-                )
+                hasher::merge_in_domain(&[left_child_hash, right_child_hash], JoinNode::DOMAIN)
             },
         )
     }
@@ -454,7 +450,7 @@ impl MastForestContributor for JoinNodeBuilder {
         self.after_exit.extend(decorators);
     }
 
-    fn with_digest(mut self, digest: crate::Word) -> Self {
+    fn with_digest(mut self, digest: Word) -> Self {
         self.digest = Some(digest);
         self
     }

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -70,7 +70,7 @@ struct LoopNodePrettyPrint<'a> {
     mast_forest: &'a MastForest,
 }
 
-impl crate::prettier::PrettyPrint for LoopNodePrettyPrint<'_> {
+impl PrettyPrint for LoopNodePrettyPrint<'_> {
     fn render(&self) -> crate::prettier::Document {
         use crate::prettier::*;
 
@@ -209,13 +209,12 @@ impl MastNodeExt for LoopNode {
             let forest_node = &forest.nodes[id];
             let forest_node_ptr = match forest_node {
                 MastNode::Loop(loop_node) => loop_node as *const LoopNode as *const (),
-                _ => panic!("Node type mismatch at {:?}", id),
+                _ => panic!("Node type mismatch at {id:?}"),
             };
             let self_as_void = self_ptr as *const ();
             debug_assert_eq!(
                 self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {:?} to be self",
-                id
+                "Node pointer mismatch: expected node at {id:?} to be self"
             );
         }
     }
@@ -353,10 +352,7 @@ impl MastForestContributor for LoopNodeBuilder {
             } else {
                 let body_hash = forest[self.body].digest();
 
-                crate::chiplets::hasher::merge_in_domain(
-                    &[body_hash, miden_crypto::Word::default()],
-                    LoopNode::DOMAIN,
-                )
+                hasher::merge_in_domain(&[body_hash, Word::default()], LoopNode::DOMAIN)
             },
         )
     }
@@ -388,7 +384,7 @@ impl MastForestContributor for LoopNodeBuilder {
         self.after_exit.extend(decorators);
     }
 
-    fn with_digest(mut self, digest: crate::Word) -> Self {
+    fn with_digest(mut self, digest: Word) -> Self {
         self.digest = Some(digest);
         self
     }

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -220,13 +220,12 @@ impl MastNodeExt for SplitNode {
             let forest_node = &forest.nodes[id];
             let forest_node_ptr = match forest_node {
                 MastNode::Split(split_node) => split_node as *const SplitNode as *const (),
-                _ => panic!("Node type mismatch at {:?}", id),
+                _ => panic!("Node type mismatch at {id:?}"),
             };
             let self_as_void = self_ptr as *const ();
             debug_assert_eq!(
                 self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {:?} to be self",
-                id
+                "Node pointer mismatch: expected node at {id:?} to be self"
             );
         }
     }
@@ -376,10 +375,7 @@ impl MastForestContributor for SplitNodeBuilder {
                 let if_branch_hash = forest[self.branches[0]].digest();
                 let else_branch_hash = forest[self.branches[1]].digest();
 
-                crate::chiplets::hasher::merge_in_domain(
-                    &[if_branch_hash, else_branch_hash],
-                    SplitNode::DOMAIN,
-                )
+                hasher::merge_in_domain(&[if_branch_hash, else_branch_hash], SplitNode::DOMAIN)
             },
         )
     }
@@ -414,7 +410,7 @@ impl MastForestContributor for SplitNodeBuilder {
         self.after_exit.extend(decorators);
     }
 
-    fn with_digest(mut self, digest: crate::Word) -> Self {
+    fn with_digest(mut self, digest: Word) -> Self {
         self.digest = Some(digest);
         self
     }

--- a/core/src/mast/node_fingerprint.rs
+++ b/core/src/mast/node_fingerprint.rs
@@ -89,9 +89,9 @@ pub fn fingerprint_from_parts(
     } else {
         let decorator_bytes_iter = pre_decorator_hash_bytes
             .iter()
-            .map(|bytes| bytes.as_slice())
-            .chain(post_decorator_hash_bytes.iter().map(|bytes| bytes.as_slice()))
-            .chain(children_decorator_roots.iter().map(|bytes| bytes.as_slice()));
+            .map(<[u8; 32]>::as_slice)
+            .chain(post_decorator_hash_bytes.iter().map(<[u8; 32]>::as_slice))
+            .chain(children_decorator_roots.iter().map(<[u8; 32]>::as_slice));
 
         let decorator_root = Blake3_256::hash_iter(decorator_bytes_iter);
         Ok(MastNodeFingerprint::with_decorator_root(node_digest, decorator_root))

--- a/core/src/mast/serialization/asm_op.rs
+++ b/core/src/mast/serialization/asm_op.rs
@@ -199,8 +199,7 @@ mod tests {
     fn test_asm_op_roundtrip_with_location() {
         let location =
             Location::new(Uri::new("test://file.masm"), ByteIndex::new(10), ByteIndex::new(20));
-        let asm_op =
-            AssemblyOp::new(Some(location.clone()), "my_proc".to_string(), 3, "mul".to_string());
+        let asm_op = AssemblyOp::new(Some(location), "my_proc".to_string(), 3, "mul".to_string());
 
         let mut builder = AsmOpDataBuilder::new();
         builder.add_asm_op(&asm_op);
@@ -237,9 +236,9 @@ mod tests {
         // Verify all restore correctly
         for (i, (info, original)) in infos.iter().zip([&asm_op1, &asm_op2, &asm_op3]).enumerate() {
             let restored = info.try_into_asm_op(&string_table, &data).unwrap();
-            assert_eq!(restored.context_name(), original.context_name(), "asm_op {}", i);
-            assert_eq!(restored.op(), original.op(), "asm_op {}", i);
-            assert_eq!(restored.num_cycles(), original.num_cycles(), "asm_op {}", i);
+            assert_eq!(restored.context_name(), original.context_name(), "asm_op {i}");
+            assert_eq!(restored.op(), original.op(), "asm_op {i}");
+            assert_eq!(restored.num_cycles(), original.num_cycles(), "asm_op {i}");
         }
     }
 

--- a/core/src/mast/serialization/basic_blocks.rs
+++ b/core/src/mast/serialization/basic_blocks.rs
@@ -96,7 +96,7 @@ fn pack_indptr_deltas(indptr: &[usize; 9]) -> [u8; 4] {
     let mut packed = [0u8; 4];
     for i in 0..8 {
         let delta = indptr[i + 1] - indptr[i];
-        debug_assert!(delta <= 9, "delta {} exceeds maximum of 9", delta);
+        debug_assert!(delta <= 9, "delta {delta} exceeds maximum of 9");
 
         let byte_idx = i / 2;
         let nibble_shift = (i % 2) * 4;
@@ -113,7 +113,7 @@ fn pack_indptr_deltas(indptr: &[usize; 9]) -> [u8; 4] {
 /// # Errors
 ///
 /// Returns `DeserializationError::InvalidValue` if any delta exceeds GROUP_SIZE.
-fn unpack_indptr_deltas(packed: &[u8; 4]) -> Result<[usize; 9], DeserializationError> {
+fn unpack_indptr_deltas(packed: [u8; 4]) -> Result<[usize; 9], DeserializationError> {
     let mut indptr = [0usize; 9];
 
     for i in 0..8 {
@@ -123,8 +123,7 @@ fn unpack_indptr_deltas(packed: &[u8; 4]) -> Result<[usize; 9], DeserializationE
 
         if delta > OP_GROUP_SIZE {
             return Err(DeserializationError::InvalidValue(format!(
-                "indptr delta {} exceeds maximum of {} at position {} (operation groups comprise at most {} ops)",
-                delta, OP_GROUP_SIZE, i, OP_GROUP_SIZE
+                "indptr delta {delta} exceeds maximum of {OP_GROUP_SIZE} at position {i} (operation groups comprise at most {OP_GROUP_SIZE} ops)"
             )));
         }
 
@@ -185,8 +184,7 @@ impl BasicBlockDataDecoder<'_> {
         let max_batches = ops_data_reader.max_alloc(BATCH_METADATA_BYTES_PER_BATCH);
         if num_batches > max_batches {
             return Err(DeserializationError::InvalidValue(format!(
-                "batch count {} exceeds remaining data capacity {}",
-                num_batches, max_batches
+                "batch count {num_batches} exceeds remaining data capacity {max_batches}"
             )));
         }
 
@@ -194,7 +192,7 @@ impl BasicBlockDataDecoder<'_> {
         let mut batch_indptrs: Vec<[usize; 9]> = Vec::with_capacity(num_batches);
         for _ in 0..num_batches {
             let packed: [u8; 4] = ops_data_reader.read()?;
-            let indptr = unpack_indptr_deltas(&packed)?;
+            let indptr = unpack_indptr_deltas(packed)?;
             batch_indptrs.push(indptr);
         }
 
@@ -274,7 +272,7 @@ impl BasicBlockDataDecoder<'_> {
                 batch_ops, *indptr, padding, groups, num_groups,
             );
             op_batch.validate_padding_semantics().map_err(|err| {
-                DeserializationError::InvalidValue(format!("batch {}: {}", batch_idx, err))
+                DeserializationError::InvalidValue(format!("batch {batch_idx}: {err}"))
             })?;
 
             op_batches.push(op_batch);
@@ -306,7 +304,7 @@ mod tests {
     #[case::some_zero_deltas([0, 0, 5, 5, 10, 10, 15, 15, 20])]
     fn test_pack_unpack_indptr_roundtrip(#[case] indptr: [usize; 9]) {
         let packed = pack_indptr_deltas(&indptr);
-        let unpacked = unpack_indptr_deltas(&packed).unwrap();
+        let unpacked = unpack_indptr_deltas(packed).unwrap();
         assert_eq!(indptr, unpacked);
     }
 
@@ -317,7 +315,7 @@ mod tests {
     #[case::delta_11_position_3([0x00, 0xb0, 0x00, 0x00], "delta 11 exceeds maximum of 9")]
     #[case::delta_14_position_7([0x00, 0x00, 0x00, 0x0e], "delta 14 exceeds maximum of 9")]
     fn test_unpack_invalid_delta(#[case] packed: [u8; 4], #[case] expected_msg: &str) {
-        let result = unpack_indptr_deltas(&packed);
+        let result = unpack_indptr_deltas(packed);
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains(expected_msg));

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -480,12 +480,11 @@ fn mast_forest_basic_block_serialization_no_decorator_duplication() {
 
     // Get the deserialized block
     let deserialized_root_id = deserialized.procedure_roots()[0];
-    let deserialized_block =
-        if let crate::mast::MastNode::Block(block) = &deserialized[deserialized_root_id] {
-            block
-        } else {
-            panic!("Expected a block node");
-        };
+    let deserialized_block = if let MastNode::Block(block) = &deserialized[deserialized_root_id] {
+        block
+    } else {
+        panic!("Expected a block node");
+    };
 
     // Verify that each decorator appears exactly once in the deserialized structure
     assert_eq!(
@@ -677,7 +676,7 @@ fn test_decorator_indices_preserved_with_padding() {
     // Add decorator at operation index 2 (the PUSH)
     let decorators = vec![(2, decorator_id)];
 
-    let block_id = BasicBlockNodeBuilder::new(operations.clone(), decorators)
+    let block_id = BasicBlockNodeBuilder::new(operations, decorators)
         .add_to_forest(&mut forest)
         .unwrap();
 
@@ -729,7 +728,7 @@ fn test_raw_vs_batched_construction_equivalence() {
         vec![Operation::Add, Operation::Mul, Operation::Push(Felt::new(100)), Operation::Drop];
 
     // Path 1: Raw construction
-    let block_id1 = BasicBlockNodeBuilder::new(operations.clone(), vec![(2, decorator_id1)])
+    let block_id1 = BasicBlockNodeBuilder::new(operations, vec![(2, decorator_id1)])
         .add_to_forest(&mut forest1)
         .unwrap();
 
@@ -781,7 +780,7 @@ fn test_raw_batched_digest_equivalence() {
 
     // Construct via Raw path
     let mut forest1 = MastForest::new();
-    let block_id1 = BasicBlockNodeBuilder::new(operations.clone(), Vec::new())
+    let block_id1 = BasicBlockNodeBuilder::new(operations, Vec::new())
         .add_to_forest(&mut forest1)
         .unwrap();
     let digest1 = forest1[block_id1].unwrap_basic_block().digest();
@@ -963,7 +962,7 @@ fn test_stripped_preserves_digests() {
     forest.make_root(join_id);
 
     // Capture original digests
-    let original_digests: Vec<_> = forest.nodes().iter().map(|n| n.digest()).collect();
+    let original_digests: Vec<_> = forest.nodes().iter().map(MastNodeExt::digest).collect();
 
     // Stripped roundtrip
     let mut stripped_bytes = Vec::new();
@@ -971,7 +970,7 @@ fn test_stripped_preserves_digests() {
     let restored = MastForest::read_from_bytes(&stripped_bytes).unwrap();
 
     // Verify digests match
-    let restored_digests: Vec<_> = restored.nodes().iter().map(|n| n.digest()).collect();
+    let restored_digests: Vec<_> = restored.nodes().iter().map(MastNodeExt::digest).collect();
     assert_eq!(original_digests, restored_digests, "Node digests should be preserved");
 }
 
@@ -1037,7 +1036,7 @@ mod proptests {
 
             // Verify all nodes match
             for (idx, original) in forest.nodes().iter().enumerate() {
-                let node_id = crate::mast::MastNodeId::new_unchecked(idx as u32);
+                let node_id = MastNodeId::new_unchecked(idx as u32);
                 let deserialized_node = &deserialized[node_id];
 
                 // Check digests match
@@ -1090,7 +1089,7 @@ mod proptests {
                 prop::sample::select(vec![
                     Operation::Add,
                     Operation::Mul,
-                    Operation::Push(crate::Felt::new(42)),
+                    Operation::Push(Felt::new(42)),
                     Operation::Drop,
                     Operation::Dup0,
                     Operation::Swap,
@@ -1271,7 +1270,7 @@ mod proptests {
 
             // Verify all node digests match
             for (idx, original) in forest.nodes().iter().enumerate() {
-                let node_id = crate::mast::MastNodeId::new_unchecked(idx as u32);
+                let node_id = MastNodeId::new_unchecked(idx as u32);
                 let restored_node = &restored[node_id];
 
                 prop_assert_eq!(
@@ -1344,11 +1343,11 @@ fn test_debuginfo_serialization_sparse() {
 
     // Verify decorators are at correct nodes
     for i in 0..10 {
-        let node_id = crate::mast::MastNodeId::new_unchecked(i);
+        let node_id = MastNodeId::new_unchecked(i);
         let orig_decorators = forest.decorator_indices_for_op(node_id, 0);
         let deser_decorators = deserialized.decorator_indices_for_op(node_id, 0);
 
-        assert_eq!(orig_decorators, deser_decorators, "Decorators at node {} should match", i);
+        assert_eq!(orig_decorators, deser_decorators, "Decorators at node {i} should match");
     }
 }
 
@@ -1382,28 +1381,26 @@ fn test_debuginfo_serialization_dense() {
 
     // Verify decorators are at correct nodes
     for i in 0..10 {
-        let node_id = crate::mast::MastNodeId::new_unchecked(i);
+        let node_id = MastNodeId::new_unchecked(i);
         let orig_decorators = forest.decorator_indices_for_op(node_id, 0);
         let deser_decorators = deserialized.decorator_indices_for_op(node_id, 0);
 
-        assert_eq!(orig_decorators, deser_decorators, "Decorators at node {} should match", i);
+        assert_eq!(orig_decorators, deser_decorators, "Decorators at node {i} should match");
 
         // Verify expected decorator presence
         if i < 8 {
-            assert_eq!(orig_decorators.len(), 1, "Node {} should have 1 decorator", i);
+            assert_eq!(orig_decorators.len(), 1, "Node {i} should have 1 decorator");
             assert_eq!(
                 deser_decorators.len(),
                 1,
-                "Node {} should have 1 decorator after deserialization",
-                i
+                "Node {i} should have 1 decorator after deserialization"
             );
         } else {
-            assert_eq!(orig_decorators.len(), 0, "Node {} should have no decorators", i);
+            assert_eq!(orig_decorators.len(), 0, "Node {i} should have no decorators");
             assert_eq!(
                 deser_decorators.len(),
                 0,
-                "Node {} should have no decorators after deserialization",
-                i
+                "Node {i} should have no decorators after deserialization"
             );
         }
     }
@@ -1706,8 +1703,7 @@ fn compute_single_block_digest_from_decoded_groups(bytes: &[u8]) -> Option<Word>
 fn test_untrusted_forest_rejects_non_full_prefix_batch() {
     let op_batches = vec![make_batch(4, Operation::Add), make_batch(2, Operation::Mul)];
 
-    let op_groups: Vec<Felt> =
-        op_batches.iter().flat_map(|batch| batch.groups()).copied().collect();
+    let op_groups: Vec<Felt> = op_batches.iter().flat_map(OpBatch::groups).copied().collect();
     let digest = hasher::hash_elements(&op_groups);
 
     let mut forest = MastForest::new();
@@ -1728,8 +1724,7 @@ fn test_untrusted_forest_rejects_non_full_prefix_batch() {
 fn test_untrusted_forest_accepts_full_prefix_batch() {
     let op_batches = vec![make_batch(OP_BATCH_SIZE, Operation::Add), make_batch(4, Operation::Mul)];
 
-    let op_groups: Vec<Felt> =
-        op_batches.iter().flat_map(|batch| batch.groups()).copied().collect();
+    let op_groups: Vec<Felt> = op_batches.iter().flat_map(OpBatch::groups).copied().collect();
     let digest = hasher::hash_elements(&op_groups);
 
     let mut forest = MastForest::new();
@@ -1919,9 +1914,9 @@ fn test_deserialization_rejects_excessive_node_count() {
     let mut bytes = Vec::new();
 
     // Write valid header
-    super::MAGIC.write_into(&mut bytes);
+    MAGIC.write_into(&mut bytes);
     bytes.write_u8(0); // flags
-    super::VERSION.write_into(&mut bytes);
+    VERSION.write_into(&mut bytes);
 
     // Write excessive node count (MAX_NODES + 1)
     let excessive_count: usize = MastForest::MAX_NODES + 1;

--- a/core/src/mast/tests.rs
+++ b/core/src/mast/tests.rs
@@ -72,7 +72,7 @@ fn test_decorator_storage_consistency_with_block_iterator() {
     ];
 
     // Add block to forest using BasicBlockNodeBuilder
-    let block_id = BasicBlockNodeBuilder::new(operations.clone(), decorators.clone())
+    let block_id = BasicBlockNodeBuilder::new(operations, decorators.clone())
         .add_to_forest(&mut forest)
         .unwrap();
 
@@ -112,12 +112,11 @@ fn test_decorator_storage_consistency_with_block_iterator() {
             .map(|(_, id)| id)
             .collect();
 
-        assert_eq!(forest_decos, block_decos, "Decorators for operation {} should match", op_idx);
+        assert_eq!(forest_decos, block_decos, "Decorators for operation {op_idx} should match");
         assert_eq!(
             forest_decos,
             &[*expected_decorator_id],
-            "Should have correct decorator for operation {}",
-            op_idx
+            "Should have correct decorator for operation {op_idx}"
         );
     }
 
@@ -135,8 +134,8 @@ fn test_decorator_storage_consistency_with_block_iterator() {
             .map(|(_, id)| id)
             .collect();
 
-        assert_eq!(forest_decos, [], "Operation {} should have no decorators", op_idx);
-        assert_eq!(block_decos, [], "Operation {} should have no decorators", op_idx);
+        assert_eq!(forest_decos, [], "Operation {op_idx} should have no decorators");
+        assert_eq!(block_decos, [], "Operation {op_idx} should have no decorators");
     }
 }
 
@@ -148,7 +147,7 @@ fn test_decorator_storage_consistency_with_empty_block() {
     let operations = vec![Operation::Push(Felt::new(1)), Operation::Add];
 
     // Add block to forest using BasicBlockNodeBuilder with no decorators
-    let block_id = BasicBlockNodeBuilder::new(operations.clone(), vec![])
+    let block_id = BasicBlockNodeBuilder::new(operations, vec![])
         .add_to_forest(&mut forest)
         .unwrap();
 
@@ -433,7 +432,7 @@ fn test_mast_forest_roundtrip_with_basic_blocks_and_decorators() {
         match op_idx {
             0 => op0_decorators.push(decorator_id),
             3 => op3_decorators.push(decorator_id),
-            _ => panic!("Unexpected decorator at operation index {}", op_idx),
+            _ => panic!("Unexpected decorator at operation index {op_idx}"),
         }
     }
     assert_eq!(op0_decorators.len(), 2);
@@ -455,7 +454,7 @@ fn test_mast_forest_serde_converts_linked_to_owned_decorators() {
     let decorators = vec![(0, deco1), (2, deco2)];
 
     // Add block to forest - this will create Linked decorators
-    let block_id = BasicBlockNodeBuilder::new(operations.clone(), decorators.clone())
+    let block_id = BasicBlockNodeBuilder::new(operations, decorators)
         .add_to_forest(&mut forest)
         .unwrap();
 
@@ -542,7 +541,7 @@ fn test_mast_forest_serializable_converts_linked_to_owned_decorators() {
     let decorators = vec![(0, deco1), (2, deco2)];
 
     // Add block to forest - this will create Linked decorators
-    let block_id = BasicBlockNodeBuilder::new(operations.clone(), decorators.clone())
+    let block_id = BasicBlockNodeBuilder::new(operations, decorators)
         .add_to_forest(&mut forest)
         .unwrap();
 
@@ -673,9 +672,8 @@ fn test_forest_borrowing_decorator_access() {
         assert_eq!(forest_borrowed_iter, expected_from_forest);
 
         // Test 6: Raw decorator iterator with forest borrowing
-        let raw_forest_iter: Vec<_> = block_node.raw_decorator_iter(&forest).collect();
         // Should include before_enter, op-indexed, and after_exit in order
-        assert_eq!(raw_forest_iter.len(), 3); // Only op-indexed decorators in this case
+        assert_eq!(block_node.raw_decorator_iter(&forest).count(), 3); // Only op-indexed decorators in this case
 
         // Test 7: Raw op indexed decorators with forest borrowing
         let raw_op_decorators = block_node.raw_op_indexed_decorators(&forest);
@@ -736,10 +734,8 @@ fn test_mast_forest_compaction_comprehensive() {
     let child2 = BasicBlockNodeBuilder::new(vec![Operation::Push(Felt::new(2))], Vec::new())
         .add_to_forest(&mut forest)
         .unwrap();
-    let join_no_deco = crate::mast::JoinNodeBuilder::new([child1, child2])
-        .add_to_forest(&mut forest)
-        .unwrap();
-    let join_with_before_deco = crate::mast::JoinNodeBuilder::new([child1, child2])
+    let join_no_deco = JoinNodeBuilder::new([child1, child2]).add_to_forest(&mut forest).unwrap();
+    let join_with_before_deco = JoinNodeBuilder::new([child1, child2])
         .with_before_enter(vec![debug_deco])
         .add_to_forest(&mut forest)
         .unwrap();
@@ -754,10 +750,10 @@ fn test_mast_forest_compaction_comprehensive() {
         BasicBlockNodeBuilder::new(vec![Operation::Assert(Felt::new(1))], Vec::new())
             .add_to_forest(&mut forest)
             .unwrap();
-    let split_no_deco = crate::mast::SplitNodeBuilder::new([split_child1, split_child2])
+    let split_no_deco = SplitNodeBuilder::new([split_child1, split_child2])
         .add_to_forest(&mut forest)
         .unwrap();
-    let split_with_after_deco = crate::mast::SplitNodeBuilder::new([split_child1, split_child2])
+    let split_with_after_deco = SplitNodeBuilder::new([split_child1, split_child2])
         .with_after_exit(vec![trace_deco])
         .add_to_forest(&mut forest)
         .unwrap();
@@ -781,10 +777,8 @@ fn test_mast_forest_compaction_comprehensive() {
     let call_target = BasicBlockNodeBuilder::new(vec![Operation::Mul], Vec::new())
         .add_to_forest(&mut forest)
         .unwrap();
-    let call_no_deco = crate::mast::CallNodeBuilder::new(call_target)
-        .add_to_forest(&mut forest)
-        .unwrap();
-    let call_with_after_deco = crate::mast::CallNodeBuilder::new(call_target)
+    let call_no_deco = CallNodeBuilder::new(call_target).add_to_forest(&mut forest).unwrap();
+    let call_with_after_deco = CallNodeBuilder::new(call_target)
         .with_after_exit(vec![trace_deco])
         .add_to_forest(&mut forest)
         .unwrap();
@@ -792,8 +786,8 @@ fn test_mast_forest_compaction_comprehensive() {
     forest.make_root(call_with_after_deco);
 
     // === Dyn nodes with before-enter decorators ===
-    let dyn_no_deco = crate::mast::DynNodeBuilder::new_dyn().add_to_forest(&mut forest).unwrap();
-    let dyn_with_before_deco = crate::mast::DynNodeBuilder::new_dyn()
+    let dyn_no_deco = DynNodeBuilder::new_dyn().add_to_forest(&mut forest).unwrap();
+    let dyn_with_before_deco = DynNodeBuilder::new_dyn()
         .with_before_enter(vec![debug_deco])
         .add_to_forest(&mut forest)
         .unwrap();
@@ -928,7 +922,7 @@ fn test_mast_forest_get_assembly_op_all_node_types() {
 
     // Create a basic block with an AssemblyOp registered for its operations
     let operations = vec![Operation::Push(Felt::new(1)), Operation::Add];
-    let bb_node_id = BasicBlockNodeBuilder::new(operations.clone(), vec![])
+    let bb_node_id = BasicBlockNodeBuilder::new(operations, vec![])
         .add_to_forest(&mut forest)
         .unwrap();
 
@@ -980,7 +974,7 @@ fn test_mast_forest_get_assembly_comprehensive_edge_cases() {
     let asm_op1 = AssemblyOp::new(None, "context1".into(), 1, "op1".into());
     let asm_op_id1 = forest.debug_info.add_asm_op(asm_op1.clone()).unwrap();
 
-    let node_id2 = BasicBlockNodeBuilder::new(operations.clone(), vec![])
+    let node_id2 = BasicBlockNodeBuilder::new(operations, vec![])
         .add_to_forest(&mut forest)
         .unwrap();
     forest.debug_info.register_asm_ops(node_id2, 2, vec![(0, asm_op_id1)]).unwrap();
@@ -1046,7 +1040,7 @@ fn test_mast_forest_get_assembly_comprehensive_edge_cases() {
     // All three indices should return the same AssemblyOp
     for idx in 1..=3 {
         let result = forest.get_assembly_op(node_id4, Some(idx));
-        assert!(result.is_some(), "Should find AssemblyOp at index {}", idx);
+        assert!(result.is_some(), "Should find AssemblyOp at index {idx}");
         assert_eq!(result.unwrap(), &asm_op_multi);
     }
 

--- a/core/src/operations/decorators/debug_var.rs
+++ b/core/src/operations/decorators/debug_var.rs
@@ -112,13 +112,13 @@ impl fmt::Display for DebugVarInfo {
         write!(f, "var.{}", self.name)?;
 
         if let Some(arg_index) = self.arg_index {
-            write!(f, "[arg{}]", arg_index)?;
+            write!(f, "[arg{arg_index}]")?;
         }
 
         write!(f, " = {}", self.value_location)?;
 
         if let Some(loc) = &self.location {
-            write!(f, " {}", loc)?;
+            write!(f, " {loc}")?;
         }
 
         Ok(())
@@ -157,17 +157,17 @@ pub enum DebugVarLocation {
 impl fmt::Display for DebugVarLocation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Stack(pos) => write!(f, "stack[{}]", pos),
-            Self::Memory(addr) => write!(f, "mem[{}]", addr),
+            Self::Stack(pos) => write!(f, "stack[{pos}]"),
+            Self::Memory(addr) => write!(f, "mem[{addr}]"),
             Self::Const(val) => write!(f, "const({})", val.as_canonical_u64()),
-            Self::Local(offset) => write!(f, "FMP{:+}", offset),
+            Self::Local(offset) => write!(f, "FMP{offset:+}"),
             Self::Expression(bytes) => {
                 write!(f, "expr(")?;
                 for (i, byte) in bytes.iter().enumerate() {
                     if i > 0 {
                         write!(f, " ")?;
                     }
-                    write!(f, "{:02x}", byte)?;
+                    write!(f, "{byte:02x}")?;
                 }
                 write!(f, ")")
             },
@@ -235,7 +235,7 @@ impl Serializable for DebugVarInfo {
         (*self.name).write_into(target);
         self.value_location.write_into(target);
         self.type_id.write_into(target);
-        self.arg_index.map(|n| n.get()).write_into(target);
+        self.arg_index.map(core::num::NonZero::get).write_into(target);
         self.location.write_into(target);
     }
 }

--- a/core/src/program/kernel.rs
+++ b/core/src/program/kernel.rs
@@ -53,7 +53,7 @@ impl Kernel {
 
         // Canonical ordering is a separate kernel invariant (not just a dedup side effect), so
         // we sort first and then validate uniqueness over the canonical representation.
-        hashes.sort_by_key(|v| v.as_bytes()); // ensure consistent order
+        hashes.sort_by_key(Word::as_bytes); // ensure consistent order
         let duplicated = hashes.windows(2).any(|data| data[0] == data[1]);
 
         if duplicated {

--- a/core/src/utils/col_matrix.rs
+++ b/core/src/utils/col_matrix.rs
@@ -60,7 +60,7 @@ impl<E: Clone + Copy> ColMatrix<E> {
 
     /// Returns an iterator over all columns in this matrix.
     pub fn columns(&self) -> impl Iterator<Item = &[E]> {
-        self.columns.iter().map(|col| col.as_slice())
+        self.columns.iter().map(Vec::as_slice)
     }
 
     /// Copies values of all columns at the specified row into the specified row slice.

--- a/core/src/utils/mod.rs
+++ b/core/src/utils/mod.rs
@@ -110,7 +110,7 @@ where
 /// Number of bytes packed into each u32 field element.
 ///
 /// Used for converting between byte arrays and u32-packed field elements in memory.
-const BYTES_PER_U32: usize = core::mem::size_of::<u32>();
+const BYTES_PER_U32: usize = size_of::<u32>();
 
 /// Converts bytes to field elements using u32 packing in little-endian format.
 ///

--- a/crates/ace-codegen/src/dag/builder.rs
+++ b/crates/ace-codegen/src/dag/builder.rs
@@ -405,7 +405,7 @@ mod tests {
         let root = source_builder.add(a, b);
         let dag = source_builder.build(root);
 
-        let rebuilt = DagBuilder::from_nodes(dag.nodes.clone());
+        let rebuilt = DagBuilder::from_nodes(dag.nodes);
         let mut foreign_builder = DagBuilder::<QuadFelt>::new();
         let foreign = foreign_builder.constant(felt(3));
 

--- a/crates/ace-codegen/src/dag/ir.rs
+++ b/crates/ace-codegen/src/dag/ir.rs
@@ -97,7 +97,7 @@ impl<EF> PeriodicColumnData<EF> {
 
     /// Maximum periodic column length (used to align powers).
     pub fn max_period(&self) -> usize {
-        self.coeffs.iter().map(|c| c.len()).max().unwrap_or(0)
+        self.coeffs.iter().map(Vec::len).max().unwrap_or(0)
     }
 
     /// Iterate over the per-column coefficient vectors.

--- a/crates/ace-codegen/src/layout/keys.rs
+++ b/crates/ace-codegen/src/layout/keys.rs
@@ -60,7 +60,7 @@ pub(crate) struct InputKeyMapper<'a> {
 
 impl InputKeyMapper<'_> {
     /// Return the input index for a key, if it exists in the layout.
-    pub(crate) fn index_of(&self, key: InputKey) -> Option<usize> {
+    pub(crate) fn index_of(self, key: InputKey) -> Option<usize> {
         let layout = self.layout;
         match key {
             InputKey::Public(i) => layout.regions.public_values.index(i),

--- a/crates/ace-codegen/src/testing.rs
+++ b/crates/ace-codegen/src/testing.rs
@@ -46,7 +46,7 @@ where
     if periodic_columns.is_empty() {
         return Vec::new();
     }
-    let max_len = periodic_columns.iter().map(|col| col.len()).max().unwrap_or(0);
+    let max_len = periodic_columns.iter().map(Vec::len).max().unwrap_or(0);
     let dft = Radix2DitParallel::<F>::default();
 
     periodic_columns

--- a/crates/assembly-syntax/src/ast/alias.rs
+++ b/crates/assembly-syntax/src/ast/alias.rs
@@ -119,11 +119,7 @@ impl crate::prettier::PrettyPrint for Alias {
     fn render(&self) -> crate::prettier::Document {
         use crate::prettier::*;
 
-        let mut doc = self
-            .docs
-            .as_ref()
-            .map(|docstring| docstring.render())
-            .unwrap_or(Document::Empty);
+        let mut doc = self.docs.as_ref().map(PrettyPrint::render).unwrap_or(Document::Empty);
 
         if self.visibility.is_public() {
             doc += display(self.visibility) + const_text(" ");

--- a/crates/assembly-syntax/src/ast/attribute/mod.rs
+++ b/crates/assembly-syntax/src/ast/attribute/mod.rs
@@ -178,7 +178,7 @@ impl prettier::PrettyPrint for Attribute {
                 let singleline_items = meta
                     .items
                     .iter()
-                    .map(|item| item.render())
+                    .map(PrettyPrint::render)
                     .reduce(|acc, item| acc + const_text(", ") + item)
                     .unwrap_or(Document::Empty);
                 let multiline_items = indent(
@@ -186,7 +186,7 @@ impl prettier::PrettyPrint for Attribute {
                     nl() + meta
                         .items
                         .iter()
-                        .map(|item| item.render())
+                        .map(PrettyPrint::render)
                         .reduce(|acc, item| acc + nl() + item)
                         .unwrap_or(Document::Empty),
                 ) + nl();

--- a/crates/assembly-syntax/src/ast/attribute/set.rs
+++ b/crates/assembly-syntax/src/ast/attribute/set.rs
@@ -44,7 +44,7 @@ impl AttributeSet {
         I: IntoIterator<Item = Attribute>,
     {
         let mut this = Self { attrs: attrs.into_iter().collect() };
-        this.attrs.sort_by_key(|attr| attr.id());
+        this.attrs.sort_by_key(Attribute::id);
         this.attrs.dedup_by_key(|attr| attr.id());
         this
     }

--- a/crates/assembly-syntax/src/ast/constants/eval.rs
+++ b/crates/assembly-syntax/src/ast/constants/eval.rs
@@ -330,7 +330,7 @@ where
 
                 if let Some(name) = path.as_ident() {
                     let name = name.with_span(path.span());
-                    if let Some(expr) = env.get(&name)?.map(|e| e.into_expr()) {
+                    if let Some(expr) = env.get(&name)?.map(CachedConstantValue::into_expr) {
                         env.on_eval_start(path.as_deref());
                         evaluating.push(path.clone());
                         continuations.push(Cont::Return(path.clone()));

--- a/crates/assembly-syntax/src/ast/constants/expr.rs
+++ b/crates/assembly-syntax/src/ast/constants/expr.rs
@@ -95,9 +95,8 @@ impl ConstantExpr {
     /// value, otherwise a bug occurred.
     #[track_caller]
     pub fn expect_value(&self) -> ConstantValue {
-        self.as_value().unwrap_or_else(|| {
-            panic!("expected constant expression to be a value, got {:#?}", self)
-        })
+        self.as_value()
+            .unwrap_or_else(|| panic!("expected constant expression to be a value, got {self:#?}"))
     }
 
     /// Try to convert this expression into a [ConstantValue], if the expression is a value.
@@ -417,7 +416,7 @@ pub enum ConstantOp {
 }
 
 impl ConstantOp {
-    const fn name(&self) -> &'static str {
+    const fn name(self) -> &'static str {
         match self {
             Self::Add => "Add",
             Self::Sub => "Sub",

--- a/crates/assembly-syntax/src/ast/constants/mod.rs
+++ b/crates/assembly-syntax/src/ast/constants/mod.rs
@@ -76,11 +76,7 @@ impl crate::prettier::PrettyPrint for Constant {
     fn render(&self) -> crate::prettier::Document {
         use crate::prettier::*;
 
-        let mut doc = self
-            .docs
-            .as_ref()
-            .map(|docstring| docstring.render())
-            .unwrap_or(Document::Empty);
+        let mut doc = self.docs.as_ref().map(PrettyPrint::render).unwrap_or(Document::Empty);
 
         doc += flatten(const_text("const") + const_text(" ") + display(&self.name));
         doc += const_text(" = ");

--- a/crates/assembly-syntax/src/ast/instruction/print.rs
+++ b/crates/assembly-syntax/src/ast/instruction/print.rs
@@ -413,9 +413,9 @@ mod tests {
         assert_eq!("push.3.4.8.9", instruction);
         let instruction = format!(
             "{}",
-            Instruction::Push(Immediate::Value(miden_debug_types::Span::unknown(
-                crate::parser::PushValue::Int(crate::parser::IntValue::U8(3))
-            )))
+            Instruction::Push(Immediate::Value(Span::unknown(crate::parser::PushValue::Int(
+                crate::parser::IntValue::U8(3)
+            ))))
         );
         assert_eq!("push.3", instruction);
 

--- a/crates/assembly-syntax/src/ast/instruction/print.rs
+++ b/crates/assembly-syntax/src/ast/instruction/print.rs
@@ -390,7 +390,11 @@ mod tests {
     use miden_core::crypto::hash::Poseidon2;
     use miden_debug_types::Span;
 
-    use crate::{Felt, ast::*};
+    use crate::{
+        Felt,
+        ast::*,
+        parser::{IntValue, PushValue},
+    };
 
     #[test]
     fn test_instruction_display() {
@@ -413,9 +417,7 @@ mod tests {
         assert_eq!("push.3.4.8.9", instruction);
         let instruction = format!(
             "{}",
-            Instruction::Push(Immediate::Value(Span::unknown(crate::parser::PushValue::Int(
-                crate::parser::IntValue::U8(3)
-            ))))
+            Instruction::Push(Immediate::Value(Span::unknown(PushValue::Int(IntValue::U8(3)))))
         );
         assert_eq!("push.3", instruction);
 

--- a/crates/assembly-syntax/src/ast/item/export.rs
+++ b/crates/assembly-syntax/src/ast/item/export.rs
@@ -47,10 +47,10 @@ impl Export {
     /// Returns the documentation for this item.
     pub fn docs(&self) -> Option<&str> {
         match self {
-            Self::Procedure(item) => item.docs().map(|spanned| spanned.into_inner()),
-            Self::Constant(item) => item.docs().map(|spanned| spanned.into_inner()),
-            Self::Type(item) => item.docs().map(|spanned| spanned.into_inner()),
-            Self::Alias(item) => item.docs().map(|spanned| spanned.into_inner()),
+            Self::Procedure(item) => item.docs().map(Span::into_inner),
+            Self::Constant(item) => item.docs().map(Span::into_inner),
+            Self::Type(item) => item.docs().map(Span::into_inner),
+            Self::Alias(item) => item.docs().map(Span::into_inner),
         }
     }
 

--- a/crates/assembly-syntax/src/ast/item/resolver/mod.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/mod.rs
@@ -114,7 +114,7 @@ impl LocalSymbolResolver {
         path: Span<&Path>,
     ) -> Result<SymbolResolution, SymbolResolutionError> {
         if path.is_absolute() {
-            return Ok(SymbolResolution::External(path.map(|p| p.into())));
+            return Ok(SymbolResolution::External(path.map(Into::into)));
         }
         log::debug!(target: "local-symbol-resolver", "resolving path '{path}'");
         let (ns, subpath) = path.split_first().expect("invalid item path");

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -432,7 +432,7 @@ impl Module {
     /// Returns true if this module has an entrypoint procedure defined,
     /// i.e. a `begin`..`end` block.
     pub fn has_entrypoint(&self) -> bool {
-        self.index_of(|p| p.is_main()).is_some()
+        self.index_of(Export::is_main).is_some()
     }
 
     /// Returns a reference to the advice map derived from this module
@@ -726,16 +726,16 @@ impl TypeResolver<SymbolResolutionError> for ModuleTypeResolver<'_> {
         &mut self,
         context: SourceSpan,
         _gid: GlobalItemIndex,
-    ) -> Result<ast::types::Type, SymbolResolutionError> {
+    ) -> Result<types::Type, SymbolResolutionError> {
         Err(SymbolResolutionError::undefined(context, &self.resolver.source_manager()))
     }
     fn get_local_type(
         &mut self,
         context: SourceSpan,
         id: ItemIndex,
-    ) -> Result<Option<ast::types::Type>, SymbolResolutionError> {
+    ) -> Result<Option<types::Type>, SymbolResolutionError> {
         match &self.module[id] {
-            super::Export::Type(ty) => match ty {
+            Export::Type(ty) => match ty {
                 TypeDecl::Alias(ty) => self.resolve(&ty.ty),
                 TypeDecl::Enum(ty) => Ok(Some(ty.ty().clone())),
             },

--- a/crates/assembly-syntax/src/ast/path/path.rs
+++ b/crates/assembly-syntax/src/ast/path/path.rs
@@ -44,7 +44,7 @@ impl<'de> serde::Deserialize<'de> for &'de Path {
         impl<'de> Visitor<'de> for PathVisitor {
             type Value = &'de Path;
 
-            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a borrowed Path")
             }
 
@@ -200,7 +200,7 @@ impl Path {
     ///
     /// Returns `None` if the path cannot be losslessly represented as a single component.
     pub fn as_ident(&self) -> Option<Ident> {
-        let mut components = self.components().filter_map(|c| c.ok());
+        let mut components = self.components().filter_map(Result::ok);
         match components.next()? {
             component @ PathComponent::Normal(_) => {
                 if components.next().is_none() {
@@ -322,7 +322,7 @@ impl Path {
         let mut components = self.components();
         match components.next()?.ok()? {
             PathComponent::Root => {
-                let first = components.next().and_then(|c| c.ok()).map(|c| c.as_str())?;
+                let first = components.next().and_then(Result::ok).map(|c| c.as_str())?;
                 Some((first, components.as_path()))
             },
             first @ PathComponent::Normal(_) => Some((first.as_str(), components.as_path())),
@@ -594,8 +594,8 @@ impl PartialEq<alloc::sync::Arc<Path>> for Path {
     }
 }
 
-impl PartialEq<alloc::borrow::Cow<'_, Path>> for Path {
-    fn eq(&self, other: &alloc::borrow::Cow<'_, Path>) -> bool {
+impl PartialEq<Cow<'_, Path>> for Path {
+    fn eq(&self, other: &Cow<'_, Path>) -> bool {
         self.inner == other.as_ref().inner
     }
 }

--- a/crates/assembly-syntax/src/ast/path/path_buf.rs
+++ b/crates/assembly-syntax/src/ast/path/path_buf.rs
@@ -372,7 +372,7 @@ impl<'de> serde::Deserialize<'de> for PathBuf {
         impl<'de> Visitor<'de> for PathVisitor {
             type Value = PathBuf;
 
-            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a valid Path/PathBuf")
             }
 
@@ -448,7 +448,7 @@ mod tests {
         assert_eq!(path.components().count(), 3);
         assert_eq!(path.last(), Some("baz"));
         assert_eq!(path.first(), Some("foo"));
-        assert_eq!(path.parent().map(|p| p.as_str()), Some("foo::bar"));
+        assert_eq!(path.parent().map(Path::as_str), Some("foo::bar"));
     }
 
     #[test]
@@ -476,7 +476,7 @@ mod tests {
         assert_eq!(path.components().count(), 3);
         assert_eq!(path.last(), Some("item"));
         assert_eq!(path.first(), Some("foo"));
-        assert_eq!(path.parent().map(|p| p.as_str()), Some("foo::\"miden::base/account@0.1.0\""));
+        assert_eq!(path.parent().map(Path::as_str), Some("foo::\"miden::base/account@0.1.0\""));
     }
 
     #[test]
@@ -560,7 +560,7 @@ mod tests {
             parent.as_str(),
             "::\"root_ns:root@1.0.0\"::abi_transform_tx_kernel_get_inputs_4"
         );
-        assert_eq!(parent.parent().map(|p| p.as_str()), Some("::\"root_ns:root@1.0.0\""));
+        assert_eq!(parent.parent().map(Path::as_str), Some("::\"root_ns:root@1.0.0\""));
 
         assert!(p2.is_absolute());
         assert_eq!(p2.components().count(), 4);
@@ -571,7 +571,7 @@ mod tests {
             parent.as_str(),
             "::\"root_ns:root@1.0.0\"::abi_transform_tx_kernel_get_inputs_4"
         );
-        assert_eq!(parent.parent().map(|p| p.as_str()), Some("::\"root_ns:root@1.0.0\""));
+        assert_eq!(parent.parent().map(Path::as_str), Some("::\"root_ns:root@1.0.0\""));
     }
 
     #[test]

--- a/crates/assembly-syntax/src/ast/procedure/name.rs
+++ b/crates/assembly-syntax/src/ast/procedure/name.rs
@@ -339,7 +339,7 @@ impl From<ProcedureName> for miette::SourceSpan {
     }
 }
 
-impl core::ops::Deref for ProcedureName {
+impl Deref for ProcedureName {
     type Target = str;
 
     #[inline(always)]

--- a/crates/assembly-syntax/src/ast/procedure/procedure.rs
+++ b/crates/assembly-syntax/src/ast/procedure/procedure.rs
@@ -262,17 +262,13 @@ impl crate::prettier::PrettyPrint for Procedure {
     fn render(&self) -> crate::prettier::Document {
         use crate::prettier::*;
 
-        let mut doc = self
-            .docs
-            .as_ref()
-            .map(|docstring| docstring.render())
-            .unwrap_or(Document::Empty);
+        let mut doc = self.docs.as_ref().map(PrettyPrint::render).unwrap_or(Document::Empty);
 
         if !self.attrs.is_empty() {
             doc += self
                 .attrs
                 .iter()
-                .map(|attr| attr.render())
+                .map(PrettyPrint::render)
                 .reduce(|acc, attr| acc + nl() + attr)
                 .unwrap_or(Document::Empty);
         }

--- a/crates/assembly-syntax/src/ast/type.rs
+++ b/crates/assembly-syntax/src/ast/type.rs
@@ -188,7 +188,7 @@ impl crate::prettier::PrettyPrint for FunctionType {
         let singleline_args = self
             .args
             .iter()
-            .map(|arg| arg.render())
+            .map(PrettyPrint::render)
             .reduce(|acc, arg| acc + const_text(", ") + arg)
             .unwrap_or(Document::Empty);
         let multiline_args = indent(
@@ -196,7 +196,7 @@ impl crate::prettier::PrettyPrint for FunctionType {
             nl() + self
                 .args
                 .iter()
-                .map(|arg| arg.render())
+                .map(PrettyPrint::render)
                 .reduce(|acc, arg| acc + const_text(",") + nl() + arg)
                 .unwrap_or(Document::Empty),
         ) + nl();
@@ -210,7 +210,7 @@ impl crate::prettier::PrettyPrint for FunctionType {
                 let results = self
                     .results
                     .iter()
-                    .map(|r| r.render())
+                    .map(PrettyPrint::render)
                     .reduce(|acc, r| acc + const_text(", ") + r)
                     .unwrap_or(Document::Empty);
                 args + const_text(" -> ") + const_text("(") + results + const_text(")")
@@ -353,11 +353,11 @@ impl TypeExpr {
             TypeExpr::Array(t) => Ok(t
                 .elem
                 .resolve_type_with_depth(resolver, depth + 1)?
-                .map(|elem| types::Type::Array(Arc::new(types::ArrayType::new(elem, t.arity))))),
+                .map(|elem| Type::Array(Arc::new(types::ArrayType::new(elem, t.arity))))),
             TypeExpr::Ptr(ty) => Ok(ty
                 .pointee
                 .resolve_type_with_depth(resolver, depth + 1)?
-                .map(|pointee| types::Type::Ptr(Arc::new(types::PointerType::new(pointee))))),
+                .map(|pointee| Type::Ptr(Arc::new(types::PointerType::new(pointee))))),
             TypeExpr::Struct(t) => {
                 let mut fields = Vec::with_capacity(t.fields.len());
                 for field in t.fields.iter() {
@@ -369,7 +369,7 @@ impl TypeExpr {
                     }
                 }
                 Ok(Some(Type::Struct(Arc::new(types::StructType::from_parts(
-                    t.name.clone().map(|id| id.into_inner()),
+                    t.name.clone().map(Ident::into_inner),
                     t.repr.into_inner(),
                     fields,
                 )))))
@@ -513,7 +513,7 @@ impl crate::prettier::PrettyPrint for PointerType {
 
         let doc = const_text("ptr<") + self.pointee.render();
         if let Some(addrspace) = self.addrspace.as_ref() {
-            doc + const_text(", ") + text(format!("addrspace({})", addrspace)) + const_text(">")
+            doc + const_text(", ") + text(format!("addrspace({addrspace})")) + const_text(">")
         } else {
             doc + const_text(">")
         }
@@ -653,7 +653,7 @@ impl crate::prettier::PrettyPrint for StructType {
         let singleline_body = self
             .fields
             .iter()
-            .map(|field| field.render())
+            .map(PrettyPrint::render)
             .reduce(|acc, field| acc + const_text(", ") + field)
             .unwrap_or(Document::Empty);
         let multiline_body = indent(
@@ -661,7 +661,7 @@ impl crate::prettier::PrettyPrint for StructType {
             nl() + self
                 .fields
                 .iter()
-                .map(|field| field.render())
+                .map(PrettyPrint::render)
                 .reduce(|acc, field| acc + const_text(",") + nl() + field)
                 .unwrap_or(Document::Empty),
         ) + nl();
@@ -810,11 +810,7 @@ impl crate::prettier::PrettyPrint for TypeAlias {
     fn render(&self) -> crate::prettier::Document {
         use crate::prettier::*;
 
-        let mut doc = self
-            .docs
-            .as_ref()
-            .map(|docstring| docstring.render())
-            .unwrap_or(Document::Empty);
+        let mut doc = self.docs.as_ref().map(PrettyPrint::render).unwrap_or(Document::Empty);
 
         if self.visibility.is_public() {
             doc += display(self.visibility) + const_text(" ");
@@ -993,16 +989,12 @@ impl crate::prettier::PrettyPrint for EnumType {
     fn render(&self) -> crate::prettier::Document {
         use crate::prettier::*;
 
-        let mut doc = self
-            .docs
-            .as_ref()
-            .map(|docstring| docstring.render())
-            .unwrap_or(Document::Empty);
+        let mut doc = self.docs.as_ref().map(PrettyPrint::render).unwrap_or(Document::Empty);
 
         let variants = self
             .variants
             .iter()
-            .map(|v| v.render())
+            .map(PrettyPrint::render)
             .reduce(|acc, v| acc + const_text(",") + nl() + v)
             .unwrap_or(Document::Empty);
 
@@ -1172,11 +1164,7 @@ impl crate::prettier::PrettyPrint for Variant {
     fn render(&self) -> crate::prettier::Document {
         use crate::prettier::*;
 
-        let doc = self
-            .docs
-            .as_ref()
-            .map(|docstring| docstring.render())
-            .unwrap_or(Document::Empty);
+        let doc = self.docs.as_ref().map(PrettyPrint::render).unwrap_or(Document::Empty);
 
         let name = display(&self.name);
         let name_and_payload = if let Some(value_ty) = self.value_ty.as_ref() {

--- a/crates/assembly-syntax/src/lib.rs
+++ b/crates/assembly-syntax/src/lib.rs
@@ -40,4 +40,4 @@ pub use self::{
 pub const MAX_REPEAT_COUNT: u32 = 1_000_000;
 
 /// The modulus of the Miden field as a raw u64 integer
-pub(crate) const FIELD_MODULUS: u64 = miden_core::Felt::ORDER_U64;
+pub(crate) const FIELD_MODULUS: u64 = Felt::ORDER_U64;

--- a/crates/assembly-syntax/src/library/mod.rs
+++ b/crates/assembly-syntax/src/library/mod.rs
@@ -13,7 +13,11 @@ use proptest::prelude::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::ast::{AttributeSet, Ident, Path, PathBuf, ProcedureName};
+#[cfg(feature = "arbitrary")]
+use crate::ast::QualifiedProcedureName;
+#[cfg(feature = "serde")]
+use crate::ast::path;
+use crate::ast::{AttributeSet, ConstantValue, Ident, Path, PathBuf, ProcedureName};
 
 mod error;
 mod module;
@@ -103,7 +107,7 @@ pub struct ProcedureExport {
     /// The id of the MAST root node of the exported procedure
     pub node: MastNodeId,
     /// The fully-qualified path of the exported procedure
-    #[cfg_attr(feature = "serde", serde(with = "crate::ast::path"))]
+    #[cfg_attr(feature = "serde", serde(with = "path"))]
     pub path: Arc<Path>,
     /// The type signature of the exported procedure, if known
     #[cfg_attr(feature = "serde", serde(default))]
@@ -163,7 +167,7 @@ impl Arbitrary for ProcedureExport {
             }));
 
         let nid = any::<MastNodeId>();
-        let name = any::<crate::ast::QualifiedProcedureName>();
+        let name = any::<QualifiedProcedureName>();
         (nid, name, signature)
             .prop_map(|(nodeid, procname, signature)| Self {
                 node: nodeid,
@@ -179,18 +183,27 @@ impl Arbitrary for ProcedureExport {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "arbitrary", derive(proptest_derive::Arbitrary))]
 #[cfg_attr(all(feature = "arbitrary", test), miden_test_serde_macros::serde_test)]
 pub struct ConstantExport {
     /// The fully-qualified path of the exported constant
-    #[cfg_attr(feature = "serde", serde(with = "crate::ast::path"))]
-    #[cfg_attr(
-        feature = "arbitrary",
-        proptest(strategy = "crate::arbitrary::path::constant_path_random_length(1)")
-    )]
+    #[cfg_attr(feature = "serde", serde(with = "path"))]
     pub path: Arc<Path>,
     /// The constant-folded AST representing the value of this constant
-    pub value: crate::ast::ConstantValue,
+    pub value: ConstantValue,
+}
+
+#[cfg(feature = "arbitrary")]
+impl Arbitrary for ConstantExport {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        let path = crate::arbitrary::path::constant_path_random_length(1);
+        let value = any::<ConstantValue>();
+
+        (path, value).prop_map(|(path, value)| Self { path, value }).boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -198,10 +211,10 @@ pub struct ConstantExport {
 #[cfg_attr(all(feature = "arbitrary", test), miden_test_serde_macros::serde_test)]
 pub struct TypeExport {
     /// The fully-qualified path of the exported type declaration
-    #[cfg_attr(feature = "serde", serde(with = "crate::ast::path"))]
+    #[cfg_attr(feature = "serde", serde(with = "path"))]
     pub path: Arc<Path>,
     /// The type bound to `name`
-    pub ty: crate::ast::types::Type,
+    pub ty: Type,
 }
 
 #[cfg(feature = "arbitrary")]
@@ -211,7 +224,7 @@ impl Arbitrary for TypeExport {
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
         use proptest::strategy::{Just, Strategy};
         let path = crate::arbitrary::path::user_defined_type_path_random_length(1);
-        let ty = Just(crate::ast::types::Type::Felt);
+        let ty = Just(Type::Felt);
 
         (path, ty).prop_map(|(path, ty)| Self { path, ty }).boxed()
     }
@@ -468,7 +481,7 @@ pub struct KernelLibrary {
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for KernelLibrary {
+impl Serialize for KernelLibrary {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -619,7 +632,7 @@ impl Deserializable for Library {
                     })
                 },
                 1 => {
-                    let value = crate::ast::ConstantValue::read_from(source)?;
+                    let value = ConstantValue::read_from(source)?;
                     LibraryExport::Constant(ConstantExport { path: path.clone(), value })
                 },
                 2 => {
@@ -646,7 +659,7 @@ impl Deserializable for Library {
 }
 
 #[cfg(feature = "serde")]
-impl serde::Serialize for Library {
+impl Serialize for Library {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -654,7 +667,7 @@ impl serde::Serialize for Library {
         use serde::ser::SerializeStruct;
 
         struct LibraryExports<'a>(&'a BTreeMap<Arc<Path>, LibraryExport>);
-        impl serde::Serialize for LibraryExports<'_> {
+        impl Serialize for LibraryExports<'_> {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
                 S: serde::Serializer,
@@ -678,7 +691,7 @@ impl serde::Serialize for Library {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for Library {
+impl<'de> Deserialize<'de> for Library {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -809,7 +822,7 @@ impl Serializable for LibraryExport {
 }
 
 #[cfg(feature = "arbitrary")]
-impl proptest::prelude::Arbitrary for Library {
+impl Arbitrary for Library {
     type Parameters = ();
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
@@ -885,5 +898,5 @@ impl proptest::prelude::Arbitrary for Library {
             .boxed()
     }
 
-    type Strategy = proptest::prelude::BoxedStrategy<Self>;
+    type Strategy = BoxedStrategy<Self>;
 }

--- a/crates/assembly-syntax/src/parse.rs
+++ b/crates/assembly-syntax/src/parse.rs
@@ -182,7 +182,7 @@ impl Parse for Arc<SourceFile> {
                 .uri()
                 .path()
                 .parse::<PathBuf>()
-                .map(|p| p.into())
+                .map(Into::into)
                 .into_diagnostic()
                 .wrap_err("cannot parse module as it has an invalid path/name")?,
         };
@@ -319,7 +319,7 @@ where
             None => self
                 .name()
                 .parse::<PathBuf>()
-                .map(|p| p.into())
+                .map(Into::into)
                 .into_diagnostic()
                 .wrap_err("cannot parse module as it has an invalid path/name")?,
         };

--- a/crates/assembly-syntax/src/parser/lexer.rs
+++ b/crates/assembly-syntax/src/parser/lexer.rs
@@ -541,7 +541,7 @@ impl<'input> Lexer<'input> {
             .map_err(|error| ParsingError::InvalidLiteral {
                 span: self.span(),
                 kind: int_error_kind_to_literal_error_kind(
-                    error.kind(),
+                    *error.kind(),
                     LiteralErrorKind::FeltOverflow,
                 ),
             })
@@ -624,7 +624,7 @@ fn pad_hex_if_needed<'a>(hex: &'a str) -> Cow<'a, str> {
         Cow::Borrowed(hex)
     } else {
         // allocate once, with exact capacity
-        let mut s = alloc::string::String::with_capacity(hex.len() + 1);
+        let mut s = String::with_capacity(hex.len() + 1);
         s.push('0');
         s.push_str(hex);
         Cow::Owned(s)
@@ -647,7 +647,7 @@ fn parse_hex<'input>(
                 ParsingError::InvalidLiteral {
                     span,
                     kind: int_error_kind_to_literal_error_kind(
-                        error.kind(),
+                        *error.kind(),
                         LiteralErrorKind::FeltOverflow,
                     ),
                 }
@@ -673,7 +673,7 @@ fn parse_hex<'input>(
                         ParsingError::InvalidLiteral {
                             span,
                             kind: int_error_kind_to_literal_error_kind(
-                                error.kind(),
+                                *error.kind(),
                                 LiteralErrorKind::FeltOverflow,
                             ),
                         }
@@ -702,7 +702,7 @@ fn parse_bin(span: SourceSpan, bin_digits: &str) -> Result<BinEncodedValue, Pars
             u32::from_str_radix(bin_digits, 2).map_err(|error| ParsingError::InvalidLiteral {
                 span,
                 kind: int_error_kind_to_literal_error_kind(
-                    error.kind(),
+                    *error.kind(),
                     LiteralErrorKind::U32Overflow,
                 ),
             })?;
@@ -743,7 +743,7 @@ fn shrink_u32_bin(n: u32) -> BinEncodedValue {
 
 #[inline]
 fn int_error_kind_to_literal_error_kind(
-    kind: &IntErrorKind,
+    kind: IntErrorKind,
     overflow: LiteralErrorKind,
 ) -> LiteralErrorKind {
     match kind {

--- a/crates/assembly-syntax/src/parser/mod.rs
+++ b/crates/assembly-syntax/src/parser/mod.rs
@@ -10,7 +10,10 @@ macro_rules! span {
 
 lalrpop_util::lalrpop_mod!(
     #[expect(clippy::all)]
+    #[expect(clippy::redundant_closure_for_method_calls)]
+    #[expect(clippy::trivially_copy_pass_by_ref)]
     #[expect(unused_lifetimes)]
+    #[expect(unused_qualifications)]
     grammar,
     "/parser/grammar.rs"
 );
@@ -95,7 +98,7 @@ impl ModuleParser {
     ) -> Result<Box<ast::Module>, Report> {
         let path = path.as_ref();
         if let Err(err) = Path::validate(path.as_str()) {
-            return Err(Report::msg(err.to_string()).with_source_code(source.clone()));
+            return Err(Report::msg(err.to_string()).with_source_code(source));
         }
         let forms = parse_forms_internal(source.clone(), &mut self.interned)
             .map_err(|err| Report::new(err).with_source_code(source.clone()))?;
@@ -270,7 +273,7 @@ mod module_walker {
         fn next_entry(
             &mut self,
             entry: &DirEntry,
-            ty: &FileType,
+            ty: FileType,
         ) -> Result<Option<ModuleEntry>, Report> {
             if ty.is_dir() {
                 let dir = entry.path();
@@ -325,7 +328,7 @@ mod module_walker {
                     .into_diagnostic();
 
                 match entry {
-                    Ok((ref entry, ref file_type)) => {
+                    Ok((ref entry, file_type)) => {
                         match self.next_entry(entry, file_type).transpose() {
                             None => {},
                             result => break result,

--- a/crates/assembly-syntax/src/sema/context.rs
+++ b/crates/assembly-syntax/src/sema/context.rs
@@ -137,7 +137,7 @@ impl AnalysisContext {
                 constant.span(),
                 PathBuf::from(constant.clone()).into(),
             ));
-            match crate::ast::constants::eval::expr(&expr, self) {
+            match constants::eval::expr(&expr, self) {
                 Ok(value) => {
                     self.constants.get_mut(constant).unwrap().value = value;
                 },

--- a/crates/assembly-syntax/src/sema/passes/const_eval.rs
+++ b/crates/assembly-syntax/src/sema/passes/const_eval.rs
@@ -61,7 +61,7 @@ where
                     ))) => {
                         // A reference to another constant was used, try to evaluate the expression
                         let expr = expr.clone();
-                        match crate::ast::constants::eval::expr(&expr, self.env) {
+                        match constants::eval::expr(&expr, self.env) {
                             Ok(ConstantExpr::Int(value)) => value,
                             // Unable to evaluate in the current context
                             Ok(ConstantExpr::Var(_) | ConstantExpr::BinaryOp { .. }) => {
@@ -131,7 +131,7 @@ where
             return ControlFlow::Continue(());
         }
 
-        match crate::ast::constants::eval::expr(&constant.value, self.env) {
+        match constants::eval::expr(&constant.value, self.env) {
             Ok(evaluated) => {
                 constant.value = evaluated;
             },
@@ -161,7 +161,7 @@ where
                 Ok(Some(CachedConstantValue::Miss(expr @ ConstantExpr::Var(_)))) => {
                     // A reference to another constant was used, try to evaluate the expression
                     let expr = expr.clone();
-                    match crate::ast::constants::eval::expr(&expr, self.env) {
+                    match constants::eval::expr(&expr, self.env) {
                         Ok(ConstantExpr::Hash(HashKind::Event, _)) => (),
                         // Unable to evaluate in the current context
                         Ok(ConstantExpr::Var(_)) => return ControlFlow::Continue(()),
@@ -203,7 +203,7 @@ where
                 },
             }
         }
-        crate::ast::visit::visit_mut_inst(self, inst)
+        visit::visit_mut_inst(self, inst)
     }
     fn visit_mut_immediate_u8(&mut self, imm: &mut Immediate<u8>) -> ControlFlow<()> {
         self.eval_const(imm)
@@ -224,7 +224,7 @@ where
                 let span = name.span();
                 match self.env.get_error(name) {
                     Ok(Some(value)) => {
-                        *imm = Immediate::Value(Span::new(span, value.clone()));
+                        *imm = Immediate::Value(Span::new(span, value));
                     },
                     // The constant is externally-defined, and not available yet
                     Ok(None) => (),
@@ -264,7 +264,7 @@ where
                     ))) => {
                         // A reference to another constant was used, try to evaluate the expression
                         let expr = expr.clone();
-                        match crate::ast::constants::eval::expr(&expr, self.env) {
+                        match constants::eval::expr(&expr, self.env) {
                             Ok(ConstantExpr::Int(value)) => {
                                 *imm = Immediate::Value(Span::new(
                                     span,
@@ -368,7 +368,7 @@ where
                     ))) => {
                         // A reference to another constant was used, try to evaluate the expression
                         let expr = expr.clone();
-                        match crate::ast::constants::eval::expr(&expr, self.env) {
+                        match constants::eval::expr(&expr, self.env) {
                             Ok(ConstantExpr::Int(value)) => {
                                 *imm = Immediate::Value(Span::new(
                                     span,
@@ -467,7 +467,7 @@ where
                     Ok(Some(CachedConstantValue::Miss(expr @ ConstantExpr::Var(_)))) => {
                         // A reference to another constant was used, try to evaluate the expression
                         let expr = expr.clone();
-                        match crate::ast::constants::eval::expr(&expr, self.env) {
+                        match constants::eval::expr(&expr, self.env) {
                             Ok(ConstantExpr::Word(value)) => {
                                 *imm = Immediate::Value(Span::new(span, *value.inner()));
                             },

--- a/crates/assembly-syntax/src/sema/passes/verify_invoke.rs
+++ b/crates/assembly-syntax/src/sema/passes/verify_invoke.rs
@@ -187,7 +187,7 @@ impl VisitMut for VerifyInvokeTargets<'_> {
                 Span::new(symbol.span(), PathBuf::from(symbol.clone()).into())
             },
         };
-        let current = self.current_procedure.as_ref().map(|p| p.as_ident());
+        let current = self.current_procedure.as_ref().map(ProcedureName::as_ident);
         if let Some(name) = path.as_ident() {
             let name = name.with_span(span);
             if current.is_some_and(|curr| curr == name) {

--- a/crates/assembly-syntax/src/testing/pattern.rs
+++ b/crates/assembly-syntax/src/testing/pattern.rs
@@ -37,11 +37,9 @@ impl Pattern {
         if !self.is_match(input) {
             panic!(
                 r"expected string was not found in emitted diagnostics:
-expected input to {expected}
-matched against: `{actual}`
-",
-                expected = self,
-                actual = input
+expected input to {self}
+matched against: `{input}`
+"
             );
         }
     }
@@ -55,12 +53,10 @@ matched against: `{actual}`
         if !self.is_match(input) {
             panic!(
                 r"expected string was not found in emitted diagnostics:
-expected input to {expected}
-matched against: `{actual}`
+expected input to {self}
+matched against: `{input}`
 full output: `{context}`
-",
-                expected = self,
-                actual = input
+"
             );
         }
     }

--- a/crates/assembly-syntax/src/testing/pattern.rs
+++ b/crates/assembly-syntax/src/testing/pattern.rs
@@ -36,10 +36,9 @@ impl Pattern {
         let input = input.as_ref();
         if !self.is_match(input) {
             panic!(
-                r"expected string was not found in emitted diagnostics:
-expected input to {self}
-matched against: `{input}`
-"
+                "expected string was not found in emitted diagnostics:\n\
+                 expected input to {self}\n\
+                 matched against: `{input}`"
             );
         }
     }
@@ -52,11 +51,10 @@ matched against: `{input}`
         let context = context.as_ref();
         if !self.is_match(input) {
             panic!(
-                r"expected string was not found in emitted diagnostics:
-expected input to {self}
-matched against: `{input}`
-full output: `{context}`
-"
+                "expected string was not found in emitted diagnostics:\n\
+                 expected input to {self}\n\
+                 matched against: `{input}`\n\
+                 full output: `{context}`"
             );
         }
     }

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -812,8 +812,7 @@ impl Assembler {
         self.apply_debug_options(&mut mast_forest);
 
         let mast = Arc::new(mast_forest);
-        let entry: Arc<Path> =
-            ast::Path::exec_path().join(ast::ProcedureName::MAIN_PROC_NAME).into();
+        let entry: Arc<Path> = Path::exec_path().join(ast::ProcedureName::MAIN_PROC_NAME).into();
         let entrypoint = LibraryExport::Procedure(ProcedureExport {
             node: entrypoint,
             path: entry.clone(),
@@ -981,7 +980,7 @@ impl Assembler {
                         procedure_gid,
                         is_program_entrypoint,
                         path,
-                        ast::Visibility::Public,
+                        Visibility::Public,
                         None,
                         module_kind.is_kernel(),
                         self.source_manager.clone(),

--- a/crates/assembly/src/assembler/product.rs
+++ b/crates/assembly/src/assembler/product.rs
@@ -51,7 +51,7 @@ impl AssemblyProduct {
     // TODO(pauls): This can be removed when we remove Library/KernelLibrary/Program
     pub fn into_program(self) -> Result<Program, Report> {
         assert_eq!(self.kind, TargetType::Executable);
-        let entry = ast::Path::exec_path().join(ast::ProcedureName::MAIN_PROC_NAME);
+        let entry = Path::exec_path().join(ast::ProcedureName::MAIN_PROC_NAME);
         let entrypoint = self.artifact.get_export_node_id(&entry);
         Ok(if let Some(kernel) = self.kernel {
             Program::with_kernel(self.artifact.mast_forest().clone(), entrypoint, kernel)

--- a/crates/assembly/src/instruction/mod.rs
+++ b/crates/assembly/src/instruction/mod.rs
@@ -594,16 +594,12 @@ impl Assembler {
             // ----- emit instruction -------------------------------------------------------------
             // emit: reads event ID from top of stack and execute the corresponding handler.
             Instruction::Emit => {
-                block_builder.push_ops([Operation::Emit]);
+                block_builder.push_ops([Emit]);
             },
             // emit.<id>: expands to `push.<id>, emit, drop` sequence leaving the stack unchanged.
             Instruction::EmitImm(event_id) => {
                 let event_id_value = event_id.expect_value();
-                block_builder.push_ops([
-                    Operation::Push(event_id_value),
-                    Operation::Emit,
-                    Operation::Drop,
-                ]);
+                block_builder.push_ops([Push(event_id_value), Emit, Drop]);
             },
 
             // ----- trace instruction ------------------------------------------------------------

--- a/crates/assembly/src/linker/callgraph.rs
+++ b/crates/assembly/src/linker/callgraph.rs
@@ -42,7 +42,7 @@ pub struct CallGraph {
 impl CallGraph {
     /// Gets the set of edges from the given caller to its callees in the graph.
     pub fn out_edges(&self, gid: GlobalItemIndex) -> &[GlobalItemIndex] {
-        self.nodes.get(&gid).map(|out_edges| out_edges.as_slice()).unwrap_or(&[])
+        self.nodes.get(&gid).map(Vec::as_slice).unwrap_or(&[])
     }
 
     /// Inserts a node in the graph for `id`, if not already present.

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -288,7 +288,7 @@ impl Linker {
                 .into_iter()
                 .enumerate()
                 .map(|(idx, item)| {
-                    let gid = module_index + ast::ItemIndex::new(idx);
+                    let gid = module_index + ItemIndex::new(idx);
                     self.callgraph.get_or_insert_node(gid);
                     Symbol::new(
                         item.name().clone(),
@@ -492,7 +492,7 @@ impl Linker {
         }
 
         // If no changes are being made, we're done
-        if self.modules.iter().all(|m| m.is_linked()) {
+        if self.modules.iter().all(LinkModule::is_linked) {
             return Ok(());
         }
 
@@ -787,7 +787,7 @@ impl Linker {
         &self,
         span: SourceSpan,
         gid: GlobalItemIndex,
-    ) -> Result<ast::types::Type, LinkerError> {
+    ) -> Result<types::Type, LinkerError> {
         use miden_assembly_syntax::ast::TypeResolver;
 
         let symbol_resolver = SymbolResolver::new(self);

--- a/crates/assembly/src/linker/module.rs
+++ b/crates/assembly/src/linker/module.rs
@@ -4,7 +4,7 @@ use core::{cell::Cell, ops::Index};
 use miden_assembly_syntax::{
     Path,
     ast::{
-        self, AliasTarget, ItemIndex, LocalSymbol, LocalSymbolResolver, ModuleIndex, ModuleKind,
+        AliasTarget, ItemIndex, LocalSymbol, LocalSymbolResolver, ModuleIndex, ModuleKind,
         SymbolResolution, SymbolResolutionError, SymbolTable,
     },
     debuginfo::{SourceManager, Span, Spanned},
@@ -230,7 +230,7 @@ impl<'a, 'b: 'a> SymbolTable for LinkModuleIter<'a, 'b> {
                     | SymbolItem::Constant(_)
                     | SymbolItem::Type(_) => {
                         let path = self.module.path.join(symbol.name());
-                        ast::LocalSymbol::Item {
+                        LocalSymbol::Item {
                             name: symbol.name().clone(),
                             resolved: SymbolResolution::Exact {
                                 gid,
@@ -244,7 +244,7 @@ impl<'a, 'b: 'a> SymbolTable for LinkModuleIter<'a, 'b> {
                         if let Some(resolved) = resolved.get() {
                             let path = self.resolver.item_path(gid);
                             let span = name.span();
-                            ast::LocalSymbol::Import {
+                            LocalSymbol::Import {
                                 name,
                                 resolution: Ok(SymbolResolution::Exact {
                                     gid: resolved,
@@ -253,7 +253,7 @@ impl<'a, 'b: 'a> SymbolTable for LinkModuleIter<'a, 'b> {
                             }
                         } else {
                             match alias.target() {
-                                AliasTarget::MastRoot(root) => ast::LocalSymbol::Import {
+                                AliasTarget::MastRoot(root) => LocalSymbol::Import {
                                     name,
                                     resolution: Ok(SymbolResolution::MastRoot(*root)),
                                 },
@@ -270,7 +270,7 @@ impl<'a, 'b: 'a> SymbolTable for LinkModuleIter<'a, 'b> {
                                         path.as_deref(),
                                         &source_manager,
                                     );
-                                    ast::LocalSymbol::Import { name, resolution }
+                                    LocalSymbol::Import { name, resolution }
                                 },
                             }
                         }

--- a/crates/assembly/src/linker/resolver/mod.rs
+++ b/crates/assembly/src/linker/resolver/mod.rs
@@ -36,7 +36,7 @@ pub struct Resolver<'a, 'b: 'a> {
 /// avoid recomputing the same information over and over again.
 #[derive(Default)]
 pub struct ResolverCache {
-    pub types: BTreeMap<GlobalItemIndex, ast::types::Type>,
+    pub types: BTreeMap<GlobalItemIndex, types::Type>,
     pub constants: BTreeMap<GlobalItemIndex, ast::ConstantValue>,
     pub evaluating_constants: BTreeMap<GlobalItemIndex, SourceSpan>,
 }

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -742,12 +742,12 @@ impl MastForestBuilder {
     ///
     /// This must be called before copying nodes from the subtree to ensure all decorator IDs
     /// can be properly remapped.
-    fn collect_decorators_from_subtree(&mut self, root_id: &MastNodeId) -> Result<(), Report> {
+    fn collect_decorators_from_subtree(&mut self, root_id: MastNodeId) -> Result<(), Report> {
         // Clear the decorator remapping for this subtree
         self.statically_linked_decorator_remapping.clear();
 
         // Iterate through all nodes in the subtree
-        for node_id in SubtreeIterator::new(root_id, &self.statically_linked_mast.clone()) {
+        for node_id in SubtreeIterator::new(&root_id, &self.statically_linked_mast.clone()) {
             // Get all decorator IDs used by this node
             let decorator_ids: Vec<DecoratorId> = {
                 let mut ids = Vec::new();
@@ -812,7 +812,7 @@ impl MastForestBuilder {
     pub fn ensure_external_link(&mut self, mast_root: Word) -> Result<MastNodeId, Report> {
         if let Some(root_id) = self.statically_linked_mast.find_procedure_root(mast_root) {
             // First, collect and copy all decorators from the subtree
-            self.collect_decorators_from_subtree(&root_id)?;
+            self.collect_decorators_from_subtree(root_id)?;
 
             // Then copy all nodes with remapped children and decorators
             for old_id in SubtreeIterator::new(&root_id, &self.statically_linked_mast.clone()) {
@@ -1026,7 +1026,7 @@ mod tests {
         ];
 
         let block1_id = builder
-            .ensure_block(block1_ops.clone(), block1_decorators, vec![], vec![], vec![])
+            .ensure_block(block1_ops, block1_decorators, vec![], vec![], vec![])
             .unwrap();
 
         // Sanity check the test itself makes sense
@@ -1047,7 +1047,7 @@ mod tests {
         ]; // [push mul] [3]
 
         let block2_id = builder
-            .ensure_block(block2_ops.clone(), block2_decorators, vec![], vec![], vec![])
+            .ensure_block(block2_ops, block2_decorators, vec![], vec![], vec![])
             .unwrap();
 
         // Merge the blocks
@@ -1158,7 +1158,7 @@ mod tests {
                             ),
                         }
                     } else {
-                        panic!("Operation index {} is out of bounds", op_idx);
+                        panic!("Operation index {op_idx} is out of bounds");
                     }
                 },
                 _ => panic!("Expected Trace decorator"),
@@ -1170,8 +1170,7 @@ mod tests {
         for expected_trace in expected_traces {
             assert!(
                 found_traces.contains(&expected_trace),
-                "Missing trace value: {}",
-                expected_trace
+                "Missing trace value: {expected_trace}"
             );
         }
 

--- a/crates/assembly/src/project.rs
+++ b/crates/assembly/src/project.rs
@@ -6,7 +6,7 @@ use std::{
 
 use miden_assembly_syntax::{
     ModuleParser,
-    ast::{self, ModuleKind, Path as MasmPath},
+    ast::{ModuleKind, Path as MasmPath},
     diagnostics::Report,
 };
 use miden_core::serde::{Deserializable, Serializable};
@@ -340,8 +340,7 @@ where
                     .map(|target| target.inner().clone())
                     .ok_or_else(|| {
                         Report::msg(format!(
-                            "dependency '{}' does not define a library target",
-                            package_id
+                            "dependency '{package_id}' does not define a library target"
                         ))
                     })?;
                 match self.try_reuse_registered_source_package(
@@ -380,8 +379,7 @@ where
                                 );
                                 if actual != expected {
                                     return Err(Report::msg(format!(
-                                        "package '{}' version '{}' is already registered as '{}', but the canonical artifact could not be loaded and rebuilding from source produced '{}'; bump the semantic version or repair the package store",
-                                        package_id, node_version, expected, actual
+                                        "package '{package_id}' version '{node_version}' is already registered as '{expected}', but the canonical artifact could not be loaded and rebuilding from source produced '{actual}'; bump the semantic version or repair the package store"
                                     )));
                                 }
                             },
@@ -395,8 +393,7 @@ where
                 let package =
                     self.load_canonical_package(package_id, &node_version)?.ok_or_else(|| {
                         Report::msg(format!(
-                            "dependency '{}' version '{}' was not found in the package registry",
-                            package_id, node_version
+                            "dependency '{package_id}' version '{node_version}' was not found in the package registry"
                         ))
                     })?;
                 ResolvedPackage {
@@ -532,8 +529,7 @@ where
                 actual.describe(),
             ))),
             None => Err(Report::msg(format!(
-                "package '{}' version '{}' is already registered, but the canonical artifact is missing source provenance; bump the semantic version",
-                package_id, version
+                "package '{package_id}' version '{version}' is already registered, but the canonical artifact is missing source provenance; bump the semantic version"
             ))),
         }?;
 
@@ -689,7 +685,7 @@ fn module_path_from_relative(
         })
         .collect::<Result<Vec<_>, Report>>()?;
 
-    if components.last().is_some_and(|component| *component == ast::Module::ROOT) {
+    if components.last().is_some_and(|component| *component == Module::ROOT) {
         components.pop();
     }
 

--- a/crates/assembly/src/project/dependency_graph.rs
+++ b/crates/assembly/src/project/dependency_graph.rs
@@ -52,7 +52,7 @@ impl DependencyGraph {
         let dependency_graph = if let Some(manifest_path) = project.manifest_path() {
             dependency_graph_builder.build_from_path(manifest_path)?
         } else {
-            dependency_graph_builder.build(project.clone())?
+            dependency_graph_builder.build(project)?
         };
 
         Ok(Self { dependency_graph, source_manager })
@@ -264,8 +264,7 @@ impl DependencyGraph {
                     .map(|target| target.inner().clone())
                     .ok_or_else(|| {
                         Report::msg(format!(
-                            "dependency '{}' does not define a library target",
-                            package_id
+                            "dependency '{package_id}' does not define a library target"
                         ))
                     })?;
                 let provenance = self.expected_source_provenance_with_visited(

--- a/crates/assembly/src/project/tests.rs
+++ b/crates/assembly/src/project/tests.rs
@@ -1436,7 +1436,7 @@ end
     context.assemble_library_package(&root_manifest, None).expect(
         "source dependency should rebuild from source when the canonical artifact is unreadable",
     );
-    assert_eq!(context.registry().loaded_packages(), vec![format!("dep@{}", dep_version)]);
+    assert_eq!(context.registry().loaded_packages(), vec![format!("dep@{dep_version}")]);
 }
 
 #[test]
@@ -2031,7 +2031,7 @@ fn preassembled_libraries_fall_back_to_embedded_kernel_when_store_artifact_is_un
     assert_eq!(embedded_kernel_package.digest(), kernel_package.digest());
     assert_eq!(
         context.registry().loaded_packages(),
-        vec![format!("kernelpkg@{}", kernel_version)]
+        vec![format!("kernelpkg@{kernel_version}")]
     );
 
     let round_tripped_program = MastPackage::read_from_bytes(&package.to_bytes())

--- a/crates/assembly/src/testing.rs
+++ b/crates/assembly/src/testing.rs
@@ -260,8 +260,7 @@ mod package_features {
 
     impl TestRegistry {
         pub fn add_package(&mut self, package: Arc<Package>) -> Version {
-            let version =
-                miden_package_registry::Version::new(package.version.clone(), package.digest());
+            let version = Version::new(package.version.clone(), package.digest());
             self.publish_package(package).expect("failed to add test package");
             version
         }
@@ -302,8 +301,7 @@ mod package_features {
                     Ok(())
                 },
                 Entry::Occupied(_) => Err(Report::msg(format!(
-                    "package '{}' version '{}' is already registered",
-                    name, semver
+                    "package '{name}' version '{semver}' is already registered"
                 ))),
             }
         }
@@ -326,8 +324,7 @@ mod package_features {
         type Error = Report;
 
         fn publish_package(&mut self, package: Arc<Package>) -> Result<Version, Self::Error> {
-            let version =
-                miden_package_registry::Version::new(package.version.clone(), package.digest());
+            let version = Version::new(package.version.clone(), package.digest());
             let dependencies = package
                 .manifest
                 .dependencies()
@@ -430,7 +427,7 @@ mod package_features {
             version: &str,
             export: &str,
             dependencies: impl IntoIterator<Item = (&'static str, &'a str, TargetType, Word)>,
-        ) -> Box<miden_mast_package::Package> {
+        ) -> Box<Package> {
             use alloc::string::ToString;
 
             use miden_assembly_syntax::source_file;

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -296,7 +296,7 @@ fn library_exports() -> Result<(), Report> {
     // make sure the library exports all exported procedures
     let expected_exports: BTreeSet<Arc<Path>> =
         [foo2.into(), foo3.into(), bar1.into(), bar2.into(), bar3.into(), bar5.into()].into();
-    let actual_exports: BTreeSet<_> = lib2.exports().map(|export| export.path()).collect();
+    let actual_exports: BTreeSet<_> = lib2.exports().map(LibraryExport::path).collect();
     assert_eq!(expected_exports, actual_exports);
 
     // make sure foo2, bar2, and bar3 map to the same MastNode
@@ -826,7 +826,7 @@ end
 #[test]
 fn enum_felt_discriminant_too_large_is_rejected() -> TestResult {
     let context = TestContext::default();
-    let modulus = miden_core::Felt::ORDER_U64;
+    let modulus = Felt::ORDER_U64;
     let source = source_file!(
         &context,
         format!(
@@ -851,7 +851,7 @@ end
 #[test]
 fn constant_expression_overflow_is_rejected() -> TestResult {
     let context = TestContext::default();
-    let modulus_minus_one = miden_core::Felt::ORDER_U64 - 1;
+    let modulus_minus_one = Felt::ORDER_U64 - 1;
     let source = source_file!(
         &context,
         format!(
@@ -4924,9 +4924,9 @@ fn issue_1644_single_forest_merge_identity() -> TestResult {
         new_merged_forest.nodes().iter().zip(merged_forest.nodes().iter()).enumerate()
     {
         if orig_node.digest() != merged_node.digest() {
-            eprintln!("Node {} digest violation:", i);
-            eprintln!("   Original: {:?}", orig_node);
-            eprintln!("   Merged:   {:?}", merged_node);
+            eprintln!("Node {i} digest violation:");
+            eprintln!("   Original: {orig_node:?}");
+            eprintln!("   Merged:   {merged_node:?}");
             eprintln!("   Original digest: {:?}", orig_node.digest());
             eprintln!("   Merged digest:   {:?}", merged_node.digest());
 
@@ -4942,7 +4942,7 @@ fn issue_1644_single_forest_merge_identity() -> TestResult {
         .enumerate()
     {
         if new_merged_forest[*orig_root].digest() != merged_forest[*merged_root].digest() {
-            eprintln!("Root {} digest violation:", i);
+            eprintln!("Root {i} digest violation:");
             eprintln!("   Original: {:?}", original_forest[*orig_root].digest());
             eprintln!("   Merged:   {:?}", merged_forest[*merged_root].digest());
             should_panic = true;
@@ -4972,7 +4972,7 @@ fn overlong_total_path_is_rejected_without_panic() {
     // but the total byte length exceeds u16::MAX (the binary serialization length prefix).
     let component = "a".repeat(255);
     let num_components: usize = 300;
-    let mut path_str = alloc::string::String::with_capacity(num_components * (component.len() + 2));
+    let mut path_str = String::with_capacity(num_components * (component.len() + 2));
     for i in 0..num_components {
         if i > 0 {
             path_str.push_str("::");

--- a/crates/debug-types/src/source_file.rs
+++ b/crates/debug-types/src/source_file.rs
@@ -54,7 +54,7 @@ impl miette::SourceCode for SourceFile {
         span: &miette::SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<alloc::boxed::Box<dyn miette::SpanContents<'a> + 'a>, miette::MietteError> {
+    ) -> Result<Box<dyn miette::SpanContents<'a> + 'a>, miette::MietteError> {
         let mut start =
             u32::try_from(span.offset()).map_err(|_| miette::MietteError::OutOfBounds)?;
         let len = u32::try_from(span.len()).map_err(|_| miette::MietteError::OutOfBounds)?;
@@ -62,7 +62,7 @@ impl miette::SourceCode for SourceFile {
         if context_lines_before > 0 {
             let line_index = self.content.line_index(start.into());
             let start_line_index = line_index.saturating_sub(context_lines_before as u32);
-            start = self.content.line_start(start_line_index).map(|idx| idx.to_u32()).unwrap_or(0);
+            start = self.content.line_start(start_line_index).map(ByteIndex::to_u32).unwrap_or(0);
         }
         if context_lines_after > 0 {
             let line_index = self.content.line_index(end.into());
@@ -382,7 +382,7 @@ impl miette::SourceCode for SourceFileRef {
         span: &miette::SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<alloc::boxed::Box<dyn miette::SpanContents<'a> + 'a>, miette::MietteError> {
+    ) -> Result<Box<dyn miette::SpanContents<'a> + 'a>, miette::MietteError> {
         self.file.read_span(span, context_lines_before, context_lines_after)
     }
 }

--- a/crates/debug-types/src/source_manager.rs
+++ b/crates/debug-types/src/source_manager.rs
@@ -343,7 +343,7 @@ impl DefaultSourceManagerImpl {
         self.files
             .push(file_clone)
             .expect("system limit: source manager has exhausted its supply of source ids");
-        self.uris.insert(uri.clone(), id);
+        self.uris.insert(uri, id);
         file
     }
 
@@ -474,7 +474,7 @@ mod error_assertions {
     use super::*;
 
     /// Asserts at compile time that the passed error has Send + Sync + 'static bounds.
-    fn _assert_error_is_send_sync_static<E: core::error::Error + Send + Sync + 'static>(_: E) {}
+    fn _assert_error_is_send_sync_static<E: Error + Send + Sync + 'static>(_: E) {}
 
     fn _assert_source_manager_error_bounds(err: SourceManagerError) {
         _assert_error_is_send_sync_static(err);

--- a/crates/debug-types/src/span.rs
+++ b/crates/debug-types/src/span.rs
@@ -68,7 +68,7 @@ impl<T> Span<T> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for Span<T> {
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for Span<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -79,7 +79,7 @@ impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for Span<T> {
 }
 
 #[cfg(feature = "serde")]
-impl<T: serde::Serialize> serde::Serialize for Span<T> {
+impl<T: Serialize> Serialize for Span<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/lib/core/build.rs
+++ b/crates/lib/core/build.rs
@@ -28,14 +28,14 @@ pub struct MarkdownRenderer {}
 impl MarkdownRenderer {
     fn write_docs_header(mut writer: &fs::File, ns: &str) {
         let header =
-            format!("\n## {}\n| Procedure | Description |\n| ----------- | ------------- |\n", ns);
+            format!("\n## {ns}\n| Procedure | Description |\n| ----------- | ------------- |\n");
         writer.write_all(header.as_bytes()).expect("unable to write header to writer");
     }
 
     fn write_docs_procedure(mut writer: &fs::File, name: &str, docs: Option<&str>) {
         if let Some(docs) = docs {
             let escaped = docs.replace('|', "\\|").replace('\n', "<br />");
-            let line = format!("| {} | {} |\n", name, escaped);
+            let line = format!("| {name} | {escaped} |\n");
             writer.write_all(line.as_bytes()).expect("unable to write func to writer");
         }
     }
@@ -137,7 +137,7 @@ fn find_masm_modules(base_dir: &Path, current_dir: &Path) -> io::Result<Vec<(Str
                     .collect::<Vec<_>>()
                     .join("::");
 
-                let label = format!("miden::core::{}", module_path);
+                let label = format!("miden::core::{module_path}");
 
                 modules.push((label, path));
             }
@@ -245,7 +245,7 @@ fn main() -> Result<(), Report> {
         .into_diagnostic()?;
 
     // Generate documentation
-    if std::env::var("MIDEN_BUILD_LIB_DOCS").is_ok() {
+    if env::var("MIDEN_BUILD_LIB_DOCS").is_ok() {
         build_core_lib_docs(&asm_dir, DOC_DIR_PATH).into_diagnostic()?;
     }
 

--- a/crates/lib/core/src/constraints_regen.rs
+++ b/crates/lib/core/src/constraints_regen.rs
@@ -198,11 +198,9 @@ pub fn constraints_eval_masm_matches_air() -> Result<(), String> {
     let artifact = compute_artifacts().map_err(|e| e.to_string())?;
     let masm = read_file(RELATION_DIGEST_PATHS.1);
     let actual_num_inputs: usize =
-        parse_masm_const(&masm, "NUM_INPUTS_CIRCUIT", "constraints_eval.masm")
-            .map_err(|e| e.to_string())?;
+        parse_masm_const(&masm, "NUM_INPUTS_CIRCUIT", "constraints_eval.masm")?;
     let actual_num_eval: usize =
-        parse_masm_const(&masm, "NUM_EVAL_GATES_CIRCUIT", "constraints_eval.masm")
-            .map_err(|e| e.to_string())?;
+        parse_masm_const(&masm, "NUM_EVAL_GATES_CIRCUIT", "constraints_eval.masm")?;
 
     let proc_start = masm
         .find("proc load_ace_circuit_description")
@@ -222,7 +220,7 @@ pub fn constraints_eval_masm_matches_air() -> Result<(), String> {
     let data_str = &masm[masm[..adv_start].len() + "adv_map CIRCUIT_COMMITMENT = [".len()..adv_end];
     let actual_data: Vec<Felt> = data_str
         .split(',')
-        .map(|s| s.trim())
+        .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(|s| {
             s.parse::<u64>()
@@ -233,9 +231,9 @@ pub fn constraints_eval_masm_matches_air() -> Result<(), String> {
     let actual_hash = Poseidon2::hash_elements(&actual_data);
 
     let actual_hash_u64: Vec<u64> =
-        actual_hash.as_elements().iter().map(|f| f.as_canonical_u64()).collect();
+        actual_hash.as_elements().iter().map(Felt::as_canonical_u64).collect();
     let expected_hash_u64: Vec<u64> =
-        artifact.circuit_commitment.iter().map(|f| f.as_canonical_u64()).collect();
+        artifact.circuit_commitment.iter().map(Felt::as_canonical_u64).collect();
 
     if actual_num_inputs != artifact.num_inputs {
         return Err(format!(
@@ -274,9 +272,7 @@ pub fn relation_digest_matches_air() -> Result<(), String> {
     let mut masm_digest: [Felt; 4] = [Felt::ZERO; 4];
     for (i, slot) in masm_digest.iter_mut().enumerate() {
         let name = format!("RELATION_DIGEST_{i}");
-        *slot = parse_masm_const::<u64>(&masm, &name, "sys/vm/mod.masm")
-            .map(Felt::new)
-            .map_err(|e| e.to_string())?;
+        *slot = parse_masm_const::<u64>(&masm, &name, "sys/vm/mod.masm").map(Felt::new)?;
     }
 
     if masm_digest != expected {

--- a/crates/lib/core/src/handlers/aead_decrypt.rs
+++ b/crates/lib/core/src/handlers/aead_decrypt.rs
@@ -95,8 +95,7 @@ pub fn handle_aead_decrypt(process: &ProcessorState) -> Result<Vec<AdviceMutatio
     let auth_tag = AuthTag::new(tag_elements);
 
     // Construct EncryptedData
-    let encrypted_data =
-        EncryptedData::from_parts(DataType::Elements, ciphertext, auth_tag, nonce.clone());
+    let encrypted_data = EncryptedData::from_parts(DataType::Elements, ciphertext, auth_tag, nonce);
 
     // Decrypt using the standard reference implementation
     // This performs tag verification internally

--- a/crates/lib/core/src/handlers/mod.rs
+++ b/crates/lib/core/src/handlers/mod.rs
@@ -56,7 +56,7 @@ pub(crate) fn read_memory_region(
     process: &ProcessorState,
     start_ptr: u64,
     len: u64,
-) -> Option<alloc::vec::Vec<Felt>> {
+) -> Option<Vec<Felt>> {
     // Validate inputs fit in u32
     let start_addr: u32 = start_ptr.try_into().ok()?;
     let len_u32: u32 = len.try_into().ok()?;

--- a/crates/lib/core/src/handlers/smt_peek.rs
+++ b/crates/lib/core/src/handlers/smt_peek.rs
@@ -51,7 +51,7 @@ pub fn handle_smt_peek(process: &ProcessorState) -> Result<Vec<AdviceMutation>, 
         .advice_provider()
         .get_tree_node(root, Felt::new(SMT_DEPTH as u64), key[3])
         .map_err(|err| SmtPeekError::AdviceProviderError {
-            message: format!("Failed to get tree node: {}", err),
+            message: format!("Failed to get tree node: {err}"),
         })?;
 
     if node == *empty_leaf {

--- a/crates/lib/core/tests/collections/mmr.rs
+++ b/crates/lib/core/tests/collections/mmr.rs
@@ -475,7 +475,7 @@ fn test_mmr_pack_roundtrip() {
     ";
     let test = build_test!(source, &stack, advice_stack, store, advice_map.iter().cloned());
     // Expected stack after pack: [HASH, ...], then swapw dropw leaves [h0, h1, h2, h3]
-    let expected_stack: Vec<u64> = hash.iter().map(|e| e.as_canonical_u64()).collect();
+    let expected_stack: Vec<u64> = hash.iter().map(Felt::as_canonical_u64).collect();
 
     let mut expect_memory: Vec<u64> = Vec::new();
 
@@ -823,5 +823,5 @@ fn digests_to_ints(digests: &[Word]) -> Vec<u64> {
 
 fn word_to_ints(word: &Word) -> Vec<u64> {
     let arr: [Felt; WORD_SIZE] = (*word).into();
-    arr.iter().map(|v| v.as_canonical_u64()).collect()
+    arr.iter().map(Felt::as_canonical_u64).collect()
 }

--- a/crates/lib/core/tests/crypto/circuit_evaluation.rs
+++ b/crates/lib/core/tests/crypto/circuit_evaluation.rs
@@ -84,7 +84,7 @@ fn circuit_evaluation_prove_verify() {
 
     // finalize the advice stack
     let adv_stack = data.repeat(num_repetitions);
-    let adv_stack: Vec<u64> = adv_stack.iter().map(|a| a.as_canonical_u64()).collect();
+    let adv_stack: Vec<u64> = adv_stack.iter().map(Felt::as_canonical_u64).collect();
 
     let test = miden_utils_testing::build_test!(source, &[], &adv_stack);
     test.expect_stack(&[]);
@@ -170,7 +170,7 @@ fn fill_inputs(layout: &miden_ace_codegen::InputLayout) -> Vec<QuadFelt> {
 }
 
 fn adjust_quotient_to_zero(
-    circuit: &miden_ace_codegen::AceCircuit<QuadFelt>,
+    circuit: &AceCircuit<QuadFelt>,
     layout: &miden_ace_codegen::InputLayout,
     inputs: &mut [QuadFelt],
 ) {
@@ -187,7 +187,7 @@ fn adjust_quotient_to_zero(
 }
 
 fn find_nonzero_quotient_slope(
-    circuit: &miden_ace_codegen::AceCircuit<QuadFelt>,
+    circuit: &AceCircuit<QuadFelt>,
     layout: &miden_ace_codegen::InputLayout,
     inputs: &mut [QuadFelt],
     root: QuadFelt,

--- a/crates/lib/core/tests/crypto/ecdsa_k256_keccak.rs
+++ b/crates/lib/core/tests/crypto/ecdsa_k256_keccak.rs
@@ -175,8 +175,7 @@ impl EventHandler for EcdsaSignatureHandler {
         };
         assert_eq!(
             provided_pk_commitment, pk_commitment,
-            "public key commitment mismatch: expected {:?}, got {:?}",
-            pk_commitment, provided_pk_commitment
+            "public key commitment mismatch: expected {pk_commitment:?}, got {provided_pk_commitment:?}"
         );
 
         // Message starts at position 5 (after event_id + pk_commitment)

--- a/crates/lib/core/tests/crypto/eddsa_ed25519.rs
+++ b/crates/lib/core/tests/crypto/eddsa_ed25519.rs
@@ -225,8 +225,7 @@ impl EventHandler for EddsaSignatureHandler {
         };
         assert_eq!(
             provided_pk_commitment, pk_commitment,
-            "public key commitment mismatch: expected {:?}, got {:?}",
-            pk_commitment, provided_pk_commitment
+            "public key commitment mismatch: expected {pk_commitment:?}, got {provided_pk_commitment:?}"
         );
 
         // Message starts at position 5 (after event_id + pk_commitment)

--- a/crates/lib/core/tests/crypto/falcon.rs
+++ b/crates/lib/core/tests/crypto/falcon.rs
@@ -82,7 +82,7 @@ pub fn push_falcon_signature(process: &ProcessorState) -> Result<Vec<AdviceMutat
     let sk_bytes: Vec<u8> = pk_sk_felts.iter().map(|f| f.as_canonical_u64() as u8).collect();
 
     // Reconstruct SecretKey from bytes
-    let sk = falcon512_poseidon2::SecretKey::read_from_bytes(&sk_bytes)
+    let sk = SecretKey::read_from_bytes(&sk_bytes)
         .map_err(|_| FalconError::MalformedSignatureKey { key_type: "Poseidon2 Falcon512" })?;
 
     let signature_result = falcon512_poseidon2::sign(&sk, msg)
@@ -113,11 +113,11 @@ fn test_falcon512_norm_sq() {
     ";
 
     // normalize(e) = e^2 - phi * (2*M*e - M^2) where phi := (e > (M - 1)/2)
-    let upper = rand::rng().random_range(Q + 1..M);
+    let upper = rng().random_range(Q + 1..M);
     let test_upper = build_test!(source, &[upper]);
     test_upper.expect_stack(&[(M - upper) * (M - upper)]);
 
-    let lower = rand::rng().random_range(0..=Q);
+    let lower = rng().random_range(0..=Q);
     let test_lower = build_test!(source, &[lower]);
     test_lower.expect_stack(&[lower * lower])
 }
@@ -386,7 +386,7 @@ fn test_mod_12289_rejects_forged_remainder_zero(#[case] a_hi: u64, #[case] a_lo:
 
     // Use the upstream test builder directly so we do not auto-register the honest
     // falcon_div handler from CoreLibrary.
-    let core_lib = miden_core_lib::CoreLibrary::default();
+    let core_lib = CoreLibrary::default();
     let test = miden_utils_testing::build_test_by_mode!(false, source, &op_stack, &adv_stack)
         .with_library(core_lib.library().clone())
         .with_event_handler(FALCON_DIV, malicious_falcon_div);
@@ -433,7 +433,7 @@ fn test_mod_12289_rejects_forged_addition_overflow() {
     let op_stack = vec![a >> 32, a & 0xffff_ffff];
     let adv_stack: Vec<u64> = vec![];
 
-    let core_lib = miden_core_lib::CoreLibrary::default();
+    let core_lib = CoreLibrary::default();
     let test = miden_utils_testing::build_test_by_mode!(false, source, &op_stack, &adv_stack)
         .with_library(core_lib.library().clone())
         .with_event_handler(FALCON_DIV, malicious_falcon_div);
@@ -477,7 +477,7 @@ fn test_mod_12289_rejects_non_u32_remainder_advice() {
     let op_stack = vec![0, 100_000];
     let adv_stack: Vec<u64> = vec![];
 
-    let core_lib = miden_core_lib::CoreLibrary::default();
+    let core_lib = CoreLibrary::default();
     let mut test = miden_utils_testing::build_test_by_mode!(false, source, &op_stack, &adv_stack);
     test.libraries.push(core_lib.library().clone());
     test.add_event_handler(FALCON_DIV, malicious_falcon_div);
@@ -552,7 +552,7 @@ fn generate_test(
 // ================================================================================================
 
 /// Creates random coefficients of a polynomial in the range (0..M) using the given RNG.
-fn random_coefficients_with_rng<R: rand::Rng>(rng: &mut R) -> Vec<Felt> {
+fn random_coefficients_with_rng<R: Rng>(rng: &mut R) -> Vec<Felt> {
     let mut res = Vec::new();
     for _i in 0..N {
         res.push(Felt::new(rng.random_range(0..M)))
@@ -597,7 +597,7 @@ fn generate_data_probabilistic_product_test(
         to_elements(h.clone())
     };
 
-    polynomials.extend(to_elements(s2.clone()));
+    polynomials.extend(to_elements(s2));
     polynomials.extend(pi.iter().map(|a| Felt::new(*a)));
 
     // get the challenge point and push it to the advice stack
@@ -611,7 +611,7 @@ fn generate_data_probabilistic_product_test(
     let advice_stack = builder.build_vec_u64();
 
     // compute hash of h and place it on the stack.
-    let h_hash = Poseidon2::hash_elements(&to_elements(h.clone()));
+    let h_hash = Poseidon2::hash_elements(&to_elements(h));
     let operand_stack = stack_from_words(&[h_hash]);
 
     (operand_stack, advice_stack)
@@ -622,5 +622,5 @@ fn generate_data_probabilistic_product_test(
 /// This matches `stack![]` semantics: `stack_from_words(&[A, B])` results in stack `[A, B, ...]`
 /// with A at position 0 (top).
 fn stack_from_words(words: &[Word]) -> Vec<u64> {
-    words.iter().flat_map(|w| w.iter().map(|f| f.as_canonical_u64())).collect()
+    words.iter().flat_map(|w| w.iter().map(Felt::as_canonical_u64)).collect()
 }

--- a/crates/lib/core/tests/mast_forest_merge.rs
+++ b/crates/lib/core/tests/mast_forest_merge.rs
@@ -75,7 +75,7 @@ fn test_core_lib_serialization_roundtrip() {
     for (idx, (orig_node, deser_node)) in
         original_forest.nodes().iter().zip(deserialized_forest.nodes()).enumerate()
     {
-        assert_eq!(orig_node.digest(), deser_node.digest(), "Node {} digest mismatch", idx);
+        assert_eq!(orig_node.digest(), deser_node.digest(), "Node {idx} digest mismatch");
 
         // For basic blocks, verify OpBatch structure is preserved
         if let (MastNode::Block(orig_block), MastNode::Block(deser_block)) = (orig_node, deser_node)
@@ -83,8 +83,7 @@ fn test_core_lib_serialization_roundtrip() {
             assert_eq!(
                 orig_block.op_batches(),
                 deser_block.op_batches(),
-                "Node {} OpBatch structure mismatch",
-                idx
+                "Node {idx} OpBatch structure mismatch"
             );
         }
     }

--- a/crates/lib/core/tests/math/u64_mod.rs
+++ b/crates/lib/core/tests/math/u64_mod.rs
@@ -698,7 +698,7 @@ fn ensure_div_doesnt_crash() {
                 }
             );
         },
-        Err(err) => panic!("Unexpected error type: {:?}", err),
+        Err(err) => panic!("Unexpected error type: {err:?}"),
     }
 
     // 2. dividend limbs not u32
@@ -720,7 +720,7 @@ fn ensure_div_doesnt_crash() {
                 }
             );
         },
-        Err(err) => panic!("Unexpected error type: {:?}", err),
+        Err(err) => panic!("Unexpected error type: {err:?}"),
     }
 }
 

--- a/crates/lib/core/tests/mem/mod.rs
+++ b/crates/lib/core/tests/mem/mod.rs
@@ -202,8 +202,7 @@ fn test_memcopy_elements() {
                 .read_element(ContextId::root(), Felt::from_u32(addr))
                 .unwrap(),
             Felt::from_u32(addr - 2000),
-            "Address {}",
-            addr
+            "Address {addr}"
         );
     }
 }

--- a/crates/lib/core/tests/stark/batch_query_gen.rs
+++ b/crates/lib/core/tests/stark/batch_query_gen.rs
@@ -144,8 +144,6 @@ fn reference_source(setup: &str) -> String {
         drop drop drop drop
     end
     "#,
-        RANDOM_COIN_OUTPUT_LEN_PTR = RANDOM_COIN_OUTPUT_LEN_PTR,
-        RANDOM_COIN_INPUT_LEN_PTR = RANDOM_COIN_INPUT_LEN_PTR,
     )
 }
 

--- a/crates/lib/core/tests/stark/verifier_recursive/mod.rs
+++ b/crates/lib/core/tests/stark/verifier_recursive/mod.rs
@@ -214,7 +214,7 @@ fn build_advice(
     //     the order observed into the Fiat-Shamir transcript).
     let final_poly = &pcs.fri_transcript.final_poly;
     let remainder_base: Vec<Felt> = QuadFelt::flatten_to_base(final_poly.to_vec());
-    let remainder_u64s: Vec<u64> = remainder_base.iter().map(|f| f.as_canonical_u64()).collect();
+    let remainder_u64s: Vec<u64> = remainder_base.iter().map(Felt::as_canonical_u64).collect();
     advice_stack.extend_from_slice(&remainder_u64s);
 
     // 14. Query PoW witness.
@@ -387,7 +387,7 @@ fn infer_widths<F, C>(batch: &BatchProof<F, C>) -> Vec<usize> {
         .openings
         .values()
         .next()
-        .map(|opening| opening.rows.iter_rows().map(|row| row.len()).collect())
+        .map(|opening| opening.rows.iter_rows().map(<[F]>::len).collect())
         .unwrap_or_default()
 }
 
@@ -400,7 +400,7 @@ fn build_kernel_digest_advice(kernel_digests: &[Word]) -> Vec<u64> {
     let mut result = Vec::with_capacity(kernel_digests.len() * 8);
     for digest in kernel_digests {
         let mut padded: Vec<u64> =
-            digest.as_elements().iter().map(|f| f.as_canonical_u64()).collect();
+            digest.as_elements().iter().map(Felt::as_canonical_u64).collect();
         padded.resize(8, 0);
         padded.reverse();
         result.extend_from_slice(&padded);
@@ -417,17 +417,17 @@ fn build_fixed_len_inputs(pub_inputs: &PublicInputs) -> Vec<u64> {
     felts.extend_from_slice(pub_inputs.stack_inputs().as_ref());
     felts.extend_from_slice(pub_inputs.stack_outputs().as_ref());
     felts.extend_from_slice(pub_inputs.pc_transcript_state().as_ref());
-    let mut fixed_len: Vec<u64> = felts.iter().map(|f| f.as_canonical_u64()).collect();
+    let mut fixed_len: Vec<u64> = felts.iter().map(Felt::as_canonical_u64).collect();
     fixed_len.resize(fixed_len.len().next_multiple_of(8), 0);
     fixed_len
 }
 
 fn commitment_to_u64s<C: Copy + Into<[Felt; 4]>>(commitment: C) -> Vec<u64> {
     let felts: [Felt; 4] = commitment.into();
-    felts.iter().map(|f| f.as_canonical_u64()).collect()
+    felts.iter().map(Felt::as_canonical_u64).collect()
 }
 
 fn challenges_to_u64s(challenges: &[Challenge]) -> Vec<u64> {
     let base: Vec<Felt> = QuadFelt::flatten_to_base(challenges.to_vec());
-    base.iter().map(|f| f.as_canonical_u64()).collect()
+    base.iter().map(Felt::as_canonical_u64).collect()
 }

--- a/crates/lib/core/tests/sys/mod.rs
+++ b/crates/lib/core/tests/sys/mod.rs
@@ -153,7 +153,7 @@ fn log_precompile_request_procedure() {
     let mut host = DefaultHost::default();
     let core_lib = CoreLibrary::default();
     host.load_library(&core_lib).expect("failed to load core library into host");
-    host.register_handler(EVENT_NAME, Arc::new(handler.clone()))
+    host.register_handler(EVENT_NAME, Arc::new(handler))
         .expect("failed to register dummy handler");
 
     let options = ProvingOptions::with_96_bit_security(HashFunction::Blake3_256);

--- a/crates/lib/core/tests/word/mod.rs
+++ b/crates/lib/core/tests/word/mod.rs
@@ -56,7 +56,7 @@ fn test_reverse() {
         prepend_word(&mut operand_stack, word);
 
         // reversew reverses [w0, w1, w2, w3] → [w3, w2, w1, w0]
-        let expected: Vec<u64> = word.iter().rev().map(|f| f.as_canonical_u64()).collect();
+        let expected: Vec<u64> = word.iter().rev().map(Felt::as_canonical_u64).collect();
         build_test!(SOURCE, &operand_stack).expect_stack(&expected);
     }
 }
@@ -142,19 +142,14 @@ fn store_word_u32s_le_stores_limbs() {
         use miden::core::word
 
         begin
-            push.{ptr}
-            push.{w3}
-            push.{w2}
-            push.{w1}
-            push.{w0}
+            push.{PTR}
+            push.{W3}
+            push.{W2}
+            push.{W1}
+            push.{W0}
             exec.word::store_word_u32s_le
         end
     ",
-        ptr = PTR,
-        w0 = W0,
-        w1 = W1,
-        w2 = W2,
-        w3 = W3,
     );
 
     let expected_mem = [w0_lo, w0_hi, w1_lo, w1_hi, w2_lo, w2_hi, w3_lo, w3_hi];

--- a/crates/package-registry/src/lib.rs
+++ b/crates/package-registry/src/lib.rs
@@ -82,7 +82,7 @@ impl PackageRecord {
 
     /// The digest of the MAST forest contained in this package
     pub fn digest(&self) -> Option<&Word> {
-        self.version.digest.as_ref().map(|word| word.inner())
+        self.version.digest.as_ref().map(LexicographicWord::inner)
     }
 
     /// Returns the package description, if known.

--- a/crates/package-registry/src/resolver/index.rs
+++ b/crates/package-registry/src/resolver/index.rs
@@ -44,7 +44,7 @@ impl InMemoryPackageRegistry {
         P: Into<PackageId>,
         V: Into<VersionRequirement>,
     {
-        let record_version = version.clone();
+        let record_version = version;
         let record = PackageRecord::new(
             record_version,
             dependencies

--- a/crates/package-registry/src/resolver/provider.rs
+++ b/crates/package-registry/src/resolver/provider.rs
@@ -44,7 +44,7 @@ impl<'a, R: PackageRegistry + ?Sized> PackageResolver<'a, R> {
         Self {
             index,
             context: ResolverContext::Workspace {
-                members: SmallVec::from_iter(members.into_iter().map(|member| member.into())),
+                members: SmallVec::from_iter(members.into_iter().map(Into::into)),
                 root: root.into(),
                 root_version: version,
             },
@@ -302,7 +302,7 @@ mod tests {
     use crate::{VersionReq, VersionRequirement};
 
     fn any() -> VersionRequirement {
-        VersionRequirement::from(VersionReq::STAR.clone())
+        VersionRequirement::from(VersionReq::STAR)
     }
 
     fn req(value: &str) -> VersionRequirement {
@@ -673,7 +673,7 @@ mod tests {
 
         assert!(matches!(
             error,
-            crate::resolver::index::InMemoryPackageStoreError::DuplicateSemanticVersion {
+            index::InMemoryPackageStoreError::DuplicateSemanticVersion {
                 package,
                 version,
             } if package == dep_id && version == "1.0.0".parse().unwrap()

--- a/crates/package-registry/src/resolver/pubgrub_compat.rs
+++ b/crates/package-registry/src/resolver/pubgrub_compat.rs
@@ -797,8 +797,6 @@ mod test {
     use std::{collections::HashSet, eprintln, format, ops::RangeBounds};
 
     use super::*;
-    use crate::semver;
-
     const OPS: &[&str] = &["^", "~", "=", "<", ">", "<=", ">="];
 
     #[test]
@@ -819,15 +817,15 @@ mod test {
                 "18446744073709551615.18446744073709551615.18446744073709551615",
             ] {
                 let raw_req = format!("{op}{psot}");
-                let req = semver::VersionReq::parse(&raw_req).unwrap();
+                let req = VersionReq::parse(&raw_req).unwrap();
                 let pver: SemverPubgrub = (&req).into();
                 let bounding_range = pver.bounding_range();
                 let raw_ver = "18446744073709551615.1.0";
-                let ver = semver::Version::parse(raw_ver).unwrap();
+                let ver = Version::parse(raw_ver).unwrap();
                 let mat = req.matches(&ver);
                 if mat != pver.contains(&ver) {
-                    eprintln!("{}", ver);
-                    eprintln!("{}", req);
+                    eprintln!("{ver}");
+                    eprintln!("{req}");
                     assert_eq!(mat, pver.contains(&ver));
                 }
 
@@ -859,15 +857,15 @@ mod test {
                 "0.0.2-r, ^0.0.1",
             ] {
                 let raw_req = format!("{op}{psot}");
-                let req = semver::VersionReq::parse(&raw_req).unwrap();
+                let req = VersionReq::parse(&raw_req).unwrap();
                 let pver: SemverPubgrub = (&req).into();
                 let bounding_range = pver.bounding_range();
                 for raw_ver in ["0.0.0-0", "0.0.1-z0", "0.0.2-z0", "0.9.8-z", "1.0.1-z0"] {
-                    let ver = semver::Version::parse(raw_ver).unwrap();
+                    let ver = Version::parse(raw_ver).unwrap();
                     let mat = req.matches(&ver);
                     if mat != pver.contains(&ver) {
-                        eprintln!("{}", ver);
-                        eprintln!("{}", req);
+                        eprintln!("{ver}");
+                        eprintln!("{req}");
                         assert_eq!(mat, pver.contains(&ver));
                     }
 
@@ -886,7 +884,7 @@ mod test {
             "0.0.2", "0.1.0-0", "0.1.0-r", "0.1.0", "0.1.1", "0.2.0-0", "0.2.0-r", "0.2.0",
             "1.0.0-0", "1.0.0-r", "1.0.0", "1.1.0", "2.0.0-0", "2.0.0-r", "2.0.0", "3.0.0",
         ];
-        let vers = raw_vers.map(|raw_ver| semver::Version::parse(raw_ver).unwrap());
+        let vers = raw_vers.map(|raw_ver| Version::parse(raw_ver).unwrap());
         assert!(vers.is_sorted());
         assert!(vers.is_sorted_by_key(SemverCompatibility::from));
         for op in OPS {
@@ -909,7 +907,7 @@ mod test {
                 "1.0.0-r, <=2.0.0-0",
             ] {
                 let raw_req = format!("{op}{psot}");
-                let req = semver::VersionReq::parse(&raw_req).unwrap();
+                let req = VersionReq::parse(&raw_req).unwrap();
                 let pver: SemverPubgrub = (&req).into();
 
                 let set: HashSet<_> = vers
@@ -917,8 +915,8 @@ mod test {
                     .filter_map(|ver| {
                         let mat = req.matches(ver);
                         if mat != pver.contains(ver) {
-                            eprintln!("{}", ver);
-                            eprintln!("{}", req);
+                            eprintln!("{ver}");
+                            eprintln!("{req}");
                             assert_eq!(mat, pver.contains(ver));
                         }
                         let cap: SemverCompatibility = ver.into();
@@ -939,10 +937,10 @@ mod test {
             "0.0.2", "0.1.0-0", "0.1.0-r", "0.1.0", "0.1.1", "0.2.0-0", "0.2.0-r", "0.2.0",
             "1.0.0-0", "1.0.0-r", "1.0.0", "1.1.0", "2.0.0-0", "2.0.0-r", "2.0.0", "3.0.0",
         ];
-        let vers = raw_vers.map(|raw_ver| semver::Version::parse(raw_ver).unwrap());
+        let vers = raw_vers.map(|raw_ver| Version::parse(raw_ver).unwrap());
         assert!(vers.is_sorted());
         assert!(vers.is_sorted_by_key(SemverCompatibility::from));
-        let reqs = vers.clone().map(|v| SemverPubgrub::singleton(v.clone()));
+        let reqs = vers.clone().map(SemverPubgrub::singleton);
         for pver in &reqs {
             pver.as_singleton().unwrap();
             // Singletons can only match one thing so they definitely only match one compatibility
@@ -956,7 +954,7 @@ mod test {
 
         for preq in req_unions {
             let set: HashSet<SemverCompatibility> =
-                vers.iter().filter(|ver| preq.contains(ver)).map(|ver| ver.into()).collect();
+                vers.iter().filter(|ver| preq.contains(ver)).map(Into::into).collect();
             let only_one_comp = preq.only_one_compatibility_range();
             assert_eq!(set.len() <= 1, only_one_comp.is_some());
             if only_one_comp.is_none() {

--- a/crates/package-registry/src/version_requirement.rs
+++ b/crates/package-registry/src/version_requirement.rs
@@ -123,10 +123,10 @@ impl<'de> Deserialize<'de> for VersionRequirement {
     {
         use core::str::FromStr;
 
-        let value = <alloc::string::String as Deserialize>::deserialize(deserializer)?;
+        let value = <String as Deserialize>::deserialize(deserializer)?;
 
         if value == "*" {
-            return Ok(Self::from(VersionReq::STAR.clone()));
+            return Ok(Self::from(VersionReq::STAR));
         }
 
         if let Some((version, digest)) = value.split_once('#') {

--- a/crates/project/src/ast/package.rs
+++ b/crates/project/src/ast/package.rs
@@ -450,7 +450,7 @@ impl Validate for ProjectFile {
                         entry.insert(None);
                     },
                     Entry::Occupied(mut entry) => {
-                        let path_span = target.path.as_ref().map(|p| p.span()).unwrap_or(span);
+                        let path_span = target.path.as_ref().map(Span::span).unwrap_or(span);
                         let conflict_label = Label::new(path_span, "conflict occurs here");
                         let path = entry.key().clone();
                         match entry.get_mut() {
@@ -482,7 +482,7 @@ impl Validate for ProjectFile {
                     entry.insert(None);
                 },
                 Entry::Occupied(mut entry) => {
-                    let ns_span = target.name.as_ref().map(|ns| ns.span()).unwrap_or(span);
+                    let ns_span = target.name.as_ref().map(Span::span).unwrap_or(span);
                     let conflict_label = Label::new(ns_span, "conflict occurs here");
                     let ns = entry.key().clone();
                     match entry.get_mut() {
@@ -509,7 +509,7 @@ impl Validate for ProjectFile {
 
         if !invalid_config.is_empty() {
             return Err(ProjectFileError::InvalidBuildTargets {
-                source_file: source.clone(),
+                source_file: source,
                 related: invalid_config,
             }
             .into());

--- a/crates/project/src/ast/parsing.rs
+++ b/crates/project/src/ast/parsing.rs
@@ -36,9 +36,9 @@ mod maybe_inherit {
 
     use super::MaybeInherit;
 
-    impl<'de, T> serde::Deserialize<'de> for MaybeInherit<T>
+    impl<'de, T> Deserialize<'de> for MaybeInherit<T>
     where
-        T: serde::Deserialize<'de>,
+        T: Deserialize<'de>,
     {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where

--- a/crates/project/src/ast/workspace.rs
+++ b/crates/project/src/ast/workspace.rs
@@ -135,7 +135,7 @@ impl Validate for WorkspaceFile {
                     "cannot use the 'workspace' option in a workspace-level dependency spec"
                 };
                 return Err(Report::from(ProjectFileError::InvalidWorkspaceDependency {
-                    source_file: source.clone(),
+                    source_file: source,
                     label: Label::new(dependency.span(), label),
                 }));
             }

--- a/crates/project/src/dependencies.rs
+++ b/crates/project/src/dependencies.rs
@@ -58,7 +58,7 @@ impl Dependency {
                 version.as_ref().map(|spanned| VersionRequirement::Semantic(spanned.clone()))
             },
         };
-        req.unwrap_or_else(|| VersionRequirement::from(VersionReq::STAR.clone()))
+        req.unwrap_or_else(|| VersionRequirement::from(VersionReq::STAR))
     }
 }
 

--- a/crates/project/src/dependencies/graph.rs
+++ b/crates/project/src/dependencies/graph.rs
@@ -339,7 +339,7 @@ impl<'a, R: PackageRegistry + ?Sized> ProjectDependencyGraphBuilder<'a, R> {
     ) -> Result<CollectedDependencyGraph, Report> {
         let root = loaded.package.name().into_inner();
         let mut graph = CollectedDependencyGraph {
-            root: root.clone(),
+            root,
             nodes: BTreeMap::new(),
             registry_requirements: BTreeMap::new(),
         };
@@ -529,10 +529,7 @@ impl<'a, R: PackageRegistry + ?Sized> ProjectDependencyGraphBuilder<'a, R> {
     ) -> Result<ProjectDependencyGraph, Report> {
         let CollectedDependencyGraph { root, nodes, registry_requirements } = collected;
         let local_packages = nodes.keys().cloned().collect::<BTreeSet<_>>();
-        let mut graph = ProjectDependencyGraph {
-            root: root.clone(),
-            nodes: BTreeMap::new(),
-        };
+        let mut graph = ProjectDependencyGraph { root, nodes: BTreeMap::new() };
 
         let direct_registry_dependencies = nodes
             .values()
@@ -720,7 +717,7 @@ impl<'a, R: PackageRegistry + ?Sized> ProjectDependencyGraphBuilder<'a, R> {
         match project {
             crate::Project::Package(package) => self.loaded_package_from_arc(package, None),
             crate::Project::WorkspacePackage { package, workspace } => {
-                let workspace_root = workspace.workspace_root().map(|path| path.to_path_buf());
+                let workspace_root = workspace.workspace_root().map(Path::to_path_buf);
                 self.loaded_package_from_arc(package, workspace_root)
             },
         }
@@ -735,7 +732,7 @@ impl<'a, R: PackageRegistry + ?Sized> ProjectDependencyGraphBuilder<'a, R> {
         match project {
             crate::Project::Package(package) => self.loaded_package_from_arc(package, None),
             crate::Project::WorkspacePackage { package, workspace } => {
-                let workspace_root = workspace.workspace_root().map(|path| path.to_path_buf());
+                let workspace_root = workspace.workspace_root().map(Path::to_path_buf);
                 self.loaded_package_from_arc(package, workspace_root)
             },
         }
@@ -746,7 +743,7 @@ impl<'a, R: PackageRegistry + ?Sized> ProjectDependencyGraphBuilder<'a, R> {
         package: Arc<Package>,
         workspace_root: Option<PathBuf>,
     ) -> Result<LoadedSourcePackage, Report> {
-        let manifest_path = package.manifest_path().map(|path| path.to_path_buf());
+        let manifest_path = package.manifest_path().map(Path::to_path_buf);
         let project_root = match manifest_path.as_ref() {
             Some(manifest_path) => Some(
                 manifest_path
@@ -817,7 +814,7 @@ impl<'a, R: PackageRegistry + ?Sized> ProjectDependencyGraphBuilder<'a, R> {
                     kind: package.kind,
                     requirements,
                 },
-                version: selected.version.clone(),
+                version: selected.version,
             },
             solver_dependencies,
         })
@@ -878,8 +875,7 @@ impl<'a, R: PackageRegistry + ?Sized> ProjectDependencyGraphBuilder<'a, R> {
             )))
         } else {
             Err(Report::msg(format!(
-                "dependency '{}' resolved to package '{}'",
-                expected_name, actual_name,
+                "dependency '{expected_name}' resolved to package '{actual_name}'",
             )))
         }
     }
@@ -1118,7 +1114,7 @@ mod tests {
 
     impl TestRegistry {
         fn insert(&mut self, name: &str, version: Version) {
-            let record_version = version.clone();
+            let record_version = version;
             self.insert_record(
                 PackageId::from(name),
                 PackageRecord::new(record_version, std::iter::empty()),
@@ -1136,8 +1132,7 @@ mod tests {
                     Ok(())
                 },
                 Entry::Occupied(_) => Err(Report::msg(format!(
-                    "package '{}' version '{}' is already registered",
-                    id, semver
+                    "package '{id}' version '{semver}' is already registered"
                 ))),
             }
         }
@@ -2050,10 +2045,10 @@ mod tests {
 
         let mut registry = TestRegistry::default();
         let dep_id = PackageId::from("dep");
-        let version010 = "0.1.0".parse::<miden_package_registry::SemVer>().unwrap();
-        let version999 = "9.9.9".parse::<miden_package_registry::SemVer>().unwrap();
-        registry.insert(&dep_id, Version::from(version010.clone()));
-        registry.insert(&dep_id, Version::from(version999.clone()));
+        let version010 = "0.1.0".parse::<SemVer>().unwrap();
+        let version999 = "9.9.9".parse::<SemVer>().unwrap();
+        registry.insert(&dep_id, Version::from(version010));
+        registry.insert(&dep_id, Version::from(version999));
         let graph = builder(&registry, &tempdir.path().join("git-cache"))
             .build_from_path(&app_manifest)
             .unwrap();

--- a/crates/project/src/package.rs
+++ b/crates/project/src/package.rs
@@ -307,7 +307,7 @@ impl Package {
 
         Ok(Box::new(Self {
             manifest_path,
-            name: package_ast.package.name.clone().map(|id| id.into()),
+            name: package_ast.package.name.map(Into::into),
             version,
             description,
             dependencies,
@@ -331,7 +331,7 @@ impl Package {
         let manifest_ast = ast::ProjectFile {
             source_file: None,
             package: ast::PackageTable {
-                name: self.name().map(|id| id.into_inner()),
+                name: self.name().map(PackageId::into_inner),
                 detail: ast::PackageDetail {
                     version: Some(
                         self.version().map(|v| ast::parsing::MaybeInherit::Value(v.clone())),

--- a/crates/project/src/workspace.rs
+++ b/crates/project/src/workspace.rs
@@ -87,7 +87,7 @@ impl Workspace {
         let members = file.workspace.members.clone();
 
         let mut workspace = Box::new(Workspace {
-            manifest_path: manifest_path.clone(),
+            manifest_path,
             members: Vec::with_capacity(members.len()),
         });
         let mut seen_member_names = Map::<String, SourceSpan>::default();
@@ -104,13 +104,12 @@ impl Workspace {
                 .into());
             };
             let relative_path = Path::new(member.as_str());
-            let member_dir =
-                crate::absolutize_path(relative_path, workspace_root).map_err(|err| {
-                    ProjectFileError::LoadWorkspaceMemberFailed {
-                        source_file: source.clone(),
-                        span: Label::new(member.span(), err.to_string()),
-                    }
-                })?;
+            let member_dir = absolutize_path(relative_path, workspace_root).map_err(|err| {
+                ProjectFileError::LoadWorkspaceMemberFailed {
+                    source_file: source.clone(),
+                    span: Label::new(member.span(), err.to_string()),
+                }
+            })?;
             if member_dir.strip_prefix(workspace_root).is_err() {
                 return Err(ProjectFileError::LoadWorkspaceMemberFailed {
                     source_file: source.clone(),

--- a/crates/test-serde-macros/src/lib.rs
+++ b/crates/test-serde-macros/src/lib.rs
@@ -155,7 +155,7 @@ pub fn serde_test(args: TokenStream, input: TokenStream) -> TokenStream {
     for (i, ty) in types.into_iter().enumerate() {
         let serde_test = if serde_test {
             let test_name =
-                Ident::new(&format!("test_serde_roundtrip_{}_{}", name, i), Span::mixed_site());
+                Ident::new(&format!("test_serde_roundtrip_{name}_{i}"), Span::mixed_site());
             quote! {
                 #[cfg(all(feature = "arbitrary", feature = "serde", test))]
                 proptest::proptest!{

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -507,7 +507,7 @@ impl Test {
             Err(err) => {
                 // If we get an error, we print the output as an error
                 #[cfg(feature = "std")]
-                std::eprintln!("{}", debug_output);
+                std::eprintln!("{debug_output}");
                 Err(err)
             },
         }
@@ -524,7 +524,7 @@ impl Test {
     pub fn prove_and_verify(&self, pub_inputs: Vec<u64>, test_fail: bool) {
         let (program, mut host) = self.get_program_and_host();
         let stack_inputs = StackInputs::try_from_ints(pub_inputs).unwrap();
-        let (mut stack_outputs, proof) = miden_prover::prove_sync(
+        let (mut stack_outputs, proof) = prove_sync(
             &program,
             stack_inputs,
             self.advice_inputs.clone(),
@@ -537,11 +537,9 @@ impl Test {
         let program_info = ProgramInfo::from(program);
         if test_fail {
             stack_outputs.as_mut()[0] += ONE;
-            assert!(
-                miden_verifier::verify(program_info, stack_inputs, stack_outputs, proof).is_err()
-            );
+            assert!(verify(program_info, stack_inputs, stack_outputs, proof).is_err());
         } else {
-            let result = miden_verifier::verify(program_info, stack_inputs, stack_outputs, proof);
+            let result = verify(program_info, stack_inputs, stack_outputs, proof);
             assert!(result.is_ok(), "error: {result:?}");
         }
     }
@@ -814,6 +812,6 @@ pub fn get_column_name(col_idx: usize) -> String {
         },
 
         // Default case
-        _ => format!("unknown_col[{}]", col_idx),
+        _ => format!("unknown_col[{col_idx}]"),
     }
 }

--- a/crates/utils-core-derive/src/lib.rs
+++ b/crates/utils-core-derive/src/lib.rs
@@ -203,7 +203,7 @@ fn generate_method_impl_for_trait_method(
         "to_builder" => {
             generate_to_builder_method(enum_name, variant_names, variant_fields, builder_type)
         },
-        _ => panic!("Unknown method: {}", method_name),
+        _ => panic!("Unknown method: {method_name}"),
     }
 }
 

--- a/crates/utils-diagnostics/src/related.rs
+++ b/crates/utils-diagnostics/src/related.rs
@@ -138,7 +138,7 @@ impl Diagnostic for RelatedLabel {
         if self.labels.is_empty() {
             None
         } else {
-            Some(Box::new(self.labels.iter().cloned().map(|l| l.into())))
+            Some(Box::new(self.labels.iter().cloned().map(Into::into)))
         }
     }
     fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {

--- a/crates/utils-diagnostics/src/reporting.rs
+++ b/crates/utils-diagnostics/src/reporting.rs
@@ -19,7 +19,7 @@ pub fn set_panic_hook() {
 pub type ReportHandlerOpts = miette::MietteHandlerOpts;
 
 #[cfg(feature = "std")]
-pub type DefaultReportHandler = miette::GraphicalReportHandler;
+pub type DefaultReportHandler = GraphicalReportHandler;
 
 #[cfg(not(feature = "std"))]
 pub type DefaultReportHandler = miette::DebugReportHandler;
@@ -63,19 +63,19 @@ impl<D: AsRef<dyn super::Diagnostic>> PrintDiagnostic<D, JSONReportHandler> {
 }
 
 impl<D: AsRef<dyn super::Diagnostic>> fmt::Display for PrintDiagnostic<D> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.handler.render_report(f, self.diag.as_ref())
     }
 }
 
 impl<D: AsRef<dyn super::Diagnostic>> fmt::Display for PrintDiagnostic<D, NarratableReportHandler> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.handler.render_report(f, self.diag.as_ref())
     }
 }
 
 impl<D: AsRef<dyn super::Diagnostic>> fmt::Display for PrintDiagnostic<D, JSONReportHandler> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.handler.render_report(f, self.diag.as_ref())
     }
 }

--- a/crates/utils-indexing/src/csr.rs
+++ b/crates/utils-indexing/src/csr.rs
@@ -441,7 +441,7 @@ mod tests {
         csr.push_empty_row().unwrap();
         csr.push_row([3]).unwrap();
 
-        let items: alloc::vec::Vec<_> = csr.iter().collect();
+        let items: Vec<_> = csr.iter().collect();
         assert_eq!(items.len(), 3);
         assert_eq!(items[0], (TestRowId::from(0), &[1, 2][..]));
         assert_eq!(items[1], (TestRowId::from(1), &[][..]));
@@ -454,7 +454,7 @@ mod tests {
         csr.push_row([10, 20]).unwrap();
         csr.push_row([30]).unwrap();
 
-        let items: alloc::vec::Vec<_> = csr.iter_enumerated().collect();
+        let items: Vec<_> = csr.iter_enumerated().collect();
         assert_eq!(items.len(), 3);
         assert_eq!(items[0], (TestRowId::from(0), 0, &10));
         assert_eq!(items[1], (TestRowId::from(0), 1, &20));

--- a/crates/utils-indexing/src/lib.rs
+++ b/crates/utils-indexing/src/lib.rs
@@ -293,7 +293,7 @@ where
 
 impl<I: Idx, T> IntoIterator for IndexVec<I, T> {
     type Item = T;
-    type IntoIter = alloc::vec::IntoIter<T>;
+    type IntoIter = vec::IntoIter<T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.raw.into_iter()

--- a/miden-vm/src/cli/data.rs
+++ b/miden-vm/src/cli/data.rs
@@ -102,7 +102,7 @@ pub struct ProgramFile<S: SourceManager = DefaultSourceManager> {
 impl ProgramFile {
     /// Reads the masm file at the specified path and parses it into a [ProgramFile].
     pub fn read(path: impl AsRef<Path>) -> Result<Self, Report> {
-        let source_manager = Arc::new(miden_assembly::DefaultSourceManager::default());
+        let source_manager = Arc::new(DefaultSourceManager::default());
         Self::read_with(path, source_manager)
     }
 }

--- a/miden-vm/tests/integration/air/chiplets/hasher.rs
+++ b/miden-vm/tests/integration/air/chiplets/hasher.rs
@@ -26,7 +26,7 @@ fn mtree_get() {
 
     let index = 3usize;
     let (leaves, store) = init_merkle_store(&[1, 2, 3, 4, 5, 6, 7, 8]);
-    let tree = MerkleTree::new(leaves.clone()).unwrap();
+    let tree = MerkleTree::new(leaves).unwrap();
 
     let stack_inputs = [
         tree.depth() as u64,
@@ -78,8 +78,8 @@ fn mtree_merge() {
 
     let leaves_a = init_merkle_store(&[1, 2, 3, 4, 5, 6, 7, 8]).0;
     let leaves_b = init_merkle_store(&[9, 10, 11, 12, 13, 14, 15, 16]).0;
-    let tree_a = MerkleTree::new(leaves_a.clone()).unwrap();
-    let tree_b = MerkleTree::new(leaves_b.clone()).unwrap();
+    let tree_a = MerkleTree::new(leaves_a).unwrap();
+    let tree_b = MerkleTree::new(leaves_b).unwrap();
     let root_a = tree_a.root();
     let root_b = tree_b.root();
     let root_merged = Poseidon2::merge(&[root_a, root_b]);
@@ -119,8 +119,8 @@ fn mtree_merge_then_get() {
     // the hmerge output.
     let leaves_a = init_merkle_store(&[1, 2, 3, 4, 5, 6, 7, 8]).0;
     let leaves_b = init_merkle_store(&[9, 10, 11, 12, 13, 14, 15, 16]).0;
-    let tree_a = MerkleTree::new(leaves_a.clone()).unwrap();
-    let tree_b = MerkleTree::new(leaves_b.clone()).unwrap();
+    let tree_a = MerkleTree::new(leaves_a).unwrap();
+    let tree_b = MerkleTree::new(leaves_b).unwrap();
     let root_a = tree_a.root();
     let root_b = tree_b.root();
 

--- a/miden-vm/tests/integration/exec.rs
+++ b/miden-vm/tests/integration/exec.rs
@@ -50,7 +50,7 @@ fn advice_map_loaded_before_execution() {
     let key = Word::new([ONE, ONE, ONE, ONE]);
     let value = vec![ONE, ONE];
 
-    let mut mast_forest = mast_forest.clone();
+    let mut mast_forest = mast_forest;
     mast_forest.advice_map_mut().insert(key, value);
     let program_with_advice_map =
         Program::new(mast_forest.into(), program_without_advice_map.entrypoint());

--- a/miden-vm/tests/integration/operations/crypto_ops.rs
+++ b/miden-vm/tests/integration/operations/crypto_ops.rs
@@ -80,7 +80,7 @@ fn hperm() {
     let expected_stack_slice = stack_inputs.iter().map(|&v| Felt::new(v)).collect::<Vec<Felt>>();
 
     let values_to_hash: Vec<u64> = vec![1, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0];
-    let mut full_inputs = values_to_hash.clone();
+    let mut full_inputs = values_to_hash;
     full_inputs.extend_from_slice(&stack_inputs);
 
     let test = build_op_test!(asm_op, &full_inputs);
@@ -107,7 +107,7 @@ fn hmerge() {
     let expected_stack_slice = stack_inputs.iter().map(|&v| Felt::new(v)).collect::<Vec<Felt>>();
 
     let values_to_hash: Vec<u64> = vec![1, 1, 0, 0, 0, 0, 0, 0];
-    let mut full_inputs = values_to_hash.clone();
+    let mut full_inputs = values_to_hash;
     full_inputs.extend_from_slice(&stack_inputs);
 
     let test = build_op_test!(asm_op, &full_inputs);
@@ -244,7 +244,7 @@ fn mtree_update() {
     let tree = MerkleTree::new(leaves.clone()).unwrap();
 
     let new_node = init_merkle_leaf(9);
-    let mut new_leaves = leaves.clone();
+    let mut new_leaves = leaves;
     new_leaves[index] = new_node;
     let new_tree = MerkleTree::new(new_leaves).unwrap();
 
@@ -282,7 +282,7 @@ fn mtree_update() {
         new_tree.root()[3].as_canonical_u64(),
     ];
 
-    let test = build_op_test!(asm_op, &stack_inputs, &[], store.clone());
+    let test = build_op_test!(asm_op, &stack_inputs, &[], store);
     test.expect_stack(&final_stack);
 }
 

--- a/miden-vm/tests/integration/operations/fri_ops.rs
+++ b/miden-vm/tests/integration/operations/fri_ops.rs
@@ -6,10 +6,8 @@ use miden_utils_testing::{Felt, TRUNCATE_STACK_PROC, build_test, push_inputs, ra
 #[test]
 fn fri_ext2fold4() {
     // create a set of random inputs
-    let mut inputs = rand_array::<Felt, 17>()
-        .iter()
-        .map(|v| v.as_canonical_u64())
-        .collect::<Vec<_>>();
+    let mut inputs =
+        rand_array::<Felt, 17>().iter().map(Felt::as_canonical_u64).collect::<Vec<_>>();
     // inputs[7] -> stack[9] = p (bit-reversed tree index).
     // The instruction computes d_seg = p & 3 and f_pos = p >> 2.
     // We want d_seg=2, f_pos=inputs[8], so p = 4*f_pos + 2.

--- a/miden-vm/tests/integration/operations/io_ops/constant_ops.rs
+++ b/miden-vm/tests/integration/operations/io_ops/constant_ops.rs
@@ -104,7 +104,7 @@ proptest! {
 
         // Calculate expected value by padding with leading zero for odd lengths
         let padded_hex = if hex_str.len() % 2 == 1 {
-            format!("0{}", hex_str)
+            format!("0{hex_str}")
         } else {
             hex_str.clone()
         };
@@ -113,7 +113,7 @@ proptest! {
         let expected = u64::from_str_radix(&padded_hex, 16).unwrap();
 
         // Build assembly operation
-        let asm_op = format!("push.0x{}", hex_str);
+        let asm_op = format!("push.0x{hex_str}");
 
         // Test that it parses and executes correctly
         let test = build_op_test!(&asm_op);

--- a/miden-vm/tests/integration/prove_verify.rs
+++ b/miden-vm/tests/integration/prove_verify.rs
@@ -39,7 +39,7 @@ fn assert_prove_verify(
 
     println!("Proof generated successfully!");
     if print_stack_outputs {
-        println!("Stack outputs: {:?}", stack_outputs);
+        println!("Stack outputs: {stack_outputs:?}");
     }
 
     if verify_recursively {
@@ -56,7 +56,7 @@ fn assert_prove_verify(
     let security_level =
         verify(program.into(), stack_inputs, stack_outputs, proof).expect("Verification failed");
 
-    println!("Verification successful! Security level: {}", security_level);
+    println!("Verification successful! Security level: {security_level}");
 }
 
 fn assert_recursive_verify(
@@ -281,7 +281,7 @@ mod recursive_verifier {
 
         let final_poly = &pcs.fri_transcript.final_poly;
         let remainder_base: Vec<Felt> = QuadFelt::flatten_to_base(final_poly.to_vec());
-        advice_stack.extend(remainder_base.iter().map(|felt| felt.as_canonical_u64()));
+        advice_stack.extend(remainder_base.iter().map(Felt::as_canonical_u64));
         advice_stack.push(pcs.query_pow_witness.as_canonical_u64());
 
         let (store, advice_map) = build_merkle_data(config, stark, log_trace_height);
@@ -413,7 +413,7 @@ mod recursive_verifier {
             .openings
             .values()
             .next()
-            .map(|opening| opening.rows.iter_rows().map(|row| row.len()).collect())
+            .map(|opening| opening.rows.iter_rows().map(<[F]>::len).collect())
             .unwrap_or_default()
     }
 
@@ -421,7 +421,7 @@ mod recursive_verifier {
         let mut result = Vec::with_capacity(kernel_digests.len() * 8);
         for digest in kernel_digests {
             let mut padded: Vec<u64> =
-                digest.as_elements().iter().map(|felt| felt.as_canonical_u64()).collect();
+                digest.as_elements().iter().map(Felt::as_canonical_u64).collect();
             padded.resize(8, 0);
             padded.reverse();
             result.extend_from_slice(&padded);
@@ -436,19 +436,19 @@ mod recursive_verifier {
         felts.extend_from_slice(pub_inputs.stack_outputs().as_ref());
         felts.extend_from_slice(pub_inputs.pc_transcript_state().as_ref());
 
-        let mut fixed_len: Vec<u64> = felts.iter().map(|felt| felt.as_canonical_u64()).collect();
+        let mut fixed_len: Vec<u64> = felts.iter().map(Felt::as_canonical_u64).collect();
         fixed_len.resize(fixed_len.len().next_multiple_of(8), 0);
         fixed_len
     }
 
     fn commitment_to_u64s<C: Copy + Into<[Felt; 4]>>(commitment: C) -> Vec<u64> {
         let felts: [Felt; 4] = commitment.into();
-        felts.iter().map(|felt| felt.as_canonical_u64()).collect()
+        felts.iter().map(Felt::as_canonical_u64).collect()
     }
 
     fn challenges_to_u64s(challenges: &[Challenge]) -> Vec<u64> {
         let base: Vec<Felt> = QuadFelt::flatten_to_base(challenges.to_vec());
-        base.iter().map(|felt| felt.as_canonical_u64()).collect()
+        base.iter().map(Felt::as_canonical_u64).collect()
     }
 }
 
@@ -528,7 +528,7 @@ mod fast_parallel {
         let advice_inputs = AdviceInputs::default();
         let mut host = default_source_manager_host();
         let trace_inputs =
-            execute_parallel_trace_inputs(&program, stack_inputs, advice_inputs.clone(), &mut host);
+            execute_parallel_trace_inputs(&program, stack_inputs, advice_inputs, &mut host);
 
         let fast_stack_outputs = *trace_inputs.stack_outputs();
 

--- a/processor/src/continuation_stack.rs
+++ b/processor/src/continuation_stack.rs
@@ -239,8 +239,7 @@ mod tests {
     #[test]
     fn get_next_clock_cycle_increment_empty_stack() {
         let stack = ContinuationStack::default();
-        let result: Vec<_> = stack.iter_continuations_for_next_clock().collect();
-        assert!(result.is_empty());
+        assert!(stack.iter_continuations_for_next_clock().next().is_none());
     }
 
     #[test]

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -42,8 +42,8 @@ pub enum ExecutionError {
     #[error("exceeded the allowed number of max cycles {0}")]
     CycleLimitExceeded(u32),
     #[error("error during processing of event {}", match event_name {
-        Some(name) => format!("'{}' (ID: {})", name, event_id),
-        None => format!("with ID: {}", event_id),
+        Some(name) => format!("'{name}' (ID: {event_id})"),
+        None => format!("with ID: {event_id}"),
     })]
     #[diagnostic()]
     EventError {

--- a/processor/src/execution/operations/crypto_ops/mod.rs
+++ b/processor/src/execution/operations/crypto_ops/mod.rs
@@ -277,7 +277,7 @@ pub(super) fn op_mrupdate<P: Processor, T: Tracer>(
 pub(super) fn op_horner_eval_base<P: Processor, T: Tracer>(
     processor: &mut P,
     tracer: &mut T,
-) -> Result<OperationHelperRegisters, crate::MemoryError> {
+) -> Result<OperationHelperRegisters, MemoryError> {
     // Stack positions: low coefficient closer to top (lower index)
     const ALPHA_ADDR_INDEX: usize = 13;
     const ACC_LOW_INDEX: usize = 14;
@@ -387,7 +387,7 @@ pub(super) fn op_horner_eval_base<P: Processor, T: Tracer>(
 pub(super) fn op_horner_eval_ext<P: Processor, T: Tracer>(
     processor: &mut P,
     tracer: &mut T,
-) -> Result<OperationHelperRegisters, crate::MemoryError> {
+) -> Result<OperationHelperRegisters, MemoryError> {
     // Stack positions: low coefficient closer to top (lower index)
     const ALPHA_ADDR_INDEX: usize = 13;
     const ACC_LOW_INDEX: usize = 14;
@@ -527,7 +527,7 @@ pub(super) fn op_log_precompile<P: Processor, T: Tracer>(
 pub(super) fn op_crypto_stream<P: Processor, T: Tracer>(
     processor: &mut P,
     tracer: &mut T,
-) -> Result<OperationHelperRegisters, crate::MemoryError> {
+) -> Result<OperationHelperRegisters, MemoryError> {
     // Stack layout: [rate(8), capacity(4), src_ptr, dst_ptr, ...]
     const SRC_PTR_IDX: usize = 12;
     const DST_PTR_IDX: usize = 13;

--- a/processor/src/execution/operations/sys_ops/tests.rs
+++ b/processor/src/execution/operations/sys_ops/tests.rs
@@ -90,7 +90,7 @@ fn test_op_clk() {
 /// The values are provided in "stack order" (top of stack first), and the result is a Vec<Felt>
 /// that can be compared with `processor.stack_top()`, where the top of the stack is at the
 /// **last** index.
-fn build_expected(values: &[u64]) -> alloc::vec::Vec<Felt> {
+fn build_expected(values: &[u64]) -> vec::Vec<Felt> {
     let mut expected = vec![ZERO; 16];
     for (i, &value) in values.iter().enumerate() {
         // In the result, top of stack is at index 15, second at 14, etc.

--- a/processor/src/fast/basic_block/sys_event_handlers.rs
+++ b/processor/src/fast/basic_block/sys_event_handlers.rs
@@ -564,9 +564,8 @@ mod tests {
         // Compute expected key by applying the permutation to the same state.
         let mut expected_state_after_perm = state_felts;
         Poseidon2::apply_permutation(&mut expected_state_after_perm);
-        let expected_key = miden_core::Word::new(
-            expected_state_after_perm[Poseidon2::DIGEST_RANGE].try_into().unwrap(),
-        );
+        let expected_key =
+            Word::new(expected_state_after_perm[Poseidon2::DIGEST_RANGE].try_into().unwrap());
 
         // The expected values are the rate portion (first 8 elements) of the *input* state.
         let expected_values = state_felts[Poseidon2::RATE_RANGE].to_vec();

--- a/processor/src/fast/tests/fast_decorator_execution_tests.rs
+++ b/processor/src/fast/tests/fast_decorator_execution_tests.rs
@@ -56,7 +56,7 @@ fn test_before_enter_decorator_executed_once_fast() {
 
     // Execute the program
     let result = processor.execute_sync(&program, &mut host);
-    assert!(result.is_ok(), "Execution failed: {:?}", result);
+    assert!(result.is_ok(), "Execution failed: {result:?}");
 
     // Verify decorator execution counts
     assert_eq!(host.get_trace_count(1), 1, "before_enter decorator should execute exactly once");
@@ -86,7 +86,7 @@ fn test_multiple_before_enter_decorators_each_once_fast() {
 
     // Execute the program
     let result = processor.execute_sync(&program, &mut host);
-    assert!(result.is_ok(), "Execution failed: {:?}", result);
+    assert!(result.is_ok(), "Execution failed: {result:?}");
 
     // Verify decorator execution counts
     assert_eq!(
@@ -132,7 +132,7 @@ fn test_multiple_after_exit_decorators_each_once_fast() {
 
     // Execute the program
     let result = processor.execute_sync(&program, &mut host);
-    assert!(result.is_ok(), "Execution failed: {:?}", result);
+    assert!(result.is_ok(), "Execution failed: {result:?}");
 
     // Verify decorator execution counts
     assert_eq!(host.get_trace_count(1), 1, "before_enter decorator should execute exactly once");
@@ -184,7 +184,7 @@ fn test_decorator_execution_order_fast() {
 
     // Execute the program
     let result = processor.execute_sync(&program, &mut host);
-    assert!(result.is_ok(), "Execution failed: {:?}", result);
+    assert!(result.is_ok(), "Execution failed: {result:?}");
 
     // Verify decorator execution counts
     assert_eq!(
@@ -233,7 +233,7 @@ fn test_processor_decorator_execution() {
         .with_tracing(true);
 
     let execution_result = processor.execute_sync(&program, &mut host);
-    assert!(execution_result.is_ok(), "Execution failed: {:?}", execution_result);
+    assert!(execution_result.is_ok(), "Execution failed: {execution_result:?}");
 
     // Check decorator execution
     insta::assert_debug_snapshot!(
@@ -277,7 +277,7 @@ fn test_no_duplication_between_inner_and_before_exit_decorators_fast() {
 
     // Execute the program
     let result = processor.execute_sync(&program, &mut host);
-    assert!(result.is_ok(), "Execution failed: {:?}", result);
+    assert!(result.is_ok(), "Execution failed: {result:?}");
 
     // Verify each decorator executes exactly once (no duplication)
     assert_eq!(host.get_trace_count(1), 1, "before_enter decorator should execute exactly once");

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -511,7 +511,7 @@ fn test_external_node_decorator_sequencing() {
 
     // Add a decorator to the lib forest to track execution inside the external node
     let lib_decorator = Decorator::Trace(2);
-    let lib_decorator_id = lib_forest.add_decorator(lib_decorator.clone()).unwrap();
+    let lib_decorator_id = lib_forest.add_decorator(lib_decorator).unwrap();
 
     let lib_operations = [Operation::Push(Felt::from_u32(1)), Operation::Add];
     // Attach the decorator to the first operation (index 0)
@@ -524,8 +524,8 @@ fn test_external_node_decorator_sequencing() {
     let mut main_forest = MastForest::new();
     let before_decorator = Decorator::Trace(1);
     let after_decorator = Decorator::Trace(3);
-    let before_id = main_forest.add_decorator(before_decorator.clone()).unwrap();
-    let after_id = main_forest.add_decorator(after_decorator.clone()).unwrap();
+    let before_id = main_forest.add_decorator(before_decorator).unwrap();
+    let after_id = main_forest.add_decorator(after_decorator).unwrap();
 
     let external_id = ExternalNodeBuilder::new(lib_forest[lib_block_id].digest())
         .with_before_enter([before_id])
@@ -542,7 +542,7 @@ fn test_external_node_decorator_sequencing() {
         .with_tracing(true);
 
     let result = processor.execute_sync(&program, &mut host);
-    assert!(result.is_ok(), "Execution failed: {:?}", result);
+    assert!(result.is_ok(), "Execution failed: {result:?}");
 
     // Verify all decorators executed
     assert_eq!(host.get_trace_count(1), 1, "before_enter decorator should execute exactly once");

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -301,7 +301,7 @@ impl AdviceProvider {
 
     /// Returns a reference to the value(s) associated with the specified key in the advice map.
     pub fn get_mapped_values(&self, key: &Word) -> Option<&[Felt]> {
-        self.map.get(key).map(|value| value.as_ref())
+        self.map.get(key).map(AsRef::as_ref)
     }
 
     /// Inserts the provided value into the advice map under the specified key.

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -18,7 +18,7 @@ pub struct StdoutWriter;
 impl fmt::Write for StdoutWriter {
     fn write_str(&mut self, _s: &str) -> fmt::Result {
         #[cfg(feature = "std")]
-        std::print!("{}", _s);
+        std::print!("{_s}");
         Ok(())
     }
 }
@@ -262,7 +262,7 @@ impl<W: fmt::Write + Sync> DefaultDebugHandler<W> {
             .into_iter()
             .map(|(addr, value_opt)| {
                 let value_string = format_value(value_opt);
-                format!("{addr:>width$}: {value_string}", width = max_addr_width)
+                format!("{addr:>max_addr_width$}: {value_string}")
             })
             .collect();
 

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -281,7 +281,7 @@ pub trait Stopper {
         &self,
         processor: &Self::Processor,
         continuation_stack: &ContinuationStack,
-        continuation_after_stop: impl FnOnce() -> Option<continuation_stack::Continuation>,
+        continuation_after_stop: impl FnOnce() -> Option<Continuation>,
     ) -> ControlFlow<BreakReason>;
 }
 
@@ -359,13 +359,13 @@ impl From<MemoryAddress> for u32 {
 }
 
 impl Display for MemoryAddress {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.0, f)
     }
 }
 
 impl LowerHex for MemoryAddress {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         LowerHex::fmt(&self.0, f)
     }
 }

--- a/processor/src/test_utils/test_host.rs
+++ b/processor/src/test_utils/test_host.rs
@@ -119,7 +119,7 @@ impl TestHost {
     /// Creates a new TestHost with a kernel forest for full consistency testing.
     pub fn with_kernel_forest(kernel_forest: Arc<MastForest>) -> Self {
         let mut store = MemMastForestStore::default();
-        store.insert(kernel_forest.clone());
+        store.insert(kernel_forest);
         Self {
             trace_collector: TraceCollector::new(),
             event_handler: Vec::new(),

--- a/processor/src/tests/debug_mode_decorator_tests.rs
+++ b/processor/src/tests/debug_mode_decorator_tests.rs
@@ -49,7 +49,7 @@ fn test_decorators_only_execute_in_debug_mode() {
     let process_debug_off = FastProcessor::new(StackInputs::default());
 
     let result = process_debug_off.execute_sync(&program, &mut host_debug_off);
-    assert!(result.is_ok(), "Execution failed: {:?}", result);
+    assert!(result.is_ok(), "Execution failed: {result:?}");
     assert!(
         host_debug_off.get_trace_count(999) == 0,
         "Decorator should NOT execute when debug mode is OFF"
@@ -63,7 +63,7 @@ fn test_decorators_only_execute_in_debug_mode() {
         .with_tracing(true);
 
     let result = process_debug_on.execute_sync(&program, &mut host_debug_on);
-    assert!(result.is_ok(), "Execution failed: {:?}", result);
+    assert!(result.is_ok(), "Execution failed: {result:?}");
     assert!(
         host_debug_on.get_trace_count(999) == 1,
         "Decorator SHOULD execute when debug mode is ON"
@@ -84,7 +84,7 @@ fn test_decorators_only_execute_in_debug_mode_off() {
 
     // Execute the program
     let result = processor.execute_sync(&program, &mut host);
-    assert!(result.is_ok(), "Execution failed: {:?}", result);
+    assert!(result.is_ok(), "Execution failed: {result:?}");
 
     // Verify that the decorator was NOT executed (trace count should be 0)
     assert_eq!(
@@ -115,7 +115,7 @@ fn test_decorators_only_execute_in_debug_mode_on() {
 
     // Execute the program
     let result = processor.execute_sync(&program, &mut host);
-    assert!(result.is_ok(), "Execution failed: {:?}", result);
+    assert!(result.is_ok(), "Execution failed: {result:?}");
 
     // Verify that the decorator WAS executed (trace count should be 1)
     assert_eq!(

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -716,7 +716,7 @@ fn test_diagnostic_procedure_not_found_call() {
     ";
         let uri = Uri::from("src.masm");
         let content = SourceContent::new(SourceLanguage::Masm, uri.clone(), src);
-        let source_file = source_manager.load_from_raw_parts(uri.clone(), content);
+        let source_file = source_manager.load_from_raw_parts(uri, content);
         Module::parse(
             PathBuf::new(module_name).unwrap(),
             miden_assembly::ast::ModuleKind::Library,
@@ -774,7 +774,7 @@ fn test_diagnostic_procedure_not_found_join() {
     ";
         let uri = Uri::from("src.masm");
         let content = SourceContent::new(SourceLanguage::Masm, uri.clone(), src);
-        let source_file = source_manager.load_from_raw_parts(uri.clone(), content);
+        let source_file = source_manager.load_from_raw_parts(uri, content);
         Module::parse(
             PathBuf::new(module_name).unwrap(),
             miden_assembly::ast::ModuleKind::Library,
@@ -835,7 +835,7 @@ fn test_diagnostic_procedure_not_found_loop() {
     ";
         let uri = Uri::from("src.masm");
         let content = SourceContent::new(SourceLanguage::Masm, uri.clone(), src);
-        let source_file = source_manager.load_from_raw_parts(uri.clone(), content);
+        let source_file = source_manager.load_from_raw_parts(uri, content);
         Module::parse(
             PathBuf::new(module_name).unwrap(),
             miden_assembly::ast::ModuleKind::Library,
@@ -897,7 +897,7 @@ fn test_diagnostic_procedure_not_found_split() {
     ";
         let uri = Uri::from("src.masm");
         let content = SourceContent::new(SourceLanguage::Masm, uri.clone(), src);
-        let source_file = source_manager.load_from_raw_parts(uri.clone(), content);
+        let source_file = source_manager.load_from_raw_parts(uri, content);
         Module::parse(
             PathBuf::new(module_name).unwrap(),
             miden_assembly::ast::ModuleKind::Library,

--- a/processor/src/trace/chiplets/ace/mod.rs
+++ b/processor/src/trace/chiplets/ace/mod.rs
@@ -33,7 +33,7 @@ pub struct Ace {
 impl Ace {
     /// Gets the total trace length of the ACE chiplet.
     pub(crate) fn trace_len(&self) -> usize {
-        self.circuit_evaluations.values().map(|eval_ctx| eval_ctx.num_rows()).sum()
+        self.circuit_evaluations.values().map(CircuitEvaluation::num_rows).sum()
     }
 
     /// Fills the portion of the main trace allocated to the ACE chiplet.

--- a/processor/src/trace/chiplets/ace/tests/mod.rs
+++ b/processor/src/trace/chiplets/ace/tests/mod.rs
@@ -12,7 +12,7 @@ use miden_air::trace::{
 };
 use miden_core::{
     Felt, WORD_SIZE, Word, ZERO,
-    field::{BasedVectorSpace, PrimeCharacteristicRing, QuadFelt},
+    field::{PrimeCharacteristicRing, QuadFelt},
 };
 
 use crate::{
@@ -255,7 +255,11 @@ fn generate_memory(circuit: &EncodedCircuit, inputs: &[QuadFelt]) -> Vec<Word> {
     // Inputs are store two by two in the fest set of words, followed by the instructions.
     let mut mem = Vec::with_capacity(2 * inputs.len() + circuit.encoded_circuit().len());
     // Add inputs
-    mem.extend(inputs.iter().flat_map(|input| input.as_basis_coefficients_slice()));
+    mem.extend(
+        inputs
+            .iter()
+            .flat_map(miden_core::field::BasedVectorSpace::as_basis_coefficients_slice),
+    );
     // Add circuit
     mem.extend(circuit.encoded_circuit().iter());
 

--- a/processor/src/trace/chiplets/hasher/mod.rs
+++ b/processor/src/trace/chiplets/hasher/mod.rs
@@ -543,7 +543,7 @@ enum MerklePathContext {
 
 impl MerklePathContext {
     /// Returns selector values for this context.
-    pub fn main_selectors(&self) -> Selectors {
+    pub fn main_selectors(self) -> Selectors {
         match self {
             Self::MpVerify => MP_VERIFY,
             Self::MrUpdateOld => MR_UPDATE_OLD,

--- a/processor/src/trace/chiplets/hasher/tests.rs
+++ b/processor/src/trace/chiplets/hasher/tests.rs
@@ -287,7 +287,7 @@ fn hash_memoization_control_blocks() {
     // Compute the expected hash
     let state = super::init_state_from_words_with_domain(&h1, &h2, domain);
     let permuted = apply_permutation(state);
-    let expected_hash: Digest = super::get_digest(&permuted);
+    let expected_hash: Digest = get_digest(&permuted);
 
     let mut hasher = Hasher::default();
 

--- a/processor/src/trace/chiplets/memory/segment.rs
+++ b/processor/src/trace/chiplets/memory/segment.rs
@@ -53,7 +53,7 @@ impl MemorySegmentTrace {
         let (word_addr, _) = addr_to_word_addr_and_idx(addr);
 
         match self.0.get(&word_addr) {
-            Some(addr_trace) => Ok(addr_trace.last().map(|access| access.word())),
+            Some(addr_trace) => Ok(addr_trace.last().map(MemorySegmentAccess::word)),
             None => Ok(None),
         }
     }

--- a/processor/src/trace/decoder/aux_trace/mod.rs
+++ b/processor/src/trace/decoder/aux_trace/mod.rs
@@ -28,7 +28,7 @@ impl AuxTraceBuilder {
     /// Builds and returns decoder auxiliary trace columns p1, p2, and p3 describing states of block
     /// stack, block hash, and op group tables respectively.
     pub fn build_aux_columns<E: ExtensionField<Felt>>(
-        &self,
+        self,
         main_trace: &MainTrace,
         challenges: &Challenges<E>,
     ) -> Vec<Vec<E>> {

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -396,7 +396,7 @@ impl ExecutionTrace {
             self.main_trace.read_row_into(i, &mut row);
             std::println!(
                 "{:?}",
-                row.iter().take(TRACE_WIDTH).map(|v| v.as_canonical_u64()).collect::<Vec<_>>()
+                row.iter().take(TRACE_WIDTH).map(Felt::as_canonical_u64).collect::<Vec<_>>()
             );
         }
     }

--- a/processor/src/trace/parallel/core_trace_fragment/mod.rs
+++ b/processor/src/trace/parallel/core_trace_fragment/mod.rs
@@ -39,7 +39,7 @@ impl BasicBlockContext {
                     .op_batches()
                     .iter()
                     .skip(batch_index)
-                    .map(|batch| batch.num_groups())
+                    .map(miden_core::mast::OpBatch::num_groups)
                     .sum::<usize>() as u64,
             ),
         })

--- a/processor/src/trace/parallel/core_trace_fragment/tests.rs
+++ b/processor/src/trace/parallel/core_trace_fragment/tests.rs
@@ -882,7 +882,7 @@ fn test_call_decoding() {
     let program_root_node = mast_forest[program_root_node_id].clone();
     mast_forest.make_root(program_root_node_id);
 
-    let program = Program::with_kernel(mast_forest.into(), program_root_node_id, kernel.clone());
+    let program = Program::with_kernel(mast_forest.into(), program_root_node_id, kernel);
 
     let (sys_trace, dec_trace, trace_len) =
         build_call_trace_helper(&program);
@@ -1183,7 +1183,7 @@ fn test_syscall_decoding() {
     let program_root_node = mast_forest[program_root_node_id].clone();
     mast_forest.make_root(program_root_node_id);
 
-    let program = Program::with_kernel(mast_forest.into(), program_root_node_id, kernel.clone());
+    let program = Program::with_kernel(mast_forest.into(), program_root_node_id, kernel);
 
     let (sys_trace, dec_trace, trace_len) =
         build_call_trace_helper(&program);
@@ -1696,7 +1696,7 @@ fn check_op_decoding(
         };
 
     for (i, flag_value) in OP_BATCH_FLAGS_RANGE.zip(expected_batch_flags) {
-        assert_eq!(trace[i][row_idx], flag_value, "op batch flag mismatch at column {}", i);
+        assert_eq!(trace[i][row_idx], flag_value, "op batch flag mismatch at column {i}");
     }
 
     // make sure the op bit extra columns for degree reduction are set correctly
@@ -1776,7 +1776,7 @@ fn build_op_batch_flags(num_groups: usize) -> [Felt; NUM_OP_BATCH_FLAGS] {
 
 use miden_air::trace::FN_HASH_RANGE;
 
-fn get_fn_hash(trace: &SystemTrace, row_idx: usize) -> miden_core::Word {
+fn get_fn_hash(trace: &SystemTrace, row_idx: usize) -> Word {
     let mut result = [ZERO; WORD_SIZE];
     // FN_HASH_RANGE is relative to the full trace, but SystemTrace only has system columns
     // System trace columns are indexed 0..SYS_TRACE_WIDTH, and FN_HASH is columns 2-5
@@ -1804,7 +1804,7 @@ fn get_hasher_state(trace: &DecoderTrace, row_idx: usize) -> [Felt; NUM_HASHER_C
     result
 }
 
-fn get_hasher_state1(trace: &DecoderTrace, row_idx: usize) -> miden_core::Word {
+fn get_hasher_state1(trace: &DecoderTrace, row_idx: usize) -> Word {
     let mut result = [ZERO; WORD_SIZE];
     for (result, column) in result.iter_mut().zip(trace[HASHER_STATE_RANGE].iter()) {
         *result = column[row_idx];
@@ -1812,7 +1812,7 @@ fn get_hasher_state1(trace: &DecoderTrace, row_idx: usize) -> miden_core::Word {
     result.into()
 }
 
-fn get_hasher_state2(trace: &DecoderTrace, row_idx: usize) -> miden_core::Word {
+fn get_hasher_state2(trace: &DecoderTrace, row_idx: usize) -> Word {
     let mut result = [ZERO; WORD_SIZE];
     for (result, column) in result.iter_mut().zip(trace[HASHER_STATE_RANGE].iter().skip(4)) {
         *result = column[row_idx];

--- a/processor/src/trace/parallel/tests.rs
+++ b/processor/src/trace/parallel/tests.rs
@@ -413,10 +413,14 @@ fn test_trace_generation_at_fragment_boundaries(
     let aux_from_fragments = trace_from_fragments.build_aux_trace(&rand_elements).unwrap();
     let aux_from_single_fragment =
         trace_from_single_fragment.build_aux_trace(&rand_elements).unwrap();
-    let aux_from_fragments =
-        aux_from_fragments.columns().map(|col| col.to_vec()).collect::<Vec<_>>();
-    let aux_from_single_fragment =
-        aux_from_single_fragment.columns().map(|col| col.to_vec()).collect::<Vec<_>>();
+    let aux_from_fragments = aux_from_fragments
+        .columns()
+        .map(<[miden_core::Felt]>::to_vec)
+        .collect::<Vec<_>>();
+    let aux_from_single_fragment = aux_from_single_fragment
+        .columns()
+        .map(<[miden_core::Felt]>::to_vec)
+        .collect::<Vec<_>>();
     assert_eq!(aux_from_fragments, aux_from_single_fragment,);
 
     // Compare deterministic traces as a compact sanity check and to keep the snapshot stable.


### PR DESCRIPTION
Opt xclippy and xclippy-fix into needless_collect, redundant_clone, redundant_closure_for_method_calls, trivially_copy_pass_by_ref, uninlined_format_args, and unused_qualifications.

Apply the required workspace cleanup manually so the stricter check passes without warnings, including generated-parser lint expectations for warnings emitted from LALRPOP output.

This is then enforced by the `make lint` + CI targets.