### PR TITLE
docs(processor): fix memory trace delta encoding comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 - [BREAKING] Refactored MAST forest serialization around fixed-layout full, stripped, and hashless sections, and bumped the MAST wire format to `0.0.3` ([#2765](https://github.com/0xMiden/miden-vm/pull/2765)).
 - Documented sortedness precondition more prominently for sorted array operations ([#2832](https://github.com/0xMiden/miden-vm/pull/2832)).
+- Corrected memory trace delta encoding comments to match first-row and same-word clock delta behavior ([#3062](https://github.com/0xMiden/miden-vm/pull/3062)).
 - [BREAKING] Updated the Miden crypto stack to `miden-crypto` and `miden-lifted-stark` v0.24, and switched digest-ordering code to `Word`'s native lexicographic ordering ([#3039](https://github.com/0xMiden/miden-vm/pull/3039)).
 - Borrowed operation slices in basic-block batching helpers to avoid cloning in the fingerprinting path ([#2994](https://github.com/0xMiden/miden-vm/pull/2994)).
 - [BREAKING] Sync execution and proving APIs now require `SyncHost`; async `Host`, `execute`, and `prove` remain available ([#2865](https://github.com/0xMiden/miden-vm/pull/2865)).

--- a/processor/src/trace/chiplets/memory/mod.rs
+++ b/processor/src/trace/chiplets/memory/mod.rs
@@ -253,8 +253,8 @@ impl Memory {
     /// [RangeChecker] chiplet instance, along with their row in the finalized execution trace.
     pub fn append_range_checks(&self, memory_start_row: RowIndex, range: &mut RangeChecker) {
         // set the previous address and clock cycle to the first address and clock cycle of the
-        // trace; we also adjust the clock cycle so that delta value for the first row would end
-        // up being ZERO. if the trace is empty, return without any further processing.
+        // trace; we also adjust the clock cycle back by 1 so that the delta for the first row
+        // equals 1. if the trace is empty, return without any further processing.
         let (mut prev_ctx, mut prev_addr, mut prev_clk) = match self.get_first_row_info() {
             Some((ctx, addr, clk)) => (ctx, addr, clk.as_canonical_u64().wrapping_sub(1)),
             None => return,
@@ -307,9 +307,9 @@ impl Memory {
     pub fn fill_trace(self, trace: &mut TraceFragment) {
         debug_assert_eq!(self.trace_len(), trace.len(), "inconsistent trace lengths");
 
-        // set the pervious address and clock cycle to the first address and clock cycle of the
-        // trace; we also adjust the clock cycle so that delta value for the first row would end
-        // up being ZERO. if the trace is empty, return without any further processing.
+        // set the previous address and clock cycle to the first address and clock cycle of the
+        // trace; we also adjust the clock cycle back by 1 so that the delta for the first row
+        // equals 1. if the trace is empty, return without any further processing.
         let (mut prev_ctx, mut prev_addr, mut prev_clk) = match self.get_first_row_info() {
             Some((ctx, addr, clk)) => (Felt::from(ctx), Felt::from_u32(addr), clk - ONE),
             None => return,

--- a/processor/src/trace/chiplets/memory/mod.rs
+++ b/processor/src/trace/chiplets/memory/mod.rs
@@ -82,7 +82,7 @@ const INIT_MEM_VALUE: Word = EMPTY_WORD;
 ///   - When the context remains the same but the word changes, these columns contain (`new_word`
 ///     - `old_word`).
 ///   - When both the context and the word remain the same, these columns contain (`new_clk` -
-///     `old_clk` - 1).
+///     `old_clk`).
 /// - `d_inv` contains the inverse of the delta between two consecutive context IDs, words, or clock
 ///   cycles computed as described above. It is the field inverse of `(d_1 * 2^16) + d_0`
 /// - `f_scw` is a flag indicating whether the context and the word of the current row are the same
@@ -92,7 +92,8 @@ const INIT_MEM_VALUE: Word = EMPTY_WORD;
 ///   checks on `w0`, `w1`, and `4 * w1`, these columns prove that memory addresses are valid 32-bit
 ///   values.
 ///
-/// For the first row of the trace, values in `d0`, `d1`, and `d_inv` are set to zeros.
+/// For the first row of the trace, `prev_clk` is initialized to `first_clk - 1`, so the delta is
+/// `1`. As a result, `d0` is set to `1`, `d1` to `0`, and `d_inv` to `1`.
 #[derive(Debug, Default)]
 pub struct Memory {
     /// Memory segment traces sorted by their execution context ID.


### PR DESCRIPTION
Closes #2815

  **Rationale**
  The doc comment for `Memory` in `processor/src/trace/chiplets/memory/mod.rs`
  contained two inaccuracies:

  1. Same-word delta was documented as `new_clk - old_clk - 1`, but both
     `append_range_checks` and `fill_trace` compute `new_clk - old_clk`.

  2. The first-row description stated `d0`, `d1`, and `d_inv` are zero.
     In reality `prev_clk` is initialized to `first_clk - 1`, so the
     first-row delta is always `1` — meaning `d0 = 1`, `d1 = 0`,
     `d_inv = 1`.

  No code changes — comments only.