### PR TITLE
core: fix static linking debug metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Added regression coverage for the exact `max_num_continuations` continuation-stack boundary ([#2995](https://github.com/0xMiden/miden-vm/pull/2995)).
 - Fixed AEAD padding handling so encrypt does not overwrite memory next to the plaintext buffer and decrypt leaves the plaintext output tail untouched ([#3008](https://github.com/0xMiden/miden-vm/pull/3008)).
 - Fixed MAST compaction after debug info is cleared so compiler-generated packages do not grow ([#3044](https://github.com/0xMiden/miden-vm/pull/3044)).
+- Fixed same-digest procedure selection so static linking and library-to-executable package conversion preserve the selected procedure's debug metadata ([#3054](https://github.com/0xMiden/miden-vm/pull/3054)).
 - Canonicalized `PathBuf::try_from(String)` to match `TryFrom<&str>`/`FromStr`, so semantically equivalent quoted path components compare and hash consistently.
 - Fixed missing smt::set validations in corelib ([#3049](https://github.com/0xMiden/miden-vm/pull/3049)).
 - Memoized semantic constant evaluation in `AnalysisContext` to prevent exponential work from shared constant-dependency graphs during parsing and semantic analysis ([#2858](https://github.com/0xMiden/miden-vm/pull/2858)).

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -471,7 +471,7 @@ fn serialize_asm_op_content_for_node(forest: &MastForest, node_id: MastNodeId) -
 ///
 /// It maps the roots ([`MastNodeId`]s) of a forest to their new [`MastNodeId`] in the merged
 /// forest. See [`MastForest::merge`] for more details.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MastForestRootMap {
     root_maps: Vec<BTreeMap<MastNodeId, MastNodeId>>,
 }

--- a/crates/assembly-syntax/src/library/mod.rs
+++ b/crates/assembly-syntax/src/library/mod.rs
@@ -473,6 +473,15 @@ impl Library {
         let export = self.exports.get(path.as_ref()).and_then(LibraryExport::as_procedure);
         export.map(|e| self.mast_forest()[e.node].digest())
     }
+
+    /// Returns the exact procedure node for the specified path, if it is present.
+    pub fn get_procedure_node_by_path(&self, path: impl AsRef<Path>) -> Option<MastNodeId> {
+        let path = path.as_ref().to_absolute();
+        self.exports
+            .get(path.as_ref())
+            .and_then(LibraryExport::as_procedure)
+            .map(|export| export.node)
+    }
 }
 
 /// Conversions
@@ -491,7 +500,7 @@ impl Library {
                 LibraryExport::Procedure(ProcedureExport { node, path, signature, attributes }) => {
                     let proc_digest = self.mast_forest[*node].digest();
                     let name = path.last().unwrap();
-                    module.add_procedure(
+                    module.add_procedure_with_provenance(
                         ProcedureName::new(name).expect("valid procedure name"),
                         proc_digest,
                         signature.clone().map(Arc::new),
@@ -671,7 +680,7 @@ impl TryFrom<Arc<Library>> for KernelLibrary {
 
                     let proc_digest = library.mast_forest[export.node].digest();
                     proc_digests.push(proc_digest);
-                    kernel_module.add_procedure(
+                    kernel_module.add_procedure_with_provenance(
                         ProcedureName::new(export.path.last().unwrap())
                             .expect("valid procedure name"),
                         proc_digest,

--- a/crates/assembly-syntax/src/library/mod.rs
+++ b/crates/assembly-syntax/src/library/mod.rs
@@ -496,6 +496,8 @@ impl Library {
                         proc_digest,
                         signature.clone().map(Arc::new),
                         attributes.clone(),
+                        Some(*node),
+                        Some(self.mast_forest.commitment()),
                     );
                 },
                 LibraryExport::Constant(ConstantExport { path, value }) => {
@@ -675,6 +677,8 @@ impl TryFrom<Arc<Library>> for KernelLibrary {
                         proc_digest,
                         export.signature.clone().map(Arc::new),
                         export.attributes.clone(),
+                        Some(export.node),
+                        Some(library.mast_forest.commitment()),
                     );
                 },
                 LibraryExport::Constant(export) => {

--- a/crates/assembly-syntax/src/library/module.rs
+++ b/crates/assembly-syntax/src/library/module.rs
@@ -3,6 +3,8 @@ use core::ops::Index;
 
 use midenc_hir_type::FunctionType;
 
+use miden_core::mast::MastNodeId;
+
 use crate::{
     Path, Word,
     ast::{self, AttributeSet, ConstantValue, Ident, ItemIndex, ProcedureName},
@@ -45,9 +47,17 @@ impl ModuleInfo {
         digest: Word,
         signature: Option<Arc<FunctionType>>,
         attributes: AttributeSet,
+        source_root_id: Option<MastNodeId>,
+        source_library_commitment: Option<Word>,
     ) {
-        self.items
-            .push(ItemInfo::Procedure(ProcedureInfo { name, digest, signature, attributes }));
+        self.items.push(ItemInfo::Procedure(ProcedureInfo {
+            name,
+            digest,
+            signature,
+            attributes,
+            source_root_id,
+            source_library_commitment,
+        }));
     }
 
     /// Adds a constant to the module.
@@ -181,6 +191,23 @@ pub struct ProcedureInfo {
     pub digest: Word,
     pub signature: Option<Arc<FunctionType>>,
     pub attributes: AttributeSet,
+    /// The exact procedure root in the source library, if known.
+    ///
+    /// This is needed when multiple exported procedures share the same digest but carry different
+    /// diagnostics metadata.
+    pub source_root_id: Option<MastNodeId>,
+    /// The commitment of the source library forest that `source_root_id` belongs to, if known.
+    pub source_library_commitment: Option<Word>,
+}
+
+impl ProcedureInfo {
+    pub fn source_root_id(&self) -> Option<MastNodeId> {
+        self.source_root_id
+    }
+
+    pub fn source_library_commitment(&self) -> Option<Word> {
+        self.source_library_commitment
+    }
 }
 
 /// Stores the name and value of a constant

--- a/crates/assembly-syntax/src/library/module.rs
+++ b/crates/assembly-syntax/src/library/module.rs
@@ -1,9 +1,8 @@
 use alloc::{sync::Arc, vec::Vec};
 use core::ops::Index;
 
-use midenc_hir_type::FunctionType;
-
 use miden_core::mast::MastNodeId;
+use midenc_hir_type::FunctionType;
 
 use crate::{
     Path, Word,
@@ -42,6 +41,17 @@ impl ModuleInfo {
 
     /// Adds a procedure to the module.
     pub fn add_procedure(
+        &mut self,
+        name: ProcedureName,
+        digest: Word,
+        signature: Option<Arc<FunctionType>>,
+        attributes: AttributeSet,
+    ) {
+        self.add_procedure_with_provenance(name, digest, signature, attributes, None, None);
+    }
+
+    /// Adds a procedure to the module with optional source provenance.
+    pub fn add_procedure_with_provenance(
         &mut self,
         name: ProcedureName,
         digest: Word,
@@ -96,12 +106,17 @@ impl ModuleInfo {
         })
     }
 
-    /// Returns the digest of the procedure with the provided name, if any.
-    pub fn get_procedure_digest_by_name(&self, name: &str) -> Option<Word> {
+    /// Returns the procedure info for the procedure with the provided name, if any.
+    pub fn get_procedure_by_name(&self, name: &str) -> Option<&ProcedureInfo> {
         self.items.iter().find_map(|info| match info {
-            ItemInfo::Procedure(proc) if proc.name.as_str() == name => Some(proc.digest),
+            ItemInfo::Procedure(proc) if proc.name.as_str() == name => Some(proc),
             _ => None,
         })
+    }
+
+    /// Returns the digest of the procedure with the provided name, if any.
+    pub fn get_procedure_digest_by_name(&self, name: &str) -> Option<Word> {
+        self.get_procedure_by_name(name).map(|proc| proc.digest)
     }
 
     /// Returns an iterator over the items in the module with their corresponding item index in the

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -666,6 +666,8 @@ impl Assembler {
                             InvokeKind::ProcRef,
                             SourceSpan::UNKNOWN,
                             item.digest,
+                            item.source_library_commitment(),
+                            item.source_root_id(),
                             mast_forest_builder,
                         )?;
                         ResolvedProcedure { node, signature: item.signature.clone() }
@@ -1470,6 +1472,8 @@ impl Assembler {
                     kind,
                     target.span(),
                     mast_root.into_inner(),
+                    None,
+                    None,
                     mast_forest_builder,
                 )?;
                 Ok(Some(ResolvedProcedure { node, signature: None }))
@@ -1488,6 +1492,8 @@ impl Assembler {
                                 kind,
                                 target.span(),
                                 p.digest,
+                                p.source_library_commitment(),
+                                p.source_root_id(),
                                 mast_forest_builder,
                             )?;
                             Ok(Some(ResolvedProcedure { node, signature: p.signature.clone() }))
@@ -1519,6 +1525,8 @@ impl Assembler {
         kind: InvokeKind,
         span: SourceSpan,
         mast_root: Word,
+        source_library_commitment: Option<Word>,
+        source_root_id: Option<MastNodeId>,
         mast_forest_builder: &mut MastForestBuilder,
     ) -> Result<MastNodeId, Report> {
         // Get the procedure from the assembler
@@ -1544,7 +1552,11 @@ impl Assembler {
             }
         }
 
-        mast_forest_builder.ensure_external_link(mast_root)
+        mast_forest_builder.ensure_external_link_with_source(
+            mast_root,
+            source_library_commitment,
+            source_root_id,
+        )
     }
 }
 

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -1468,6 +1468,10 @@ impl Assembler {
         let resolved = self.linker.resolve_invoke_target(&caller, target)?;
         match resolved {
             SymbolResolution::MastRoot(mast_root) => {
+                // Literal MAST-root references in MASM do not carry any source-level provenance,
+                // so there is no exact source root or source package commitment to thread through
+                // here. We could try to guess based on linked libraries, but any such heuristic
+                // would be ambiguous when multiple procedures share the same digest.
                 let node = self.ensure_valid_procedure_mast_root(
                     kind,
                     target.span(),

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -1185,11 +1185,7 @@ impl MastForestBuilder {
             return self.copy_statically_linked_subtree(root_id);
         }
 
-        if let Some(root_id) = self.statically_linked_mast.find_procedure_root(mast_root) {
-            self.copy_statically_linked_subtree(root_id)
-        } else {
-            self.ensure_node(ExternalNodeBuilder::new(mast_root))
-        }
+        self.ensure_node(ExternalNodeBuilder::new(mast_root))
     }
 
     fn find_statically_linked_root(
@@ -1198,17 +1194,24 @@ impl MastForestBuilder {
         source_root_id: Option<MastNodeId>,
         mast_root: Word,
     ) -> Option<MastNodeId> {
-        let forest_idx = self
-            .statically_linked_forest_indices_by_commitment
-            .get(&source_library_commitment?)?;
-        let merged_root =
-            self.statically_linked_root_map.map_root(*forest_idx, &source_root_id?)?;
+        if let (Some(source_library_commitment), Some(source_root_id)) =
+            (source_library_commitment, source_root_id)
+        {
+            let exact_root = self
+                .statically_linked_forest_indices_by_commitment
+                .get(&source_library_commitment)
+                .and_then(|forest_idx| {
+                    self.statically_linked_root_map.map_root(*forest_idx, &source_root_id)
+                });
 
-        if self.statically_linked_mast[merged_root].digest() == mast_root {
-            Some(merged_root)
-        } else {
-            None
+            if let Some(exact_root) = exact_root
+                .filter(|root_id| self.statically_linked_mast[*root_id].digest() == mast_root)
+            {
+                return Some(exact_root);
+            }
         }
+
+        self.statically_linked_mast.find_procedure_root(mast_root)
     }
 
     /// Copies a subtree from the statically linked forest into the builder's forest.

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -11,8 +11,8 @@ use miden_core::{
     mast::{
         AsmOpId, BasicBlockNode, BasicBlockNodeBuilder, DecoratorFingerprint, DecoratorId,
         ExternalNodeBuilder, JoinNodeBuilder, MastForest, MastForestContributor, MastForestError,
-        MastNode, MastNodeBuilder, MastNodeExt, MastNodeFingerprint, MastNodeId, Remapping,
-        SubtreeIterator,
+        MastForestRootMap, MastNode, MastNodeBuilder, MastNodeExt, MastNodeFingerprint, MastNodeId,
+        Remapping, SubtreeIterator,
     },
     operations::{AssemblyOp, Decorator, DecoratorList, Operation},
     serde::Serializable,
@@ -71,6 +71,12 @@ pub struct MastForestBuilder {
     /// A MastForest that contains the MAST of all statically-linked libraries, it's used to find
     /// precompiled procedures and copy their subtrees instead of inserting external nodes.
     statically_linked_mast: Arc<MastForest>,
+    /// Maps each statically linked source forest commitment to its position in the merged forest
+    /// root map.
+    statically_linked_forest_indices_by_commitment: BTreeMap<Word, usize>,
+    /// Maps procedure roots from each source static library to their new root ID in the merged
+    /// static forest.
+    statically_linked_root_map: MastForestRootMap,
     /// Keeps track of the new ids assigned to nodes that are copied from the MAST of
     /// statically-linked libraries.
     statically_linked_mast_remapping: Remapping,
@@ -108,8 +114,14 @@ impl MastForestBuilder {
         static_libraries: impl IntoIterator<Item = &'a MastForest>,
     ) -> Result<Self, Report> {
         // All statically-linked libraries are merged into a single MastForest.
-        let forests = static_libraries.into_iter();
-        let (statically_linked_mast, _remapping) = MastForest::merge(forests).into_diagnostic()?;
+        let forests = static_libraries.into_iter().collect::<Vec<_>>();
+        let statically_linked_forest_indices_by_commitment = forests
+            .iter()
+            .enumerate()
+            .map(|(idx, forest)| (forest.commitment(), idx))
+            .collect();
+        let (statically_linked_mast, statically_linked_root_map) =
+            MastForest::merge(forests.iter().copied()).into_diagnostic()?;
         // The AdviceMap of the statically-linked forest is copied to the forest being built.
         //
         // This might include excess advice map data in the built MastForest, but we currently do
@@ -120,6 +132,8 @@ impl MastForestBuilder {
         Ok(MastForestBuilder {
             mast_forest,
             statically_linked_mast: Arc::new(statically_linked_mast),
+            statically_linked_forest_indices_by_commitment,
+            statically_linked_root_map,
             emit_debug_info: true,
             ..Self::default()
         })
@@ -1157,14 +1171,43 @@ impl MastForestBuilder {
     ///   the inserted subtree is returned.
     /// * If dynamically-linked, then an external node is inserted, and its MastNodeId is returned
     ///
-    /// TODO(#2990): when multiple roots share the same digest but carry
-    /// different metadata, this always picks the first match. Needs a source
-    /// MastNodeId threaded from ProcedureInfo through the linker.
-    pub fn ensure_external_link(&mut self, mast_root: Word) -> Result<MastNodeId, Report> {
+    /// Adds a node corresponding to the given MAST root, preferring an exact source root when
+    /// provenance from a statically-linked library is available.
+    pub fn ensure_external_link_with_source(
+        &mut self,
+        mast_root: Word,
+        source_library_commitment: Option<Word>,
+        source_root_id: Option<MastNodeId>,
+    ) -> Result<MastNodeId, Report> {
+        if let Some(root_id) =
+            self.find_statically_linked_root(source_library_commitment, source_root_id, mast_root)
+        {
+            return self.copy_statically_linked_subtree(root_id);
+        }
+
         if let Some(root_id) = self.statically_linked_mast.find_procedure_root(mast_root) {
             self.copy_statically_linked_subtree(root_id)
         } else {
             self.ensure_node(ExternalNodeBuilder::new(mast_root))
+        }
+    }
+
+    fn find_statically_linked_root(
+        &self,
+        source_library_commitment: Option<Word>,
+        source_root_id: Option<MastNodeId>,
+        mast_root: Word,
+    ) -> Option<MastNodeId> {
+        let forest_idx = self
+            .statically_linked_forest_indices_by_commitment
+            .get(&source_library_commitment?)?;
+        let merged_root =
+            self.statically_linked_root_map.map_root(*forest_idx, &source_root_id?)?;
+
+        if self.statically_linked_mast[merged_root].digest() == mast_root {
+            Some(merged_root)
+        } else {
+            None
         }
     }
 
@@ -1842,8 +1885,9 @@ mod tests {
         static_forest.make_root(static_block_id);
 
         let mut builder = MastForestBuilder::new([&static_forest]).unwrap();
-        let copied_block_id =
-            builder.ensure_external_link(static_forest[static_block_id].digest()).unwrap();
+        let copied_block_id = builder
+            .ensure_external_link_with_source(static_forest[static_block_id].digest(), None, None)
+            .unwrap();
 
         let local_var_id = builder
             .add_debug_var(DebugVarInfo::new("y", DebugVarLocation::Stack(1)))
@@ -1920,8 +1964,9 @@ mod tests {
         let expected_padded_idx = static_forest.debug_info().asm_ops_for_node(static_block)[0].0;
 
         let mut builder = MastForestBuilder::new([&static_forest]).unwrap();
-        let copied_block_id =
-            builder.ensure_external_link(static_forest[static_block].digest()).unwrap();
+        let copied_block_id = builder
+            .ensure_external_link_with_source(static_forest[static_block].digest(), None, None)
+            .unwrap();
         let local_block_id = builder
             .ensure_block(ops, Vec::new(), vec![(8, asm_op)], vec![], vec![], vec![])
             .unwrap();
@@ -2089,7 +2134,9 @@ mod tests {
         let (static_forest, _) = source_builder.build();
 
         let mut builder = MastForestBuilder::new([&static_forest]).unwrap();
-        let linked = builder.ensure_external_link(static_forest[alias_a].digest()).unwrap();
+        let linked = builder
+            .ensure_external_link_with_source(static_forest[alias_a].digest(), None, None)
+            .unwrap();
         builder.mast_forest.make_root(linked);
         let (forest, _) = builder.build();
 
@@ -2101,11 +2148,10 @@ mod tests {
         );
     }
 
-    /// Digest-based linking picks the first root, so the second alias gets
-    /// the wrong metadata. Fixing this needs #2990.
+    /// Provenance-aware static linking can select the exact same-digest root instead of falling
+    /// back to the first digest match.
     #[test]
-    #[ignore = "requires #2990: source MastNodeId in ProcedureInfo"]
-    fn repro_statically_linked_same_digest_root_uses_first_alias_metadata() {
+    fn test_static_link_with_source_root_preserves_selected_alias_metadata() {
         let mut source_builder = MastForestBuilder::new(&[]).unwrap();
 
         let alias_a = source_builder
@@ -2144,10 +2190,15 @@ mod tests {
         };
         let (exact_forest, _) = exact_builder.build();
 
-        let mut digest_builder = MastForestBuilder::new([&static_forest]).unwrap();
-        let linked_alias_b =
-            digest_builder.ensure_external_link(static_forest[alias_b].digest()).unwrap();
-        let (linked_forest, _) = digest_builder.build();
+        let mut provenance_builder = MastForestBuilder::new([&static_forest]).unwrap();
+        let linked_alias_b = provenance_builder
+            .ensure_external_link_with_source(
+                static_forest[alias_b].digest(),
+                Some(static_forest.commitment()),
+                Some(alias_b),
+            )
+            .unwrap();
+        let (linked_forest, _) = provenance_builder.build();
 
         assert_eq!(
             exact_forest
@@ -2164,7 +2215,7 @@ mod tests {
                 .unwrap()
                 .context_name(),
             "alias_b",
-            "linking the second same-digest root by digest should preserve that root's metadata",
+            "provenance-aware linking should preserve the selected same-digest root metadata",
         );
     }
 }

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -115,6 +115,10 @@ impl MastForestBuilder {
     ) -> Result<Self, Report> {
         // All statically-linked libraries are merged into a single MastForest.
         let forests = static_libraries.into_iter().collect::<Vec<_>>();
+        // TODO(#3067): `MastForest::commitment()` only hashes procedure root digests, so two
+        // forests with identical roots but different debug metadata share the same commitment.
+        // Using that commitment as a lookup key can point provenance from one static library at
+        // another library's root map and still select the wrong diagnostics metadata.
         let statically_linked_forest_indices_by_commitment = forests
             .iter()
             .enumerate()

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -20,8 +20,8 @@ use miden_core::{
     events::EventId,
     field::PrimeField64,
     mast::{
-        CallNodeBuilder, JoinNodeBuilder, LoopNodeBuilder, MastForestContributor, MastNodeExt,
-        MastNodeId, SplitNodeBuilder,
+        CallNodeBuilder, JoinNodeBuilder, LoopNodeBuilder, MastForestContributor, MastNode,
+        MastNodeExt, MastNodeId, SplitNodeBuilder,
     },
     operations::Operation,
     program::Program,
@@ -374,6 +374,59 @@ fn library_procedure_collision() -> Result<(), Report> {
 
     // Keeping those procedures distinct adds one more node to the library forest.
     assert_eq!(lib2.mast_forest().num_nodes(), 6);
+
+    Ok(())
+}
+
+#[test]
+fn static_library_same_digest_procedure_uses_exact_root_metadata() -> Result<(), Report> {
+    let context = TestContext::new();
+
+    let aliases = r#"
+        pub proc alias_a
+            add
+        end
+
+        pub proc alias_b
+            add
+        end
+    "#;
+    let aliases = parse_module!(&context, "lib::aliases", aliases);
+    let library = Assembler::new(context.source_manager()).assemble_library([aliases])?;
+
+    let program_source = source_file!(
+        &context,
+        r#"
+        use lib::aliases
+
+        begin
+            exec.aliases::alias_b
+        end
+        "#
+    );
+
+    let program = Assembler::new(context.source_manager())
+        .with_static_library(library)?
+        .assemble_program(program_source)?;
+
+    let body_node_id = {
+        let root = program.entrypoint();
+        match &program.mast_forest()[root] {
+            MastNode::Join(join_node) => join_node.second(),
+            _ => root,
+        }
+    };
+    let context_name = program
+        .mast_forest()
+        .debug_info()
+        .first_asm_op_for_node(body_node_id)
+        .expect("statically linked procedure should preserve asm-op metadata")
+        .context_name();
+
+    assert!(
+        context_name.ends_with("alias_b"),
+        "expected alias_b metadata, got {context_name}"
+    );
 
     Ok(())
 }

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -228,9 +228,7 @@ impl Package {
             )));
         }
         let main_path = MasmPath::exec_path().join(ast::ProcedureName::MAIN_PROC_NAME);
-        if let Some(digest) = self.mast.get_procedure_root_by_path(&main_path)
-            && let Some(entrypoint) = self.mast.mast_forest().find_procedure_root(digest)
-        {
+        if let Some(entrypoint) = self.mast.get_procedure_node_by_path(&main_path) {
             let mast_forest = self.mast.mast_forest().clone();
             let kernel_dependency = self.kernel_runtime_dependency()?.cloned();
             match (self.try_embedded_kernel_library()?, kernel_dependency) {
@@ -392,24 +390,29 @@ impl Package {
             return Err(Report::msg("expected library but got an executable"));
         }
 
+        let entrypoint_namespace = entrypoint.namespace().to_absolute();
         let module = self
             .mast
             .module_infos()
-            .find(|info| info.path() == entrypoint.namespace())
+            .find(|info| info.path() == entrypoint_namespace.as_ref())
             .ok_or_else(|| {
                 Report::msg(format!(
                     "invalid entrypoint: library does not contain a module named '{}'",
                     entrypoint.namespace()
                 ))
             })?;
-        if let Some(digest) = module.get_procedure_digest_by_name(entrypoint.name()) {
+        if let Some(procedure) = module.get_procedure_by_name(entrypoint.name()) {
             let mast_forest = self.mast.mast_forest().clone();
-            let node_id = mast_forest.find_procedure_root(digest).ok_or_else(|| {
-                Report::msg(
-                    "invalid entrypoint: malformed library - procedure exported, but digest has \
-                     no node in the forest",
-                )
-            })?;
+            let digest = procedure.digest;
+            let node_id = procedure
+                .source_root_id()
+                .or_else(|| mast_forest.find_procedure_root(digest))
+                .ok_or_else(|| {
+                    Report::msg(
+                        "invalid entrypoint: malformed library - procedure exported, but digest \
+                         has no node in the forest",
+                    )
+                })?;
 
             let exec_path: Arc<MasmPath> =
                 MasmPath::exec_path().join(masm::ProcedureName::MAIN_PROC_NAME).into();
@@ -515,15 +518,16 @@ fn arbitrary_library() -> Arc<Library> {
 #[cfg(test)]
 mod tests {
     use alloc::{collections::BTreeMap, sync::Arc, vec, vec::Vec};
+    use core::str::FromStr;
 
     use miden_assembly_syntax::{
         Library,
-        ast::{Path as AstPath, PathBuf},
+        ast::{Path as AstPath, PathBuf, ProcedureName, QualifiedProcedureName},
         library::{LibraryExport, ProcedureExport as LibraryProcedureExport},
     };
     use miden_core::{
         mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, MastNodeId},
-        operations::Operation,
+        operations::{AssemblyOp, Operation},
         serde::Serializable,
     };
 
@@ -554,6 +558,35 @@ mod tests {
         exports.insert(path, LibraryExport::Procedure(export));
 
         Arc::new(Library::new(Arc::new(forest), exports).expect("failed to build library"))
+    }
+
+    fn build_same_digest_library(exports: &[(&str, &str)]) -> Arc<Library> {
+        let mut forest = MastForest::new();
+        let mut library_exports = BTreeMap::new();
+
+        for (path_str, context_name) in exports {
+            let asm_op_id = forest
+                .debug_info_mut()
+                .add_asm_op(AssemblyOp::new(None, (*context_name).into(), 1, "add".into()))
+                .expect("failed to add asm op");
+            let node_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+                .add_to_forest(&mut forest)
+                .expect("failed to build basic block");
+            let num_ops = forest[node_id].get_basic_block().unwrap().num_operations() as usize;
+            forest
+                .debug_info_mut()
+                .register_asm_ops(node_id, num_ops, vec![(0, asm_op_id)])
+                .expect("failed to register asm ops");
+            forest.make_root(node_id);
+
+            let path = absolute_path(path_str);
+            library_exports.insert(
+                Arc::clone(&path),
+                LibraryExport::Procedure(LibraryProcedureExport::new(node_id, path)),
+            );
+        }
+
+        Arc::new(Library::new(Arc::new(forest), library_exports).expect("failed to build library"))
     }
 
     fn build_package(
@@ -643,5 +676,46 @@ mod tests {
             .expect_err("multiple kernel runtime dependencies should be rejected");
 
         assert!(error.to_string().contains("declares multiple kernel runtime dependencies"));
+    }
+
+    #[test]
+    fn make_executable_preserves_selected_same_digest_root_metadata() {
+        let library =
+            build_same_digest_library(&[("app::alias_a", "alias_a"), ("app::alias_b", "alias_b")]);
+        let package = *Package::from_library(
+            PackageId::from("app"),
+            Version::new(1, 0, 0),
+            TargetType::Library,
+            library,
+            [],
+        );
+
+        let entrypoint = QualifiedProcedureName::from_str("app::alias_b").unwrap();
+        let executable = package.make_executable(&entrypoint).unwrap();
+
+        let main_path =
+            miden_assembly_syntax::Path::exec_path().join(ProcedureName::MAIN_PROC_NAME);
+        let entrypoint_node = executable.mast.get_procedure_node_by_path(&main_path).unwrap();
+        assert_eq!(
+            executable
+                .mast
+                .mast_forest()
+                .debug_info()
+                .first_asm_op_for_node(entrypoint_node)
+                .unwrap()
+                .context_name(),
+            "alias_b"
+        );
+
+        let program = executable.try_into_program().unwrap();
+        assert_eq!(
+            program
+                .mast_forest()
+                .debug_info()
+                .first_asm_op_for_node(program.entrypoint())
+                .unwrap()
+                .context_name(),
+            "alias_b"
+        );
     }
 }


### PR DESCRIPTION
When a statically linked library contains two procedures with identical operations but different source mappings, they share the same MAST digest. The linker resolves procedure references by digest only, so it always picks the first root — the second procedure silently inherits the first's diagnostics metadata. This patch fixes it.

Fixes https://github.com/0xMiden/miden-vm/issues/2990

