### PR TITLE
test: Speed up repeated assembler tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Added `prove_from_trace_sync(...)` for proving from pre-executed trace inputs ([#2865](https://github.com/0xMiden/miden-vm/pull/2865)).
 - [BREAKING] Reduced the prove-from-trace API to post-execution trace inputs: `TraceBuildInputs` no longer carries full execution output, `prove_from_trace_sync()` takes `TraceProvingInputs`, and `ProvingOptions` no longer include `ExecutionOptions` ([#2948](https://github.com/0xMiden/miden-vm/pull/2948)).
 - Redesigned the hasher chiplet to use a controller/permutation split architecture with permutation calls deduplication ([#2927](https://github.com/0xMiden/miden-vm/pull/2927)).
+- Cached repeated test compilations to speed up assembler tests without changing coverage, and fixed the core library build watch path ([#3047](https://github.com/0xMiden/miden-vm/pull/3047)).
 - Documented that enum variants are module-level constants and must be unique within a module ([#2932]((https://github.com/0xMiden/miden-vm/pull/2932)).
 - Refactor trace generation to row-major format ([#2937](https://github.com/0xMiden/miden-vm/pull/2937)).
 - Documented non-overlap requirement for `memcopy_words`, `memcopy_elements`, and AEAD encrypt/decrypt procedures ([#2941](https://github.com/0xMiden/miden-vm/pull/2941)).

--- a/crates/lib/core/build.rs
+++ b/crates/lib/core/build.rs
@@ -204,7 +204,9 @@ fn main() -> Result<(), Report> {
     // or its builder changed:
     println!("cargo:rerun-if-changed=asm");
     println!("cargo:rerun-if-env-changed=MIDEN_BUILD_LIB_DOCS");
-    println!("cargo:rerun-if-changed=../assembly/src");
+    // NOTE: path is relative to the package root (crates/lib/core/), so we need
+    // ../../ to reach crates/assembly/src.
+    println!("cargo:rerun-if-changed=../../assembly/src");
 
     miden_assembly::diagnostics::reporting::set_hook(Box::new(|_| {
         Box::new(ReportHandlerOpts::new().build())

--- a/crates/lib/core/tests/word/mod.rs
+++ b/crates/lib/core/tests/word/mod.rs
@@ -12,7 +12,7 @@ use rstest::rstest;
 #[case::lt("lt", &[Ordering::Less])]
 #[case::lte("lte", &[Ordering::Less, Ordering::Equal])]
 fn test_word_comparison(#[case] proc_name: &str, #[case] valid_ords: &[Ordering]) {
-    let source = &format!(
+    let source = format!(
         "
         use miden::core::word
 
@@ -22,6 +22,7 @@ fn test_word_comparison(#[case] proc_name: &str, #[case] valid_ords: &[Ordering]
     "
     );
 
+    let test = build_test!(&source);
     let mut seed = 0xfacade;
 
     for i in 0..1000 {
@@ -37,7 +38,7 @@ fn test_word_comparison(#[case] proc_name: &str, #[case] valid_ords: &[Ordering]
 
         let expected = u64::from(valid_ords.contains(&expected_cmp));
 
-        build_test!(source, &operand_stack).expect_stack(&[expected]);
+        test.expect_stack_with_inputs(&operand_stack, &[expected]);
     }
 }
 
@@ -49,6 +50,7 @@ fn test_reverse() {
         end
     ";
 
+    let test = build_test!(SOURCE);
     let mut seed = 0xfacade;
     for _ in 0..1000 {
         let word = rand::seeded_word(&mut seed);
@@ -57,7 +59,7 @@ fn test_reverse() {
 
         // reversew reverses [w0, w1, w2, w3] → [w3, w2, w1, w0]
         let expected: Vec<u64> = word.iter().rev().map(Felt::as_canonical_u64).collect();
-        build_test!(SOURCE, &operand_stack).expect_stack(&expected);
+        test.expect_stack_with_inputs(&operand_stack, &expected);
     }
 }
 
@@ -103,6 +105,7 @@ fn test_preserving_eq() {
         end
     ";
 
+    let test = build_test!(SOURCE);
     let mut seed = 0xfacade;
     for i in 0..1000 {
         let lhs = rand::seeded_word(&mut seed);
@@ -116,7 +119,7 @@ fn test_preserving_eq() {
         let mut expected: Vec<u64> = vec![is_equal.into()];
         expected.extend(operand_stack.iter());
 
-        build_test!(SOURCE, &operand_stack).expect_stack(&expected);
+        test.expect_stack_with_inputs(&operand_stack, &expected);
     }
 }
 

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -89,6 +89,39 @@ proc truncate_stack
 end
 ";
 
+// COMPILE CACHE
+// ================================================================================================
+
+/// Key for the process-local compile cache, keyed by all inputs that affect compilation output.
+///
+/// The source manager identity is included so cached programs keep their debug/source mapping local
+/// to the test context that produced them.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg(all(feature = "std", not(target_family = "wasm")))]
+struct CompileCacheKey {
+    source_manager: usize,
+    source: SourceCacheKey,
+    kernel_source: Option<SourceCacheKey>,
+    add_modules: Vec<(String, String)>,
+    library_digests: Vec<Word>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg(all(feature = "std", not(target_family = "wasm")))]
+struct SourceCacheKey {
+    uri: String,
+    source: String,
+}
+
+#[cfg(all(feature = "std", not(target_family = "wasm")))]
+type CompileCacheValue = (Program, Option<KernelLibrary>);
+
+#[cfg(all(feature = "std", not(target_family = "wasm")))]
+type CompileCache = std::collections::HashMap<CompileCacheKey, CompileCacheValue>;
+
+#[cfg(all(feature = "std", not(target_family = "wasm")))]
+static COMPILE_CACHE: std::sync::Mutex<Option<CompileCache>> = std::sync::Mutex::new(None);
+
 // TEST HANDLER
 // ================================================================================================
 
@@ -377,6 +410,26 @@ impl Test {
         Ok(())
     }
 
+    /// Executes the test with the provided stack inputs and asserts the final stack state.
+    ///
+    /// This preserves the same execution coverage as [`expect_stack`](Self::expect_stack): traced
+    /// execution, step/resume execution comparison, and trace construction are all still run.
+    #[cfg(not(target_family = "wasm"))]
+    #[track_caller]
+    pub fn expect_stack_with_inputs(&self, stack_inputs: &[u64], final_stack: &[u64]) {
+        let trace = self
+            .execute_with_stack_inputs(stack_inputs)
+            .inspect_err(|_err| {
+                #[cfg(feature = "std")]
+                std::eprintln!("{}", PrintDiagnostic::new_without_color(_err))
+            })
+            .expect("failed to execute");
+
+        let result = trace.last_stack_state().as_int_vec();
+        let expected = resize_to_min_stack_depth(final_stack);
+        assert_eq!(expected, result, "Expected stack to be {:?}, found {:?}", expected, result);
+    }
+
     // UTILITY METHODS
     // --------------------------------------------------------------------------------------------
 
@@ -387,6 +440,18 @@ impl Test {
     /// Returns an error if compilation of the program source or the kernel fails.
     pub fn compile(&self) -> Result<(Program, Option<KernelLibrary>), Report> {
         use miden_assembly::{Assembler, ParseOptions, ast::ModuleKind};
+
+        #[cfg(all(feature = "std", not(target_family = "wasm")))]
+        let cache_key = self.compile_cache_key();
+
+        #[cfg(all(feature = "std", not(target_family = "wasm")))]
+        {
+            let mut cache_guard = COMPILE_CACHE.lock().unwrap();
+            let cache = cache_guard.get_or_insert_with(Default::default);
+            if let Some(cached) = cache.get(&cache_key) {
+                return Ok((cached.0.clone(), cached.1.clone()));
+            }
+        }
 
         // Enable debug tracing to stderr via the MIDEN_LOG environment variable, if present
         #[cfg(not(target_family = "wasm"))]
@@ -422,17 +487,49 @@ impl Test {
             assembler.link_dynamic_library(library).unwrap();
         }
 
-        Ok((assembler.assemble_program(self.source.clone())?, kernel_lib))
+        let result = (assembler.assemble_program(self.source.clone())?, kernel_lib);
+
+        #[cfg(all(feature = "std", not(target_family = "wasm")))]
+        {
+            let mut cache_guard = COMPILE_CACHE.lock().unwrap();
+            let cache = cache_guard.get_or_insert_with(Default::default);
+            cache.insert(cache_key, (result.0.clone(), result.1.clone()));
+        }
+
+        Ok(result)
     }
 
     /// Compiles the test's source to a Program and executes it with the tests inputs. Returns a
     /// resulting execution trace or error.
     ///
-    /// Internally, this also checks that the slow and fast processors agree on the stack
-    /// outputs.
+    /// Internally, this also checks that traced execution and step/resume execution agree on the
+    /// stack outputs.
     #[cfg(not(target_family = "wasm"))]
     #[track_caller]
     pub fn execute(&self) -> Result<ExecutionTrace, ExecutionError> {
+        self.execute_with_stack_inputs_inner(self.stack_inputs)
+    }
+
+    /// Compiles the test's source and executes it with the provided stack inputs.
+    ///
+    /// This uses the same traced execution, step/resume comparison, and trace construction path as
+    /// [`execute`](Self::execute).
+    #[cfg(not(target_family = "wasm"))]
+    #[track_caller]
+    pub fn execute_with_stack_inputs(
+        &self,
+        stack_inputs: &[u64],
+    ) -> Result<ExecutionTrace, ExecutionError> {
+        let stack_inputs = StackInputs::try_from_ints(stack_inputs.to_vec()).unwrap();
+        self.execute_with_stack_inputs_inner(stack_inputs)
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[track_caller]
+    fn execute_with_stack_inputs_inner(
+        &self,
+        stack_inputs: StackInputs,
+    ) -> Result<ExecutionTrace, ExecutionError> {
         // Note: we fix a large fragment size here, as we're not testing the fragment boundaries
         // with these tests (which are tested separately), but rather only the per-fragment trace
         // generation logic - though not too big so as to over-allocate memory.
@@ -443,7 +540,7 @@ impl Test {
 
         let fast_stack_result = {
             let fast_processor = FastProcessor::new_with_options(
-                self.stack_inputs,
+                stack_inputs,
                 self.advice_inputs.clone(),
                 miden_processor::ExecutionOptions::default()
                     .with_debugging(self.in_debug_mode)
@@ -453,8 +550,8 @@ impl Test {
             fast_processor.execute_trace_inputs_sync(&program, &mut host)
         };
 
-        // compare fast and slow processors' stack outputs
-        self.assert_result_with_step_execution(&fast_stack_result);
+        // Compare traced full execution and step/resume execution stack outputs.
+        self.assert_result_with_step_execution(stack_inputs, &fast_stack_result);
 
         fast_stack_result.and_then(|trace_inputs| {
             let trace = build_trace(trace_inputs)?;
@@ -610,6 +707,7 @@ impl Test {
     #[cfg(not(target_family = "wasm"))]
     fn assert_result_with_step_execution(
         &self,
+        stack_inputs: StackInputs,
         fast_result: &Result<TraceBuildInputs, ExecutionError>,
     ) {
         fn compare_results(
@@ -657,7 +755,7 @@ impl Test {
         let mut host = host.with_source_manager(self.source_manager.clone());
 
         let fast_result_by_step = {
-            let fast_process = FastProcessor::new(self.stack_inputs)
+            let fast_process = FastProcessor::new(stack_inputs)
                 .with_advice(self.advice_inputs.clone())
                 .with_debugging(self.in_debug_mode)
                 .with_tracing(self.in_debug_mode);
@@ -667,9 +765,34 @@ impl Test {
         compare_results(
             fast_result.as_ref().map(|trace_inputs| *trace_inputs.stack_outputs()),
             &fast_result_by_step,
-            "fast processor",
-            "fast processor by step",
+            "traced execution",
+            "step/resume execution",
         );
+    }
+
+    #[cfg(all(feature = "std", not(target_family = "wasm")))]
+    fn compile_cache_key(&self) -> CompileCacheKey {
+        CompileCacheKey {
+            source_manager: Arc::as_ptr(&self.source_manager) as usize,
+            source: SourceCacheKey::from_source_file(self.source.as_ref()),
+            kernel_source: self.kernel_source.as_deref().map(SourceCacheKey::from_source_file),
+            add_modules: self
+                .add_modules
+                .iter()
+                .map(|(path, source)| (path.to_string(), source.clone()))
+                .collect(),
+            library_digests: self.libraries.iter().map(|library| *library.digest()).collect(),
+        }
+    }
+}
+
+#[cfg(all(feature = "std", not(target_family = "wasm")))]
+impl SourceCacheKey {
+    fn from_source_file(source_file: &SourceFile) -> Self {
+        Self {
+            uri: source_file.uri().as_str().to_string(),
+            source: source_file.as_str().to_string(),
+        }
     }
 }
 


### PR DESCRIPTION
This speeds up repeated assembler tests by caching successful `Test::compile()` results inside the test process. Tests that run the same program with many stack inputs can now reuse the compiled program instead of rebuilding it each time.

The coverage stays the same. Each run still executes the traced path, checks step/resume execution, and builds the trace before checking the final stack.

The word tests now build each test program once and pass different stack inputs through the same full execution path.

This also fixes the miden-core-lib build script watch path so changes under crates/assembly/src correctly trigger rebuilds.