### PR TITLE
ci: stop link checker config errors from opening issues

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -40,7 +40,6 @@ jobs:
           fail: ${{ steps.flags.outputs.fail_fast }}
           args: |
             --verbose
-            --exclude-mail
             --exclude "localhost"
             --exclude "127.0.0.1"
             --exclude "^file://"
@@ -51,8 +50,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Fail if lychee did not produce a link report
+        if: steps.lychee.outputs.exit_code != '0'
+        run: |
+          if [ ! -s ./lychee/out.md ] || ! grep -q '^# Summary' ./lychee/out.md; then
+            echo "::error::lychee exited before producing a link-check summary. Check the Link Checker step for a workflow or tool configuration error."
+            exit 1
+          fi
+
       - name: Open issue on failure (only if fail-fast is false)
-        if: steps.lychee.outputs.exit_code != 0 && steps.flags.outputs.fail_fast != 'true'
+        if: steps.lychee.outputs.exit_code != '0' && steps.flags.outputs.fail_fast != 'true'
         uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5.0.1
         with:
           title: Link Checker Report


### PR DESCRIPTION
lychee-action v2.8.0 runs lychee v0.23, where --exclude-mail is no longer accepted. On scheduled runs we set fail: false, so the action captured that CLI error as a non-zero exit_code, wrote only a stub report, and the next step opened a Link Checker Report issue even though no links had been checked (see #3017 #3020 #3030).

- Remove the obsolete flag because mail links are opt-in now, and require a real lychee markdown summary before opening an issue. 
- If lychee fails *before* producing a report, fail the workflow so configuration errors stay in CI logs, instead of becoming low-signal documentation issues.