### PR TITLE
docs(assembly): fix adv_pipe memory address notation in instruction reference

### DIFF
--- a/docs/src/user_docs/assembly/instruction_reference.md
+++ b/docs/src/user_docs/assembly/instruction_reference.md
@@ -188,7 +188,7 @@ Instructions for moving data between the stack and other sources like program co
 | ------------ | ---------------- | ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `adv_push.n` | `[ ... ]`        | `[a, ...]`       | n      | Pops `n` values from advice stack to operand stack (1st popped is deepest). Valid `n` in `1..=16`. Fails if advice stack has `< n` values.                                      |
 | `adv_loadw`  | `[0,0,0,0, ...]` | `[A, ...]`       | 1      | Pops word `A` (4 elements) from advice stack, overwrites top word of operand stack. Fails if advice stack has `< 4` values.                                                     |
-| `adv_pipe`   | `[C,B,A,a,...]`  | `[E,D,A,a',...]` | 1      | Pops 2 words `[D,E]` from advice stack. Overwrites top 2 words of operand stack. Writes `[D,E]` to memory at `a` and `a+1`. `a' ← a+2`. Fails if advice stack has `< 8` values. |
+| `adv_pipe`   | `[C,B,A,a,...]`  | `[E,D,A,a',...]` | 1      | Pops 2 words `[D,E]` from advice stack. Overwrites top 2 words of operand stack. Writes `[D,E]` to memory at `a` and `a+4`. `a' ← a+8`. Fails if advice stack has `< 8` values. |
 
 #### Injecting into Advice Provider (System Events - 3 cycles)
 


### PR DESCRIPTION
 Closes #3006

  **Rationale**
  The `adv_pipe` entry in `instruction_reference.md` described the memory
  writes as targeting `a` and `a+1` with `a' ← a+2`, which implies
  word-level addressing. Since memory is element-addressable and each word
  is 4 elements, the correct notation is `a` and `a+4` with `a' ← a+8`.

  This was already documented correctly in `io_operations.md` and in the
  design doc (`docs/src/design/stack/io_ops.md`). This change makes
  `instruction_reference.md` consistent with both.

  **Test plan**
  Documentation-only change; no code paths affected.