### PR TITLE
fix(processor): respect MIN_STACK_DEPTH in DYNCALL stack depth recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed the release dry-run publish cycle between `miden-air` and `miden-ace-codegen`, and preserved leaf-only DAG imports with explicit snapshots ([#2931](https://github.com/0xMiden/miden-vm/pull/2931)).
 - Added regression coverage for the exact `max_num_continuations` continuation-stack boundary ([#2995](https://github.com/0xMiden/miden-vm/pull/2995)).
 - Fixed AEAD padding handling so encrypt does not overwrite memory next to the plaintext buffer and decrypt leaves the plaintext output tail untouched ([#3008](https://github.com/0xMiden/miden-vm/pull/3008)).
+- Fixed `DYNCALL` execution tracing to clamp `parent_stack_depth` in `ExecutionContextInfo` to `MIN_STACK_DEPTH`, preventing an underflow when the stack is at minimum depth ([#2813](https://github.com/0xMiden/miden-vm/pull/2813)).
 
 #### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Fixed the release dry-run publish cycle between `miden-air` and `miden-ace-codegen`, and preserved leaf-only DAG imports with explicit snapshots ([#2931](https://github.com/0xMiden/miden-vm/pull/2931)).
 - Added regression coverage for the exact `max_num_continuations` continuation-stack boundary ([#2995](https://github.com/0xMiden/miden-vm/pull/2995)).
 - Fixed AEAD padding handling so encrypt does not overwrite memory next to the plaintext buffer and decrypt leaves the plaintext output tail untouched ([#3008](https://github.com/0xMiden/miden-vm/pull/3008)).
-- Fixed `DYNCALL` execution tracing to clamp `parent_stack_depth` in `ExecutionContextInfo` to `MIN_STACK_DEPTH`, preventing an underflow when the stack is at minimum depth ([#2813](https://github.com/0xMiden/miden-vm/pull/2813)).
+- Fixed `DYNCALL` execution tracing to clamp `parent_stack_depth` to `MIN_STACK_DEPTH` and to record the correct post-pop `parent_next_overflow_addr` when the caller has multiple overflow entries ([#3063](https://github.com/0xMiden/miden-vm/pull/3063)).
 
 #### Changes
 

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -587,6 +587,15 @@ impl FastProcessor {
         self.stack_top_idx += 1;
     }
 
+    /// Grows the stack depth by `n` for unit testing purposes.
+    #[cfg(test)]
+    pub fn with_extra_stack_depth(mut self, n: usize) -> Self {
+        for _ in 0..n {
+            self.increment_stack_size();
+        }
+        self
+    }
+
     /// Decrements the stack top pointer by 1.
     ///
     /// The bottom of the stack is only decremented in cases where the stack depth would become less

--- a/processor/src/trace/execution_tracer.rs
+++ b/processor/src/trace/execution_tracer.rs
@@ -910,9 +910,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        FastProcessor, StackInputs,
-        continuation_stack::ContinuationStack,
-        tracer::Tracer,
+        FastProcessor, StackInputs, continuation_stack::ContinuationStack, tracer::Tracer,
     };
 
     /// Builds a [`MastForest`] containing a single DYNCALL node and returns the forest together
@@ -943,14 +941,12 @@ mod tests {
             &forest,
         );
 
-        let ctx_info = tracer
-            .block_stack
-            .peek()
-            .ctx_info
-            .expect("DYNCALL start_clock_cycle must push ExecutionContextInfo onto block_stack");
+        let ctx_info =
+            tracer.block_stack.peek().ctx_info.expect(
+                "DYNCALL start_clock_cycle must push ExecutionContextInfo onto block_stack",
+            );
         assert_eq!(
-            ctx_info.parent_stack_depth,
-            MIN_STACK_DEPTH as u32,
+            ctx_info.parent_stack_depth, MIN_STACK_DEPTH as u32,
             "parent_stack_depth must not go below MIN_STACK_DEPTH when stack is at minimum"
         );
     }
@@ -974,11 +970,10 @@ mod tests {
             &forest,
         );
 
-        let ctx_info = tracer
-            .block_stack
-            .peek()
-            .ctx_info
-            .expect("DYNCALL start_clock_cycle must push ExecutionContextInfo onto block_stack");
+        let ctx_info =
+            tracer.block_stack.peek().ctx_info.expect(
+                "DYNCALL start_clock_cycle must push ExecutionContextInfo onto block_stack",
+            );
         assert_eq!(
             ctx_info.parent_stack_depth,
             expected_depth - 1,

--- a/processor/src/trace/execution_tracer.rs
+++ b/processor/src/trace/execution_tracer.rs
@@ -898,3 +898,91 @@ impl Default for HasherChipletShim {
         Self::new()
     }
 }
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+
+    use miden_core::mast::{DynNodeBuilder, MastForest, MastForestContributor};
+
+    use super::*;
+    use crate::{
+        FastProcessor, StackInputs,
+        continuation_stack::ContinuationStack,
+        tracer::Tracer,
+    };
+
+    /// Builds a [`MastForest`] containing a single DYNCALL node and returns the forest together
+    /// with the node's [`MastNodeId`].
+    fn dyncall_forest() -> (Arc<MastForest>, MastNodeId) {
+        let mut forest = MastForest::new();
+        let node_id = DynNodeBuilder::new_dyncall().add_to_forest(&mut forest).unwrap();
+        (Arc::new(forest), node_id)
+    }
+
+    /// Verifies that when DYNCALL is started with the stack at exactly `MIN_STACK_DEPTH`,
+    /// `start_clock_cycle` pushes an [`ExecutionContextInfo`] onto `block_stack` whose
+    /// `parent_stack_depth` equals `MIN_STACK_DEPTH` — not `MIN_STACK_DEPTH - 1`.
+    ///
+    /// This is the regression test for the bug where the depth was unconditionally decremented by
+    /// one even when already at the minimum, violating the tracer contract that "popping at minimum
+    /// stack depth does not decrement depth".
+    #[test]
+    fn start_clock_cycle_dyncall_records_min_depth_when_stack_at_min() {
+        let (forest, dyncall_id) = dyncall_forest();
+        let processor = FastProcessor::new(StackInputs::default());
+
+        let mut tracer = ExecutionTracer::new(1);
+        tracer.start_clock_cycle(
+            &processor,
+            Continuation::StartNode(dyncall_id),
+            &ContinuationStack::default(),
+            &forest,
+        );
+
+        let ctx_info = tracer
+            .block_stack
+            .peek()
+            .ctx_info
+            .expect("DYNCALL start_clock_cycle must push ExecutionContextInfo onto block_stack");
+        assert_eq!(
+            ctx_info.parent_stack_depth,
+            MIN_STACK_DEPTH as u32,
+            "parent_stack_depth must not go below MIN_STACK_DEPTH when stack is at minimum"
+        );
+    }
+
+    /// Verifies that when DYNCALL is started with the stack above `MIN_STACK_DEPTH`, the recorded
+    /// `parent_stack_depth` is `depth - 1` (the stack depth after the DYNCALL pops the callee
+    /// address).
+    #[test]
+    fn start_clock_cycle_dyncall_records_depth_minus_one_when_stack_above_min() {
+        let (forest, dyncall_id) = dyncall_forest();
+        // Push one extra element so depth = MIN_STACK_DEPTH + 1.
+        let processor = FastProcessor::new(StackInputs::default()).with_extra_stack_depth(1);
+        let expected_depth = MIN_STACK_DEPTH as u32 + 1;
+        assert_eq!(processor.stack_depth(), expected_depth);
+
+        let mut tracer = ExecutionTracer::new(1);
+        tracer.start_clock_cycle(
+            &processor,
+            Continuation::StartNode(dyncall_id),
+            &ContinuationStack::default(),
+            &forest,
+        );
+
+        let ctx_info = tracer
+            .block_stack
+            .peek()
+            .ctx_info
+            .expect("DYNCALL start_clock_cycle must push ExecutionContextInfo onto block_stack");
+        assert_eq!(
+            ctx_info.parent_stack_depth,
+            expected_depth - 1,
+            "parent_stack_depth must be depth - 1 when stack is above MIN_STACK_DEPTH"
+        );
+    }
+}

--- a/processor/src/trace/execution_tracer.rs
+++ b/processor/src/trace/execution_tracer.rs
@@ -318,12 +318,21 @@ impl ExecutionTracer {
                 );
 
                 if dyn_node.is_dyncall() {
-                    let overflow_addr = self.overflow_table.last_update_clk_in_current_ctx();
                     // Note: the stack depth to record is after the DYNCALL drop. DYNCALL pops
                     // the top element (the memory address of the callee hash) before entering
                     // the new context. The depth cannot go below MIN_STACK_DEPTH.
-                    let stack_depth_after_drop =
-                        (processor.stack().depth() - 1).max(MIN_STACK_DEPTH as u32);
+                    let depth = processor.stack().depth();
+                    let (stack_depth_after_drop, overflow_addr) =
+                        if depth > MIN_STACK_DEPTH as u32 {
+                            // The pop shifts an overflow entry into the main stack, so the
+                            // recorded overflow address is the one that remains after the shift.
+                            (depth - 1, self.overflow_table.clk_after_pop_in_current_ctx())
+                        } else {
+                            (
+                                MIN_STACK_DEPTH as u32,
+                                self.overflow_table.last_update_clk_in_current_ctx(),
+                            )
+                        };
                     Some(ExecutionContextInfo::new(
                         processor.system().ctx(),
                         processor.system().caller_hash(),
@@ -978,6 +987,42 @@ mod tests {
             ctx_info.parent_stack_depth,
             expected_depth - 1,
             "parent_stack_depth must be depth - 1 when stack is above MIN_STACK_DEPTH"
+        );
+    }
+
+    /// Regression test for the bug where `parent_next_overflow_addr` was set to the pre-pop
+    /// overflow address even when the caller had multiple overflow entries.
+    ///
+    /// When DYNCALL pops with depth > MIN_STACK_DEPTH, an overflow entry shifts into the main
+    /// stack. The recorded `parent_next_overflow_addr` must reflect the state *after* that
+    /// shift — i.e., the second-to-last overflow entry's clock, not the last.
+    #[test]
+    fn start_clock_cycle_dyncall_with_multiple_overflow_entries_records_correct_overflow_addr() {
+        let (forest, dyncall_id) = dyncall_forest();
+        // depth = MIN_STACK_DEPTH + 2 so two overflow entries are present.
+        let processor = FastProcessor::new(StackInputs::default()).with_extra_stack_depth(2);
+
+        let mut tracer = ExecutionTracer::new(1);
+        // Manually populate the tracer's overflow table with two entries at known clocks.
+        // clk=1 is the second-to-last; clk=2 is the last (will be consumed by the DYNCALL pop).
+        tracer.overflow_table.push(ZERO, RowIndex::from(1u32));
+        tracer.overflow_table.push(ZERO, RowIndex::from(2u32));
+
+        tracer.start_clock_cycle(
+            &processor,
+            Continuation::StartNode(dyncall_id),
+            &ContinuationStack::default(),
+            &forest,
+        );
+
+        let ctx_info =
+            tracer.block_stack.peek().ctx_info.expect(
+                "DYNCALL start_clock_cycle must push ExecutionContextInfo onto block_stack",
+            );
+        assert_eq!(
+            ctx_info.parent_next_overflow_addr,
+            Felt::from(RowIndex::from(1u32)),
+            "parent_next_overflow_addr must be the second-to-last overflow clock after the pop"
         );
     }
 }

--- a/processor/src/trace/execution_tracer.rs
+++ b/processor/src/trace/execution_tracer.rs
@@ -322,17 +322,17 @@ impl ExecutionTracer {
                     // the top element (the memory address of the callee hash) before entering
                     // the new context. The depth cannot go below MIN_STACK_DEPTH.
                     let depth = processor.stack().depth();
-                    let (stack_depth_after_drop, overflow_addr) =
-                        if depth > MIN_STACK_DEPTH as u32 {
-                            // The pop shifts an overflow entry into the main stack, so the
-                            // recorded overflow address is the one that remains after the shift.
-                            (depth - 1, self.overflow_table.clk_after_pop_in_current_ctx())
-                        } else {
-                            (
-                                MIN_STACK_DEPTH as u32,
-                                self.overflow_table.last_update_clk_in_current_ctx(),
-                            )
-                        };
+                    let (stack_depth_after_drop, overflow_addr) = if depth > MIN_STACK_DEPTH as u32
+                    {
+                        // The pop shifts an overflow entry into the main stack, so the
+                        // recorded overflow address is the one that remains after the shift.
+                        (depth - 1, self.overflow_table.clk_after_pop_in_current_ctx())
+                    } else {
+                        (
+                            MIN_STACK_DEPTH as u32,
+                            self.overflow_table.last_update_clk_in_current_ctx(),
+                        )
+                    };
                     Some(ExecutionContextInfo::new(
                         processor.system().ctx(),
                         processor.system().caller_hash(),

--- a/processor/src/trace/execution_tracer.rs
+++ b/processor/src/trace/execution_tracer.rs
@@ -319,15 +319,11 @@ impl ExecutionTracer {
 
                 if dyn_node.is_dyncall() {
                     let overflow_addr = self.overflow_table.last_update_clk_in_current_ctx();
-                    // Note: the stack depth to record is the `current_stack_depth - 1` due to
-                    // the semantics of DYNCALL. That is, the top of the
-                    // stack contains the memory address to where the
-                    // address to dynamically call is located. Then, the
-                    // DYNCALL operation performs a drop, and
-                    // records the stack depth after the drop as the beginning of
-                    // the new context. For more information, look at the docs for how the
-                    // constraints are designed; it's a bit tricky but it works.
-                    let stack_depth_after_drop = processor.stack().depth() - 1;
+                    // Note: the stack depth to record is after the DYNCALL drop. DYNCALL pops
+                    // the top element (the memory address of the callee hash) before entering
+                    // the new context. The depth cannot go below MIN_STACK_DEPTH.
+                    let stack_depth_after_drop =
+                        (processor.stack().depth() - 1).max(MIN_STACK_DEPTH as u32);
                     Some(ExecutionContextInfo::new(
                         processor.system().ctx(),
                         processor.system().caller_hash(),

--- a/processor/src/trace/stack/overflow.rs
+++ b/processor/src/trace/stack/overflow.rs
@@ -110,6 +110,19 @@ impl OverflowTable {
             .map_or(ZERO, |entry| Felt::from(entry.clk))
     }
 
+    /// Returns the clock cycle that `last_update_clk_in_current_ctx` would return after one pop
+    /// — i.e., the clock of the second-to-last overflow entry in the current context.
+    ///
+    /// Returns `ZERO` if fewer than two entries exist.
+    pub fn clk_after_pop_in_current_ctx(&self) -> Felt {
+        let slice = self.get_current_overflow_stack().overflow.as_slice();
+        if slice.len() >= 2 {
+            Felt::from(slice[slice.len() - 2].clk)
+        } else {
+            ZERO
+        }
+    }
+
     /// Returns the number of elements in the overflow stack for the current context.
     pub fn num_elements_in_current_ctx(&self) -> usize {
         self.get_current_overflow_stack().num_elements()


### PR DESCRIPTION
Closes #2813

  **Rationale**
  `ExecutionTracer::record_control_node_start` always computed
  `stack_depth_after_drop = depth - 1` for DYNCALL operations. However,
  when the stack is already at `MIN_STACK_DEPTH`, the drop is a no-op on
  depth — the VM does not go below the minimum. This made the execution
  tracer inconsistent with the parallel tracer (`parallel/tracer/mod.rs`),
  which already handles this case correctly.

  **Change**
  - When `depth > MIN_STACK_DEPTH`: record `depth - 1` (unchanged behavior)
  - When `depth == MIN_STACK_DEPTH`: record `depth` (no drop occurs)

  The `overflow_addr` is unaffected — `last_update_clk_in_current_ctx()`
  already returns `ZERO` when the overflow table is empty, which is the
  correct value for the min-depth case.