### PR TITLE
fix(mast): compact() preserves stripped debug-info state

### DIFF
--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -259,12 +259,28 @@ impl MastForest {
     /// // compacted_forest is now compacted with duplicate nodes merged
     /// ```
     pub fn compact(self) -> (MastForest, MastForestRootMap) {
-        // Merge with itself to deduplicate nodes
+        // Track whether debug info was stripped before compaction. The merge process rebuilds
+        // internal CSR (Compressed Sparse Row) indptr structures for each added node, which
+        // introduces per-node overhead in the DebugInfo even when all debug data is empty.
+        // By re-clearing after merge, we ensure the compacted output is never larger (in
+        // serialized form) than the already-stripped input.
+        let debug_info_was_empty = self.debug_info.is_empty();
+
+        // Merge with itself to deduplicate nodes.
         // Note: This cannot fail for a self-merge under normal conditions.
         // The only possible failures (TooManyNodes, TooManyDecorators) would require the
         // original forest to be at capacity limits, at which point compaction wouldn't help.
-        MastForest::merge([&self])
-            .expect("Failed to compact MastForest: this should never happen during self-merge")
+        let (mut forest, root_map) = MastForest::merge([&self])
+            .expect("Failed to compact MastForest: this should never happen during self-merge");
+
+        // If the source had no debug info, propagate that property to the compacted result.
+        // This prevents the merge from silently inflating the DebugInfo section of an already-
+        // stripped forest due to CSR indptr overhead introduced during node processing.
+        if debug_info_was_empty {
+            forest.clear_debug_info();
+        }
+
+        (forest, root_map)
     }
 
     /// Merges all `forests` into a new [`MastForest`].


### PR DESCRIPTION
## Summary

Fixes #3035.

After calling `clear_debug_info()` on a `MastForest` followed by `compact()`, the serialized output (via `to_bytes()`) was **larger** than the result of `clear_debug_info()` alone.

## Root Cause

`compact()` delegates to `MastForest::merge([&self])`, which:

1. Allocates a fresh `MastForest::new()` — whose `DebugInfo` starts truly empty.
2. Processes every node individually, and as each node is added, the internal `op_decorator_storage` CSR (Compressed Sparse Row) `indptr` vector grows by one entry — **even when all actual debug data is empty**.

This per-node CSR overhead means the merged forest's `DebugInfo` serializes to more bytes than the `DebugInfo::empty_for_nodes(n)` produced by `clear_debug_info()`.

Note: `DebugInfo::is_empty()` only checks whether the data fields (decorators, asm_ops, debug_vars, error_codes, procedure_names) are empty. It does **not** account for the CSR `indptr` overhead, so there is no cheap way to detect this inflation during serialization.

## Fix

Before merging, we record whether `self.debug_info.is_empty()`. If the source had no debug info, we call `clear_debug_info()` on the merged result to discard any CSR overhead the merge introduced. This guarantees:

```
clear_debug_info() + compact() serialized size ≤ clear_debug_info() serialized size
```

The check is safe for forests that **do** have debug info — the branch is only taken when all data fields were already absent.

## Reproduction (from issue)

```rust
let mut note_mast = package.mast.mast_forest().as_ref().clone();
note_mast.clear_debug_info();
let stripped_size = note_mast.to_bytes().len();
let (compacted, _) = note_mast.compact();
let compacted_size = compacted.to_bytes().len();
assert!(compacted_size <= stripped_size,
    "compact() should never inflate a stripped forest: {} > {}", compacted_size, stripped_size);
```

Before this fix: `compact_size > stripped_size`. After: `compact_size <= stripped_size`.
