### PR TITLE
Clean up MAST forest wire layout and untrusted validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - [BREAKING] Refactored MAST forest serialization around fixed-layout full, stripped, and hashless sections, and bumped the MAST wire format to `0.0.3` ([#2765](https://github.com/0xMiden/miden-vm/pull/2765)).
 - Optimized call graph topological sort from O(V\*E) to O(V + E) by pre-computing in-degrees ([#2830](https://github.com/0xMiden/miden-vm/pull/2830)).
 - [BREAKING] Cleaned up the unreleased MAST forest wire format, with stable node IDs, stricter untrusted validation, and sorted external node digests before node entries ([#3055](https://github.com/0xMiden/miden-vm/pull/3055)).
+- [BREAKING] Cleaned up the unreleased MAST forest wire format, with stable node IDs and stricter untrusted validation ([#3055](https://github.com/0xMiden/miden-vm/pull/3055)).
 - Documented sortedness precondition more prominently for sorted array operations ([#2832](https://github.com/0xMiden/miden-vm/pull/2832)).
 - Removed AIR constraint tagging instrumentation, applied a uniform constraint description style across components, and optimized constraint evaluation ([#2856](https://github.com/0xMiden/miden-vm/pull/2856)).
 - [BREAKING] Sync execution and proving APIs now require `SyncHost`; async `Host`, `execute`, and `prove` remain available ([#2865](https://github.com/0xMiden/miden-vm/pull/2865)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,6 @@
 
 - [BREAKING] Refactored MAST forest serialization around fixed-layout full, stripped, and hashless sections, and bumped the MAST wire format to `0.0.3` ([#2765](https://github.com/0xMiden/miden-vm/pull/2765)).
 - Optimized call graph topological sort from O(V\*E) to O(V + E) by pre-computing in-degrees ([#2830](https://github.com/0xMiden/miden-vm/pull/2830)).
-- [BREAKING] Cleaned up the unreleased MAST forest wire format, with stable node IDs, stricter untrusted validation, and sorted external node digests before node entries ([#3055](https://github.com/0xMiden/miden-vm/pull/3055)).
 - [BREAKING] Cleaned up the unreleased MAST forest wire format, with stable node IDs and stricter untrusted validation ([#3055](https://github.com/0xMiden/miden-vm/pull/3055)).
 - Documented sortedness precondition more prominently for sorted array operations ([#2832](https://github.com/0xMiden/miden-vm/pull/2832)).
 - Removed AIR constraint tagging instrumentation, applied a uniform constraint description style across components, and optimized constraint evaluation ([#2856](https://github.com/0xMiden/miden-vm/pull/2856)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 
 - [BREAKING] Refactored MAST forest serialization around fixed-layout full, stripped, and hashless sections, and bumped the MAST wire format to `0.0.3` ([#2765](https://github.com/0xMiden/miden-vm/pull/2765)).
 - Optimized call graph topological sort from O(V\*E) to O(V + E) by pre-computing in-degrees ([#2830](https://github.com/0xMiden/miden-vm/pull/2830)).
+- [BREAKING] Cleaned up the unreleased MAST forest wire format, with stable node IDs, stricter untrusted validation, and sorted external node digests before node entries ([#3055](https://github.com/0xMiden/miden-vm/pull/3055)).
 - Documented sortedness precondition more prominently for sorted array operations ([#2832](https://github.com/0xMiden/miden-vm/pull/2832)).
 - Removed AIR constraint tagging instrumentation, applied a uniform constraint description style across components, and optimized constraint evaluation ([#2856](https://github.com/0xMiden/miden-vm/pull/2856)).
 - [BREAKING] Sync execution and proving APIs now require `SyncHost`; async `Host`, `execute`, and `prove` remain available ([#2865](https://github.com/0xMiden/miden-vm/pull/2865)).

--- a/air/src/trace/main_trace.rs
+++ b/air/src/trace/main_trace.rs
@@ -69,7 +69,7 @@ pub struct MainTraceRow<T> {
 
 impl<T> Borrow<MainTraceRow<T>> for [T] {
     fn borrow(&self) -> &MainTraceRow<T> {
-        debug_assert_eq!(self.len(), crate::TRACE_WIDTH);
+        debug_assert_eq!(self.len(), TRACE_WIDTH);
         let (prefix, shorts, suffix) = unsafe { self.align_to::<MainTraceRow<T>>() };
         debug_assert!(prefix.is_empty(), "Alignment should match");
         debug_assert!(suffix.is_empty(), "Alignment should match");
@@ -80,7 +80,7 @@ impl<T> Borrow<MainTraceRow<T>> for [T] {
 
 impl<T> BorrowMut<MainTraceRow<T>> for [T] {
     fn borrow_mut(&mut self) -> &mut MainTraceRow<T> {
-        debug_assert_eq!(self.len(), crate::TRACE_WIDTH);
+        debug_assert_eq!(self.len(), TRACE_WIDTH);
         let (prefix, shorts, suffix) = unsafe { self.align_to_mut::<MainTraceRow<T>>() };
         debug_assert!(prefix.is_empty(), "Alignment should match");
         debug_assert!(suffix.is_empty(), "Alignment should match");

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -1333,15 +1333,6 @@ pub enum MastForestError {
         expected: Word,
         computed: Word,
     },
-    #[error(
-        "external digests are not sorted: slot {previous_slot} ({previous:?}) is greater than slot {slot} ({current:?})"
-    )]
-    ExternalDigestsNotSorted {
-        previous_slot: usize,
-        slot: usize,
-        previous: Word,
-        current: Word,
-    },
     #[error("deserialization failed: {0}")]
     Deserialization(DeserializationError),
 }

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -1333,6 +1333,15 @@ pub enum MastForestError {
         expected: Word,
         computed: Word,
     },
+    #[error(
+        "external digests are not sorted: slot {previous_slot} ({previous:?}) is greater than slot {slot} ({current:?})"
+    )]
+    ExternalDigestsNotSorted {
+        previous_slot: usize,
+        slot: usize,
+        previous: Word,
+        current: Word,
+    },
     #[error("deserialization failed: {0}")]
     Deserialization(DeserializationError),
 }

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -74,14 +74,13 @@ pub use node::{
     OpBatch, OperationOrDecorator, SplitNode, SplitNodeBuilder,
 };
 
+#[cfg(feature = "serde")]
+use crate::serde::SliceReader;
 use crate::{
     Felt, Word,
     advice::AdviceMap,
     operations::{AssemblyOp, DebugVarInfo, Decorator},
-    serde::{
-        BudgetedReader, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-        SliceReader,
-    },
+    serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
     utils::{Idx, IndexVec, hash_string_to_word},
 };
 
@@ -93,6 +92,9 @@ pub use debuginfo::{
 
 mod serialization;
 pub use serialization::{MastForestView, MastNodeEntry, MastNodeInfo, SerializedMastForest};
+
+mod untrusted;
+pub use untrusted::UntrustedMastForest;
 
 mod merger;
 pub(crate) use merger::MastForestMerger;
@@ -1360,220 +1362,5 @@ impl<'de> Deserialize<'de> for MastForest {
         let bytes = Vec::<u8>::deserialize(deserializer)?;
         let mut slice_reader = SliceReader::new(&bytes);
         Deserializable::read_from(&mut slice_reader).map_err(serde::de::Error::custom)
-    }
-}
-
-// UNTRUSTED MAST FOREST
-// ================================================================================================
-
-/// A [`MastForest`] deserialized from untrusted input that has not yet been validated.
-///
-/// This type wraps a serialized-backed, decoded MAST representation that has not had its node
-/// hashes verified. Before using the forest, callers must call [`validate()`](Self::validate) to
-/// materialize and verify structural integrity and node hashes.
-///
-/// # Usage
-///
-/// ```ignore
-/// // Deserialize from untrusted bytes
-/// let untrusted = UntrustedMastForest::read_from_bytes(&bytes)?;
-///
-/// // Validate structure and hashes
-/// let forest = untrusted.validate()?;
-///
-/// // Now safe to use
-/// let root = forest.procedure_roots()[0];
-/// ```
-///
-/// # Security
-///
-/// This type exists to provide type-level safety for untrusted deserialization. The validation
-/// performed by [`validate()`](Self::validate) includes:
-///
-/// 1. **Structural validation**: Checks that basic block batch invariants are satisfied and
-///    procedure names reference valid roots.
-/// 2. **Topological ordering**: Verifies that all node references point to nodes that appear
-///    earlier in the forest (no forward references).
-/// 3. **Hash recomputation**: Recomputes the digest for every node and verifies it matches the
-///    stored digest.
-#[derive(Debug, Clone)]
-pub struct UntrustedMastForest {
-    bytes: Vec<u8>,
-    layout: serialization::ForestLayout,
-    advice_map: AdviceMap,
-    debug_info: DebugInfo,
-    remaining_allocation_budget: Option<usize>,
-}
-
-impl UntrustedMastForest {
-    /// Validates the forest by checking structural invariants and recomputing all node hashes.
-    ///
-    /// This method performs a complete validation of the deserialized forest:
-    ///
-    /// 1. If wire node hashes are present, recomputes all non-external node hashes and requires
-    ///    them to match the serialized digests.
-    /// 2. If the payload is hashless, uses the digests rebuilt during materialization.
-    /// 3. Validates structural invariants, topological ordering, and procedure-name roots.
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(MastForest)` if validation succeeds
-    /// - `Err(MastForestError)` with details about the first validation failure
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if:
-    /// - Deferred materialization from serialized form fails ([`MastForestError::Deserialization`])
-    /// - Any basic block has invalid batch structure ([`MastForestError::InvalidBatchPadding`])
-    /// - Any procedure name references a non-root digest
-    ///   ([`MastForestError::InvalidProcedureNameDigest`])
-    /// - Any node references a child that appears later in the forest
-    ///   ([`MastForestError::ForwardReference`])
-    /// - Any non-external wire digest does not match the recomputed digest
-    ///   ([`MastForestError::HashMismatch`])
-    /// - Any node's digest cannot be recomputed because structural validation fails first
-    ///
-    /// Security convention:
-    /// - Hashless payloads rebuild non-external digests from structure during materialization.
-    /// - If wire node hashes are present, validation recomputes them and requires them to match.
-    /// - External node digests are marshaled as opaque values and are not semantically resolved
-    ///   here.
-    pub fn validate(self) -> Result<MastForest, MastForestError> {
-        let is_hashless = self.layout.is_hashless();
-        let forest = self.into_materialized().map_err(MastForestError::Deserialization)?;
-
-        // Step 1: Validate over-specified wire hashes instead of silently rewriting them.
-        if !is_hashless {
-            forest.validate_node_hashes()?;
-        }
-
-        // Step 2: Validate the recomputed forest.
-        forest.validate()?;
-
-        Ok(forest)
-    }
-
-    /// Deserializes an [`UntrustedMastForest`] from bytes.
-    ///
-    /// This method uses a [`BudgetedReader`] plus a bounded validation-allocation budget derived
-    /// from the input size to protect against denial-of-service attacks from malicious input.
-    /// The default validation budget includes room for the retained serialized copy used by the
-    /// deferred-validation path, in addition to stripped/hashless helper allocations. Concretely,
-    /// the default is `bytes.len()` for parsing and `bytes.len() * 7` for validation allocations.
-    /// That `* 7` factor is a coarse convenience bound, not an exact peak-memory formula.
-    ///
-    /// For explicit parsing and validation limits, use
-    /// [`read_from_bytes_with_budgets`](Self::read_from_bytes_with_budgets).
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// // Read from untrusted source
-    /// let untrusted = UntrustedMastForest::read_from_bytes(&bytes)?;
-    ///
-    /// // Validate before use
-    /// let forest = untrusted.validate()?;
-    /// ```
-    pub fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
-        Self::read_from_bytes_with_budgets(
-            bytes,
-            bytes.len(),
-            serialization::default_untrusted_allocation_budget(bytes.len()),
-        )
-    }
-
-    /// Deserializes an [`UntrustedMastForest`] from bytes and returns the raw wire flags.
-    ///
-    /// This enables callers to inspect serializer intent flags (e.g., HASHLESS) without affecting
-    /// the untrusted deserialization path.
-    pub fn read_from_bytes_with_flags(bytes: &[u8]) -> Result<(Self, u8), DeserializationError> {
-        Self::read_from_bytes_with_budgets_and_flags(
-            bytes,
-            bytes.len(),
-            serialization::default_untrusted_allocation_budget(bytes.len()),
-        )
-    }
-
-    /// Deserializes an [`UntrustedMastForest`] from bytes with a byte budget.
-    ///
-    /// This method uses a [`BudgetedReader`] to limit memory consumption during deserialization,
-    /// protecting against denial-of-service attacks from malicious input that claims to contain
-    /// an excessive number of elements.
-    ///
-    /// # Arguments
-    ///
-    /// * `bytes` - The serialized forest bytes
-    /// * `budget` - Maximum bytes to consume while parsing the wire payload and pre-sizing
-    ///   wire-driven collections via [`BudgetedReader`]
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// // Read from untrusted source with an explicit parsing budget
-    /// let untrusted = UntrustedMastForest::read_from_bytes_with_budget(&bytes, bytes.len())?;
-    ///
-    /// // Validate before use
-    /// let forest = untrusted.validate()?;
-    /// ```
-    ///
-    /// # Security
-    ///
-    /// The budget limits:
-    /// - Pre-allocation sizes when deserializing collections (via `max_alloc`)
-    /// - Total bytes consumed during deserialization
-    ///
-    /// This prevents attacks where malicious input claims an unrealistic number of elements
-    /// (e.g., `len = 2^60`), causing excessive memory allocation before any data is read.
-    ///
-    /// To also cap stripped/hashless validation helper allocations, use
-    /// [`read_from_bytes_with_budgets`](Self::read_from_bytes_with_budgets).
-    pub fn read_from_bytes_with_budget(
-        bytes: &[u8],
-        budget: usize,
-    ) -> Result<Self, DeserializationError> {
-        let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
-        serialization::read_untrusted_with_flags(&mut reader).map(|(forest, _flags)| forest)
-    }
-
-    /// Deserializes an [`UntrustedMastForest`] from bytes with a byte budget and returns flags.
-    pub fn read_from_bytes_with_budget_and_flags(
-        bytes: &[u8],
-        budget: usize,
-    ) -> Result<(Self, u8), DeserializationError> {
-        let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
-        serialization::read_untrusted_with_flags(&mut reader)
-    }
-
-    /// Deserializes an [`UntrustedMastForest`] from bytes with separate parsing and validation
-    /// budgets.
-    ///
-    /// `parsing_budget` limits wire-driven parsing and collection pre-sizing. `validation_budget`
-    /// additionally caps tracked stripped/hashless helper allocations such as empty debug-info
-    /// scaffolding, digest slot tables, and rebuilt digest tables.
-    pub fn read_from_bytes_with_budgets(
-        bytes: &[u8],
-        parsing_budget: usize,
-        validation_budget: usize,
-    ) -> Result<Self, DeserializationError> {
-        let mut reader = BudgetedReader::new(SliceReader::new(bytes), parsing_budget);
-        serialization::read_untrusted_with_flags_and_allocation_budget(
-            &mut reader,
-            validation_budget,
-        )
-        .map(|(forest, _flags)| forest)
-    }
-
-    /// Deserializes an [`UntrustedMastForest`] from bytes with separate parsing and validation
-    /// budgets and returns flags.
-    pub fn read_from_bytes_with_budgets_and_flags(
-        bytes: &[u8],
-        parsing_budget: usize,
-        validation_budget: usize,
-    ) -> Result<(Self, u8), DeserializationError> {
-        let mut reader = BudgetedReader::new(SliceReader::new(bytes), parsing_budget);
-        serialization::read_untrusted_with_flags_and_allocation_budget(
-            &mut reader,
-            validation_budget,
-        )
     }
 }

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -6,6 +6,7 @@ use crate::mast::node::MastNodeExt;
 use crate::{
     mast::{MastForestContributor, MastNode, MastNodeId, Word, node::MastNodeBuilder},
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    utils::Idx,
 };
 
 // CONSTANTS
@@ -70,28 +71,50 @@ impl MastNodeEntry {
 
     /// Constructs a new [`MastNodeEntry`] from a [`MastNode`].
     pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
+        Self::new_inner(mast_node, ops_offset, None)
+    }
+
+    /// Constructs a new [`MastNodeEntry`] from a [`MastNode`], remapping child IDs when needed.
+    #[deprecated(note = "use MastNodeEntry::new(); remapped wire ordering has been removed")]
+    pub fn new_with_id_remap(
+        mast_node: &MastNode,
+        ops_offset: NodeDataOffset,
+        id_remap: Option<&[u32]>,
+    ) -> Self {
+        Self::new_inner(mast_node, ops_offset, id_remap)
+    }
+
+    fn new_inner(
+        mast_node: &MastNode,
+        ops_offset: NodeDataOffset,
+        id_remap: Option<&[u32]>,
+    ) -> Self {
         use MastNode::*;
 
         if !matches!(mast_node, &Block(_)) {
             debug_assert_eq!(ops_offset, 0);
         }
 
+        let remap_id = |id: MastNodeId| -> u32 {
+            id_remap.and_then(|remap| remap.get(id.to_usize()).copied()).unwrap_or(id.0)
+        };
+
         match mast_node {
             Block(_) => Self::Block { ops_offset },
             Join(join_node) => Self::Join {
-                left_child_id: join_node.first().0,
-                right_child_id: join_node.second().0,
+                left_child_id: remap_id(join_node.first()),
+                right_child_id: remap_id(join_node.second()),
             },
             Split(split_node) => Self::Split {
-                if_branch_id: split_node.on_true().0,
-                else_branch_id: split_node.on_false().0,
+                if_branch_id: remap_id(split_node.on_true()),
+                else_branch_id: remap_id(split_node.on_false()),
             },
-            Loop(loop_node) => Self::Loop { body_id: loop_node.body().0 },
+            Loop(loop_node) => Self::Loop { body_id: remap_id(loop_node.body()) },
             Call(call_node) => {
                 if call_node.is_syscall() {
-                    Self::SysCall { callee_id: call_node.callee().0 }
+                    Self::SysCall { callee_id: remap_id(call_node.callee()) }
                 } else {
-                    Self::Call { callee_id: call_node.callee().0 }
+                    Self::Call { callee_id: remap_id(call_node.callee()) }
                 }
             },
             Dyn(dyn_node) => {

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -6,7 +6,6 @@ use crate::mast::node::MastNodeExt;
 use crate::{
     mast::{MastForestContributor, MastNode, MastNodeId, Word, node::MastNodeBuilder},
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
-    utils::Idx,
 };
 
 // CONSTANTS
@@ -71,41 +70,28 @@ impl MastNodeEntry {
 
     /// Constructs a new [`MastNodeEntry`] from a [`MastNode`].
     pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
-        Self::new_with_id_remap(mast_node, ops_offset, None)
-    }
-
-    /// Constructs a new [`MastNodeEntry`] from a [`MastNode`], remapping child IDs when needed.
-    pub fn new_with_id_remap(
-        mast_node: &MastNode,
-        ops_offset: NodeDataOffset,
-        id_remap: Option<&[u32]>,
-    ) -> Self {
         use MastNode::*;
 
         if !matches!(mast_node, &Block(_)) {
             debug_assert_eq!(ops_offset, 0);
         }
 
-        let remap_id = |id: MastNodeId| -> u32 {
-            id_remap.and_then(|remap| remap.get(id.to_usize()).copied()).unwrap_or(id.0)
-        };
-
         match mast_node {
             Block(_) => Self::Block { ops_offset },
             Join(join_node) => Self::Join {
-                left_child_id: remap_id(join_node.first()),
-                right_child_id: remap_id(join_node.second()),
+                left_child_id: join_node.first().0,
+                right_child_id: join_node.second().0,
             },
             Split(split_node) => Self::Split {
-                if_branch_id: remap_id(split_node.on_true()),
-                else_branch_id: remap_id(split_node.on_false()),
+                if_branch_id: split_node.on_true().0,
+                else_branch_id: split_node.on_false().0,
             },
-            Loop(loop_node) => Self::Loop { body_id: remap_id(loop_node.body()) },
+            Loop(loop_node) => Self::Loop { body_id: loop_node.body().0 },
             Call(call_node) => {
                 if call_node.is_syscall() {
-                    Self::SysCall { callee_id: remap_id(call_node.callee()) }
+                    Self::SysCall { callee_id: call_node.callee().0 }
                 } else {
-                    Self::Call { callee_id: remap_id(call_node.callee()) }
+                    Self::Call { callee_id: call_node.callee().0 }
                 }
             },
             Dyn(dyn_node) => {
@@ -334,17 +320,8 @@ impl MastNodeInfo {
     /// For non-basic block nodes, `ops_offset` is ignored, and should be set to 0.
     #[cfg(test)]
     pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
-        Self::new_with_id_remap(mast_node, ops_offset, None)
-    }
-
-    #[cfg(test)]
-    pub fn new_with_id_remap(
-        mast_node: &MastNode,
-        ops_offset: NodeDataOffset,
-        id_remap: Option<&[u32]>,
-    ) -> Self {
         Self {
-            entry: MastNodeEntry::new_with_id_remap(mast_node, ops_offset, id_remap),
+            entry: MastNodeEntry::new(mast_node, ops_offset),
             digest: mast_node.digest(),
         }
     }

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -75,7 +75,6 @@ impl MastNodeEntry {
     }
 
     /// Constructs a new [`MastNodeEntry`] from a [`MastNode`], remapping child IDs when needed.
-    #[deprecated(note = "use MastNodeEntry::new(); remapped wire ordering has been removed")]
     pub fn new_with_id_remap(
         mast_node: &MastNode,
         ops_offset: NodeDataOffset,

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -6,6 +6,7 @@ use crate::mast::node::MastNodeExt;
 use crate::{
     mast::{MastForestContributor, MastNode, MastNodeId, Word, node::MastNodeBuilder},
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    utils::Idx,
 };
 
 // CONSTANTS
@@ -70,28 +71,41 @@ impl MastNodeEntry {
 
     /// Constructs a new [`MastNodeEntry`] from a [`MastNode`].
     pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
+        Self::new_with_id_remap(mast_node, ops_offset, None)
+    }
+
+    /// Constructs a new [`MastNodeEntry`] from a [`MastNode`], remapping child IDs when needed.
+    pub fn new_with_id_remap(
+        mast_node: &MastNode,
+        ops_offset: NodeDataOffset,
+        id_remap: Option<&[u32]>,
+    ) -> Self {
         use MastNode::*;
 
         if !matches!(mast_node, &Block(_)) {
             debug_assert_eq!(ops_offset, 0);
         }
 
+        let remap_id = |id: MastNodeId| -> u32 {
+            id_remap.and_then(|remap| remap.get(id.to_usize()).copied()).unwrap_or(id.0)
+        };
+
         match mast_node {
             Block(_) => Self::Block { ops_offset },
             Join(join_node) => Self::Join {
-                left_child_id: join_node.first().0,
-                right_child_id: join_node.second().0,
+                left_child_id: remap_id(join_node.first()),
+                right_child_id: remap_id(join_node.second()),
             },
             Split(split_node) => Self::Split {
-                if_branch_id: split_node.on_true().0,
-                else_branch_id: split_node.on_false().0,
+                if_branch_id: remap_id(split_node.on_true()),
+                else_branch_id: remap_id(split_node.on_false()),
             },
-            Loop(loop_node) => Self::Loop { body_id: loop_node.body().0 },
+            Loop(loop_node) => Self::Loop { body_id: remap_id(loop_node.body()) },
             Call(call_node) => {
                 if call_node.is_syscall() {
-                    Self::SysCall { callee_id: call_node.callee().0 }
+                    Self::SysCall { callee_id: remap_id(call_node.callee()) }
                 } else {
-                    Self::Call { callee_id: call_node.callee().0 }
+                    Self::Call { callee_id: remap_id(call_node.callee()) }
                 }
             },
             Dyn(dyn_node) => {
@@ -320,8 +334,17 @@ impl MastNodeInfo {
     /// For non-basic block nodes, `ops_offset` is ignored, and should be set to 0.
     #[cfg(test)]
     pub fn new(mast_node: &MastNode, ops_offset: NodeDataOffset) -> Self {
+        Self::new_with_id_remap(mast_node, ops_offset, None)
+    }
+
+    #[cfg(test)]
+    pub fn new_with_id_remap(
+        mast_node: &MastNode,
+        ops_offset: NodeDataOffset,
+        id_remap: Option<&[u32]>,
+    ) -> Self {
         Self {
-            entry: MastNodeEntry::new(mast_node, ops_offset),
+            entry: MastNodeEntry::new_with_id_remap(mast_node, ops_offset, id_remap),
             digest: mast_node.digest(),
         }
     }

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -255,7 +255,10 @@ impl Deserializable for MastNodeEntry {
             },
             DYN => Ok(Self::Dyn),
             DYNCALL => Ok(Self::Dyncall),
-            EXTERNAL => Ok(Self::External),
+            EXTERNAL => {
+                let _digest_slot = Self::decode_u32_payload(payload)?;
+                Ok(Self::External)
+            },
             _ => Err(DeserializationError::InvalidValue(format!(
                 "Invalid tag for MAST node: {discriminant}"
             ))),
@@ -265,6 +268,119 @@ impl Deserializable for MastNodeEntry {
     /// Returns the fixed serialized size: always 8 bytes (u64).
     fn min_serialized_size() -> usize {
         Self::SERIALIZED_SIZE
+    }
+}
+
+/// Fixed-width wire entry for one MAST node.
+///
+/// `entry` stores the node shape and child/basic-block references. External nodes do not carry
+/// their digest inline: `external_digest_slot` points into the sorted external-digest prefix of the
+/// serialized forest. The slot is present if and only if `entry` is [`MastNodeEntry::External`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct MastNodeWireEntry {
+    entry: MastNodeEntry,
+    external_digest_slot: Option<u32>,
+}
+
+impl MastNodeWireEntry {
+    pub(super) fn new(entry: MastNodeEntry, external_digest_slot: Option<u32>) -> Self {
+        debug_assert_eq!(matches!(entry, MastNodeEntry::External), external_digest_slot.is_some());
+        Self { entry, external_digest_slot }
+    }
+
+    pub(super) fn entry(self) -> MastNodeEntry {
+        self.entry
+    }
+
+    pub(super) fn external_digest_slot(self) -> Option<u32> {
+        self.external_digest_slot
+    }
+}
+
+impl Serializable for MastNodeWireEntry {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        let discriminant = self.entry.discriminant() as u64;
+        assert!(discriminant <= 0b1111);
+
+        let payload = match self.entry {
+            MastNodeEntry::Join {
+                left_child_id: left,
+                right_child_id: right,
+            } => MastNodeEntry::encode_u32_pair(left, right),
+            MastNodeEntry::Split {
+                if_branch_id: if_branch,
+                else_branch_id: else_branch,
+            } => MastNodeEntry::encode_u32_pair(if_branch, else_branch),
+            MastNodeEntry::Loop { body_id: body } => MastNodeEntry::encode_u32_payload(body),
+            MastNodeEntry::Block { ops_offset } => MastNodeEntry::encode_u32_payload(ops_offset),
+            MastNodeEntry::Call { callee_id } => MastNodeEntry::encode_u32_payload(callee_id),
+            MastNodeEntry::SysCall { callee_id } => MastNodeEntry::encode_u32_payload(callee_id),
+            MastNodeEntry::Dyn | MastNodeEntry::Dyncall => 0,
+            MastNodeEntry::External => MastNodeEntry::encode_u32_payload(
+                self.external_digest_slot
+                    .expect("external wire entries must carry a digest slot"),
+            ),
+        };
+
+        let value = (discriminant << 60) | payload;
+        target.write_u64(value);
+    }
+}
+
+impl Deserializable for MastNodeWireEntry {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let (discriminant, payload) = {
+            let value = source.read_u64()?;
+
+            let discriminant = (value >> 60) as u8;
+            let payload = value & 0x0f_ff_ff_ff_ff_ff_ff_ff;
+
+            (discriminant, payload)
+        };
+
+        let (entry, external_digest_slot) = match discriminant {
+            JOIN => {
+                let (left_child_id, right_child_id) = MastNodeEntry::decode_u32_pair(payload);
+                (MastNodeEntry::Join { left_child_id, right_child_id }, None)
+            },
+            SPLIT => {
+                let (if_branch_id, else_branch_id) = MastNodeEntry::decode_u32_pair(payload);
+                (MastNodeEntry::Split { if_branch_id, else_branch_id }, None)
+            },
+            LOOP => {
+                let body_id = MastNodeEntry::decode_u32_payload(payload)?;
+                (MastNodeEntry::Loop { body_id }, None)
+            },
+            BLOCK => {
+                let ops_offset = MastNodeEntry::decode_u32_payload(payload)?;
+                (MastNodeEntry::Block { ops_offset }, None)
+            },
+            CALL => {
+                let callee_id = MastNodeEntry::decode_u32_payload(payload)?;
+                (MastNodeEntry::Call { callee_id }, None)
+            },
+            SYSCALL => {
+                let callee_id = MastNodeEntry::decode_u32_payload(payload)?;
+                (MastNodeEntry::SysCall { callee_id }, None)
+            },
+            DYN => (MastNodeEntry::Dyn, None),
+            DYNCALL => (MastNodeEntry::Dyncall, None),
+            EXTERNAL => {
+                let digest_slot = MastNodeEntry::decode_u32_payload(payload)?;
+                (MastNodeEntry::External, Some(digest_slot))
+            },
+            _ => {
+                return Err(DeserializationError::InvalidValue(format!(
+                    "Invalid tag for MAST node: {discriminant}"
+                )));
+            },
+        };
+
+        Ok(Self { entry, external_digest_slot })
+    }
+
+    fn min_serialized_size() -> usize {
+        MastNodeEntry::SERIALIZED_SIZE
     }
 }
 

--- a/core/src/mast/serialization/info.rs
+++ b/core/src/mast/serialization/info.rs
@@ -255,10 +255,7 @@ impl Deserializable for MastNodeEntry {
             },
             DYN => Ok(Self::Dyn),
             DYNCALL => Ok(Self::Dyncall),
-            EXTERNAL => {
-                let _digest_slot = Self::decode_u32_payload(payload)?;
-                Ok(Self::External)
-            },
+            EXTERNAL => Ok(Self::External),
             _ => Err(DeserializationError::InvalidValue(format!(
                 "Invalid tag for MAST node: {discriminant}"
             ))),
@@ -268,119 +265,6 @@ impl Deserializable for MastNodeEntry {
     /// Returns the fixed serialized size: always 8 bytes (u64).
     fn min_serialized_size() -> usize {
         Self::SERIALIZED_SIZE
-    }
-}
-
-/// Fixed-width wire entry for one MAST node.
-///
-/// `entry` stores the node shape and child/basic-block references. External nodes do not carry
-/// their digest inline: `external_digest_slot` points into the sorted external-digest prefix of the
-/// serialized forest. The slot is present if and only if `entry` is [`MastNodeEntry::External`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct MastNodeWireEntry {
-    entry: MastNodeEntry,
-    external_digest_slot: Option<u32>,
-}
-
-impl MastNodeWireEntry {
-    pub(super) fn new(entry: MastNodeEntry, external_digest_slot: Option<u32>) -> Self {
-        debug_assert_eq!(matches!(entry, MastNodeEntry::External), external_digest_slot.is_some());
-        Self { entry, external_digest_slot }
-    }
-
-    pub(super) fn entry(self) -> MastNodeEntry {
-        self.entry
-    }
-
-    pub(super) fn external_digest_slot(self) -> Option<u32> {
-        self.external_digest_slot
-    }
-}
-
-impl Serializable for MastNodeWireEntry {
-    fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let discriminant = self.entry.discriminant() as u64;
-        assert!(discriminant <= 0b1111);
-
-        let payload = match self.entry {
-            MastNodeEntry::Join {
-                left_child_id: left,
-                right_child_id: right,
-            } => MastNodeEntry::encode_u32_pair(left, right),
-            MastNodeEntry::Split {
-                if_branch_id: if_branch,
-                else_branch_id: else_branch,
-            } => MastNodeEntry::encode_u32_pair(if_branch, else_branch),
-            MastNodeEntry::Loop { body_id: body } => MastNodeEntry::encode_u32_payload(body),
-            MastNodeEntry::Block { ops_offset } => MastNodeEntry::encode_u32_payload(ops_offset),
-            MastNodeEntry::Call { callee_id } => MastNodeEntry::encode_u32_payload(callee_id),
-            MastNodeEntry::SysCall { callee_id } => MastNodeEntry::encode_u32_payload(callee_id),
-            MastNodeEntry::Dyn | MastNodeEntry::Dyncall => 0,
-            MastNodeEntry::External => MastNodeEntry::encode_u32_payload(
-                self.external_digest_slot
-                    .expect("external wire entries must carry a digest slot"),
-            ),
-        };
-
-        let value = (discriminant << 60) | payload;
-        target.write_u64(value);
-    }
-}
-
-impl Deserializable for MastNodeWireEntry {
-    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let (discriminant, payload) = {
-            let value = source.read_u64()?;
-
-            let discriminant = (value >> 60) as u8;
-            let payload = value & 0x0f_ff_ff_ff_ff_ff_ff_ff;
-
-            (discriminant, payload)
-        };
-
-        let (entry, external_digest_slot) = match discriminant {
-            JOIN => {
-                let (left_child_id, right_child_id) = MastNodeEntry::decode_u32_pair(payload);
-                (MastNodeEntry::Join { left_child_id, right_child_id }, None)
-            },
-            SPLIT => {
-                let (if_branch_id, else_branch_id) = MastNodeEntry::decode_u32_pair(payload);
-                (MastNodeEntry::Split { if_branch_id, else_branch_id }, None)
-            },
-            LOOP => {
-                let body_id = MastNodeEntry::decode_u32_payload(payload)?;
-                (MastNodeEntry::Loop { body_id }, None)
-            },
-            BLOCK => {
-                let ops_offset = MastNodeEntry::decode_u32_payload(payload)?;
-                (MastNodeEntry::Block { ops_offset }, None)
-            },
-            CALL => {
-                let callee_id = MastNodeEntry::decode_u32_payload(payload)?;
-                (MastNodeEntry::Call { callee_id }, None)
-            },
-            SYSCALL => {
-                let callee_id = MastNodeEntry::decode_u32_payload(payload)?;
-                (MastNodeEntry::SysCall { callee_id }, None)
-            },
-            DYN => (MastNodeEntry::Dyn, None),
-            DYNCALL => (MastNodeEntry::Dyncall, None),
-            EXTERNAL => {
-                let digest_slot = MastNodeEntry::decode_u32_payload(payload)?;
-                (MastNodeEntry::External, Some(digest_slot))
-            },
-            _ => {
-                return Err(DeserializationError::InvalidValue(format!(
-                    "Invalid tag for MAST node: {discriminant}"
-                )));
-            },
-        };
-
-        Ok(Self { entry, external_digest_slot })
-    }
-
-    fn min_serialized_size() -> usize {
-        MastNodeEntry::SERIALIZED_SIZE
     }
 }
 

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -360,20 +360,21 @@ fn validate_node_entries(
     external_node_count: usize,
 ) -> Result<(), DeserializationError> {
     let mut reader = SliceReader::new(node_entries);
+    let mut counted_externals = 0usize;
 
-    for index in 0..node_count {
+    for _ in 0..node_count {
         let node_entry = MastNodeEntry::read_from(&mut reader)?;
-        if index < external_node_count {
-            if !matches!(node_entry, MastNodeEntry::External) {
-                return Err(DeserializationError::InvalidValue(format!(
-                    "node entry {index} must be External because the header reserves the first {external_node_count} nodes for externals"
-                )));
-            }
-        } else if matches!(node_entry, MastNodeEntry::External) {
-            return Err(DeserializationError::InvalidValue(format!(
-                "node entry {index} must not be External because only the first {external_node_count} nodes may be externals"
-            )));
+        if matches!(node_entry, MastNodeEntry::External) {
+            counted_externals = counted_externals.checked_add(1).ok_or_else(|| {
+                DeserializationError::InvalidValue("external node count overflow".to_string())
+            })?;
         }
+    }
+
+    if counted_externals != external_node_count {
+        return Err(DeserializationError::InvalidValue(format!(
+            "header external node count {external_node_count} does not match {counted_externals} external node entries"
+        )));
     }
 
     Ok(())

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -26,17 +26,16 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ForestLayout {
     pub(super) node_count: usize,
+    pub(super) internal_node_count: usize,
+    pub(super) external_node_count: usize,
     pub(super) roots_count: usize,
     pub(super) roots_offset: usize,
     pub(super) basic_block_offset: usize,
     pub(super) basic_block_len: usize,
     pub(super) node_entry_offset: usize,
     pub(super) external_digest_offset: usize,
-    #[cfg(test)]
-    pub(super) external_digest_count: usize,
     pub(super) node_hash_offset: Option<usize>,
-    #[cfg(test)]
-    pub(super) node_hash_count: usize,
+    pub(super) advice_map_offset: usize,
 }
 
 /// Raw wire flags from the MAST header.
@@ -97,31 +96,8 @@ impl ForestLayout {
     }
 
     #[cfg(test)]
-    pub(super) fn advice_map_offset(
-        &self,
-        bytes_len: usize,
-    ) -> Result<usize, DeserializationError> {
-        let digest_section_end = if let Some(node_hash_offset) = self.node_hash_offset {
-            node_hash_offset
-                .checked_add(self.node_hash_count * crate::Word::min_serialized_size())
-                .ok_or_else(|| {
-                    DeserializationError::InvalidValue("node hash section overflow".to_string())
-                })?
-        } else {
-            self.external_digest_offset
-                .checked_add(self.external_digest_count * crate::Word::min_serialized_size())
-                .ok_or_else(|| {
-                    DeserializationError::InvalidValue(
-                        "external digest section overflow".to_string(),
-                    )
-                })?
-        };
-
-        if digest_section_end > bytes_len {
-            return Err(DeserializationError::UnexpectedEOF);
-        }
-
-        Ok(digest_section_end)
+    pub(super) fn advice_map_offset(&self) -> Result<usize, DeserializationError> {
+        Ok(self.advice_map_offset)
     }
 }
 
@@ -281,6 +257,31 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
     }
     validate_budgeted_count(source, node_count, MastNodeEntry::SERIALIZED_SIZE, "node count")?;
 
+    let internal_node_count = source.read_usize()?;
+    let external_node_count = source.read_usize()?;
+    let total_node_count = internal_node_count
+        .checked_add(external_node_count)
+        .ok_or_else(|| DeserializationError::InvalidValue("node count overflow".to_string()))?;
+    if total_node_count != node_count {
+        return Err(DeserializationError::InvalidValue(format!(
+            "internal node count {internal_node_count} plus external node count {external_node_count} must equal total node count {node_count}"
+        )));
+    }
+    validate_budgeted_count(
+        source,
+        external_node_count,
+        crate::Word::min_serialized_size(),
+        "external node count",
+    )?;
+    if !is_hashless {
+        validate_budgeted_count(
+            source,
+            internal_node_count,
+            crate::Word::min_serialized_size(),
+            "internal node count",
+        )?;
+    }
+
     let roots_count = source.read_usize()?;
     validate_budgeted_count(source, roots_count, size_of::<u32>(), "root count")?;
     let roots_offset = source.offset();
@@ -291,56 +292,91 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
 
     let basic_block_len = source.read_usize()?;
     let basic_block_offset = source.offset();
-    let _basic_block_data = source.read_slice(basic_block_len)?;
-
-    let node_entry_offset = source.offset();
-    let mut external_digest_count = 0usize;
-    for _ in 0..node_count {
-        let node_entry = MastNodeEntry::read_from(source)?;
-        if matches!(node_entry, MastNodeEntry::External) {
-            external_digest_count = external_digest_count.checked_add(1).ok_or_else(|| {
-                DeserializationError::InvalidValue("external digest count overflow".to_string())
-            })?;
-        }
-    }
-
-    let external_digest_offset = source.offset();
-    let external_digests_len = external_digest_count
+    let external_digests_len = external_node_count
         .checked_mul(crate::Word::min_serialized_size())
         .ok_or_else(|| {
             DeserializationError::InvalidValue("external digest length overflow".to_string())
         })?;
-    let _external_digests = source.read_slice(external_digests_len)?;
+    let node_entries_len =
+        node_count.checked_mul(MastNodeEntry::SERIALIZED_SIZE).ok_or_else(|| {
+            DeserializationError::InvalidValue("node entry length overflow".to_string())
+        })?;
+    let node_hash_len =
+        if is_hashless {
+            0
+        } else {
+            internal_node_count.checked_mul(crate::Word::min_serialized_size()).ok_or_else(
+                || DeserializationError::InvalidValue("node hash length overflow".to_string()),
+            )?
+        };
+    let core_tail_len = basic_block_len
+        .checked_add(node_entries_len)
+        .and_then(|len| len.checked_add(external_digests_len))
+        .and_then(|len| len.checked_add(node_hash_len))
+        .ok_or_else(|| {
+            DeserializationError::InvalidValue("core payload length overflow".to_string())
+        })?;
+    let core_tail = source.read_slice(core_tail_len)?;
 
-    let node_hash_count = node_count.checked_sub(external_digest_count).ok_or_else(|| {
-        DeserializationError::InvalidValue("node hash count underflow".to_string())
+    let node_entry_offset = basic_block_offset.checked_add(basic_block_len).ok_or_else(|| {
+        DeserializationError::InvalidValue("node entry offset overflow".to_string())
     })?;
+    let external_digest_offset =
+        node_entry_offset.checked_add(node_entries_len).ok_or_else(|| {
+            DeserializationError::InvalidValue("external digest offset overflow".to_string())
+        })?;
     let node_hash_offset = if is_hashless {
         None
     } else {
-        let offset = source.offset();
-        let node_hash_len =
-            node_hash_count.checked_mul(crate::Word::min_serialized_size()).ok_or_else(|| {
-                DeserializationError::InvalidValue("node hash length overflow".to_string())
-            })?;
-        let _node_hashes = source.read_slice(node_hash_len)?;
-        Some(offset)
+        Some(external_digest_offset.checked_add(external_digests_len).ok_or_else(|| {
+            DeserializationError::InvalidValue("node hash offset overflow".to_string())
+        })?)
     };
+    let advice_map_offset = basic_block_offset.checked_add(core_tail_len).ok_or_else(|| {
+        DeserializationError::InvalidValue("advice map offset overflow".to_string())
+    })?;
+
+    let node_entries_slice = &core_tail[basic_block_len..basic_block_len + node_entries_len];
+    validate_node_entries(node_entries_slice, node_count, external_node_count)?;
 
     Ok(ForestLayout {
         node_count,
+        internal_node_count,
+        external_node_count,
         roots_count,
         roots_offset,
         basic_block_offset,
         basic_block_len,
         node_entry_offset,
         external_digest_offset,
-        #[cfg(test)]
-        external_digest_count,
         node_hash_offset,
-        #[cfg(test)]
-        node_hash_count,
+        advice_map_offset,
     })
+}
+
+fn validate_node_entries(
+    node_entries: &[u8],
+    node_count: usize,
+    external_node_count: usize,
+) -> Result<(), DeserializationError> {
+    let mut reader = SliceReader::new(node_entries);
+
+    for index in 0..node_count {
+        let node_entry = MastNodeEntry::read_from(&mut reader)?;
+        if index < external_node_count {
+            if !matches!(node_entry, MastNodeEntry::External) {
+                return Err(DeserializationError::InvalidValue(format!(
+                    "node entry {index} must be External because the header reserves the first {external_node_count} nodes for externals"
+                )));
+            }
+        } else if matches!(node_entry, MastNodeEntry::External) {
+            return Err(DeserializationError::InvalidValue(format!(
+                "node entry {index} must not be External because only the first {external_node_count} nodes may be externals"
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 fn validate_budgeted_count<R: ByteReader>(

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -1,7 +1,8 @@
 use alloc::{format, string::ToString, vec::Vec};
 
 use super::{
-    FLAG_HASHLESS, FLAG_STRIPPED, FLAGS_RESERVED_MASK, MAGIC, MastForest, MastNodeEntry, VERSION,
+    FLAG_HASHLESS, FLAG_STRIPPED, FLAGS_RESERVED_MASK, MAGIC, MastForest, MastNodeEntry,
+    MastNodeWireEntry, VERSION,
 };
 use crate::{
     mast::MastNodeId,
@@ -33,7 +34,7 @@ pub(crate) struct ForestLayout {
     pub(super) basic_block_offset: usize,
     pub(super) basic_block_len: usize,
     pub(super) node_entry_offset: usize,
-    pub(super) external_digest_offset: usize,
+    pub(super) node_digest_offset: usize,
     pub(super) node_hash_offset: Option<usize>,
     pub(super) advice_map_offset: usize,
 }
@@ -78,6 +79,14 @@ impl ForestLayout {
         bytes: &[u8],
         index: usize,
     ) -> Result<MastNodeEntry, DeserializationError> {
+        self.read_node_wire_entry_at(bytes, index).map(MastNodeWireEntry::entry)
+    }
+
+    pub(super) fn read_node_wire_entry_at(
+        &self,
+        bytes: &[u8],
+        index: usize,
+    ) -> Result<MastNodeWireEntry, DeserializationError> {
         if index >= self.node_count {
             return Err(DeserializationError::InvalidValue(format!(
                 "node index {} out of bounds for {} nodes",
@@ -92,7 +101,7 @@ impl ForestLayout {
             index,
             "node entry",
         )?);
-        MastNodeEntry::read_from(&mut reader)
+        MastNodeWireEntry::read_from(&mut reader)
     }
 
     #[cfg(test)]
@@ -309,34 +318,38 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
                 || DeserializationError::InvalidValue("node hash length overflow".to_string()),
             )?
         };
+    let node_digest_len = external_digests_len.checked_add(node_hash_len).ok_or_else(|| {
+        DeserializationError::InvalidValue("node digest length overflow".to_string())
+    })?;
     let core_tail_len = basic_block_len
-        .checked_add(node_entries_len)
-        .and_then(|len| len.checked_add(external_digests_len))
-        .and_then(|len| len.checked_add(node_hash_len))
+        .checked_add(node_digest_len)
+        .and_then(|len| len.checked_add(node_entries_len))
         .ok_or_else(|| {
             DeserializationError::InvalidValue("core payload length overflow".to_string())
         })?;
     let core_tail = source.read_slice(core_tail_len)?;
 
-    let node_entry_offset = basic_block_offset.checked_add(basic_block_len).ok_or_else(|| {
-        DeserializationError::InvalidValue("node entry offset overflow".to_string())
+    let node_digest_offset = basic_block_offset.checked_add(basic_block_len).ok_or_else(|| {
+        DeserializationError::InvalidValue("node digest offset overflow".to_string())
     })?;
-    let external_digest_offset =
-        node_entry_offset.checked_add(node_entries_len).ok_or_else(|| {
-            DeserializationError::InvalidValue("external digest offset overflow".to_string())
-        })?;
     let node_hash_offset = if is_hashless {
         None
     } else {
-        Some(external_digest_offset.checked_add(external_digests_len).ok_or_else(|| {
+        Some(node_digest_offset.checked_add(external_digests_len).ok_or_else(|| {
             DeserializationError::InvalidValue("node hash offset overflow".to_string())
         })?)
     };
+    let node_entry_offset = node_digest_offset.checked_add(node_digest_len).ok_or_else(|| {
+        DeserializationError::InvalidValue("node entry offset overflow".to_string())
+    })?;
     let advice_map_offset = basic_block_offset.checked_add(core_tail_len).ok_or_else(|| {
         DeserializationError::InvalidValue("advice map offset overflow".to_string())
     })?;
 
-    let node_entries_slice = &core_tail[basic_block_len..basic_block_len + node_entries_len];
+    let node_entries_start = basic_block_len.checked_add(node_digest_len).ok_or_else(|| {
+        DeserializationError::InvalidValue("node entries slice offset overflow".to_string())
+    })?;
+    let node_entries_slice = &core_tail[node_entries_start..node_entries_start + node_entries_len];
     validate_node_entries(node_entries_slice, node_count, external_node_count)?;
 
     Ok(ForestLayout {
@@ -348,7 +361,7 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
         basic_block_offset,
         basic_block_len,
         node_entry_offset,
-        external_digest_offset,
+        node_digest_offset,
         node_hash_offset,
         advice_map_offset,
     })
@@ -361,10 +374,29 @@ fn validate_node_entries(
 ) -> Result<(), DeserializationError> {
     let mut reader = SliceReader::new(node_entries);
     let mut counted_externals = 0usize;
+    let mut seen_external_slots = Vec::new();
+    seen_external_slots.try_reserve_exact(external_node_count).map_err(|err| {
+        DeserializationError::InvalidValue(format!(
+            "failed to reserve external digest slot tracking for {external_node_count} nodes: {err}",
+        ))
+    })?;
+    seen_external_slots.resize(external_node_count, false);
 
     for _ in 0..node_count {
-        let node_entry = MastNodeEntry::read_from(&mut reader)?;
-        if matches!(node_entry, MastNodeEntry::External) {
+        let wire_entry = MastNodeWireEntry::read_from(&mut reader)?;
+        if let Some(digest_slot) = wire_entry.external_digest_slot() {
+            let digest_slot = digest_slot as usize;
+            if digest_slot >= external_node_count {
+                return Err(DeserializationError::InvalidValue(format!(
+                    "external digest slot {digest_slot} out of bounds for {external_node_count} external digests"
+                )));
+            }
+            if seen_external_slots[digest_slot] {
+                return Err(DeserializationError::InvalidValue(format!(
+                    "external digest slot {digest_slot} is referenced by more than one node entry"
+                )));
+            }
+            seen_external_slots[digest_slot] = true;
             counted_externals = counted_externals.checked_add(1).ok_or_else(|| {
                 DeserializationError::InvalidValue("external node count overflow".to_string())
             })?;
@@ -374,6 +406,11 @@ fn validate_node_entries(
     if counted_externals != external_node_count {
         return Err(DeserializationError::InvalidValue(format!(
             "header external node count {external_node_count} does not match {counted_externals} external node entries"
+        )));
+    }
+    if let Some(missing_slot) = seen_external_slots.iter().position(|seen| !seen) {
+        return Err(DeserializationError::InvalidValue(format!(
+            "external digest slot {missing_slot} is not referenced by any node entry"
         )));
     }
 

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -247,7 +247,11 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
     source: &mut R,
     is_hashless: bool,
 ) -> Result<ForestLayout, DeserializationError> {
-    let node_count = source.read_usize()?;
+    let internal_node_count = source.read_usize()?;
+    let external_node_count = source.read_usize()?;
+    let node_count = internal_node_count
+        .checked_add(external_node_count)
+        .ok_or_else(|| DeserializationError::InvalidValue("node count overflow".to_string()))?;
     if node_count > MastForest::MAX_NODES {
         return Err(DeserializationError::InvalidValue(format!(
             "node count {} exceeds maximum allowed {}",
@@ -256,17 +260,6 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
         )));
     }
     validate_budgeted_count(source, node_count, MastNodeEntry::SERIALIZED_SIZE, "node count")?;
-
-    let internal_node_count = source.read_usize()?;
-    let external_node_count = source.read_usize()?;
-    let total_node_count = internal_node_count
-        .checked_add(external_node_count)
-        .ok_or_else(|| DeserializationError::InvalidValue("node count overflow".to_string()))?;
-    if total_node_count != node_count {
-        return Err(DeserializationError::InvalidValue(format!(
-            "internal node count {internal_node_count} plus external node count {external_node_count} must equal total node count {node_count}"
-        )));
-    }
     validate_budgeted_count(
         source,
         external_node_count,

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -1,8 +1,7 @@
 use alloc::{format, string::ToString, vec::Vec};
 
 use super::{
-    FLAG_HASHLESS, FLAG_STRIPPED, FLAGS_RESERVED_MASK, MAGIC, MastForest, MastNodeEntry,
-    MastNodeWireEntry, VERSION,
+    FLAG_HASHLESS, FLAG_STRIPPED, FLAGS_RESERVED_MASK, MAGIC, MastForest, MastNodeEntry, VERSION,
 };
 use crate::{
     mast::MastNodeId,
@@ -34,7 +33,7 @@ pub(crate) struct ForestLayout {
     pub(super) basic_block_offset: usize,
     pub(super) basic_block_len: usize,
     pub(super) node_entry_offset: usize,
-    pub(super) node_digest_offset: usize,
+    pub(super) external_digest_offset: usize,
     pub(super) node_hash_offset: Option<usize>,
     pub(super) advice_map_offset: usize,
 }
@@ -79,14 +78,6 @@ impl ForestLayout {
         bytes: &[u8],
         index: usize,
     ) -> Result<MastNodeEntry, DeserializationError> {
-        self.read_node_wire_entry_at(bytes, index).map(MastNodeWireEntry::entry)
-    }
-
-    pub(super) fn read_node_wire_entry_at(
-        &self,
-        bytes: &[u8],
-        index: usize,
-    ) -> Result<MastNodeWireEntry, DeserializationError> {
         if index >= self.node_count {
             return Err(DeserializationError::InvalidValue(format!(
                 "node index {} out of bounds for {} nodes",
@@ -101,7 +92,7 @@ impl ForestLayout {
             index,
             "node entry",
         )?);
-        MastNodeWireEntry::read_from(&mut reader)
+        MastNodeEntry::read_from(&mut reader)
     }
 
     #[cfg(test)]
@@ -318,38 +309,34 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
                 || DeserializationError::InvalidValue("node hash length overflow".to_string()),
             )?
         };
-    let node_digest_len = external_digests_len.checked_add(node_hash_len).ok_or_else(|| {
-        DeserializationError::InvalidValue("node digest length overflow".to_string())
-    })?;
     let core_tail_len = basic_block_len
-        .checked_add(node_digest_len)
-        .and_then(|len| len.checked_add(node_entries_len))
+        .checked_add(node_entries_len)
+        .and_then(|len| len.checked_add(external_digests_len))
+        .and_then(|len| len.checked_add(node_hash_len))
         .ok_or_else(|| {
             DeserializationError::InvalidValue("core payload length overflow".to_string())
         })?;
     let core_tail = source.read_slice(core_tail_len)?;
 
-    let node_digest_offset = basic_block_offset.checked_add(basic_block_len).ok_or_else(|| {
-        DeserializationError::InvalidValue("node digest offset overflow".to_string())
+    let node_entry_offset = basic_block_offset.checked_add(basic_block_len).ok_or_else(|| {
+        DeserializationError::InvalidValue("node entry offset overflow".to_string())
     })?;
+    let external_digest_offset =
+        node_entry_offset.checked_add(node_entries_len).ok_or_else(|| {
+            DeserializationError::InvalidValue("external digest offset overflow".to_string())
+        })?;
     let node_hash_offset = if is_hashless {
         None
     } else {
-        Some(node_digest_offset.checked_add(external_digests_len).ok_or_else(|| {
+        Some(external_digest_offset.checked_add(external_digests_len).ok_or_else(|| {
             DeserializationError::InvalidValue("node hash offset overflow".to_string())
         })?)
     };
-    let node_entry_offset = node_digest_offset.checked_add(node_digest_len).ok_or_else(|| {
-        DeserializationError::InvalidValue("node entry offset overflow".to_string())
-    })?;
     let advice_map_offset = basic_block_offset.checked_add(core_tail_len).ok_or_else(|| {
         DeserializationError::InvalidValue("advice map offset overflow".to_string())
     })?;
 
-    let node_entries_start = basic_block_len.checked_add(node_digest_len).ok_or_else(|| {
-        DeserializationError::InvalidValue("node entries slice offset overflow".to_string())
-    })?;
-    let node_entries_slice = &core_tail[node_entries_start..node_entries_start + node_entries_len];
+    let node_entries_slice = &core_tail[basic_block_len..basic_block_len + node_entries_len];
     validate_node_entries(node_entries_slice, node_count, external_node_count)?;
 
     Ok(ForestLayout {
@@ -361,7 +348,7 @@ fn scan_layout_sections<R: OffsetTrackingReader>(
         basic_block_offset,
         basic_block_len,
         node_entry_offset,
-        node_digest_offset,
+        external_digest_offset,
         node_hash_offset,
         advice_map_offset,
     })
@@ -374,29 +361,10 @@ fn validate_node_entries(
 ) -> Result<(), DeserializationError> {
     let mut reader = SliceReader::new(node_entries);
     let mut counted_externals = 0usize;
-    let mut seen_external_slots = Vec::new();
-    seen_external_slots.try_reserve_exact(external_node_count).map_err(|err| {
-        DeserializationError::InvalidValue(format!(
-            "failed to reserve external digest slot tracking for {external_node_count} nodes: {err}",
-        ))
-    })?;
-    seen_external_slots.resize(external_node_count, false);
 
     for _ in 0..node_count {
-        let wire_entry = MastNodeWireEntry::read_from(&mut reader)?;
-        if let Some(digest_slot) = wire_entry.external_digest_slot() {
-            let digest_slot = digest_slot as usize;
-            if digest_slot >= external_node_count {
-                return Err(DeserializationError::InvalidValue(format!(
-                    "external digest slot {digest_slot} out of bounds for {external_node_count} external digests"
-                )));
-            }
-            if seen_external_slots[digest_slot] {
-                return Err(DeserializationError::InvalidValue(format!(
-                    "external digest slot {digest_slot} is referenced by more than one node entry"
-                )));
-            }
-            seen_external_slots[digest_slot] = true;
+        let node_entry = MastNodeEntry::read_from(&mut reader)?;
+        if matches!(node_entry, MastNodeEntry::External) {
             counted_externals = counted_externals.checked_add(1).ok_or_else(|| {
                 DeserializationError::InvalidValue("external node count overflow".to_string())
             })?;
@@ -406,11 +374,6 @@ fn validate_node_entries(
     if counted_externals != external_node_count {
         return Err(DeserializationError::InvalidValue(format!(
             "header external node count {external_node_count} does not match {counted_externals} external node entries"
-        )));
-    }
-    if let Some(missing_slot) = seen_external_slots.iter().position(|seen| !seen) {
-        return Err(DeserializationError::InvalidValue(format!(
-            "external digest slot {missing_slot} is not referenced by any node entry"
         )));
     }
 

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -82,10 +82,9 @@
 //! use, so supporting a separate "hashless but with debug info" mode would add another wire mode
 //! without changing the validation semantics.
 //!
-//! External nodes are serialized first, sorted lexicographically by digest (breaking ties by
-//! original node index). This makes both digest sections dense by prefix/suffix: external digests
-//! occupy the first `external_node_count` slots, and internal digests occupy the remaining
-//! `internal_node_count` slots when present.
+//! Readers recover per-node digest lookup by scanning node entries once and building a compact
+//! "slot by node index" table. This preserves random access without forcing all digests into the
+//! same contiguous array on the wire.
 //!
 //! Public entry points adopt these policies:
 //! - [`MastForest::read_from_bytes`]: trusted full payload, no hashless support.
@@ -109,7 +108,6 @@ use crate::{
         BudgetedReader, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
         SliceReader,
     },
-    utils::Idx,
 };
 
 pub(crate) mod asm_op;
@@ -158,7 +156,8 @@ type StringIndex = usize;
 /// Default multiplier for the untrusted validation allocation budget.
 ///
 /// The budgeted byte reader limits wire-driven parsing. Hashless and stripped validation also
-/// needs transient per-node allocations for empty debug-info scaffolding and rebuilt digest data.
+/// needs transient per-node allocations for the slot table, empty debug-info scaffolding, and
+/// rebuilt digest data.
 /// The generic untrusted path also retains a recorded copy of the consumed
 /// serialized payload for deferred validation.
 ///
@@ -243,37 +242,6 @@ impl Serializable for MastForest {
 }
 
 impl MastForest {
-    fn serialization_order(&self) -> (Vec<usize>, Vec<u32>) {
-        let mut ordered_indices = Vec::with_capacity(self.nodes.len());
-        let mut forest_to_serialized = vec![0u32; self.nodes.len()];
-
-        let mut external_indices = self
-            .nodes
-            .iter()
-            .enumerate()
-            .filter(|(_, node)| node.is_external())
-            .map(|(index, node)| (index, node.digest()))
-            .collect::<Vec<_>>();
-        external_indices.sort_by_key(|(index, digest)| (*digest, *index));
-
-        for (serialized_index, (forest_index, _)) in external_indices.into_iter().enumerate() {
-            ordered_indices.push(forest_index);
-            forest_to_serialized[forest_index] = serialized_index as u32;
-        }
-
-        for (forest_index, node) in self.nodes.iter().enumerate() {
-            if node.is_external() {
-                continue;
-            }
-
-            let serialized_index = ordered_indices.len();
-            ordered_indices.push(forest_index);
-            forest_to_serialized[forest_index] = serialized_index as u32;
-        }
-
-        (ordered_indices, forest_to_serialized)
-    }
-
     /// Internal serialization with options.
     ///
     /// When `stripped` is true, the DebugInfo section is omitted and the FLAGS byte
@@ -299,36 +267,26 @@ impl MastForest {
         let node_count = self.nodes.len();
         let external_node_count = self.nodes.iter().filter(|node| node.is_external()).count();
         let internal_node_count = node_count - external_node_count;
-        let (serialization_order, forest_to_serialized) = self.serialization_order();
         target.write_usize(node_count);
         target.write_usize(internal_node_count);
         target.write_usize(external_node_count);
 
         // roots
-        let roots: Vec<u32> = self
-            .roots
-            .iter()
-            .map(|root_id| forest_to_serialized[root_id.to_usize()])
-            .collect();
+        let roots: Vec<u32> = self.roots.iter().copied().map(u32::from).collect();
         roots.write_into(target);
 
         let mut mast_node_entries = Vec::with_capacity(self.nodes.len());
         let mut external_digests = Vec::new();
         let mut node_hashes = Vec::new();
 
-        for forest_index in serialization_order {
-            let mast_node = &self.nodes.as_slice()[forest_index];
+        for mast_node in self.nodes.iter() {
             let ops_offset = if let MastNode::Block(basic_block) = mast_node {
                 basic_block_data_builder.encode_basic_block(basic_block)
             } else {
                 0
             };
 
-            mast_node_entries.push(MastNodeEntry::new_with_id_remap(
-                mast_node,
-                ops_offset,
-                Some(&forest_to_serialized),
-            ));
+            mast_node_entries.push(MastNodeEntry::new(mast_node, ops_offset));
             if mast_node.is_external() {
                 external_digests.push(mast_node.digest());
             } else if !hashless {

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -3,8 +3,9 @@
 //!
 //! The main goal is to keep random access cheap in stripped and hashless modes. Node structure
 //! stays in one fixed-width section. Variable-size data lives in separate sections. Internal node
-//! digests also live in a separate section so hashless payloads can omit them without changing the
-//! structural layout.
+//! digests live in the internal suffix of the node-digest section so hashless payloads can omit
+//! them without changing the structural layout. External digests remain in the prefix because they
+//! cannot be rebuilt from local structure.
 //!
 //! Wire flags describe serializer intent, not reader trust policy. Trusted [`MastForest`] reads
 //! reject hashless payloads. [`crate::mast::UntrustedMastForest`] accepts them and rebuilds
@@ -48,17 +49,15 @@
 //! (Basic block data section)
 //! - basic block data (padded operations + batch metadata)
 //!
+//! (Node digest section)
+//! - sorted external-node digest prefix (`Vec<Word>`, sorted lexicographically by wire bytes)
+//! - internal-node digest suffix (`Vec<Word>`, ordered by node index; omitted if FLAGS bit 1 is
+//!   set)
+//!
 //! (Node entries section)
 //! - fixed-width structural node entries (`Vec<MastNodeEntry>`)
 //! - `Block` entries store offsets into the basic-block section above
-//!
-//! (External digest section)
-//! - digests for `External` nodes only (`Vec<Word>`, ordered by node index)
-//! - lookup is dense-by-kind: the Nth external node uses slot N in this section
-//!
-//! (Node hash section - omitted if FLAGS bit 1 is set)
-//! - digests for all non-external nodes (`Vec<Word>`, ordered by node index)
-//! - lookup is also dense-by-kind: the Nth non-external node uses slot N in this section
+//! - serialized `External` entries store a digest slot into the sorted external prefix above
 //!
 //! (Advice map section)
 //! - Advice map (`AdviceMap`)
@@ -83,8 +82,8 @@
 //! without changing the validation semantics.
 //!
 //! Readers recover per-node digest lookup by scanning node entries once and building a compact
-//! "slot by node index" table. This preserves random access without forcing all digests into the
-//! same contiguous array on the wire.
+//! "slot by node index" table. This preserves random access while keeping external digest lookup
+//! explicit and independent from in-memory node order.
 //!
 //! Public entry points adopt these policies:
 //! - [`MastForest::read_from_bytes`]: trusted full payload, no hashless support.
@@ -114,6 +113,7 @@ pub(crate) mod asm_op;
 pub(crate) mod decorator;
 
 mod info;
+use info::MastNodeWireEntry;
 pub use info::{MastNodeEntry, MastNodeInfo};
 
 mod view;
@@ -124,7 +124,10 @@ pub(super) use layout::ForestLayout;
 use layout::{OffsetTrackingReader, TrackingReader, WireFlags, read_header_and_scan_layout};
 
 mod resolved;
-use resolved::{ResolvedSerializedForest, basic_block_offset_for_node_index};
+pub(super) use resolved::external_digest_order_violation;
+use resolved::{
+    ResolvedSerializedForest, basic_block_offset_for_node_index, compare_words_by_wire,
+};
 
 mod basic_blocks;
 use basic_blocks::{BasicBlockDataBuilder, basic_block_data_len};
@@ -197,11 +200,11 @@ const FLAG_STRIPPED: u8 = 0x01;
 
 /// Flag indicating that the internal node-hash section is omitted from the wire payload.
 ///
-/// External digests still remain serialized in their own section because they cannot be rebuilt
-/// from local structure. This flag implies [`FLAG_STRIPPED`] because no supported consumer treats
-/// wire `DebugInfo` as trusted in hashless mode: [`crate::mast::MastForest`] rejects `HASHLESS`,
-/// [`SerializedMastForest::new`] accepts it only for structural inspection, and the untrusted path
-/// rebuilds the data it actually trusts before use.
+/// External digests still remain serialized in the node-digest prefix because they cannot be
+/// rebuilt from local structure. This flag implies [`FLAG_STRIPPED`] because no supported consumer
+/// treats wire `DebugInfo` as trusted in hashless mode: [`crate::mast::MastForest`] rejects
+/// `HASHLESS`, [`SerializedMastForest::new`] accepts it only for structural inspection, and the
+/// untrusted path rebuilds the data it actually trusts before use.
 pub(super) const FLAG_HASHLESS: u8 = 0x02;
 
 /// Mask for reserved flag bits that must be zero.
@@ -226,10 +229,11 @@ const FLAGS_RESERVED_MASK: u8 = 0xfc;
 ///   Removed `breakpoint` instruction (#2655).
 /// - [0, 0, 3]: Added HASHLESS flag (bit 1). HASHLESS implies STRIPPED. Trusted deserialization
 ///   rejects HASHLESS. Split fixed-width node entries from digest storage. External digests moved
-///   to a dedicated section. Hashless serialization omits the general node-hash section entirely.
-///   Dropped the serialized decorator-count field because it was not used by the wire layout or
-///   deserializers. Before any public release on this branch, the same unreleased wire version also
-///   grew explicit internal/external node counts in the header.
+///   to a sorted node-digest prefix and serialized `External` entries now carry a digest slot.
+///   Hashless serialization omits the internal node-digest suffix entirely. Dropped the serialized
+///   decorator-count field because it was not used by the wire layout or deserializers. Before any
+///   public release on this branch, the same unreleased wire version also grew explicit
+///   internal/external node counts in the header.
 const VERSION: [u8; 3] = [0, 0, 3];
 
 // MAST FOREST SERIALIZATION/DESERIALIZATION
@@ -275,33 +279,55 @@ impl MastForest {
         let roots: Vec<u32> = self.roots.iter().copied().map(u32::from).collect();
         roots.write_into(target);
 
+        let mut sorted_external_digests = Vec::with_capacity(external_node_count);
+        for (node_index, mast_node) in self.nodes.iter().enumerate() {
+            if mast_node.is_external() {
+                sorted_external_digests.push((mast_node.digest(), node_index));
+            }
+        }
+        sorted_external_digests.sort_unstable_by(
+            |(left_digest, left_index), (right_digest, right_index)| {
+                compare_words_by_wire(left_digest, right_digest)
+                    .then_with(|| left_index.cmp(right_index))
+            },
+        );
+
+        let mut external_digest_slot_by_node = Vec::new();
+        external_digest_slot_by_node.resize(node_count, None);
+        for (slot, (_, node_index)) in sorted_external_digests.iter().enumerate() {
+            let slot = u32::try_from(slot)
+                .expect("external digest slot should fit in u32 because MastForest node ids do");
+            external_digest_slot_by_node[*node_index] = Some(slot);
+        }
+
         let mut mast_node_entries = Vec::with_capacity(self.nodes.len());
-        let mut external_digests = Vec::new();
         let mut node_hashes = Vec::new();
 
-        for mast_node in self.nodes.iter() {
+        for (node_index, mast_node) in self.nodes.iter().enumerate() {
             let ops_offset = if let MastNode::Block(basic_block) = mast_node {
                 basic_block_data_builder.encode_basic_block(basic_block)
             } else {
                 0
             };
 
-            mast_node_entries.push(MastNodeEntry::new(mast_node, ops_offset));
-            if mast_node.is_external() {
-                external_digests.push(mast_node.digest());
+            let mast_node_entry = MastNodeEntry::new(mast_node, ops_offset);
+            let external_digest_slot = if mast_node.is_external() {
+                let digest_slot = external_digest_slot_by_node[node_index]
+                    .expect("external node should have a digest slot");
+                Some(digest_slot)
             } else if !hashless {
                 node_hashes.push(mast_node.digest());
-            }
+                None
+            } else {
+                None
+            };
+            mast_node_entries.push(MastNodeWireEntry::new(mast_node_entry, external_digest_slot));
         }
 
         let basic_block_data = basic_block_data_builder.finalize();
         basic_block_data.write_into(target);
 
-        for mast_node_entry in mast_node_entries {
-            mast_node_entry.write_into(target);
-        }
-
-        for digest in external_digests {
+        for (digest, _) in sorted_external_digests {
             digest.write_into(target);
         }
 
@@ -309,6 +335,10 @@ impl MastForest {
             for digest in node_hashes {
                 digest.write_into(target);
             }
+        }
+
+        for mast_node_entry in mast_node_entries {
+            mast_node_entry.write_into(target);
         }
 
         self.advice_map.write_into(target);
@@ -440,7 +470,7 @@ impl<'a> SerializedMastForest<'a> {
     /// - If the internal-hash section is present, non-external node digests are read from it.
     /// - If the internal-hash section is absent, the first digest-backed access rebuilds all
     ///   non-external node digests from structure and caches them.
-    /// - External node digests are always read from the external-digest section.
+    /// - External node digests are always read from the sorted external prefix.
     ///
     /// # Examples
     ///
@@ -639,6 +669,10 @@ impl SerializedMastForest<'_> {
 
     fn node_entry_offset(&self) -> usize {
         self.layout.node_entry_offset
+    }
+
+    fn node_digest_offset(&self) -> usize {
+        self.layout.node_digest_offset
     }
 
     fn node_hash_offset(&self) -> Option<usize> {

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -39,6 +39,8 @@
 //!
 //! (Counts)
 //! - nodes count (`usize`)
+//! - internal nodes count (`usize`)
+//! - external nodes count (`usize`)
 //!
 //! (Procedure roots section)
 //! - procedure roots (`Vec<u32>` as MastNodeId values)
@@ -80,9 +82,10 @@
 //! use, so supporting a separate "hashless but with debug info" mode would add another wire mode
 //! without changing the validation semantics.
 //!
-//! Readers recover per-node digest lookup by scanning node entries once and building a compact
-//! "slot by node index" table. This preserves random access without forcing all digests into the
-//! same contiguous array on the wire.
+//! External nodes are serialized first, sorted lexicographically by digest (breaking ties by
+//! original node index). This makes both digest sections dense by prefix/suffix: external digests
+//! occupy the first `external_node_count` slots, and internal digests occupy the remaining
+//! `internal_node_count` slots when present.
 //!
 //! Public entry points adopt these policies:
 //! - [`MastForest::read_from_bytes`]: trusted full payload, no hashless support.
@@ -106,6 +109,7 @@ use crate::{
         BudgetedReader, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
         SliceReader,
     },
+    utils::Idx,
 };
 
 pub(crate) mod asm_op;
@@ -119,7 +123,7 @@ pub use view::MastForestView;
 
 mod layout;
 pub(super) use layout::ForestLayout;
-use layout::{TrackingReader, WireFlags, read_header_and_scan_layout};
+use layout::{OffsetTrackingReader, TrackingReader, WireFlags, read_header_and_scan_layout};
 
 mod resolved;
 use resolved::{ResolvedSerializedForest, basic_block_offset_for_node_index};
@@ -154,8 +158,8 @@ type StringIndex = usize;
 /// Default multiplier for the untrusted validation allocation budget.
 ///
 /// The budgeted byte reader limits wire-driven parsing. Hashless and stripped validation also
-/// needs transient per-node allocations for the slot table, empty debug-info scaffolding, and
-/// rebuilt digest table. The generic untrusted path also retains a recorded copy of the consumed
+/// needs transient per-node allocations for empty debug-info scaffolding and rebuilt digest data.
+/// The generic untrusted path also retains a recorded copy of the consumed
 /// serialized payload for deferred validation.
 ///
 /// This convenience multiplier is therefore a coarse "wire bytes plus worst-case helper
@@ -225,7 +229,8 @@ const FLAGS_RESERVED_MASK: u8 = 0xfc;
 ///   rejects HASHLESS. Split fixed-width node entries from digest storage. External digests moved
 ///   to a dedicated section. Hashless serialization omits the general node-hash section entirely.
 ///   Dropped the serialized decorator-count field because it was not used by the wire layout or
-///   deserializers.
+///   deserializers. Before any public release on this branch, the same unreleased wire version also
+///   grew explicit internal/external node counts in the header.
 const VERSION: [u8; 3] = [0, 0, 3];
 
 // MAST FOREST SERIALIZATION/DESERIALIZATION
@@ -238,6 +243,37 @@ impl Serializable for MastForest {
 }
 
 impl MastForest {
+    fn serialization_order(&self) -> (Vec<usize>, Vec<u32>) {
+        let mut ordered_indices = Vec::with_capacity(self.nodes.len());
+        let mut forest_to_serialized = vec![0u32; self.nodes.len()];
+
+        let mut external_indices = self
+            .nodes
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| node.is_external())
+            .map(|(index, node)| (index, node.digest()))
+            .collect::<Vec<_>>();
+        external_indices.sort_by_key(|(index, digest)| (*digest, *index));
+
+        for (serialized_index, (forest_index, _)) in external_indices.into_iter().enumerate() {
+            ordered_indices.push(forest_index);
+            forest_to_serialized[forest_index] = serialized_index as u32;
+        }
+
+        for (forest_index, node) in self.nodes.iter().enumerate() {
+            if node.is_external() {
+                continue;
+            }
+
+            let serialized_index = ordered_indices.len();
+            ordered_indices.push(forest_index);
+            forest_to_serialized[forest_index] = serialized_index as u32;
+        }
+
+        (ordered_indices, forest_to_serialized)
+    }
+
     /// Internal serialization with options.
     ///
     /// When `stripped` is true, the DebugInfo section is omitted and the FLAGS byte
@@ -259,25 +295,40 @@ impl MastForest {
         // version
         target.write_bytes(&VERSION);
 
-        // node count
-        target.write_usize(self.nodes.len());
+        // header counts
+        let node_count = self.nodes.len();
+        let external_node_count = self.nodes.iter().filter(|node| node.is_external()).count();
+        let internal_node_count = node_count - external_node_count;
+        let (serialization_order, forest_to_serialized) = self.serialization_order();
+        target.write_usize(node_count);
+        target.write_usize(internal_node_count);
+        target.write_usize(external_node_count);
 
         // roots
-        let roots: Vec<u32> = self.roots.iter().copied().map(u32::from).collect();
+        let roots: Vec<u32> = self
+            .roots
+            .iter()
+            .map(|root_id| forest_to_serialized[root_id.to_usize()])
+            .collect();
         roots.write_into(target);
 
         let mut mast_node_entries = Vec::with_capacity(self.nodes.len());
         let mut external_digests = Vec::new();
         let mut node_hashes = Vec::new();
 
-        for mast_node in self.nodes.iter() {
+        for forest_index in serialization_order {
+            let mast_node = &self.nodes.as_slice()[forest_index];
             let ops_offset = if let MastNode::Block(basic_block) = mast_node {
                 basic_block_data_builder.encode_basic_block(basic_block)
             } else {
                 0
             };
 
-            mast_node_entries.push(MastNodeEntry::new(mast_node, ops_offset));
+            mast_node_entries.push(MastNodeEntry::new_with_id_remap(
+                mast_node,
+                ops_offset,
+                Some(&forest_to_serialized),
+            ));
             if mast_node.is_external() {
                 external_digests.push(mast_node.digest());
             } else if !hashless {
@@ -330,6 +381,8 @@ fn serialized_size_hint(forest: &MastForest, stripped: bool, hashless: bool) -> 
 
     let mut size = MAGIC.len() + 1 + VERSION.len();
     size += node_count.get_size_hint();
+    size += non_external_count.get_size_hint();
+    size += external_count.get_size_hint();
 
     let roots_len = forest.roots.len();
     size += roots_len.get_size_hint();
@@ -623,7 +676,7 @@ impl MastForestView for MastForest {
 #[cfg(test)]
 impl SerializedMastForest<'_> {
     fn advice_map_offset(&self) -> Result<usize, DeserializationError> {
-        self.layout.advice_map_offset(self.bytes.len())
+        self.layout.advice_map_offset()
     }
 
     fn node_entry_offset(&self) -> usize {
@@ -779,6 +832,7 @@ fn decode_from_reader_inner<R: ByteReader>(
 ) -> Result<(WireFlags, super::UntrustedMastForest), DeserializationError> {
     let mut recording = TrackingReader::new_recording(source);
     let (flags, layout) = read_header_and_scan_layout(&mut recording, allow_hashless)?;
+    debug_assert_eq!(recording.offset(), layout.advice_map_offset);
 
     let advice_map = AdviceMap::read_from(&mut recording)?;
     let debug_info = if flags.is_stripped() {

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -267,7 +267,6 @@ impl MastForest {
         let node_count = self.nodes.len();
         let external_node_count = self.nodes.iter().filter(|node| node.is_external()).count();
         let internal_node_count = node_count - external_node_count;
-        target.write_usize(node_count);
         target.write_usize(internal_node_count);
         target.write_usize(external_node_count);
 
@@ -338,7 +337,6 @@ fn serialized_size_hint(forest: &MastForest, stripped: bool, hashless: bool) -> 
     let non_external_count = node_count - external_count;
 
     let mut size = MAGIC.len() + 1 + VERSION.len();
-    size += node_count.get_size_hint();
     size += non_external_count.get_size_hint();
     size += external_count.get_size_hint();
 

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -3,9 +3,8 @@
 //!
 //! The main goal is to keep random access cheap in stripped and hashless modes. Node structure
 //! stays in one fixed-width section. Variable-size data lives in separate sections. Internal node
-//! digests live in the internal suffix of the node-digest section so hashless payloads can omit
-//! them without changing the structural layout. External digests remain in the prefix because they
-//! cannot be rebuilt from local structure.
+//! digests also live in a separate section so hashless payloads can omit them without changing the
+//! structural layout.
 //!
 //! Wire flags describe serializer intent, not reader trust policy. Trusted [`MastForest`] reads
 //! reject hashless payloads. [`crate::mast::UntrustedMastForest`] accepts them and rebuilds
@@ -49,15 +48,17 @@
 //! (Basic block data section)
 //! - basic block data (padded operations + batch metadata)
 //!
-//! (Node digest section)
-//! - sorted external-node digest prefix (`Vec<Word>`, sorted lexicographically by wire bytes)
-//! - internal-node digest suffix (`Vec<Word>`, ordered by node index; omitted if FLAGS bit 1 is
-//!   set)
-//!
 //! (Node entries section)
 //! - fixed-width structural node entries (`Vec<MastNodeEntry>`)
 //! - `Block` entries store offsets into the basic-block section above
-//! - serialized `External` entries store a digest slot into the sorted external prefix above
+//!
+//! (External digest section)
+//! - digests for `External` nodes only (`Vec<Word>`, ordered by node index)
+//! - lookup is dense-by-kind: the Nth external node uses slot N in this section
+//!
+//! (Node hash section - omitted if FLAGS bit 1 is set)
+//! - digests for all non-external nodes (`Vec<Word>`, ordered by node index)
+//! - lookup is also dense-by-kind: the Nth non-external node uses slot N in this section
 //!
 //! (Advice map section)
 //! - Advice map (`AdviceMap`)
@@ -82,8 +83,8 @@
 //! without changing the validation semantics.
 //!
 //! Readers recover per-node digest lookup by scanning node entries once and building a compact
-//! "slot by node index" table. This preserves random access while keeping external digest lookup
-//! explicit and independent from in-memory node order.
+//! "slot by node index" table. This preserves random access without forcing all digests into the
+//! same contiguous array on the wire.
 //!
 //! Public entry points adopt these policies:
 //! - [`MastForest::read_from_bytes`]: trusted full payload, no hashless support.
@@ -113,7 +114,6 @@ pub(crate) mod asm_op;
 pub(crate) mod decorator;
 
 mod info;
-use info::MastNodeWireEntry;
 pub use info::{MastNodeEntry, MastNodeInfo};
 
 mod view;
@@ -124,10 +124,7 @@ pub(super) use layout::ForestLayout;
 use layout::{OffsetTrackingReader, TrackingReader, WireFlags, read_header_and_scan_layout};
 
 mod resolved;
-pub(super) use resolved::external_digest_order_violation;
-use resolved::{
-    ResolvedSerializedForest, basic_block_offset_for_node_index, compare_words_by_wire,
-};
+use resolved::{ResolvedSerializedForest, basic_block_offset_for_node_index};
 
 mod basic_blocks;
 use basic_blocks::{BasicBlockDataBuilder, basic_block_data_len};
@@ -200,11 +197,11 @@ const FLAG_STRIPPED: u8 = 0x01;
 
 /// Flag indicating that the internal node-hash section is omitted from the wire payload.
 ///
-/// External digests still remain serialized in the node-digest prefix because they cannot be
-/// rebuilt from local structure. This flag implies [`FLAG_STRIPPED`] because no supported consumer
-/// treats wire `DebugInfo` as trusted in hashless mode: [`crate::mast::MastForest`] rejects
-/// `HASHLESS`, [`SerializedMastForest::new`] accepts it only for structural inspection, and the
-/// untrusted path rebuilds the data it actually trusts before use.
+/// External digests still remain serialized in their own section because they cannot be rebuilt
+/// from local structure. This flag implies [`FLAG_STRIPPED`] because no supported consumer treats
+/// wire `DebugInfo` as trusted in hashless mode: [`crate::mast::MastForest`] rejects `HASHLESS`,
+/// [`SerializedMastForest::new`] accepts it only for structural inspection, and the untrusted path
+/// rebuilds the data it actually trusts before use.
 pub(super) const FLAG_HASHLESS: u8 = 0x02;
 
 /// Mask for reserved flag bits that must be zero.
@@ -229,11 +226,10 @@ const FLAGS_RESERVED_MASK: u8 = 0xfc;
 ///   Removed `breakpoint` instruction (#2655).
 /// - [0, 0, 3]: Added HASHLESS flag (bit 1). HASHLESS implies STRIPPED. Trusted deserialization
 ///   rejects HASHLESS. Split fixed-width node entries from digest storage. External digests moved
-///   to a sorted node-digest prefix and serialized `External` entries now carry a digest slot.
-///   Hashless serialization omits the internal node-digest suffix entirely. Dropped the serialized
-///   decorator-count field because it was not used by the wire layout or deserializers. Before any
-///   public release on this branch, the same unreleased wire version also grew explicit
-///   internal/external node counts in the header.
+///   to a dedicated section. Hashless serialization omits the general node-hash section entirely.
+///   Dropped the serialized decorator-count field because it was not used by the wire layout or
+///   deserializers. Before any public release on this branch, the same unreleased wire version also
+///   grew explicit internal/external node counts in the header.
 const VERSION: [u8; 3] = [0, 0, 3];
 
 // MAST FOREST SERIALIZATION/DESERIALIZATION
@@ -279,55 +275,33 @@ impl MastForest {
         let roots: Vec<u32> = self.roots.iter().copied().map(u32::from).collect();
         roots.write_into(target);
 
-        let mut sorted_external_digests = Vec::with_capacity(external_node_count);
-        for (node_index, mast_node) in self.nodes.iter().enumerate() {
-            if mast_node.is_external() {
-                sorted_external_digests.push((mast_node.digest(), node_index));
-            }
-        }
-        sorted_external_digests.sort_unstable_by(
-            |(left_digest, left_index), (right_digest, right_index)| {
-                compare_words_by_wire(left_digest, right_digest)
-                    .then_with(|| left_index.cmp(right_index))
-            },
-        );
-
-        let mut external_digest_slot_by_node = Vec::new();
-        external_digest_slot_by_node.resize(node_count, None);
-        for (slot, (_, node_index)) in sorted_external_digests.iter().enumerate() {
-            let slot = u32::try_from(slot)
-                .expect("external digest slot should fit in u32 because MastForest node ids do");
-            external_digest_slot_by_node[*node_index] = Some(slot);
-        }
-
         let mut mast_node_entries = Vec::with_capacity(self.nodes.len());
+        let mut external_digests = Vec::new();
         let mut node_hashes = Vec::new();
 
-        for (node_index, mast_node) in self.nodes.iter().enumerate() {
+        for mast_node in self.nodes.iter() {
             let ops_offset = if let MastNode::Block(basic_block) = mast_node {
                 basic_block_data_builder.encode_basic_block(basic_block)
             } else {
                 0
             };
 
-            let mast_node_entry = MastNodeEntry::new(mast_node, ops_offset);
-            let external_digest_slot = if mast_node.is_external() {
-                let digest_slot = external_digest_slot_by_node[node_index]
-                    .expect("external node should have a digest slot");
-                Some(digest_slot)
+            mast_node_entries.push(MastNodeEntry::new(mast_node, ops_offset));
+            if mast_node.is_external() {
+                external_digests.push(mast_node.digest());
             } else if !hashless {
                 node_hashes.push(mast_node.digest());
-                None
-            } else {
-                None
-            };
-            mast_node_entries.push(MastNodeWireEntry::new(mast_node_entry, external_digest_slot));
+            }
         }
 
         let basic_block_data = basic_block_data_builder.finalize();
         basic_block_data.write_into(target);
 
-        for (digest, _) in sorted_external_digests {
+        for mast_node_entry in mast_node_entries {
+            mast_node_entry.write_into(target);
+        }
+
+        for digest in external_digests {
             digest.write_into(target);
         }
 
@@ -335,10 +309,6 @@ impl MastForest {
             for digest in node_hashes {
                 digest.write_into(target);
             }
-        }
-
-        for mast_node_entry in mast_node_entries {
-            mast_node_entry.write_into(target);
         }
 
         self.advice_map.write_into(target);
@@ -470,7 +440,7 @@ impl<'a> SerializedMastForest<'a> {
     /// - If the internal-hash section is present, non-external node digests are read from it.
     /// - If the internal-hash section is absent, the first digest-backed access rebuilds all
     ///   non-external node digests from structure and caches them.
-    /// - External node digests are always read from the sorted external prefix.
+    /// - External node digests are always read from the external-digest section.
     ///
     /// # Examples
     ///
@@ -669,10 +639,6 @@ impl SerializedMastForest<'_> {
 
     fn node_entry_offset(&self) -> usize {
         self.layout.node_entry_offset
-    }
-
-    fn node_digest_offset(&self) -> usize {
-        self.layout.node_digest_offset
     }
 
     fn node_hash_offset(&self) -> Option<usize> {

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -17,14 +17,9 @@ use crate::{
 /// Digest sources for a parsed serialized forest.
 ///
 /// Non-external nodes either read from the internal-hash section or from a rebuilt in-memory hash
-/// table. External nodes always read from the external-digest section.
+/// table. External nodes always read from the external-digest prefix section.
 #[derive(Debug, Clone)]
 struct ForestDigests {
-    /// Dense slot index for each node within its digest section.
-    ///
-    /// External nodes index into the external-digest section. All other nodes index into the
-    /// general node-hash section or the rebuilt hash table.
-    slot_by_node: Vec<u32>,
     /// Source of non-external digests.
     ///
     /// `None` means the serialized bytes still contain the internal node-hash section, so
@@ -50,15 +45,13 @@ impl ForestDigests {
     ///
     /// `bytes` and `layout` provide the already-scanned structural wire view. When
     /// `remaining_allocation_budget` is `Some`, helper allocations needed for untrusted validation
-    /// such as the slot table and rebuilt hash table are charged against that budget. Trusted
+    /// such as the rebuilt hash table are charged against that budget. Trusted
     /// structural views pass `None` here, which keeps the previous unbudgeted inspection behavior.
     fn new(
         bytes: &[u8],
         layout: &ForestLayout,
-        mut remaining_allocation_budget: Option<&mut usize>,
+        remaining_allocation_budget: Option<&mut usize>,
     ) -> Result<Self, DeserializationError> {
-        let slot_by_node =
-            build_digest_slot_by_node(bytes, layout, remaining_allocation_budget.as_deref_mut())?;
         // If the internal-hash section is absent, rebuild all non-external digests once and cache
         // them for later lookups.
         let hash_table = if layout.node_hash_offset.is_none() {
@@ -67,7 +60,7 @@ impl ForestDigests {
             None
         };
 
-        Ok(Self { slot_by_node, hash_table })
+        Ok(Self { hash_table })
     }
 
     fn digest_at(
@@ -77,16 +70,14 @@ impl ForestDigests {
         index: usize,
         entry: MastNodeEntry,
     ) -> Result<crate::Word, DeserializationError> {
-        let digest_slot = self.slot_by_node.get(index).copied().ok_or_else(|| {
-            DeserializationError::InvalidValue(format!(
-                "node index {} out of bounds for {} digest slots",
-                index,
-                self.slot_by_node.len()
-            ))
-        })? as usize;
-
         if matches!(entry, MastNodeEntry::External) {
-            return read_digest_entry(bytes, layout.external_digest_offset, digest_slot);
+            if index >= layout.external_node_count {
+                return Err(DeserializationError::InvalidValue(format!(
+                    "external node index {} out of bounds for {} external digests",
+                    index, layout.external_node_count
+                )));
+            }
+            return read_digest_entry(bytes, layout.external_digest_offset, index);
         }
 
         if let Some(hash_table) = &self.hash_table {
@@ -104,6 +95,18 @@ impl ForestDigests {
                 "hash-backed digest lookup requested but node hash section is absent".to_string(),
             )
         })?;
+        let digest_slot = index.checked_sub(layout.external_node_count).ok_or_else(|| {
+            DeserializationError::InvalidValue(format!(
+                "internal node index {} must be at least {}",
+                index, layout.external_node_count
+            ))
+        })?;
+        if digest_slot >= layout.internal_node_count {
+            return Err(DeserializationError::InvalidValue(format!(
+                "internal digest slot {} out of bounds for {} internal digests",
+                digest_slot, layout.internal_node_count
+            )));
+        }
         read_digest_entry(bytes, node_hash_offset, digest_slot)
     }
 }
@@ -189,7 +192,7 @@ impl<'a> ResolvedSerializedForest<'a> {
     /// Returns the digest for the node at `index`.
     ///
     /// The caller-supplied index is checked via [`Self::node_entry_at`] before the digest lookup
-    /// reaches the internal slot table.
+    /// reaches the digest source selected for that node kind.
     pub(super) fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
         let entry = self.node_entry_at(index)?;
         self.node_digest_for_entry(index, entry)
@@ -206,7 +209,11 @@ impl<'a> ResolvedSerializedForest<'a> {
 
     #[cfg(test)]
     pub(super) fn digest_slot_at(&self, index: usize) -> usize {
-        self.digests.slot_by_node[index] as usize
+        if index < self.layout.external_node_count {
+            index
+        } else {
+            index - self.layout.external_node_count
+        }
     }
 }
 
@@ -241,42 +248,6 @@ fn basic_block_data(
     Ok(&bytes[basic_block_offset..end])
 }
 
-fn build_digest_slot_by_node(
-    bytes: &[u8],
-    layout: &ForestLayout,
-    remaining_allocation_budget: Option<&mut usize>,
-) -> Result<Vec<u32>, DeserializationError> {
-    // Digest sections are packed densely by node kind rather than by absolute node index.
-    // This scan records, for each node index, which slot to read from in the corresponding digest
-    // source.
-    let mut slots = Vec::new();
-    reserve_node_capacity(
-        &mut slots,
-        layout.node_count,
-        "digest slot table",
-        remaining_allocation_budget,
-    )?;
-    let mut external_slot = 0u32;
-    let mut node_hash_slot = 0u32;
-
-    for index in 0..layout.node_count {
-        let entry = layout.read_node_entry_at(bytes, index)?;
-        if matches!(entry, MastNodeEntry::External) {
-            slots.push(external_slot);
-            external_slot = external_slot.checked_add(1).ok_or_else(|| {
-                DeserializationError::InvalidValue("external digest slot overflow".to_string())
-            })?;
-        } else {
-            slots.push(node_hash_slot);
-            node_hash_slot = node_hash_slot.checked_add(1).ok_or_else(|| {
-                DeserializationError::InvalidValue("node hash slot overflow".to_string())
-            })?;
-        }
-    }
-
-    Ok(slots)
-}
-
 fn recompute_hash_table(
     bytes: &[u8],
     layout: &ForestLayout,
@@ -295,8 +266,6 @@ fn recompute_hash_table(
         "hash table",
         remaining_allocation_budget,
     )?;
-    let mut external_digest_index = 0usize;
-
     for index in 0..layout.node_count {
         let entry = layout.read_node_entry_at(bytes, index)?;
         let computed = match entry {
@@ -337,12 +306,7 @@ fn recompute_hash_table(
             MastNodeEntry::Dyn => DynNode::DYN_DEFAULT_DIGEST,
             MastNodeEntry::Dyncall => DynNode::DYNCALL_DEFAULT_DIGEST,
             MastNodeEntry::External => {
-                let digest =
-                    read_digest_entry(bytes, layout.external_digest_offset, external_digest_index)?;
-                external_digest_index = external_digest_index.checked_add(1).ok_or_else(|| {
-                    DeserializationError::InvalidValue("external digest index overflow".to_string())
-                })?;
-                digest
+                read_digest_entry(bytes, layout.external_digest_offset, index)?
             },
         };
 

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -11,19 +11,19 @@ use crate::{
         CallNode, DebugInfo, DynNode, JoinNode, LoopNode, SplitNode,
         serialization::{basic_blocks::BasicBlockDataDecoder, layout::read_fixed_section_entry},
     },
-    serde::{Deserializable, DeserializationError, SliceReader},
+    serde::{Deserializable, DeserializationError, Serializable, SliceReader},
 };
 
 /// Digest sources for a parsed serialized forest.
 ///
-/// Non-external nodes either read from the internal-hash section or from a rebuilt in-memory hash
-/// table. External nodes always read from the external-digest section.
+/// Non-external nodes either read from the internal-hash suffix or from a rebuilt in-memory hash
+/// table. External nodes always read from the external-digest prefix.
 #[derive(Debug, Clone)]
 struct ForestDigests {
     /// Dense slot index for each node within its digest section.
     ///
-    /// External nodes index into the external-digest section. All other nodes index into the
-    /// general node-hash section or the rebuilt hash table.
+    /// External nodes index into the external prefix of the node-digest section. All other nodes
+    /// index into the internal suffix or the rebuilt hash table.
     slot_by_node: Vec<u32>,
     /// Source of non-external digests.
     ///
@@ -86,7 +86,7 @@ impl ForestDigests {
         })? as usize;
 
         if matches!(entry, MastNodeEntry::External) {
-            return read_digest_entry(bytes, layout.external_digest_offset, digest_slot);
+            return read_digest_entry(bytes, layout.node_digest_offset, digest_slot);
         }
 
         if let Some(hash_table) = &self.hash_table {
@@ -253,17 +253,12 @@ fn build_digest_slot_by_node(
         "digest slot table",
         remaining_allocation_budget,
     )?;
-    let mut external_slot = 0u32;
     let mut node_hash_slot = 0u32;
 
     for index in 0..layout.node_count {
-        let entry = layout.read_node_entry_at(bytes, index)?;
-        let slot = if matches!(entry, MastNodeEntry::External) {
-            let slot = external_slot;
-            external_slot = external_slot.checked_add(1).ok_or_else(|| {
-                DeserializationError::InvalidValue("external digest slot overflow".to_string())
-            })?;
-            slot
+        let wire_entry = layout.read_node_wire_entry_at(bytes, index)?;
+        let slot = if let Some(digest_slot) = wire_entry.external_digest_slot() {
+            digest_slot
         } else {
             let slot = node_hash_slot;
             node_hash_slot = node_hash_slot.checked_add(1).ok_or_else(|| {
@@ -275,7 +270,6 @@ fn build_digest_slot_by_node(
     }
 
     debug_assert_eq!(node_hash_slot as usize, layout.internal_node_count);
-    debug_assert_eq!(external_slot as usize, layout.external_node_count);
 
     Ok(slots)
 }
@@ -298,9 +292,9 @@ fn recompute_hash_table(
         "hash table",
         remaining_allocation_budget,
     )?;
-    let mut external_slot = 0usize;
     for index in 0..layout.node_count {
-        let entry = layout.read_node_entry_at(bytes, index)?;
+        let wire_entry = layout.read_node_wire_entry_at(bytes, index)?;
+        let entry = wire_entry.entry();
         let computed = match entry {
             MastNodeEntry::Block { ops_offset } => {
                 let op_batches = basic_block_data_decoder.decode_operations(ops_offset)?;
@@ -339,12 +333,12 @@ fn recompute_hash_table(
             MastNodeEntry::Dyn => DynNode::DYN_DEFAULT_DIGEST,
             MastNodeEntry::Dyncall => DynNode::DYNCALL_DEFAULT_DIGEST,
             MastNodeEntry::External => {
-                let digest =
-                    read_digest_entry(bytes, layout.external_digest_offset, external_slot)?;
-                external_slot = external_slot.checked_add(1).ok_or_else(|| {
-                    DeserializationError::InvalidValue("external digest slot overflow".to_string())
+                let digest_slot = wire_entry.external_digest_slot().ok_or_else(|| {
+                    DeserializationError::InvalidValue(
+                        "external node entry missing digest slot".to_string(),
+                    )
                 })?;
-                digest
+                read_digest_entry(bytes, layout.node_digest_offset, digest_slot as usize)?
             },
         };
 
@@ -352,6 +346,50 @@ fn recompute_hash_table(
     }
 
     Ok(digests)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::mast) struct ExternalDigestOrderViolation {
+    pub(in crate::mast) previous_slot: usize,
+    pub(in crate::mast) slot: usize,
+    pub(in crate::mast) previous: crate::Word,
+    pub(in crate::mast) current: crate::Word,
+}
+
+pub(in crate::mast) fn external_digest_order_violation(
+    bytes: &[u8],
+    layout: &ForestLayout,
+) -> Result<Option<ExternalDigestOrderViolation>, DeserializationError> {
+    let mut previous = None;
+    for slot in 0..layout.external_node_count {
+        let current = read_digest_entry(bytes, layout.node_digest_offset, slot)?;
+        if let Some(previous_digest) = previous
+            && compare_words_by_wire(&previous_digest, &current).is_gt()
+        {
+            return Ok(Some(ExternalDigestOrderViolation {
+                previous_slot: slot - 1,
+                slot,
+                previous: previous_digest,
+                current,
+            }));
+        }
+        previous = Some(current);
+    }
+
+    Ok(None)
+}
+
+pub(super) fn compare_words_by_wire(
+    left: &crate::Word,
+    right: &crate::Word,
+) -> core::cmp::Ordering {
+    serialized_word_bytes(left).cmp(&serialized_word_bytes(right))
+}
+
+fn serialized_word_bytes(word: &crate::Word) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(crate::Word::min_serialized_size());
+    word.write_into(&mut bytes);
+    bytes
 }
 
 fn reserve_node_capacity<T>(

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -17,9 +17,14 @@ use crate::{
 /// Digest sources for a parsed serialized forest.
 ///
 /// Non-external nodes either read from the internal-hash section or from a rebuilt in-memory hash
-/// table. External nodes always read from the external-digest prefix section.
+/// table. External nodes always read from the external-digest section.
 #[derive(Debug, Clone)]
 struct ForestDigests {
+    /// Dense slot index for each node within its digest section.
+    ///
+    /// External nodes index into the external-digest section. All other nodes index into the
+    /// general node-hash section or the rebuilt hash table.
+    slot_by_node: Vec<u32>,
     /// Source of non-external digests.
     ///
     /// `None` means the serialized bytes still contain the internal node-hash section, so
@@ -50,8 +55,10 @@ impl ForestDigests {
     fn new(
         bytes: &[u8],
         layout: &ForestLayout,
-        remaining_allocation_budget: Option<&mut usize>,
+        mut remaining_allocation_budget: Option<&mut usize>,
     ) -> Result<Self, DeserializationError> {
+        let slot_by_node =
+            build_digest_slot_by_node(bytes, layout, remaining_allocation_budget.as_deref_mut())?;
         // If the internal-hash section is absent, rebuild all non-external digests once and cache
         // them for later lookups.
         let hash_table = if layout.node_hash_offset.is_none() {
@@ -60,7 +67,7 @@ impl ForestDigests {
             None
         };
 
-        Ok(Self { hash_table })
+        Ok(Self { slot_by_node, hash_table })
     }
 
     fn digest_at(
@@ -70,14 +77,16 @@ impl ForestDigests {
         index: usize,
         entry: MastNodeEntry,
     ) -> Result<crate::Word, DeserializationError> {
+        let digest_slot = self.slot_by_node.get(index).copied().ok_or_else(|| {
+            DeserializationError::InvalidValue(format!(
+                "node index {} out of bounds for {} digest slots",
+                index,
+                self.slot_by_node.len()
+            ))
+        })? as usize;
+
         if matches!(entry, MastNodeEntry::External) {
-            if index >= layout.external_node_count {
-                return Err(DeserializationError::InvalidValue(format!(
-                    "external node index {} out of bounds for {} external digests",
-                    index, layout.external_node_count
-                )));
-            }
-            return read_digest_entry(bytes, layout.external_digest_offset, index);
+            return read_digest_entry(bytes, layout.external_digest_offset, digest_slot);
         }
 
         if let Some(hash_table) = &self.hash_table {
@@ -95,18 +104,6 @@ impl ForestDigests {
                 "hash-backed digest lookup requested but node hash section is absent".to_string(),
             )
         })?;
-        let digest_slot = index.checked_sub(layout.external_node_count).ok_or_else(|| {
-            DeserializationError::InvalidValue(format!(
-                "internal node index {} must be at least {}",
-                index, layout.external_node_count
-            ))
-        })?;
-        if digest_slot >= layout.internal_node_count {
-            return Err(DeserializationError::InvalidValue(format!(
-                "internal digest slot {} out of bounds for {} internal digests",
-                digest_slot, layout.internal_node_count
-            )));
-        }
         read_digest_entry(bytes, node_hash_offset, digest_slot)
     }
 }
@@ -192,7 +189,7 @@ impl<'a> ResolvedSerializedForest<'a> {
     /// Returns the digest for the node at `index`.
     ///
     /// The caller-supplied index is checked via [`Self::node_entry_at`] before the digest lookup
-    /// reaches the digest source selected for that node kind.
+    /// reaches the internal slot table.
     pub(super) fn node_digest_at(&self, index: usize) -> Result<crate::Word, DeserializationError> {
         let entry = self.node_entry_at(index)?;
         self.node_digest_for_entry(index, entry)
@@ -209,11 +206,7 @@ impl<'a> ResolvedSerializedForest<'a> {
 
     #[cfg(test)]
     pub(super) fn digest_slot_at(&self, index: usize) -> usize {
-        if index < self.layout.external_node_count {
-            index
-        } else {
-            index - self.layout.external_node_count
-        }
+        self.digests.slot_by_node[index] as usize
     }
 }
 
@@ -248,6 +241,45 @@ fn basic_block_data(
     Ok(&bytes[basic_block_offset..end])
 }
 
+fn build_digest_slot_by_node(
+    bytes: &[u8],
+    layout: &ForestLayout,
+    remaining_allocation_budget: Option<&mut usize>,
+) -> Result<Vec<u32>, DeserializationError> {
+    let mut slots = Vec::new();
+    reserve_node_capacity(
+        &mut slots,
+        layout.node_count,
+        "digest slot table",
+        remaining_allocation_budget,
+    )?;
+    let mut external_slot = 0u32;
+    let mut node_hash_slot = 0u32;
+
+    for index in 0..layout.node_count {
+        let entry = layout.read_node_entry_at(bytes, index)?;
+        let slot = if matches!(entry, MastNodeEntry::External) {
+            let slot = external_slot;
+            external_slot = external_slot.checked_add(1).ok_or_else(|| {
+                DeserializationError::InvalidValue("external digest slot overflow".to_string())
+            })?;
+            slot
+        } else {
+            let slot = node_hash_slot;
+            node_hash_slot = node_hash_slot.checked_add(1).ok_or_else(|| {
+                DeserializationError::InvalidValue("node hash slot overflow".to_string())
+            })?;
+            slot
+        };
+        slots.push(slot);
+    }
+
+    debug_assert_eq!(node_hash_slot as usize, layout.internal_node_count);
+    debug_assert_eq!(external_slot as usize, layout.external_node_count);
+
+    Ok(slots)
+}
+
 fn recompute_hash_table(
     bytes: &[u8],
     layout: &ForestLayout,
@@ -266,6 +298,7 @@ fn recompute_hash_table(
         "hash table",
         remaining_allocation_budget,
     )?;
+    let mut external_slot = 0usize;
     for index in 0..layout.node_count {
         let entry = layout.read_node_entry_at(bytes, index)?;
         let computed = match entry {
@@ -306,7 +339,12 @@ fn recompute_hash_table(
             MastNodeEntry::Dyn => DynNode::DYN_DEFAULT_DIGEST,
             MastNodeEntry::Dyncall => DynNode::DYNCALL_DEFAULT_DIGEST,
             MastNodeEntry::External => {
-                read_digest_entry(bytes, layout.external_digest_offset, index)?
+                let digest =
+                    read_digest_entry(bytes, layout.external_digest_offset, external_slot)?;
+                external_slot = external_slot.checked_add(1).ok_or_else(|| {
+                    DeserializationError::InvalidValue("external digest slot overflow".to_string())
+                })?;
+                digest
             },
         };
 

--- a/core/src/mast/serialization/resolved.rs
+++ b/core/src/mast/serialization/resolved.rs
@@ -11,19 +11,19 @@ use crate::{
         CallNode, DebugInfo, DynNode, JoinNode, LoopNode, SplitNode,
         serialization::{basic_blocks::BasicBlockDataDecoder, layout::read_fixed_section_entry},
     },
-    serde::{Deserializable, DeserializationError, Serializable, SliceReader},
+    serde::{Deserializable, DeserializationError, SliceReader},
 };
 
 /// Digest sources for a parsed serialized forest.
 ///
-/// Non-external nodes either read from the internal-hash suffix or from a rebuilt in-memory hash
-/// table. External nodes always read from the external-digest prefix.
+/// Non-external nodes either read from the internal-hash section or from a rebuilt in-memory hash
+/// table. External nodes always read from the external-digest section.
 #[derive(Debug, Clone)]
 struct ForestDigests {
     /// Dense slot index for each node within its digest section.
     ///
-    /// External nodes index into the external prefix of the node-digest section. All other nodes
-    /// index into the internal suffix or the rebuilt hash table.
+    /// External nodes index into the external-digest section. All other nodes index into the
+    /// general node-hash section or the rebuilt hash table.
     slot_by_node: Vec<u32>,
     /// Source of non-external digests.
     ///
@@ -86,7 +86,7 @@ impl ForestDigests {
         })? as usize;
 
         if matches!(entry, MastNodeEntry::External) {
-            return read_digest_entry(bytes, layout.node_digest_offset, digest_slot);
+            return read_digest_entry(bytes, layout.external_digest_offset, digest_slot);
         }
 
         if let Some(hash_table) = &self.hash_table {
@@ -253,12 +253,17 @@ fn build_digest_slot_by_node(
         "digest slot table",
         remaining_allocation_budget,
     )?;
+    let mut external_slot = 0u32;
     let mut node_hash_slot = 0u32;
 
     for index in 0..layout.node_count {
-        let wire_entry = layout.read_node_wire_entry_at(bytes, index)?;
-        let slot = if let Some(digest_slot) = wire_entry.external_digest_slot() {
-            digest_slot
+        let entry = layout.read_node_entry_at(bytes, index)?;
+        let slot = if matches!(entry, MastNodeEntry::External) {
+            let slot = external_slot;
+            external_slot = external_slot.checked_add(1).ok_or_else(|| {
+                DeserializationError::InvalidValue("external digest slot overflow".to_string())
+            })?;
+            slot
         } else {
             let slot = node_hash_slot;
             node_hash_slot = node_hash_slot.checked_add(1).ok_or_else(|| {
@@ -270,6 +275,7 @@ fn build_digest_slot_by_node(
     }
 
     debug_assert_eq!(node_hash_slot as usize, layout.internal_node_count);
+    debug_assert_eq!(external_slot as usize, layout.external_node_count);
 
     Ok(slots)
 }
@@ -292,9 +298,9 @@ fn recompute_hash_table(
         "hash table",
         remaining_allocation_budget,
     )?;
+    let mut external_slot = 0usize;
     for index in 0..layout.node_count {
-        let wire_entry = layout.read_node_wire_entry_at(bytes, index)?;
-        let entry = wire_entry.entry();
+        let entry = layout.read_node_entry_at(bytes, index)?;
         let computed = match entry {
             MastNodeEntry::Block { ops_offset } => {
                 let op_batches = basic_block_data_decoder.decode_operations(ops_offset)?;
@@ -333,12 +339,12 @@ fn recompute_hash_table(
             MastNodeEntry::Dyn => DynNode::DYN_DEFAULT_DIGEST,
             MastNodeEntry::Dyncall => DynNode::DYNCALL_DEFAULT_DIGEST,
             MastNodeEntry::External => {
-                let digest_slot = wire_entry.external_digest_slot().ok_or_else(|| {
-                    DeserializationError::InvalidValue(
-                        "external node entry missing digest slot".to_string(),
-                    )
+                let digest =
+                    read_digest_entry(bytes, layout.external_digest_offset, external_slot)?;
+                external_slot = external_slot.checked_add(1).ok_or_else(|| {
+                    DeserializationError::InvalidValue("external digest slot overflow".to_string())
                 })?;
-                read_digest_entry(bytes, layout.node_digest_offset, digest_slot as usize)?
+                digest
             },
         };
 
@@ -346,50 +352,6 @@ fn recompute_hash_table(
     }
 
     Ok(digests)
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::mast) struct ExternalDigestOrderViolation {
-    pub(in crate::mast) previous_slot: usize,
-    pub(in crate::mast) slot: usize,
-    pub(in crate::mast) previous: crate::Word,
-    pub(in crate::mast) current: crate::Word,
-}
-
-pub(in crate::mast) fn external_digest_order_violation(
-    bytes: &[u8],
-    layout: &ForestLayout,
-) -> Result<Option<ExternalDigestOrderViolation>, DeserializationError> {
-    let mut previous = None;
-    for slot in 0..layout.external_node_count {
-        let current = read_digest_entry(bytes, layout.node_digest_offset, slot)?;
-        if let Some(previous_digest) = previous
-            && compare_words_by_wire(&previous_digest, &current).is_gt()
-        {
-            return Ok(Some(ExternalDigestOrderViolation {
-                previous_slot: slot - 1,
-                slot,
-                previous: previous_digest,
-                current,
-            }));
-        }
-        previous = Some(current);
-    }
-
-    Ok(None)
-}
-
-pub(super) fn compare_words_by_wire(
-    left: &crate::Word,
-    right: &crate::Word,
-) -> core::cmp::Ordering {
-    serialized_word_bytes(left).cmp(&serialized_word_bytes(right))
-}
-
-fn serialized_word_bytes(word: &crate::Word) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(crate::Word::min_serialized_size());
-    word.write_into(&mut bytes);
-    bytes
 }
 
 fn reserve_node_capacity<T>(

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -470,6 +470,17 @@ fn test_operation_encoded_size_push_varint_boundaries() {
     }
 }
 
+#[test]
+fn mast_node_entry_external_rejects_oversized_payload() {
+    let oversized_payload = u32::MAX as u64 + 1;
+    let raw_external_entry = (8u64 << 60) | oversized_payload;
+    let mut bytes = Vec::new();
+    raw_external_entry.write_into(&mut bytes);
+
+    let result = MastNodeEntry::read_from(&mut SliceReader::new(&bytes));
+    assert_matches!(result, Err(DeserializationError::InvalidValue(_)));
+}
+
 fn assert_serialized_view_matches_forest(forest: &MastForest) {
     let mut bytes = Vec::new();
     forest.write_stripped(&mut bytes);
@@ -607,6 +618,16 @@ fn node_hash_digest_offset(view: &SerializedMastForest<'_>, node_index: usize) -
     view.node_hash_offset().unwrap() + digest_slot * Word::min_serialized_size()
 }
 
+fn external_digest_offset(view: &SerializedMastForest<'_>, node_index: usize) -> usize {
+    let digest_slot = view.digest_slot_at(node_index);
+    view.node_digest_offset() + digest_slot * Word::min_serialized_size()
+}
+
+fn read_word_at(bytes: &[u8], offset: usize) -> Word {
+    let mut reader = SliceReader::new(&bytes[offset..offset + Word::min_serialized_size()]);
+    Word::read_from(&mut reader).unwrap()
+}
+
 fn rewrite_debug_info_procedure_name_digest(
     bytes: &[u8],
     from_digest: Word,
@@ -671,6 +692,146 @@ fn test_serialized_mast_forest_hashless_accepts_external_nodes_parse_only() {
     assert_eq!(view.node_count(), 1);
     assert!(view.node_info_at(0).is_ok());
     assert_eq!(view.node_digest_at(0).unwrap(), external_digest);
+}
+
+#[test]
+fn test_serialized_mast_forest_external_digests_are_sorted_on_wire() {
+    let mut forest = MastForest::new();
+    let largest = Word::new([
+        Felt::new_unchecked(30),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+    ]);
+    let smallest = Word::new([
+        Felt::new_unchecked(10),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+    ]);
+    let middle = Word::new([
+        Felt::new_unchecked(20),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+    ]);
+
+    let largest_id = ExternalNodeBuilder::new(largest).add_to_forest(&mut forest).unwrap();
+    let smallest_id = ExternalNodeBuilder::new(smallest).add_to_forest(&mut forest).unwrap();
+    let middle_id = ExternalNodeBuilder::new(middle).add_to_forest(&mut forest).unwrap();
+    forest.make_root(largest_id);
+    forest.make_root(smallest_id);
+    forest.make_root(middle_id);
+
+    let bytes = forest.to_bytes();
+    let view = SerializedMastForest::new(&bytes).unwrap();
+
+    assert_eq!(read_word_at(&bytes, view.node_digest_offset()), smallest);
+    assert_eq!(
+        read_word_at(&bytes, view.node_digest_offset() + Word::min_serialized_size()),
+        middle
+    );
+    assert_eq!(
+        read_word_at(&bytes, view.node_digest_offset() + 2 * Word::min_serialized_size()),
+        largest
+    );
+    assert_eq!(view.node_digest_at(largest_id.to_usize()).unwrap(), largest);
+    assert_eq!(view.node_digest_at(smallest_id.to_usize()).unwrap(), smallest);
+    assert_eq!(view.node_digest_at(middle_id.to_usize()).unwrap(), middle);
+    assert_eq!(
+        read_word_at(&bytes, external_digest_offset(&view, largest_id.to_usize())),
+        largest
+    );
+    assert_eq!(
+        read_word_at(&bytes, external_digest_offset(&view, smallest_id.to_usize())),
+        smallest
+    );
+    assert_eq!(
+        read_word_at(&bytes, external_digest_offset(&view, middle_id.to_usize())),
+        middle
+    );
+}
+
+#[test]
+fn test_serialized_mast_forest_hashless_keeps_sorted_external_prefix() {
+    let mut forest = MastForest::new();
+    let external_high = Word::new([
+        Felt::new_unchecked(9),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+    ]);
+    let external_low = Word::new([
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+    ]);
+
+    let _block = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let high_id = ExternalNodeBuilder::new(external_high).add_to_forest(&mut forest).unwrap();
+    let low_id = ExternalNodeBuilder::new(external_low).add_to_forest(&mut forest).unwrap();
+    forest.make_root(high_id);
+    forest.make_root(low_id);
+
+    let mut bytes = Vec::new();
+    forest.write_hashless(&mut bytes);
+    let view = SerializedMastForest::new(&bytes).unwrap();
+
+    assert!(view.node_hash_offset().is_none());
+    assert_eq!(read_word_at(&bytes, view.node_digest_offset()), external_low);
+    assert_eq!(
+        read_word_at(&bytes, view.node_digest_offset() + Word::min_serialized_size()),
+        external_high
+    );
+    assert_eq!(view.node_digest_at(high_id.to_usize()).unwrap(), external_high);
+    assert_eq!(view.node_digest_at(low_id.to_usize()).unwrap(), external_low);
+}
+
+#[test]
+fn test_untrusted_forest_rejects_unsorted_external_digest_prefix() {
+    let mut forest = MastForest::new();
+    let external_high = Word::new([
+        Felt::new_unchecked(9),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+    ]);
+    let external_low = Word::new([
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+        Felt::new_unchecked(0),
+    ]);
+
+    let high_id = ExternalNodeBuilder::new(external_high).add_to_forest(&mut forest).unwrap();
+    let low_id = ExternalNodeBuilder::new(external_low).add_to_forest(&mut forest).unwrap();
+    forest.make_root(high_id);
+    forest.make_root(low_id);
+
+    let mut corrupted = forest.to_bytes();
+    let view = SerializedMastForest::new(&corrupted).unwrap();
+    let first_digest = view.node_digest_offset();
+    let second_digest = first_digest + Word::min_serialized_size();
+    for index in 0..Word::min_serialized_size() {
+        corrupted.swap(first_digest + index, second_digest + index);
+    }
+
+    assert!(MastForest::read_from_bytes(&corrupted).is_ok());
+
+    let untrusted = UntrustedMastForest::read_from_bytes(&corrupted).unwrap();
+    let result = untrusted.validate();
+    assert_matches!(
+        result,
+        Err(MastForestError::ExternalDigestsNotSorted {
+            previous_slot: 0,
+            slot: 1,
+            previous,
+            current,
+        }) if previous == external_high && current == external_low
+    );
 }
 
 /// Test that a forest with a node whose child ids are larger than its own id serializes and

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -440,7 +440,7 @@ fn serialize_deserialize_all_nodes() {
     let serialized_mast_forest = mast_forest.to_bytes();
     let deserialized_mast_forest = MastForest::read_from_bytes(&serialized_mast_forest).unwrap();
 
-    assert_roundtrip_matches_serialized_view(&serialized_mast_forest, &deserialized_mast_forest);
+    assert_eq!(mast_forest, deserialized_mast_forest);
 }
 
 #[test]
@@ -477,57 +477,17 @@ fn assert_serialized_view_matches_forest(forest: &MastForest) {
     let view = SerializedMastForest::new(&bytes).unwrap();
     assert_eq!(view.node_count(), forest.nodes().len());
 
-    let mut serialized_order = forest
-        .nodes()
-        .iter()
-        .enumerate()
-        .filter(|(_, node)| node.is_external())
-        .map(|(index, node)| (index, node.digest()))
-        .collect::<Vec<_>>();
-    serialized_order.sort_by_key(|(index, digest)| (*digest, *index));
-    let mut forest_to_serialized = vec![0u32; forest.nodes().len()];
-    let mut ordered_indices = Vec::with_capacity(forest.nodes().len());
-    for (serialized_index, (forest_index, _)) in serialized_order.into_iter().enumerate() {
-        ordered_indices.push(forest_index);
-        forest_to_serialized[forest_index] = serialized_index as u32;
-    }
-    for (forest_index, node) in forest.nodes().iter().enumerate() {
-        if node.is_external() {
-            continue;
-        }
-        let serialized_index = ordered_indices.len();
-        ordered_indices.push(forest_index);
-        forest_to_serialized[forest_index] = serialized_index as u32;
-    }
-
     let mut bb_builder = BasicBlockDataBuilder::new();
-    for (idx, forest_index) in ordered_indices.into_iter().enumerate() {
-        let node = &forest.nodes()[forest_index];
+    for (idx, node) in forest.nodes().iter().enumerate() {
         let ops_offset = if let MastNode::Block(block) = node {
             bb_builder.encode_basic_block(block)
         } else {
             0
         };
-        let expected =
-            MastNodeInfo::new_with_id_remap(node, ops_offset, Some(&forest_to_serialized));
+        let expected = MastNodeInfo::new(node, ops_offset);
         let actual = view.node_info_at(idx).unwrap();
         assert_eq!(expected.to_bytes(), actual.to_bytes());
     }
-}
-
-fn assert_roundtrip_matches_serialized_view(bytes: &[u8], forest: &MastForest) {
-    let view = SerializedMastForest::new(bytes).unwrap();
-
-    assert_eq!(forest.node_count(), view.node_count());
-    for index in 0..view.node_count() {
-        assert_eq!(
-            forest.node_info_at(index).unwrap().to_bytes(),
-            view.node_info_at(index).unwrap().to_bytes()
-        );
-        assert_eq!(forest.node_digest_at(index).unwrap(), view.node_digest_at(index).unwrap());
-    }
-
-    assert_eq!(forest.procedure_roots().to_vec(), view.procedure_roots().unwrap());
 }
 
 #[test]
@@ -1382,7 +1342,7 @@ fn test_deserialization_rejects_mismatched_header_counts() {
     assert_matches!(
         result,
         Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("must be External because the header reserves the first 1 nodes for externals")
+            if msg.contains("header external node count 1 does not match 0 external node entries")
     );
 }
 
@@ -1727,7 +1687,7 @@ mod proptests {
 
     use super::*;
     use crate::{
-        mast::{BasicBlockNodeBuilder, MastForest, arbitrary::MastForestParams},
+        mast::{BasicBlockNodeBuilder, MastForest, MastNode, arbitrary::MastForestParams},
         operations::Decorator,
     };
 
@@ -1747,32 +1707,65 @@ mod proptests {
                 max_dyns: 1,
             })
         ) {
+            // Serialize
             let serialized = forest.to_bytes();
+
+            // Deserialize
             let deserialized = MastForest::read_from_bytes(&serialized)
                 .expect("Deserialization should succeed");
-            let view = SerializedMastForest::new(&serialized).expect("Serialized view should parse");
 
-            prop_assert_eq!(deserialized.node_count(), view.node_count(), "Node count should match");
-            for index in 0..view.node_count() {
-                prop_assert_eq!(
-                    deserialized.node_info_at(index).unwrap().to_bytes(),
-                    view.node_info_at(index).unwrap().to_bytes(),
-                    "Node {}: serialized node info should match validated forest",
-                    index
-                );
-                prop_assert_eq!(
-                    deserialized.node_digest_at(index).unwrap(),
-                    view.node_digest_at(index).unwrap(),
-                    "Node {}: digest should match serialized view",
-                    index
-                );
-            }
-
+            // Verify node count
             prop_assert_eq!(
-                deserialized.procedure_roots().to_vec(),
-                view.procedure_roots().unwrap(),
-                "Procedure roots should match serialized view"
+                forest.num_nodes(),
+                deserialized.num_nodes(),
+                "Node count should match"
             );
+
+            // Verify all nodes match
+            for (idx, original) in forest.nodes().iter().enumerate() {
+                let node_id = MastNodeId::new_unchecked(idx as u32);
+                let deserialized_node = &deserialized[node_id];
+
+                // Check digests match
+                prop_assert_eq!(
+                    original.digest(),
+                    deserialized_node.digest(),
+                    "Node {:?} digest mismatch", node_id
+                );
+
+                // For basic blocks, verify OpBatch structure and decorators are preserved
+                if let MastNode::Block(original_block) = original
+                    && let MastNode::Block(deserialized_block) = deserialized_node
+                {
+                    prop_assert_eq!(
+                        original_block.op_batches(),
+                        deserialized_block.op_batches(),
+                        "Node {:?}: OpBatch mismatch", node_id
+                    );
+
+                    let orig_decorators: Vec<_> =
+                        original_block.indexed_decorator_iter(&forest).collect();
+                    let deser_decorators: Vec<_> =
+                        deserialized_block.indexed_decorator_iter(&deserialized).collect();
+
+                    prop_assert_eq!(
+                        orig_decorators.len(),
+                        deser_decorators.len(),
+                        "Node {:?}: Decorator count mismatch", node_id
+                    );
+
+                    for ((orig_idx, orig_dec_id), (deser_idx, deser_dec_id)) in
+                        orig_decorators.iter().zip(&deser_decorators)
+                    {
+                        prop_assert_eq!(orig_idx, deser_idx, "Node {:?}: Decorator index mismatch", node_id);
+                        prop_assert_eq!(
+                            forest.decorator_by_id(*orig_dec_id),
+                            deserialized.decorator_by_id(*deser_dec_id),
+                            "Node {:?}: Decorator content mismatch", node_id
+                        );
+                    }
+                }
+            }
         }
 
         /// Property test: multi-batch basic blocks should preserve exact structure
@@ -1946,34 +1939,32 @@ mod proptests {
                 max_dyns: 1,
             })
         ) {
+            // Stripped serialization
             let mut stripped_bytes = Vec::new();
             forest.write_stripped(&mut stripped_bytes);
+
+            // Deserialize
             let restored = MastForest::read_from_bytes(&stripped_bytes)
                 .expect("Stripped deserialization should succeed");
-            let view =
-                SerializedMastForest::new(&stripped_bytes).expect("Serialized view should parse");
 
-            prop_assert_eq!(restored.node_count(), view.node_count(), "Node count should match");
-            for index in 0..view.node_count() {
+            // Verify node count matches
+            prop_assert_eq!(
+                forest.num_nodes(),
+                restored.num_nodes(),
+                "Node count should match"
+            );
+
+            // Verify all node digests match
+            for (idx, original) in forest.nodes().iter().enumerate() {
+                let node_id = MastNodeId::new_unchecked(idx as u32);
+                let restored_node = &restored[node_id];
+
                 prop_assert_eq!(
-                    restored.node_info_at(index).unwrap().to_bytes(),
-                    view.node_info_at(index).unwrap().to_bytes(),
-                    "Node {}: serialized node info should match restored forest",
-                    index
-                );
-                prop_assert_eq!(
-                    restored.node_digest_at(index).unwrap(),
-                    view.node_digest_at(index).unwrap(),
-                    "Node {}: digest should match serialized view",
-                    index
+                    original.digest(),
+                    restored_node.digest(),
+                    "Node {:?} digest mismatch", node_id
                 );
             }
-
-            prop_assert_eq!(
-                restored.procedure_roots().to_vec(),
-                view.procedure_roots().unwrap(),
-                "Procedure roots should match serialized view"
-            );
 
             prop_assert!(
                 restored.debug_info.is_empty(),
@@ -2618,7 +2609,7 @@ fn test_untrusted_forest_validates_all_node_types() {
     let untrusted = UntrustedMastForest::read_from_bytes(&bytes).unwrap();
     let validated = untrusted.validate().unwrap();
 
-    assert_roundtrip_matches_serialized_view(&bytes, &validated);
+    assert_eq!(forest, validated);
 }
 
 /// Test that UntrustedMastForest::validate works with stripped serialization.

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -470,17 +470,6 @@ fn test_operation_encoded_size_push_varint_boundaries() {
     }
 }
 
-#[test]
-fn mast_node_entry_external_rejects_oversized_payload() {
-    let oversized_payload = u32::MAX as u64 + 1;
-    let raw_external_entry = (8u64 << 60) | oversized_payload;
-    let mut bytes = Vec::new();
-    raw_external_entry.write_into(&mut bytes);
-
-    let result = MastNodeEntry::read_from(&mut SliceReader::new(&bytes));
-    assert_matches!(result, Err(DeserializationError::InvalidValue(_)));
-}
-
 fn assert_serialized_view_matches_forest(forest: &MastForest) {
     let mut bytes = Vec::new();
     forest.write_stripped(&mut bytes);
@@ -618,16 +607,6 @@ fn node_hash_digest_offset(view: &SerializedMastForest<'_>, node_index: usize) -
     view.node_hash_offset().unwrap() + digest_slot * Word::min_serialized_size()
 }
 
-fn external_digest_offset(view: &SerializedMastForest<'_>, node_index: usize) -> usize {
-    let digest_slot = view.digest_slot_at(node_index);
-    view.node_digest_offset() + digest_slot * Word::min_serialized_size()
-}
-
-fn read_word_at(bytes: &[u8], offset: usize) -> Word {
-    let mut reader = SliceReader::new(&bytes[offset..offset + Word::min_serialized_size()]);
-    Word::read_from(&mut reader).unwrap()
-}
-
 fn rewrite_debug_info_procedure_name_digest(
     bytes: &[u8],
     from_digest: Word,
@@ -692,146 +671,6 @@ fn test_serialized_mast_forest_hashless_accepts_external_nodes_parse_only() {
     assert_eq!(view.node_count(), 1);
     assert!(view.node_info_at(0).is_ok());
     assert_eq!(view.node_digest_at(0).unwrap(), external_digest);
-}
-
-#[test]
-fn test_serialized_mast_forest_external_digests_are_sorted_on_wire() {
-    let mut forest = MastForest::new();
-    let largest = Word::new([
-        Felt::new_unchecked(30),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-    ]);
-    let smallest = Word::new([
-        Felt::new_unchecked(10),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-    ]);
-    let middle = Word::new([
-        Felt::new_unchecked(20),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-    ]);
-
-    let largest_id = ExternalNodeBuilder::new(largest).add_to_forest(&mut forest).unwrap();
-    let smallest_id = ExternalNodeBuilder::new(smallest).add_to_forest(&mut forest).unwrap();
-    let middle_id = ExternalNodeBuilder::new(middle).add_to_forest(&mut forest).unwrap();
-    forest.make_root(largest_id);
-    forest.make_root(smallest_id);
-    forest.make_root(middle_id);
-
-    let bytes = forest.to_bytes();
-    let view = SerializedMastForest::new(&bytes).unwrap();
-
-    assert_eq!(read_word_at(&bytes, view.node_digest_offset()), smallest);
-    assert_eq!(
-        read_word_at(&bytes, view.node_digest_offset() + Word::min_serialized_size()),
-        middle
-    );
-    assert_eq!(
-        read_word_at(&bytes, view.node_digest_offset() + 2 * Word::min_serialized_size()),
-        largest
-    );
-    assert_eq!(view.node_digest_at(largest_id.to_usize()).unwrap(), largest);
-    assert_eq!(view.node_digest_at(smallest_id.to_usize()).unwrap(), smallest);
-    assert_eq!(view.node_digest_at(middle_id.to_usize()).unwrap(), middle);
-    assert_eq!(
-        read_word_at(&bytes, external_digest_offset(&view, largest_id.to_usize())),
-        largest
-    );
-    assert_eq!(
-        read_word_at(&bytes, external_digest_offset(&view, smallest_id.to_usize())),
-        smallest
-    );
-    assert_eq!(
-        read_word_at(&bytes, external_digest_offset(&view, middle_id.to_usize())),
-        middle
-    );
-}
-
-#[test]
-fn test_serialized_mast_forest_hashless_keeps_sorted_external_prefix() {
-    let mut forest = MastForest::new();
-    let external_high = Word::new([
-        Felt::new_unchecked(9),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-    ]);
-    let external_low = Word::new([
-        Felt::new_unchecked(3),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-    ]);
-
-    let _block = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
-        .add_to_forest(&mut forest)
-        .unwrap();
-    let high_id = ExternalNodeBuilder::new(external_high).add_to_forest(&mut forest).unwrap();
-    let low_id = ExternalNodeBuilder::new(external_low).add_to_forest(&mut forest).unwrap();
-    forest.make_root(high_id);
-    forest.make_root(low_id);
-
-    let mut bytes = Vec::new();
-    forest.write_hashless(&mut bytes);
-    let view = SerializedMastForest::new(&bytes).unwrap();
-
-    assert!(view.node_hash_offset().is_none());
-    assert_eq!(read_word_at(&bytes, view.node_digest_offset()), external_low);
-    assert_eq!(
-        read_word_at(&bytes, view.node_digest_offset() + Word::min_serialized_size()),
-        external_high
-    );
-    assert_eq!(view.node_digest_at(high_id.to_usize()).unwrap(), external_high);
-    assert_eq!(view.node_digest_at(low_id.to_usize()).unwrap(), external_low);
-}
-
-#[test]
-fn test_untrusted_forest_rejects_unsorted_external_digest_prefix() {
-    let mut forest = MastForest::new();
-    let external_high = Word::new([
-        Felt::new_unchecked(9),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-    ]);
-    let external_low = Word::new([
-        Felt::new_unchecked(3),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-        Felt::new_unchecked(0),
-    ]);
-
-    let high_id = ExternalNodeBuilder::new(external_high).add_to_forest(&mut forest).unwrap();
-    let low_id = ExternalNodeBuilder::new(external_low).add_to_forest(&mut forest).unwrap();
-    forest.make_root(high_id);
-    forest.make_root(low_id);
-
-    let mut corrupted = forest.to_bytes();
-    let view = SerializedMastForest::new(&corrupted).unwrap();
-    let first_digest = view.node_digest_offset();
-    let second_digest = first_digest + Word::min_serialized_size();
-    for index in 0..Word::min_serialized_size() {
-        corrupted.swap(first_digest + index, second_digest + index);
-    }
-
-    assert!(MastForest::read_from_bytes(&corrupted).is_ok());
-
-    let untrusted = UntrustedMastForest::read_from_bytes(&corrupted).unwrap();
-    let result = untrusted.validate();
-    assert_matches!(
-        result,
-        Err(MastForestError::ExternalDigestsNotSorted {
-            previous_slot: 0,
-            slot: 1,
-            previous,
-            current,
-        }) if previous == external_high && current == external_low
-    );
 }
 
 /// Test that a forest with a node whose child ids are larger than its own id serializes and

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -895,7 +895,6 @@ fn mast_forest_deserialize_invalid_ops_offset_fails() {
     let mut reader = SliceReader::new(&serialized);
 
     let _: [u8; 8] = reader.read_array().unwrap(); // magic (4) + flags (1) + version (3)
-    let _node_count: usize = reader.read().unwrap();
     let _internal_node_count: usize = reader.read().unwrap();
     let _external_node_count: usize = reader.read().unwrap();
     let _roots: Vec<u32> = Deserializable::read_from(&mut reader).unwrap();
@@ -1246,12 +1245,11 @@ fn assert_header_flags(bytes: &[u8], expected_flags: u8) {
     assert_eq!(&bytes[5..8], &[0, 0, 3], "Version should be [0, 0, 3]");
 }
 
-fn read_header_counts(bytes: &[u8]) -> (usize, usize, usize) {
+fn read_header_counts(bytes: &[u8]) -> (usize, usize) {
     let mut offset = 8;
-    let node_count = read_usize_at(bytes, &mut offset).unwrap();
     let internal_node_count = read_usize_at(bytes, &mut offset).unwrap();
     let external_node_count = read_usize_at(bytes, &mut offset).unwrap();
-    (node_count, internal_node_count, external_node_count)
+    (internal_node_count, external_node_count)
 }
 
 #[test]
@@ -1285,9 +1283,7 @@ fn test_header_counts_match_node_kinds() {
         .unwrap();
     forest.make_root(join_id);
 
-    let (node_count, internal_node_count, external_node_count) =
-        read_header_counts(&forest.to_bytes());
-    assert_eq!(node_count, 3);
+    let (internal_node_count, external_node_count) = read_header_counts(&forest.to_bytes());
     assert_eq!(internal_node_count, 2);
     assert_eq!(external_node_count, 1);
 }
@@ -1321,7 +1317,6 @@ fn test_deserialization_rejects_mismatched_header_counts() {
 
     let mut bytes = forest.to_bytes();
     let mut offset = 8;
-    let _node_count = read_usize_at(&bytes, &mut offset).unwrap();
     let internal_count_offset = offset;
     let _internal_node_count = read_usize_at(&bytes, &mut offset).unwrap();
     let external_count_offset = offset;
@@ -2371,8 +2366,6 @@ fn locate_single_block_indptr_and_digest_offsets(bytes: &[u8]) -> (usize, usize)
     // header: MAGIC (4) + FLAGS (1) + VERSION (3)
     let _header: [u8; 8] = cursor.read_array().unwrap();
 
-    let node_count: usize = cursor.read().unwrap();
-    assert_eq!(node_count, 1);
     let internal_node_count: usize = cursor.read().unwrap();
     assert_eq!(internal_node_count, 1);
     let external_node_count: usize = cursor.read().unwrap();
@@ -2647,9 +2640,10 @@ fn test_deserialization_rejects_excessive_node_count() {
     bytes.write_u8(0); // flags
     VERSION.write_into(&mut bytes);
 
-    // Write excessive node count (MAX_NODES + 1)
+    // Write excessive derived node count (MAX_NODES + 1 internal nodes)
     let excessive_count: usize = MastForest::MAX_NODES + 1;
     excessive_count.write_into(&mut bytes);
+    0usize.write_into(&mut bytes);
 
     // Attempt to deserialize - should fail before any large allocation
     let result = MastForest::read_from_bytes(&bytes);
@@ -2672,6 +2666,7 @@ fn test_untrusted_deserialization_rejects_node_count_above_budget_bound() {
     VERSION.write_into(&mut bytes);
 
     2usize.write_into(&mut bytes);
+    0usize.write_into(&mut bytes);
 
     let result = UntrustedMastForest::read_from_bytes_with_budget(&bytes, bytes.len());
     assert!(result.is_err());

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -440,7 +440,7 @@ fn serialize_deserialize_all_nodes() {
     let serialized_mast_forest = mast_forest.to_bytes();
     let deserialized_mast_forest = MastForest::read_from_bytes(&serialized_mast_forest).unwrap();
 
-    assert_eq!(mast_forest, deserialized_mast_forest);
+    assert_roundtrip_matches_serialized_view(&serialized_mast_forest, &deserialized_mast_forest);
 }
 
 #[test]
@@ -477,17 +477,57 @@ fn assert_serialized_view_matches_forest(forest: &MastForest) {
     let view = SerializedMastForest::new(&bytes).unwrap();
     assert_eq!(view.node_count(), forest.nodes().len());
 
+    let mut serialized_order = forest
+        .nodes()
+        .iter()
+        .enumerate()
+        .filter(|(_, node)| node.is_external())
+        .map(|(index, node)| (index, node.digest()))
+        .collect::<Vec<_>>();
+    serialized_order.sort_by_key(|(index, digest)| (*digest, *index));
+    let mut forest_to_serialized = vec![0u32; forest.nodes().len()];
+    let mut ordered_indices = Vec::with_capacity(forest.nodes().len());
+    for (serialized_index, (forest_index, _)) in serialized_order.into_iter().enumerate() {
+        ordered_indices.push(forest_index);
+        forest_to_serialized[forest_index] = serialized_index as u32;
+    }
+    for (forest_index, node) in forest.nodes().iter().enumerate() {
+        if node.is_external() {
+            continue;
+        }
+        let serialized_index = ordered_indices.len();
+        ordered_indices.push(forest_index);
+        forest_to_serialized[forest_index] = serialized_index as u32;
+    }
+
     let mut bb_builder = BasicBlockDataBuilder::new();
-    for (idx, node) in forest.nodes().iter().enumerate() {
+    for (idx, forest_index) in ordered_indices.into_iter().enumerate() {
+        let node = &forest.nodes()[forest_index];
         let ops_offset = if let MastNode::Block(block) = node {
             bb_builder.encode_basic_block(block)
         } else {
             0
         };
-        let expected = MastNodeInfo::new(node, ops_offset);
+        let expected =
+            MastNodeInfo::new_with_id_remap(node, ops_offset, Some(&forest_to_serialized));
         let actual = view.node_info_at(idx).unwrap();
         assert_eq!(expected.to_bytes(), actual.to_bytes());
     }
+}
+
+fn assert_roundtrip_matches_serialized_view(bytes: &[u8], forest: &MastForest) {
+    let view = SerializedMastForest::new(bytes).unwrap();
+
+    assert_eq!(forest.node_count(), view.node_count());
+    for index in 0..view.node_count() {
+        assert_eq!(
+            forest.node_info_at(index).unwrap().to_bytes(),
+            view.node_info_at(index).unwrap().to_bytes()
+        );
+        assert_eq!(forest.node_digest_at(index).unwrap(), view.node_digest_at(index).unwrap());
+    }
+
+    assert_eq!(forest.procedure_roots().to_vec(), view.procedure_roots().unwrap());
 }
 
 #[test]
@@ -896,6 +936,8 @@ fn mast_forest_deserialize_invalid_ops_offset_fails() {
 
     let _: [u8; 8] = reader.read_array().unwrap(); // magic (4) + flags (1) + version (3)
     let _node_count: usize = reader.read().unwrap();
+    let _internal_node_count: usize = reader.read().unwrap();
+    let _external_node_count: usize = reader.read().unwrap();
     let _roots: Vec<u32> = Deserializable::read_from(&mut reader).unwrap();
     let _basic_block_data: Vec<u8> = Deserializable::read_from(&mut reader).unwrap();
 
@@ -1244,6 +1286,14 @@ fn assert_header_flags(bytes: &[u8], expected_flags: u8) {
     assert_eq!(&bytes[5..8], &[0, 0, 3], "Version should be [0, 0, 3]");
 }
 
+fn read_header_counts(bytes: &[u8]) -> (usize, usize, usize) {
+    let mut offset = 8;
+    let node_count = read_usize_at(bytes, &mut offset).unwrap();
+    let internal_node_count = read_usize_at(bytes, &mut offset).unwrap();
+    let external_node_count = read_usize_at(bytes, &mut offset).unwrap();
+    (node_count, internal_node_count, external_node_count)
+}
+
 #[test]
 fn test_header_flags_for_all_serialization_modes() {
     let mut forest = MastForest::new();
@@ -1263,6 +1313,25 @@ fn test_header_flags_for_all_serialization_modes() {
     assert_header_flags(&hashless_bytes, 0x03);
 }
 
+#[test]
+fn test_header_counts_match_node_kinds() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let external_id = ExternalNodeBuilder::new(Word::default()).add_to_forest(&mut forest).unwrap();
+    let join_id = JoinNodeBuilder::new([block_id, external_id])
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(join_id);
+
+    let (node_count, internal_node_count, external_node_count) =
+        read_header_counts(&forest.to_bytes());
+    assert_eq!(node_count, 3);
+    assert_eq!(internal_node_count, 2);
+    assert_eq!(external_node_count, 1);
+}
+
 /// Test that legacy version headers are rejected.
 #[test]
 fn test_legacy_version_is_rejected() {
@@ -1279,6 +1348,41 @@ fn test_legacy_version_is_rejected() {
     assert_matches!(
         result,
         Err(DeserializationError::InvalidValue(msg)) if msg.contains("Unsupported version")
+    );
+}
+
+#[test]
+fn test_deserialization_rejects_mismatched_header_counts() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let mut bytes = forest.to_bytes();
+    let mut offset = 8;
+    let _node_count = read_usize_at(&bytes, &mut offset).unwrap();
+    let internal_count_offset = offset;
+    let _internal_node_count = read_usize_at(&bytes, &mut offset).unwrap();
+    let external_count_offset = offset;
+    let _external_node_count = read_usize_at(&bytes, &mut offset).unwrap();
+
+    let mut encoded_internal = Vec::new();
+    0usize.write_into(&mut encoded_internal);
+    let mut encoded_external = Vec::new();
+    1usize.write_into(&mut encoded_external);
+    assert_eq!(encoded_internal.len(), 1);
+    assert_eq!(encoded_external.len(), 1);
+    bytes[internal_count_offset..internal_count_offset + encoded_internal.len()]
+        .copy_from_slice(&encoded_internal);
+    bytes[external_count_offset..external_count_offset + encoded_external.len()]
+        .copy_from_slice(&encoded_external);
+
+    let result = SerializedMastForest::new(&bytes);
+    assert_matches!(
+        result,
+        Err(DeserializationError::InvalidValue(msg))
+            if msg.contains("must be External because the header reserves the first 1 nodes for externals")
     );
 }
 
@@ -1623,7 +1727,7 @@ mod proptests {
 
     use super::*;
     use crate::{
-        mast::{BasicBlockNodeBuilder, MastForest, MastNode, arbitrary::MastForestParams},
+        mast::{BasicBlockNodeBuilder, MastForest, arbitrary::MastForestParams},
         operations::Decorator,
     };
 
@@ -1643,66 +1747,32 @@ mod proptests {
                 max_dyns: 1,
             })
         ) {
-            // Serialize
             let serialized = forest.to_bytes();
-
-            // Deserialize
             let deserialized = MastForest::read_from_bytes(&serialized)
                 .expect("Deserialization should succeed");
+            let view = SerializedMastForest::new(&serialized).expect("Serialized view should parse");
 
-            // Verify node count
-            prop_assert_eq!(
-                forest.num_nodes(),
-                deserialized.num_nodes(),
-                "Node count should match"
-            );
-
-            // Verify all nodes match
-            for (idx, original) in forest.nodes().iter().enumerate() {
-                let node_id = MastNodeId::new_unchecked(idx as u32);
-                let deserialized_node = &deserialized[node_id];
-
-                // Check digests match
+            prop_assert_eq!(deserialized.node_count(), view.node_count(), "Node count should match");
+            for index in 0..view.node_count() {
                 prop_assert_eq!(
-                    original.digest(),
-                    deserialized_node.digest(),
-                    "Node {:?} digest mismatch", node_id
+                    deserialized.node_info_at(index).unwrap().to_bytes(),
+                    view.node_info_at(index).unwrap().to_bytes(),
+                    "Node {}: serialized node info should match validated forest",
+                    index
                 );
-
-                // For basic blocks, verify OpBatch structure and decorators are preserved
-                if let MastNode::Block(original_block) = original
-                    && let MastNode::Block(deserialized_block) = deserialized_node
-                {
-                    prop_assert_eq!(
-                        original_block.op_batches(),
-                        deserialized_block.op_batches(),
-                        "Node {:?}: OpBatch mismatch", node_id
-                    );
-
-                    let orig_decorators: Vec<_> =
-                        original_block.indexed_decorator_iter(&forest).collect();
-                    let deser_decorators: Vec<_> =
-                        deserialized_block.indexed_decorator_iter(&deserialized).collect();
-
-                    prop_assert_eq!(
-                        orig_decorators.len(),
-                        deser_decorators.len(),
-                        "Node {:?}: Decorator count mismatch", node_id
-                    );
-
-                    for ((orig_idx, orig_dec_id), (deser_idx, deser_dec_id)) in
-                        orig_decorators.iter().zip(&deser_decorators)
-                    {
-                        prop_assert_eq!(orig_idx, deser_idx, "Node {:?}: Decorator index mismatch", node_id);
-                        prop_assert_eq!(
-                            forest.decorator_by_id(*orig_dec_id),
-                            deserialized.decorator_by_id(*deser_dec_id),
-                            "Node {:?}: Decorator content mismatch", node_id
-                        );
-                    }
-                }
-
+                prop_assert_eq!(
+                    deserialized.node_digest_at(index).unwrap(),
+                    view.node_digest_at(index).unwrap(),
+                    "Node {}: digest should match serialized view",
+                    index
+                );
             }
+
+            prop_assert_eq!(
+                deserialized.procedure_roots().to_vec(),
+                view.procedure_roots().unwrap(),
+                "Procedure roots should match serialized view"
+            );
         }
 
         /// Property test: multi-batch basic blocks should preserve exact structure
@@ -1876,34 +1946,35 @@ mod proptests {
                 max_dyns: 1,
             })
         ) {
-            // Stripped serialization
             let mut stripped_bytes = Vec::new();
             forest.write_stripped(&mut stripped_bytes);
-
-            // Deserialize
             let restored = MastForest::read_from_bytes(&stripped_bytes)
                 .expect("Stripped deserialization should succeed");
+            let view =
+                SerializedMastForest::new(&stripped_bytes).expect("Serialized view should parse");
 
-            // Verify node count matches
-            prop_assert_eq!(
-                forest.num_nodes(),
-                restored.num_nodes(),
-                "Node count should match"
-            );
-
-            // Verify all node digests match
-            for (idx, original) in forest.nodes().iter().enumerate() {
-                let node_id = MastNodeId::new_unchecked(idx as u32);
-                let restored_node = &restored[node_id];
-
+            prop_assert_eq!(restored.node_count(), view.node_count(), "Node count should match");
+            for index in 0..view.node_count() {
                 prop_assert_eq!(
-                    original.digest(),
-                    restored_node.digest(),
-                    "Node {:?} digest mismatch", node_id
+                    restored.node_info_at(index).unwrap().to_bytes(),
+                    view.node_info_at(index).unwrap().to_bytes(),
+                    "Node {}: serialized node info should match restored forest",
+                    index
+                );
+                prop_assert_eq!(
+                    restored.node_digest_at(index).unwrap(),
+                    view.node_digest_at(index).unwrap(),
+                    "Node {}: digest should match serialized view",
+                    index
                 );
             }
 
-            // Verify debug info is empty
+            prop_assert_eq!(
+                restored.procedure_roots().to_vec(),
+                view.procedure_roots().unwrap(),
+                "Procedure roots should match serialized view"
+            );
+
             prop_assert!(
                 restored.debug_info.is_empty(),
                 "DebugInfo should be empty after stripped roundtrip"
@@ -2311,6 +2382,10 @@ fn locate_single_block_indptr_and_digest_offsets(bytes: &[u8]) -> (usize, usize)
 
     let node_count: usize = cursor.read().unwrap();
     assert_eq!(node_count, 1);
+    let internal_node_count: usize = cursor.read().unwrap();
+    assert_eq!(internal_node_count, 1);
+    let external_node_count: usize = cursor.read().unwrap();
+    assert_eq!(external_node_count, 0);
 
     let _roots: Vec<u32> = Deserializable::read_from(&mut cursor).unwrap();
 
@@ -2543,7 +2618,7 @@ fn test_untrusted_forest_validates_all_node_types() {
     let untrusted = UntrustedMastForest::read_from_bytes(&bytes).unwrap();
     let validated = untrusted.validate().unwrap();
 
-    assert_eq!(forest, validated);
+    assert_roundtrip_matches_serialized_view(&bytes, &validated);
 }
 
 /// Test that UntrustedMastForest::validate works with stripped serialization.

--- a/core/src/mast/untrusted.rs
+++ b/core/src/mast/untrusted.rs
@@ -1,0 +1,216 @@
+use alloc::vec::Vec;
+
+use super::{AdviceMap, DebugInfo, MastForest, MastForestError, serialization};
+use crate::serde::{BudgetedReader, DeserializationError, SliceReader};
+
+/// A [`MastForest`] deserialized from untrusted input that has not yet been validated.
+///
+/// This type wraps a serialized-backed, decoded MAST representation that has not had its node
+/// hashes verified. Before using the forest, callers must call [`validate()`](Self::validate) to
+/// materialize and verify structural integrity and node hashes.
+///
+/// # Usage
+///
+/// ```ignore
+/// // Deserialize from untrusted bytes
+/// let untrusted = UntrustedMastForest::read_from_bytes(&bytes)?;
+///
+/// // Validate structure and hashes
+/// let forest = untrusted.validate()?;
+///
+/// // Now safe to use
+/// let root = forest.procedure_roots()[0];
+/// ```
+///
+/// # Security
+///
+/// This type exists to provide type-level safety for untrusted deserialization. The validation
+/// performed by [`validate()`](Self::validate) includes:
+///
+/// 1. **Structural validation**: Checks that basic block batch invariants are satisfied and
+///    procedure names reference valid roots.
+/// 2. **Topological ordering**: Verifies that all node references point to nodes that appear
+///    earlier in the forest (no forward references).
+/// 3. **Hash recomputation**: Recomputes the digest for every node and verifies it matches the
+///    stored digest.
+#[derive(Debug, Clone)]
+pub struct UntrustedMastForest {
+    pub(super) bytes: Vec<u8>,
+    pub(super) layout: serialization::ForestLayout,
+    pub(super) advice_map: AdviceMap,
+    pub(super) debug_info: DebugInfo,
+    pub(super) remaining_allocation_budget: Option<usize>,
+}
+
+impl UntrustedMastForest {
+    /// Validates the forest by checking structural invariants and recomputing all node hashes.
+    ///
+    /// This method performs a complete validation of the deserialized forest:
+    ///
+    /// 1. If wire node hashes are present, recomputes all non-external node hashes and requires
+    ///    them to match the serialized digests.
+    /// 2. If the payload is hashless, uses the digests rebuilt during materialization.
+    /// 3. Validates structural invariants, topological ordering, and procedure-name roots.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(MastForest)` if validation succeeds
+    /// - `Err(MastForestError)` with details about the first validation failure
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Deferred materialization from serialized form fails ([`MastForestError::Deserialization`])
+    /// - Any basic block has invalid batch structure ([`MastForestError::InvalidBatchPadding`])
+    /// - Any procedure name references a non-root digest
+    ///   ([`MastForestError::InvalidProcedureNameDigest`])
+    /// - Any node references a child that appears later in the forest
+    ///   ([`MastForestError::ForwardReference`])
+    /// - Any non-external wire digest does not match the recomputed digest
+    ///   ([`MastForestError::HashMismatch`])
+    /// - Any node's digest cannot be recomputed because structural validation fails first
+    ///
+    /// Security convention:
+    /// - Hashless payloads rebuild non-external digests from structure during materialization.
+    /// - If wire node hashes are present, validation recomputes them and requires them to match.
+    /// - External node digests are marshaled as opaque values and are not semantically resolved
+    ///   here.
+    pub fn validate(self) -> Result<MastForest, MastForestError> {
+        let is_hashless = self.layout.is_hashless();
+        let forest = self.into_materialized().map_err(MastForestError::Deserialization)?;
+
+        // Step 1: Validate over-specified wire hashes instead of silently rewriting them.
+        if !is_hashless {
+            forest.validate_node_hashes()?;
+        }
+
+        // Step 2: Validate the recomputed forest.
+        forest.validate()?;
+
+        Ok(forest)
+    }
+
+    /// Deserializes an [`UntrustedMastForest`] from bytes.
+    ///
+    /// This method uses a [`BudgetedReader`] plus a bounded validation-allocation budget derived
+    /// from the input size to protect against denial-of-service attacks from malicious input.
+    /// The default validation budget includes room for the retained serialized copy used by the
+    /// deferred-validation path, in addition to stripped/hashless helper allocations. Concretely,
+    /// the default is `bytes.len()` for parsing and `bytes.len() * 7` for validation allocations.
+    /// That `* 7` factor is a coarse convenience bound, not an exact peak-memory formula.
+    ///
+    /// For explicit parsing and validation limits, use
+    /// [`read_from_bytes_with_budgets`](Self::read_from_bytes_with_budgets).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Read from untrusted source
+    /// let untrusted = UntrustedMastForest::read_from_bytes(&bytes)?;
+    ///
+    /// // Validate before use
+    /// let forest = untrusted.validate()?;
+    /// ```
+    pub fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
+        Self::read_from_bytes_with_budgets(
+            bytes,
+            bytes.len(),
+            serialization::default_untrusted_allocation_budget(bytes.len()),
+        )
+    }
+
+    /// Deserializes an [`UntrustedMastForest`] from bytes and returns the raw wire flags.
+    ///
+    /// This enables callers to inspect serializer intent flags (e.g., HASHLESS) without affecting
+    /// the untrusted deserialization path.
+    pub fn read_from_bytes_with_flags(bytes: &[u8]) -> Result<(Self, u8), DeserializationError> {
+        Self::read_from_bytes_with_budgets_and_flags(
+            bytes,
+            bytes.len(),
+            serialization::default_untrusted_allocation_budget(bytes.len()),
+        )
+    }
+
+    /// Deserializes an [`UntrustedMastForest`] from bytes with a byte budget.
+    ///
+    /// This method uses a [`BudgetedReader`] to limit memory consumption during deserialization,
+    /// protecting against denial-of-service attacks from malicious input that claims to contain
+    /// an excessive number of elements.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - The serialized forest bytes
+    /// * `budget` - Maximum bytes to consume while parsing the wire payload and pre-sizing
+    ///   wire-driven collections via [`BudgetedReader`]
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Read from untrusted source with an explicit parsing budget
+    /// let untrusted = UntrustedMastForest::read_from_bytes_with_budget(&bytes, bytes.len())?;
+    ///
+    /// // Validate before use
+    /// let forest = untrusted.validate()?;
+    /// ```
+    ///
+    /// # Security
+    ///
+    /// The budget limits:
+    /// - Pre-allocation sizes when deserializing collections (via `max_alloc`)
+    /// - Total bytes consumed during deserialization
+    ///
+    /// This prevents attacks where malicious input claims an unrealistic number of elements
+    /// (e.g., `len = 2^60`), causing excessive memory allocation before any data is read.
+    ///
+    /// To also cap stripped/hashless validation helper allocations, use
+    /// [`read_from_bytes_with_budgets`](Self::read_from_bytes_with_budgets).
+    pub fn read_from_bytes_with_budget(
+        bytes: &[u8],
+        budget: usize,
+    ) -> Result<Self, DeserializationError> {
+        let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
+        serialization::read_untrusted_with_flags(&mut reader).map(|(forest, _flags)| forest)
+    }
+
+    /// Deserializes an [`UntrustedMastForest`] from bytes with a byte budget and returns flags.
+    pub fn read_from_bytes_with_budget_and_flags(
+        bytes: &[u8],
+        budget: usize,
+    ) -> Result<(Self, u8), DeserializationError> {
+        let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
+        serialization::read_untrusted_with_flags(&mut reader)
+    }
+
+    /// Deserializes an [`UntrustedMastForest`] from bytes with separate parsing and validation
+    /// budgets.
+    ///
+    /// `parsing_budget` limits wire-driven parsing and collection pre-sizing. `validation_budget`
+    /// additionally caps tracked stripped/hashless helper allocations such as empty debug-info
+    /// scaffolding and rebuilt digest tables.
+    pub fn read_from_bytes_with_budgets(
+        bytes: &[u8],
+        parsing_budget: usize,
+        validation_budget: usize,
+    ) -> Result<Self, DeserializationError> {
+        let mut reader = BudgetedReader::new(SliceReader::new(bytes), parsing_budget);
+        serialization::read_untrusted_with_flags_and_allocation_budget(
+            &mut reader,
+            validation_budget,
+        )
+        .map(|(forest, _flags)| forest)
+    }
+
+    /// Deserializes an [`UntrustedMastForest`] from bytes with separate parsing and validation
+    /// budgets and returns flags.
+    pub fn read_from_bytes_with_budgets_and_flags(
+        bytes: &[u8],
+        parsing_budget: usize,
+        validation_budget: usize,
+    ) -> Result<(Self, u8), DeserializationError> {
+        let mut reader = BudgetedReader::new(SliceReader::new(bytes), parsing_budget);
+        serialization::read_untrusted_with_flags_and_allocation_budget(
+            &mut reader,
+            validation_budget,
+        )
+    }
+}

--- a/core/src/mast/untrusted.rs
+++ b/core/src/mast/untrusted.rs
@@ -68,6 +68,8 @@ impl UntrustedMastForest {
     ///   ([`MastForestError::ForwardReference`])
     /// - Any non-external wire digest does not match the recomputed digest
     ///   ([`MastForestError::HashMismatch`])
+    /// - External digest slots are not sorted lexicographically on the wire
+    ///   ([`MastForestError::ExternalDigestsNotSorted`])
     /// - Any node's digest cannot be recomputed because structural validation fails first
     ///
     /// Security convention:
@@ -77,6 +79,18 @@ impl UntrustedMastForest {
     ///   here.
     pub fn validate(self) -> Result<MastForest, MastForestError> {
         let is_hashless = self.layout.is_hashless();
+        if let Some(violation) =
+            serialization::external_digest_order_violation(&self.bytes, &self.layout)
+                .map_err(MastForestError::Deserialization)?
+        {
+            return Err(MastForestError::ExternalDigestsNotSorted {
+                previous_slot: violation.previous_slot,
+                slot: violation.slot,
+                previous: violation.previous,
+                current: violation.current,
+            });
+        }
+
         let forest = self.into_materialized().map_err(MastForestError::Deserialization)?;
 
         // Step 1: Validate over-specified wire hashes instead of silently rewriting them.

--- a/core/src/mast/untrusted.rs
+++ b/core/src/mast/untrusted.rs
@@ -185,8 +185,8 @@ impl UntrustedMastForest {
     /// budgets.
     ///
     /// `parsing_budget` limits wire-driven parsing and collection pre-sizing. `validation_budget`
-    /// additionally caps tracked stripped/hashless helper allocations such as empty debug-info
-    /// scaffolding and rebuilt digest tables.
+    /// additionally caps tracked stripped/hashless helper allocations such as digest slot tables,
+    /// empty debug-info scaffolding, and rebuilt digest tables.
     pub fn read_from_bytes_with_budgets(
         bytes: &[u8],
         parsing_budget: usize,

--- a/core/src/mast/untrusted.rs
+++ b/core/src/mast/untrusted.rs
@@ -68,8 +68,6 @@ impl UntrustedMastForest {
     ///   ([`MastForestError::ForwardReference`])
     /// - Any non-external wire digest does not match the recomputed digest
     ///   ([`MastForestError::HashMismatch`])
-    /// - External digest slots are not sorted lexicographically on the wire
-    ///   ([`MastForestError::ExternalDigestsNotSorted`])
     /// - Any node's digest cannot be recomputed because structural validation fails first
     ///
     /// Security convention:
@@ -79,18 +77,6 @@ impl UntrustedMastForest {
     ///   here.
     pub fn validate(self) -> Result<MastForest, MastForestError> {
         let is_hashless = self.layout.is_hashless();
-        if let Some(violation) =
-            serialization::external_digest_order_violation(&self.bytes, &self.layout)
-                .map_err(MastForestError::Deserialization)?
-        {
-            return Err(MastForestError::ExternalDigestsNotSorted {
-                previous_slot: violation.previous_slot,
-                slot: violation.slot,
-                previous: violation.previous,
-                current: violation.current,
-            });
-        }
-
         let forest = self.into_materialized().map_err(MastForestError::Deserialization)?;
 
         // Step 1: Validate over-specified wire hashes instead of silently rewriting them.

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -558,7 +558,9 @@ fn locate_first_node_hash(bytes: &[u8]) -> (usize, usize) {
     offset += 1;
     offset += 3;
 
-    let node_count = read_usize_vint64(bytes, &mut offset);
+    let _node_count = read_usize_vint64(bytes, &mut offset);
+    let internal_node_count = read_usize_vint64(bytes, &mut offset);
+    let external_node_count = read_usize_vint64(bytes, &mut offset);
 
     // Roots: len (usize) + elements (u32 LE)
     let roots_len = read_usize_vint64(bytes, &mut offset);
@@ -568,23 +570,9 @@ fn locate_first_node_hash(bytes: &[u8]) -> (usize, usize) {
     let bb_len = read_usize_vint64(bytes, &mut offset);
     offset += bb_len;
 
-    // Fixed-width node entries: one 8-byte entry per node. External nodes carry their digest in a
-    // separate section before internal node hashes, so count them while walking the entry table.
-    let mut external_count = 0usize;
-    for _ in 0..node_count {
-        let end = offset.checked_add(8).expect("offset overflow while reading node entry");
-        let entry_bytes: [u8; 8] = bytes[offset..end].try_into().expect("out-of-bounds node entry");
-        let entry = u64::from_le_bytes(entry_bytes);
-        let discriminant = (entry >> 60) as u8;
-        if discriminant == 8 {
-            external_count += 1;
-        }
-        offset = end;
-    }
+    offset += external_node_count * 32;
 
-    offset += external_count * 32;
-
-    (offset, node_count)
+    (offset, internal_node_count)
 }
 
 fn build_library_bytes_with_spoofed_first_node_digest(

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -558,9 +558,11 @@ fn locate_first_node_hash(bytes: &[u8]) -> (usize, usize) {
     offset += 1;
     offset += 3;
 
-    let node_count = read_usize_vint64(bytes, &mut offset);
     let internal_node_count = read_usize_vint64(bytes, &mut offset);
     let external_node_count = read_usize_vint64(bytes, &mut offset);
+    let node_count = internal_node_count
+        .checked_add(external_node_count)
+        .expect("node count overflow");
 
     // Roots: len (usize) + elements (u32 LE)
     let roots_len = read_usize_vint64(bytes, &mut offset);

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -558,7 +558,7 @@ fn locate_first_node_hash(bytes: &[u8]) -> (usize, usize) {
     offset += 1;
     offset += 3;
 
-    let _node_count = read_usize_vint64(bytes, &mut offset);
+    let node_count = read_usize_vint64(bytes, &mut offset);
     let internal_node_count = read_usize_vint64(bytes, &mut offset);
     let external_node_count = read_usize_vint64(bytes, &mut offset);
 
@@ -570,6 +570,7 @@ fn locate_first_node_hash(bytes: &[u8]) -> (usize, usize) {
     let bb_len = read_usize_vint64(bytes, &mut offset);
     offset += bb_len;
 
+    offset += node_count * 8;
     offset += external_node_count * 32;
 
     (offset, internal_node_count)


### PR DESCRIPTION
Fixes #3043.

This cleans up the MAST forest wire format on top of #2765.

The wire format now stores clear node counts, keeps node IDs stable when reading and writing, and puts external node digests in a sorted prefix before node entries. Hashless data still keeps external digests, but omits internal digests.

Untrusted reads now keep the wire bytes until `validate()` is called. Validation checks structure, child links, rebuilt hashes, external digest slots, and external digest sort order before returning a trusted `MastForest`.