### PR TITLE
Align u256 user docs with LE stack limb order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Refactor trace generation to row-major format ([#2937](https://github.com/0xMiden/miden-vm/pull/2937)).
 - Documented non-overlap requirement for `memcopy_words`, `memcopy_elements`, and AEAD encrypt/decrypt procedures ([#2941](https://github.com/0xMiden/miden-vm/pull/2941)).
 - Aligned AEAD key/nonce stack-order documentation and handler comments with the runtime contract ([#3036](https://github.com/0xMiden/miden-vm/pull/3036)).
+- Aligned `core_lib::math::u256` user docs with unified LE stack limb ordering (`a0/b0` on top), removing conflicting `[b7..b0, a7..a0]` notation ([#3066](https://github.com/0xMiden/miden-vm/pull/3066)).
 - Added chainable `Test` builders for common test setup in `miden-utils-testing` ([#2957](https://github.com/0xMiden/miden-vm/pull/2957)).
 - Added fuzz coverage for package semantic deserialization and project parsing, loading, and assembly ([#3015](https://github.com/0xMiden/miden-vm/pull/3015)).
 - Speed-up AUX range check trace generation by changing divisors to a flat Vec layout ([#2966](https://github.com/0xMiden/miden-vm/pull/2966)).

--- a/docs/src/user_docs/core_lib/math/u256.md
+++ b/docs/src/user_docs/core_lib/math/u256.md
@@ -16,9 +16,9 @@ A `u256` value is represented as a struct with two `u128` components:
 pub type u256 = struct { hi: u128, lo: u128 }
 ```
 
-When placed on the stack, a 256-bit integer is encoded using eight 32-bit limbs (elements). The least-significant limb is assumed to be deeper in the stack. For example, a u256 value consisting of limbs `[a7, a6, a5, a4, a3, a2, a1, a0]` would be positioned on the stack like so:
+When placed on the stack, a 256-bit integer is encoded using eight 32-bit limbs (elements). The least-significant limb is assumed to be on top of the stack. For example, a u256 value consisting of limbs `[a0, a1, a2, a3, a4, a5, a6, a7]` would be positioned on the stack like so:
 ```
-[a7, a6, a5, a4, a3, a2, a1, a0, ...]
+[a0, a1, a2, a3, a4, a5, a6, a7, ...]
 ```
 where `a0` is the least significant 32-bit limb and `a7` is the most significant.
 
@@ -30,21 +30,21 @@ The procedures in this module assume that the input values are represented using
 
 | Procedure     | Description |
 |---------------|-------------|
-| wrapping_add  | Performs addition of two unsigned 256-bit integers discarding the overflow.<br/><br/>**Stack transition:** `[b7..b0, a7..a0, ...] -> [c7..c0, ...]`<br/>where `c = (a + b) % 2^256` |
-| wrapping_sub  | Performs subtraction of two unsigned 256-bit integers discarding the underflow.<br/><br/>**Stack transition:** `[b7..b0, a7..a0, ...] -> [c7..c0, ...]`<br/>where `c = (a - b) % 2^256` |
-| wrapping_mul  | Performs multiplication of two unsigned 256-bit integers discarding the overflow.<br/><br/>**Stack transition:** `[b7..b0, a7..a0, ...] -> [c7..c0, ...]`<br/>where `c = (a * b) % 2^256` |
+| wrapping_add  | Performs addition of two unsigned 256-bit integers discarding the overflow.<br/><br/>**Stack transition:** `[b0..b7, a0..a7, ...] -> [c0..c7, ...]`<br/>where `c = (a + b) % 2^256` |
+| wrapping_sub  | Performs subtraction of two unsigned 256-bit integers discarding the underflow.<br/><br/>**Stack transition:** `[b0..b7, a0..a7, ...] -> [c0..c7, ...]`<br/>where `c = (a - b) % 2^256` |
+| wrapping_mul  | Performs multiplication of two unsigned 256-bit integers discarding the overflow.<br/><br/>**Stack transition:** `[b0..b7, a0..a7, ...] -> [c0..c7, ...]`<br/>where `c = (a * b) % 2^256` |
 
 ## Comparison operations
 
 | Procedure | Description |
 |-----------|-------------|
-| eq        | Checks equality of two unsigned 256-bit integers.<br/><br/>**Stack transition:** `[b7..b0, a7..a0, ...] -> [c, ...]`<br/>where `c = 1` when `a == b`, and `0` otherwise. |
-| eqz       | Checks if an unsigned 256-bit integer equals zero.<br/><br/>**Stack transition:** `[a7..a0, ...] -> [c, ...]`<br/>where `c = 1` when `a == 0`, and `0` otherwise. |
+| eq        | Checks equality of two unsigned 256-bit integers.<br/><br/>**Stack transition:** `[b0..b7, a0..a7, ...] -> [c, ...]`<br/>where `c = 1` when `a == b`, and `0` otherwise. |
+| eqz       | Checks if an unsigned 256-bit integer equals zero.<br/><br/>**Stack transition:** `[a0..a7, ...] -> [c, ...]`<br/>where `c = 1` when `a == 0`, and `0` otherwise. |
 
 ## Bitwise operations
 
 | Procedure | Description |
 |-----------|-------------|
-| and       | Performs bitwise AND of two unsigned 256-bit integers.<br/><br/>**Stack transition:** `[b7..b0, a7..a0, ...] -> [c7..c0, ...]`<br/>where `c = a AND b` |
-| or        | Performs bitwise OR of two unsigned 256-bit integers.<br/><br/>**Stack transition:** `[b7..b0, a7..a0, ...] -> [c7..c0, ...]`<br/>where `c = a OR b` |
-| xor       | Performs bitwise XOR of two unsigned 256-bit integers.<br/><br/>**Stack transition:** `[b7..b0, a7..a0, ...] -> [c7..c0, ...]`<br/>where `c = a XOR b` |
+| and       | Performs bitwise AND of two unsigned 256-bit integers.<br/><br/>**Stack transition:** `[b0..b7, a0..a7, ...] -> [c0..c7, ...]`<br/>where `c = a AND b` |
+| or        | Performs bitwise OR of two unsigned 256-bit integers.<br/><br/>**Stack transition:** `[b0..b7, a0..a7, ...] -> [c0..c7, ...]`<br/>where `c = a OR b` |
+| xor       | Performs bitwise XOR of two unsigned 256-bit integers.<br/><br/>**Stack transition:** `[b0..b7, a0..a7, ...] -> [c0..c7, ...]`<br/>where `c = a XOR b` |


### PR DESCRIPTION
  ## Describe your changes
                                                                                                                                                          
  This PR fixes a user-facing documentation inconsistency in `u256` stack limb ordering.                                                                  
                                                                                                                                                          
  `docs/src/user_docs/core_lib/math/u256.md` previously described stack transitions as `[b7..b0, a7..a0]`, which conflicts with the LE convention already used in core docs, MASM comments, and tests (`[b0..b7, a0..a7]`, low limb on top).
                                                                                                                                                          
  ### What changed                                                                                                                                        
  - Updated the `u256` stack representation text to explicitly state that the least-significant limb is on top of the stack.                              
  - Updated all stack transition examples in this page to LE order:                                                                                       
    - arithmetic (`wrapping_add`, `wrapping_sub`, `wrapping_mul`)                                                                                         
    - comparison (`eq`, `eqz`)                                                                                                                            
    - bitwise (`and`, `or`, `xor`)                                                                                                                        
                                                                                                                                                          
  ### Why                                                                                                                                                 
  This removes ambiguity for external users building input stacks and aligns user docs with the actual implementation/testing contract.                   
                                                                                                                                                          
  ## Checklist before requesting a review
  - [x] Repo forked and branch created from `next` according to naming convention.                                                                        
  - [x] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).                                                                           
  - [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).                           
  - [ ] Relevant issues are linked in the PR description.                                                                                                 
    - Related context: #2547, #2614
  - [x] Tests added for new functionality.                                                                                                                
    - N/A: docs-only change.                                                                                                                              
  - [x] Documentation/comments updated according to changes.                                                                                              
  - [ ] Updated `CHANGELOG.md`                                                                                                                            
    - Not updated (docs-only fix).  