### PR TITLE
chore: bump midenc-hir-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8853fff7b8c4ddc51842843f644349aacd45f0dabcb978083997308f401567e3"
+checksum = "8a9cecc109a7be41d364710d92d43c2912ef4620c8d243a2399e596f90594036"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ miden-verifier          = { path = "./verifier", version = "0.23.0", default-fea
 miden-crypto     = { version = "0.24", default-features = false }
 miden-formatting = { version = "0.1", default-features = false }
 miden-lifted-stark = { version = "0.24", default-features = false }
-midenc-hir-type  = { version = "0.5.4", default-features = false }
+midenc-hir-type  = { version = "0.6.0", default-features = false }
 
 # Serialization
 bincode = "1.3"


### PR DESCRIPTION
Bump `midenc-hir-types`  to 0.6.0.
Followup of #3039.