### PR TITLE
ci: Add cargo-shear CI and remove unused workspace dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,18 @@ jobs:
       - name: Check dependencies with cargo-deny
         run: cargo deny check
 
+  cargo-shear:
+    name: cargo-shear on ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Install cargo-shear
+        run: cargo install cargo-shear --version 1.11.2 --locked
+      - name: Check for unused dependencies
+        run: make shear
+
   workspace-inheritance:
     name: workspace inheritance on ubuntu-latest
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1279,7 +1279,6 @@ dependencies = [
  "miden-utils-indexing",
  "proptest",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -1334,7 +1333,6 @@ dependencies = [
  "criterion",
  "derive_more",
  "insta",
- "itertools 0.14.0",
  "miden-crypto",
  "miden-debug-types",
  "miden-formatting",
@@ -1375,12 +1373,9 @@ dependencies = [
  "miden-verifier",
  "num",
  "num-bigint",
- "pretty_assertions",
  "rand 0.9.4",
  "rand_chacha",
  "rstest",
- "serde",
- "serde_json",
  "thiserror",
 ]
 
@@ -1521,7 +1516,6 @@ dependencies = [
 name = "miden-mast-package"
 version = "0.23.0"
 dependencies = [
- "derive_more",
  "miden-assembly-syntax",
  "miden-core",
  "miden-debug-types",
@@ -1578,7 +1572,6 @@ dependencies = [
  "miden-mast-package",
  "pubgrub",
  "serde",
- "serde_json",
  "smallvec",
  "thiserror",
 ]
@@ -1614,12 +1607,8 @@ dependencies = [
  "miden-core",
  "miden-mast-package",
  "miden-package-registry",
- "miden-test-serde-macros",
- "proptest",
- "proptest-derive",
  "serde",
  "serde-untagged",
- "serde_json",
  "tempfile",
  "thiserror",
  "toml",
@@ -1637,7 +1626,6 @@ dependencies = [
  "miden-debug-types",
  "miden-processor",
  "serde",
- "thiserror",
  "tokio",
  "tracing",
 ]
@@ -1719,7 +1707,6 @@ dependencies = [
  "miden-crypto",
  "miden-debug-types",
  "miden-miette",
- "paste",
  "tracing",
 ]
 
@@ -1740,7 +1727,6 @@ dependencies = [
  "loom",
  "once_cell",
  "parking_lot",
- "proptest",
 ]
 
 [[package]]
@@ -1777,10 +1763,7 @@ dependencies = [
  "miden-prover",
  "miden-test-utils",
  "miden-verifier",
- "num-bigint",
  "predicates",
- "pretty_assertions",
- "rand_chacha",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,9 +77,6 @@ midenc-hir-type  = { version = "0.6.0", default-features = false }
 # Serialization
 bincode = "1.3"
 
-# Constraints to resolve duplicates
-windows-sys = "0.61"
-
 # Third-party crates
 criterion       = { version = "0.7" }
 derive_more     = { version = "2.0", features = ["from"] }
@@ -100,8 +97,6 @@ thiserror       = { version = "2.0", default-features = false }
 tokio           = { version = "1.48", default-features = false }
 tracing         = { version = "0.1", default-features = false, features = ["attributes"] }
 
-# WASM support
-getrandom = { version = "0.2", default-features = false, features = ["js"] }
 loom = "0.7"
 miette = { package = "miden-miette", version = "8.0", default-features = false }
 num-bigint = "0.4"

--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,12 @@ format: ## Runs Format using nightly toolchain
 format-check: ## Runs Format using nightly toolchain but only in check mode
 	cargo +nightly fmt --all --check
 
+.PHONY: shear
+shear: ## Runs cargo-shear to find unused or misplaced dependencies
+	cargo shear
 
 .PHONY: lint
-lint: xclippy xclippy-fix format ## Runs all linting tasks: check with xclippy, fix issues, then format
+lint: xclippy xclippy-fix format shear ## Runs all linting tasks: check with xclippy, fix issues, format, then cargo-shear
 
 # --- docs ----------------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ shear: ## Runs cargo-shear to find unused or misplaced dependencies
 	cargo shear
 
 .PHONY: lint
-lint: xclippy xclippy-fix format shear ## Runs all linting tasks: check with xclippy, fix issues, format, then cargo-shear
+lint: xclippy xclippy-fix format ## Runs all linting tasks: check with xclippy, fix issues, then format
 
 # --- docs ----------------------------------------------------------------------------------------
 

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -33,7 +33,6 @@ miden-utils-indexing.workspace = true
 
 # External dependencies
 thiserror.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -54,7 +54,6 @@ miden-utils-sync.workspace = true
 
 # External dependencies
 derive_more.workspace = true
-itertools.workspace = true
 num-derive = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 proptest = { workspace = true, optional = true }

--- a/core/src/mast/debuginfo/asm_op_storage.rs
+++ b/core/src/mast/debuginfo/asm_op_storage.rs
@@ -186,7 +186,7 @@ impl OpToAsmOpId {
     /// Returns all `(op_idx, AsmOpId)` pairs for the given node, or an empty vec if the
     /// node has no asm ops.
     pub fn asm_ops_for_node(&self, node_id: MastNodeId) -> Vec<(usize, AsmOpId)> {
-        self.inner.row(node_id).map(|r| r.to_vec()).unwrap_or_default()
+        self.inner.row(node_id).unwrap_or_default().to_vec()
     }
 
     /// Validates the CSR structure integrity.

--- a/core/src/mast/debuginfo/debug_var_storage.rs
+++ b/core/src/mast/debuginfo/debug_var_storage.rs
@@ -460,7 +460,7 @@ impl OpToDebugVarIds {
         };
 
         let mut result = Vec::new();
-        for (op_offset, op_idx) in op_range.clone().enumerate() {
+        for (op_offset, op_idx) in op_range.enumerate() {
             if op_idx + 1 >= self.op_indptr_for_var_ids.len() {
                 break;
             }

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -14,6 +14,9 @@ homepage.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
+[package.metadata.cargo-shear]
+ignored = ["serde_json"]
+
 [features]
 default = ["std"]
 std = [

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -54,13 +54,10 @@ miden-utils-testing.workspace = true
 miden-verifier.workspace = true
 num = { version = "0.4" }
 num-bigint = { workspace = true }
-pretty_assertions = { workspace = true, features = ["std"] }
 rand = { version = "0.9", default-features = false }
 rand_chacha = { workspace = true }
 rstest = { workspace = true }
 bincode.workspace = true
-serde.workspace = true
-serde_json.workspace = true
 
 [build-dependencies]
 env_logger.workspace = true

--- a/crates/mast-package/Cargo.toml
+++ b/crates/mast-package/Cargo.toml
@@ -30,7 +30,6 @@ miden-core.workspace = true
 miden-debug-types.workspace = true
 
 # External dependencies
-derive_more.workspace = true
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/package-registry/Cargo.toml
+++ b/crates/package-registry/Cargo.toml
@@ -30,7 +30,6 @@ thiserror.workspace = true
 
 [dev-dependencies]
 miden-core.workspace = true
-serde_json.workspace = true
 
 [lints.rust]
 unused_assignments = "allow"

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -15,7 +15,7 @@ edition.workspace = true
 
 [features]
 default = ["std", "serde"]
-arbitrary = ["std", "dep:proptest-derive", "dep:proptest", "miden-assembly-syntax/arbitrary"]
+arbitrary = ["std", "miden-assembly-syntax/arbitrary"]
 resolver = ["std", "miden-package-registry/resolver"]
 std = ["miden-assembly-syntax/std", "serde/std", "thiserror/std", "toml/std", "miden-package-registry/std", "miden-package-registry/resolver", "tempfile/getrandom"]
 serde = ["dep:serde", "dep:serde-untagged", "miden-assembly-syntax/serde", "miden-core/serde", "miden-package-registry/serde", "toml/serde", "toml/parse", "toml/display"]
@@ -25,8 +25,6 @@ miden-assembly-syntax.workspace = true
 miden-core.workspace = true
 miden-mast-package.workspace = true
 miden-package-registry.workspace = true
-proptest = { workspace = true, optional = true }
-proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde-untagged = { workspace = true, optional = true }
 thiserror.workspace = true
@@ -35,8 +33,6 @@ toml = { workspace = true }
 [dev-dependencies]
 miden-core.workspace = true
 miden-mast-package = { workspace = true, features = ["arbitrary"] }
-miden-test-serde-macros.workspace = true
-serde_json.workspace = true
 tempfile.workspace = true
 toml = { workspace = true, features = ["std", "serde", "parse"] }
 

--- a/crates/utils-diagnostics/Cargo.toml
+++ b/crates/utils-diagnostics/Cargo.toml
@@ -25,5 +25,4 @@ miette = { workspace = true, features = [
     "derive",
 ] }
 miden-crypto.workspace = true
-paste.workspace = true
 tracing.workspace = true

--- a/crates/utils-sync/Cargo.toml
+++ b/crates/utils-sync/Cargo.toml
@@ -25,7 +25,6 @@ parking_lot = { version = "0.12", optional = true }
 
 [dev-dependencies]
 loom = { workspace = true }
-proptest.workspace = true
 
 [target.'cfg(loom)'.dependencies]
 loom.workspace = true

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -70,7 +70,6 @@ internal = ["dep:hex", "serde", "std"]
 # Miden dependencies
 miden-assembly.workspace = true
 miden-core.workspace = true
-miden-crypto.workspace = true
 miden-debug-types.workspace = true
 miden-processor.workspace = true
 miden-prover.workspace = true
@@ -92,12 +91,10 @@ assert_cmd = { version = "2.1" }
 bincode = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
 escargot = { version = "0.5" }
+miden-crypto.workspace = true
 miden-processor = { workspace = true, features = ["testing"] }
 miden-lifted-stark.workspace = true
 miden-utils-testing.workspace = true
-num-bigint = { workspace = true }
 predicates = { version = "3.1" }
-pretty_assertions = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
-rand_chacha = { workspace = true }
 walkdir = { version = "2.5" }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -22,16 +22,15 @@ std = ["miden-air/std", "miden-debug-types/std", "miden-processor/std"]
 # Miden dependencies
 miden-air.workspace = true
 miden-core.workspace = true
-miden-debug-types.workspace = true
 miden-processor.workspace = true
 miden-crypto.workspace = true
 
 # External dependencies
 bincode.workspace = true
 serde.workspace = true
-thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 miden-assembly.workspace = true
+miden-debug-types.workspace = true
 tokio = { workspace = true, features = ["macros", "rt"] }


### PR DESCRIPTION
This adds a cargo-shear check to CI and introduces a `make shear` target for the same check. 

It removes unused dependencies found across the workspace, keeps builds working for wasm.