### PR TITLE
Merge audit fixes into next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed constant evaluation across semantic analysis and linking so exported constants no longer retain private local dependencies and cross-module constant chains resolve in the defining module ([#2873](https://github.com/0xMiden/miden-vm/pull/2873)).
 - Memoized semantic constant evaluation in `AnalysisContext` to prevent exponential work from shared constant-dependency graphs during parsing and semantic analysis ([#2858](https://github.com/0xMiden/miden-vm/pull/2858)).
 - Fixed quote-equivalent path ambiguity in library deserialization and linker symbol resolution ([#2836](https://github.com/0xMiden/miden-vm/pull/2836)).
+- Treat serialized libraries and kernel libraries as untrusted MAST forests during deserialization, rejecting spoofed node digests ([#2863](https://github.com/0xMiden/miden-vm/pull/2863)).
 
 ## 0.22.0 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [BREAKING] Reject oversized modules at resolver construction instead of building partial resolver state or panicking ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
 - Return a normal assembly error when `pub use <digest> -> <name>` does not resolve to an exported procedure ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
 - [BREAKING] Reject non-procedure invoke targets during semantic analysis, and return an assembly error instead of panicking if one still reaches assembly ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
+- Added `Package::content_digest()` to identify package contents without changing the MAST digest, including manifest data and semantic package metadata ([#2909](https://github.com/0xMiden/miden-vm/pull/2909)).
 
 ## 0.22.0 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Memoized semantic constant evaluation in `AnalysisContext` to prevent exponential work from shared constant-dependency graphs during parsing and semantic analysis ([#2858](https://github.com/0xMiden/miden-vm/pull/2858)).
 - Fixed quote-equivalent path ambiguity in library deserialization and linker symbol resolution ([#2836](https://github.com/0xMiden/miden-vm/pull/2836)).
 - Treat serialized libraries and kernel libraries as untrusted MAST forests during deserialization, rejecting spoofed node digests ([#2863](https://github.com/0xMiden/miden-vm/pull/2863)).
+- Return typed cycle errors for self-recursive and rootless procedure call graphs, and roll back linker state on failure ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
+- [BREAKING] Reject oversized modules at resolver construction instead of building partial resolver state or panicking ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
+- Return a normal assembly error when `pub use <digest> -> <name>` does not resolve to an exported procedure ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
+- [BREAKING] Reject non-procedure invoke targets during semantic analysis, and return an assembly error instead of panicking if one still reaches assembly ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
 
 ## 0.22.0 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Enforced canonical kernel procedure-hash validation on binary and serde deserialization paths, and expanded serde deserialization fuzz coverage for related artifact types ([#2849](https://github.com/0xMiden/miden-vm/pull/2849)).
 - Fixed constant evaluation across semantic analysis and linking so exported constants no longer retain private local dependencies and cross-module constant chains resolve in the defining module ([#2873](https://github.com/0xMiden/miden-vm/pull/2873)).
 - Memoized semantic constant evaluation in `AnalysisContext` to prevent exponential work from shared constant-dependency graphs during parsing and semantic analysis ([#2858](https://github.com/0xMiden/miden-vm/pull/2858)).
+- Fixed quote-equivalent path ambiguity in library deserialization and linker symbol resolution ([#2836](https://github.com/0xMiden/miden-vm/pull/2836)).
 
 ## 0.22.0 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Hardened basic-block batch validation and decode-time padding checks to reject inconsistent padded groups and prevent raw-helper underflow/panic paths on malformed forests ([#2839](https://github.com/0xMiden/miden-vm/pull/2839)).
 - Enforced canonical kernel procedure-hash validation on binary and serde deserialization paths, and expanded serde deserialization fuzz coverage for related artifact types ([#2849](https://github.com/0xMiden/miden-vm/pull/2849)).
 - Fixed constant evaluation across semantic analysis and linking so exported constants no longer retain private local dependencies and cross-module constant chains resolve in the defining module ([#2873](https://github.com/0xMiden/miden-vm/pull/2873)).
+- Memoized semantic constant evaluation in `AnalysisContext` to prevent exponential work from shared constant-dependency graphs during parsing and semantic analysis ([#2858](https://github.com/0xMiden/miden-vm/pull/2858)).
 
 ## 0.22.0 (TBD)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,6 @@
 - Fixed AEAD padding handling so encrypt does not overwrite memory next to the plaintext buffer and decrypt leaves the plaintext output tail untouched ([#3008](https://github.com/0xMiden/miden-vm/pull/3008)).
 - Fixed MAST compaction after debug info is cleared so compiler-generated packages do not grow ([#3044](https://github.com/0xMiden/miden-vm/pull/3044)).
 - Canonicalized `PathBuf::try_from(String)` to match `TryFrom<&str>`/`FromStr`, so semantically equivalent quoted path components compare and hash consistently.
-- Set a bound on `ContinuationStack` size, checked during execution ([#2824](https://github.com/0xMiden/miden-vm/pull/2824)).
-- Prevented a trace-generation panic by validating op batch groups in basic blocks ([#2782](https://github.com/0xMiden/miden-vm/pull/2782)).
-- Validated push immediate group commitments and slot placement to reject invalid immediates ([#2779](https://github.com/0xMiden/miden-vm/pull/2779)).
-- Fixed undefined behavior in parallel trace generation by limiting H0 batch inversion to initialized rows ([#2842](https://github.com/0xMiden/miden-vm/pull/2842)).
-- Hardened boundary and overflow checks for `u64::shr`, `ilog2`, `u32clz`, and Falcon `mod_12289` ([#2808](https://github.com/0xMiden/miden-vm/pull/2808)).
-- Hardened basic-block batch validation and decode-time padding checks to reject inconsistent padded groups and prevent raw-helper underflow/panic paths on malformed forests ([#2839](https://github.com/0xMiden/miden-vm/pull/2839)).
-- Enforced canonical kernel procedure-hash validation on binary and serde deserialization paths, and expanded serde deserialization fuzz coverage for related artifact types ([#2849](https://github.com/0xMiden/miden-vm/pull/2849)).
-- Fixed constant evaluation across semantic analysis and linking so exported constants no longer retain private local dependencies and cross-module constant chains resolve in the defining module ([#2873](https://github.com/0xMiden/miden-vm/pull/2873)).
 - Memoized semantic constant evaluation in `AnalysisContext` to prevent exponential work from shared constant-dependency graphs during parsing and semantic analysis ([#2858](https://github.com/0xMiden/miden-vm/pull/2858)).
 - Fixed quote-equivalent path ambiguity in library deserialization and linker symbol resolution ([#2836](https://github.com/0xMiden/miden-vm/pull/2836)).
 - Treat serialized libraries and kernel libraries as untrusted MAST forests during deserialization, rejecting spoofed node digests ([#2863](https://github.com/0xMiden/miden-vm/pull/2863)).
@@ -142,7 +134,7 @@
 - Added bounds to attacker-controlled allocation sizes in advice map and keccak256/sha512 precompiles ([#2805](https://github.com/0xMiden/miden-vm/pull/2805)).
 - Hardened boundary and overflow checks for `u64::shr`, `ilog2`, `u32clz`, and Falcon `mod_12289` ([#2808](https://github.com/0xMiden/miden-vm/pull/2808)).
 - `build_trace()` no longer panics when no core trace contexts are provided ([#2809](https://github.com/0xMiden/miden-vm/pull/2809)).
-- Set a bound on `ContinuationStack` size, checked during execution ([#2824](https://github.com/0xMiden/miden-vm/pull/2824)).
+- Set a bound on `ContinuationStack` size, checked during execution ([#2825](https://github.com/0xMiden/miden-vm/pull/2825)).
 - Hardened basic-block batch validation and decode-time padding checks to reject inconsistent padded groups and prevent raw-helper underflow/panic paths on malformed forests ([#2839](https://github.com/0xMiden/miden-vm/pull/2839)).
 - Fixed undefined behavior in parallel trace generation by limiting H0 batch inversion to initialized rows ([#2842](https://github.com/0xMiden/miden-vm/pull/2842)).
 - `Visit` and `VisitMut` traits now properly visit enum type discriminant values, as well as the new payload `TypeExpr` when present ([#2848](https://github.com/0xMiden/miden-vm/pull/2848)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,9 +2394,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",

--- a/crates/assembly-syntax/src/ast/item/index.rs
+++ b/crates/assembly-syntax/src/ast/item/index.rs
@@ -3,9 +3,22 @@
 #[repr(transparent)]
 pub struct ItemIndex(u16);
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("invalid item index: too many items")]
+pub struct ItemIndexError {
+    attempted: usize,
+}
+
 impl ItemIndex {
+    pub const MAX_ITEMS: usize = u16::MAX as usize + 1;
+
     pub fn new(id: usize) -> Self {
-        Self(id.try_into().expect("invalid item index: too many items"))
+        Self::try_new(id).expect("invalid item index: too many items")
+    }
+
+    pub fn try_new(id: usize) -> Result<Self, ItemIndexError> {
+        let raw = id.try_into().map_err(|_| ItemIndexError { attempted: id })?;
+        Ok(Self(raw))
     }
 
     #[inline(always)]
@@ -97,5 +110,86 @@ impl core::ops::Add<ItemIndex> for ModuleIndex {
 impl core::fmt::Display for ModuleIndex {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", &self.as_usize())
+    }
+}
+
+#[cfg(test)]
+mod regression_tests {
+    use std::{string::String, sync::Arc};
+
+    use miden_debug_types::{DefaultSourceManager, SourceSpan, Span};
+
+    use super::ItemIndex;
+    use crate::{
+        Parse, ParseOptions, Path,
+        ast::{
+            Constant, ConstantExpr, Export, Ident, Module, ModuleKind, SymbolResolutionError,
+            Visibility,
+        },
+        parser::IntValue,
+        sema::{LimitKind, SemanticAnalysisError, SyntaxError},
+    };
+
+    fn huge_library_masm() -> String {
+        let num_consts = usize::from(u16::MAX) + 2;
+        let mut masm = String::with_capacity(num_consts * 16);
+        for i in 0..num_consts {
+            masm.push_str("const A");
+            masm.push_str(&format!("{i}"));
+            masm.push_str(" = 0\n");
+        }
+        masm
+    }
+
+    fn oversized_module_for_resolver() -> Module {
+        let mut module = Module::new(ModuleKind::Library, Path::new("::m::huge"));
+        for i in 0..=ItemIndex::MAX_ITEMS {
+            module.items.push(Export::Constant(Constant::new(
+                SourceSpan::UNKNOWN,
+                Visibility::Private,
+                Ident::new(format!("A{i}")).expect("valid identifier"),
+                ConstantExpr::Int(Span::unknown(IntValue::from(0u8))),
+            )));
+        }
+        module
+    }
+
+    #[test]
+    fn too_many_items_in_module_is_rejected_during_analysis() {
+        let source_manager = Arc::new(DefaultSourceManager::default());
+        let err = huge_library_masm()
+            .parse_with_options(
+                source_manager,
+                ParseOptions::new(ModuleKind::Library, Path::new("::m::huge")),
+            )
+            .expect_err("expected oversized module to be rejected during analysis");
+
+        let syntax_error = err.downcast_ref::<SyntaxError>().expect("expected SyntaxError report");
+        assert!(
+            syntax_error.errors.iter().any(|error| {
+                matches!(error, SemanticAnalysisError::LimitExceeded { kind: LimitKind::Items, .. })
+            }),
+            "expected item-limit error, got {:?}",
+            syntax_error.errors
+        );
+    }
+
+    #[test]
+    fn resolving_name_in_too_large_module_returns_structured_error() {
+        let source_manager = Arc::new(DefaultSourceManager::default());
+        let module = oversized_module_for_resolver();
+        let result = module.resolve(Span::unknown("A0"), source_manager);
+
+        assert!(matches!(result, Err(SymbolResolutionError::TooManyItemsInModule { .. })));
+    }
+
+    #[test]
+    fn resolver_construction_for_too_large_module_returns_structured_error() {
+        let source_manager = Arc::new(DefaultSourceManager::default());
+        let module = oversized_module_for_resolver();
+
+        let result = module.resolver(source_manager);
+
+        assert!(matches!(result, Err(SymbolResolutionError::TooManyItemsInModule { .. })));
     }
 }

--- a/crates/assembly-syntax/src/ast/item/resolver/error.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/error.rs
@@ -87,18 +87,6 @@ impl SymbolResolutionError {
         }
     }
 
-    pub fn duplicate_symbol(
-        span: SourceSpan,
-        symbol: Arc<str>,
-        source_manager: &dyn SourceManager,
-    ) -> Self {
-        Self::DuplicateSymbol {
-            span,
-            source_file: source_manager.get(span.source_id()).ok(),
-            symbol,
-        }
-    }
-
     pub fn invalid_alias_target(
         span: SourceSpan,
         referrer: SourceSpan,

--- a/crates/assembly-syntax/src/ast/item/resolver/error.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/error.rs
@@ -18,15 +18,6 @@ pub enum SymbolResolutionError {
         #[source_code]
         source_file: Option<Arc<SourceFile>>,
     },
-    #[error("ambiguous symbol reference: duplicate definition for '{symbol}'")]
-    #[diagnostic(help("this symbol name is defined more than once in the same scope"))]
-    DuplicateSymbol {
-        #[label("ambiguous symbol reference")]
-        span: SourceSpan,
-        #[source_code]
-        source_file: Option<Arc<SourceFile>>,
-        symbol: Arc<str>,
-    },
     #[error("invalid symbol reference")]
     #[diagnostic(help(
         "references to a subpath of an imported symbol require the imported item to be a module"

--- a/crates/assembly-syntax/src/ast/item/resolver/error.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/error.rs
@@ -18,6 +18,15 @@ pub enum SymbolResolutionError {
         #[source_code]
         source_file: Option<Arc<SourceFile>>,
     },
+    #[error("ambiguous symbol reference: duplicate definition for '{symbol}'")]
+    #[diagnostic(help("this symbol name is defined more than once in the same scope"))]
+    DuplicateSymbol {
+        #[label("ambiguous symbol reference")]
+        span: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        symbol: Arc<str>,
+    },
     #[error("invalid symbol reference")]
     #[diagnostic(help(
         "references to a subpath of an imported symbol require the imported item to be a module"
@@ -84,6 +93,18 @@ impl SymbolResolutionError {
         Self::UndefinedSymbol {
             span,
             source_file: source_manager.get(span.source_id()).ok(),
+        }
+    }
+
+    pub fn duplicate_symbol(
+        span: SourceSpan,
+        symbol: Arc<str>,
+        source_manager: &dyn SourceManager,
+    ) -> Self {
+        Self::DuplicateSymbol {
+            span,
+            source_file: source_manager.get(span.source_id()).ok(),
+            symbol,
         }
     }
 

--- a/crates/assembly-syntax/src/ast/item/resolver/error.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/error.rs
@@ -5,7 +5,10 @@ use alloc::sync::Arc;
 
 use miden_debug_types::{SourceFile, SourceManager, SourceSpan};
 
-use crate::diagnostics::{Diagnostic, RelatedLabel, miette};
+use crate::{
+    ast::ItemIndex,
+    diagnostics::{Diagnostic, RelatedLabel, miette},
+};
 
 /// Represents an error that occurs during symbol resolution
 #[derive(Debug, Clone, thiserror::Error, Diagnostic)]
@@ -76,6 +79,15 @@ pub enum SymbolResolutionError {
         #[source_code]
         source_file: Option<Arc<SourceFile>>,
         max_depth: usize,
+    },
+    #[error("too many items in module")]
+    #[diagnostic(help("break this module up into smaller modules"))]
+    TooManyItemsInModule {
+        #[label("module item count exceeds the supported limit of {max_items}")]
+        span: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        max_items: usize,
     },
 }
 
@@ -174,6 +186,14 @@ impl SymbolResolutionError {
             span,
             source_file: source_manager.get(span.source_id()).ok(),
             max_depth,
+        }
+    }
+
+    pub fn too_many_items_in_module(span: SourceSpan, source_manager: &dyn SourceManager) -> Self {
+        Self::TooManyItemsInModule {
+            span,
+            source_file: source_manager.get(span.source_id()).ok(),
+            max_items: ItemIndex::MAX_ITEMS,
         }
     }
 }

--- a/crates/assembly-syntax/src/ast/item/resolver/mod.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/mod.rs
@@ -65,18 +65,21 @@ impl Spanned for SymbolResolution {
 ///
 /// This is used as a low-level symbol resolution primitive in the linker as well.
 pub struct LocalSymbolResolver {
+    source_manager: Arc<dyn SourceManager>,
     symbols: LocalSymbolTable,
 }
 
 impl LocalSymbolResolver {
     /// Create a new resolver using the provided [SymbolTable] and [SourceManager].
-    pub fn new<S>(symbols: S, source_manager: Arc<dyn SourceManager>) -> Self
+    pub fn new<S>(
+        symbols: S,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self, SymbolResolutionError>
     where
         S: SymbolTable,
     {
-        Self {
-            symbols: LocalSymbolTable::new(symbols, source_manager),
-        }
+        let symbols = LocalSymbolTable::new(symbols, source_manager.clone())?;
+        Ok(Self { source_manager, symbols })
     }
 
     /// Expand `path` using `get_import` to resolve a raw symbol name to an import in the current
@@ -97,7 +100,7 @@ impl LocalSymbolResolver {
 
     #[inline]
     pub fn source_manager(&self) -> Arc<dyn SourceManager> {
-        self.symbols.source_manager_arc()
+        self.source_manager.clone()
     }
 
     /// Try to resolve `name` to an item, either local or external
@@ -142,7 +145,7 @@ impl LocalSymbolResolver {
                 Err(SymbolResolutionError::invalid_sub_path(
                     path.span(),
                     item.span(),
-                    self.symbols.source_manager(),
+                    &*self.source_manager,
                 ))
             },
             SymbolResolution::MastRoot(digest) => {
@@ -156,7 +159,7 @@ impl LocalSymbolResolver {
                 Err(SymbolResolutionError::invalid_sub_path(
                     path.span(),
                     digest.span(),
-                    self.symbols.source_manager(),
+                    &*self.source_manager,
                 ))
             },
             SymbolResolution::Module { id, path, .. } => {

--- a/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
@@ -1,4 +1,8 @@
-use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    vec::Vec,
+};
 
 use miden_debug_types::{SourceManager, Span, Spanned};
 
@@ -117,6 +121,7 @@ impl LocalSymbol {
 pub(super) struct LocalSymbolTable {
     source_manager: Arc<dyn SourceManager>,
     symbols: BTreeMap<Arc<str>, ItemIndex>,
+    duplicate_symbols: BTreeSet<Arc<str>>,
     items: Vec<LocalSymbol>,
 }
 
@@ -135,6 +140,7 @@ impl LocalSymbolTable {
         S: SymbolTable,
     {
         let mut symbols = BTreeMap::default();
+        let mut duplicate_symbols = BTreeSet::default();
         let mut items = Vec::with_capacity(16);
 
         for (i, symbol) in iter.symbols(source_manager.clone()).enumerate() {
@@ -149,11 +155,18 @@ impl LocalSymbolTable {
                 LocalSymbol::Import { name, .. } => name.clone().into_inner(),
             };
 
-            symbols.insert(name, id);
+            if symbols.insert(name.clone(), id).is_some() {
+                duplicate_symbols.insert(name);
+            }
             items.push(symbol);
         }
 
-        Self { source_manager, symbols, items }
+        Self {
+            source_manager,
+            symbols,
+            duplicate_symbols,
+            items,
+        }
     }
 
     #[inline(always)]
@@ -180,6 +193,13 @@ impl LocalSymbolTable {
     pub fn get(&self, name: Span<&str>) -> Result<SymbolResolution, SymbolResolutionError> {
         log::debug!(target: "symbol-table", "attempting to resolve '{name}'");
         let (span, name) = name.into_parts();
+        if self.duplicate_symbols.contains(name) {
+            return Err(SymbolResolutionError::duplicate_symbol(
+                span,
+                Arc::from(name),
+                &self.source_manager,
+            ));
+        }
         let Some(item) = self.symbols.get(name).copied() else {
             return Err(SymbolResolutionError::undefined(span, &self.source_manager));
         };

--- a/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
@@ -1,8 +1,4 @@
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-    vec::Vec,
-};
+use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 
 use miden_debug_types::{SourceManager, Span, Spanned};
 
@@ -121,7 +117,6 @@ impl LocalSymbol {
 pub(super) struct LocalSymbolTable {
     source_manager: Arc<dyn SourceManager>,
     symbols: BTreeMap<Arc<str>, ItemIndex>,
-    duplicate_symbols: BTreeSet<Arc<str>>,
     items: Vec<LocalSymbol>,
 }
 
@@ -140,7 +135,6 @@ impl LocalSymbolTable {
         S: SymbolTable,
     {
         let mut symbols = BTreeMap::default();
-        let mut duplicate_symbols = BTreeSet::default();
         let mut items = Vec::with_capacity(16);
 
         for (i, symbol) in iter.symbols(source_manager.clone()).enumerate() {
@@ -155,18 +149,15 @@ impl LocalSymbolTable {
                 LocalSymbol::Import { name, .. } => name.clone().into_inner(),
             };
 
-            if symbols.insert(name.clone(), id).is_some() {
-                duplicate_symbols.insert(name);
+            if let Some(prev) = symbols.insert(name.clone(), id) {
+                panic!(
+                    "duplicate symbol '{name}' reached local resolver construction (previous={prev:?}, current={id:?})"
+                );
             }
             items.push(symbol);
         }
 
-        Self {
-            source_manager,
-            symbols,
-            duplicate_symbols,
-            items,
-        }
+        Self { source_manager, symbols, items }
     }
 
     #[inline(always)]
@@ -193,13 +184,6 @@ impl LocalSymbolTable {
     pub fn get(&self, name: Span<&str>) -> Result<SymbolResolution, SymbolResolutionError> {
         log::debug!(target: "symbol-table", "attempting to resolve '{name}'");
         let (span, name) = name.into_parts();
-        if self.duplicate_symbols.contains(name) {
-            return Err(SymbolResolutionError::duplicate_symbol(
-                span,
-                Arc::from(name),
-                &self.source_manager,
-            ));
-        }
         let Some(item) = self.symbols.get(name).copied() else {
             return Err(SymbolResolutionError::undefined(span, &self.source_manager));
         };
@@ -497,5 +481,32 @@ mod tests {
             },
             other => panic!("expected external resolution, got {other:?}"),
         }
+    }
+
+    #[cfg(test)]
+    struct DuplicateSymbolsForInvariantTest;
+
+    #[cfg(test)]
+    impl SymbolTable for DuplicateSymbolsForInvariantTest {
+        type SymbolIter = alloc::vec::IntoIter<LocalSymbol>;
+
+        fn symbols(&self, _source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter {
+            let first = LocalSymbol::Item {
+                name: crate::ast::Ident::new("dup").expect("valid identifier"),
+                resolved: SymbolResolution::Local(Span::unknown(ItemIndex::new(0))),
+            };
+            let second = LocalSymbol::Item {
+                name: crate::ast::Ident::new("dup").expect("valid identifier"),
+                resolved: SymbolResolution::Local(Span::unknown(ItemIndex::new(1))),
+            };
+            alloc::vec![first, second].into_iter()
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "duplicate symbol 'dup' reached local resolver construction")]
+    fn local_symbol_table_rejects_duplicate_symbols() {
+        let source_manager: Arc<dyn SourceManager> = Arc::new(DefaultSourceManager::default());
+        let _table = LocalSymbolTable::new(DuplicateSymbolsForInvariantTest, source_manager);
     }
 }

--- a/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
@@ -538,13 +538,13 @@ mod tests {
     fn checked_symbols_rejects_oversized_module() {
         let source_manager: Arc<dyn SourceManager> = Arc::new(DefaultSourceManager::default());
         let mut module =
-            crate::ast::Module::new(crate::ast::ModuleKind::Library, crate::Path::new("::m::huge"));
+            crate::ast::Module::new(crate::ast::ModuleKind::Library, Path::new("::m::huge"));
 
         for i in 0..=ItemIndex::MAX_ITEMS {
             module.items.push(crate::ast::Export::Constant(crate::ast::Constant::new(
                 SourceSpan::UNKNOWN,
                 crate::ast::Visibility::Private,
-                crate::ast::Ident::new(format!("A{i}")).expect("valid identifier"),
+                Ident::new(format!("A{i}")).expect("valid identifier"),
                 crate::ast::ConstantExpr::Int(Span::unknown(crate::parser::IntValue::from(0u8))),
             )));
         }
@@ -591,11 +591,11 @@ mod tests {
 
         fn symbols(&self, _source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter {
             let first = LocalSymbol::Item {
-                name: crate::ast::Ident::new("dup").expect("valid identifier"),
+                name: Ident::new("dup").expect("valid identifier"),
                 resolved: SymbolResolution::Local(Span::unknown(ItemIndex::new(0))),
             };
             let second = LocalSymbol::Item {
-                name: crate::ast::Ident::new("dup").expect("valid identifier"),
+                name: Ident::new("dup").expect("valid identifier"),
                 resolved: SymbolResolution::Local(Span::unknown(ItemIndex::new(1))),
             };
             alloc::vec![first, second].into_iter()

--- a/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
@@ -1,6 +1,6 @@
 use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 
-use miden_debug_types::{SourceManager, Span, Spanned};
+use miden_debug_types::{SourceManager, SourceSpan, Span, Spanned};
 
 use super::{SymbolResolution, SymbolResolutionError};
 use crate::{
@@ -15,6 +15,9 @@ use crate::{
 const MAX_ALIAS_EXPANSION_DEPTH: usize = 128;
 
 /// This trait abstracts over any type which acts as a symbol table, e.g. a [crate::ast::Module].
+///
+/// Resolver construction uses [Self::checked_symbols], which must either return the full symbol
+/// set or a structured error.
 pub trait SymbolTable {
     /// The concrete iterator type for the container.
     type SymbolIter: Iterator<Item = LocalSymbol>;
@@ -22,27 +25,50 @@ pub trait SymbolTable {
     /// Get an iterator over the symbols in this symbol table, using the provided [SourceManager]
     /// to emit errors for symbols which are invalid/unresolvable.
     fn symbols(&self, source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter;
+
+    /// Get an iterator over the symbols in this symbol table, returning a structured error if the
+    /// full symbol set cannot be represented exactly.
+    ///
+    /// Override this when exact resolver construction needs validation, such as rejecting oversized
+    /// symbol sets.
+    fn checked_symbols(
+        &self,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self::SymbolIter, SymbolResolutionError> {
+        Ok(self.symbols(source_manager))
+    }
 }
 
 impl SymbolTable for &crate::library::ModuleInfo {
     type SymbolIter = alloc::vec::IntoIter<LocalSymbol>;
 
     fn symbols(&self, _source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter {
-        let module_items = self.items();
-        let mut items = Vec::with_capacity(module_items.len());
+        let mut items = Vec::with_capacity(self.raw_items().len());
 
-        for (index, item) in module_items {
+        for (i, item) in self.raw_items().iter().enumerate() {
             let name = item.name().clone();
             let span = name.span();
-
-            assert_eq!(index.as_usize(), items.len());
             items.push(LocalSymbol::Item {
                 name,
-                resolved: SymbolResolution::Local(Span::new(span, index)),
+                resolved: SymbolResolution::Local(Span::new(span, ItemIndex::new(i))),
             });
         }
 
         items.into_iter()
+    }
+
+    fn checked_symbols(
+        &self,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self::SymbolIter, SymbolResolutionError> {
+        if self.raw_items().len() > ItemIndex::MAX_ITEMS {
+            Err(SymbolResolutionError::too_many_items_in_module(
+                SourceSpan::UNKNOWN,
+                &*source_manager,
+            ))
+        } else {
+            Ok(self.symbols(source_manager))
+        }
     }
 }
 
@@ -90,6 +116,17 @@ impl SymbolTable for &crate::ast::Module {
 
         items.into_iter()
     }
+
+    fn checked_symbols(
+        &self,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self::SymbolIter, SymbolResolutionError> {
+        if self.items.len() > ItemIndex::MAX_ITEMS {
+            Err(SymbolResolutionError::too_many_items_in_module(self.span(), &*source_manager))
+        } else {
+            Ok(self.symbols(source_manager))
+        }
+    }
 }
 
 /// Represents a symbol within the context of a single module
@@ -130,20 +167,30 @@ impl core::ops::Index<ItemIndex> for LocalSymbolTable {
 }
 
 impl LocalSymbolTable {
-    pub fn new<S>(iter: S, source_manager: Arc<dyn SourceManager>) -> Self
+    fn build<I>(iter: I, source_manager: Arc<dyn SourceManager>) -> Self
     where
-        S: SymbolTable,
+        I: Iterator<Item = LocalSymbol>,
     {
         let mut symbols = BTreeMap::default();
         let mut items = Vec::with_capacity(16);
 
-        for (i, symbol) in iter.symbols(source_manager.clone()).enumerate() {
+        for (i, symbol) in iter.enumerate() {
+            let id = ItemIndex::try_new(i)
+                .expect("symbol iterators used by LocalSymbolTable::build must be pre-validated");
+            let symbol = match symbol {
+                LocalSymbol::Item {
+                    name,
+                    resolved: SymbolResolution::Local(local),
+                } => LocalSymbol::Item {
+                    name,
+                    resolved: SymbolResolution::Local(Span::new(local.span(), id)),
+                },
+                symbol => symbol,
+            };
             log::debug!(target: "symbol-table::new", "registering {} symbol: {}", match symbol {
                 LocalSymbol::Item { .. } => "local",
                 LocalSymbol::Import { .. } => "imported",
             }, symbol.name());
-
-            let id = ItemIndex::new(i);
             let name = match &symbol {
                 LocalSymbol::Item { name, .. } => name.clone().into_inner(),
                 LocalSymbol::Import { name, .. } => name.clone().into_inner(),
@@ -163,14 +210,15 @@ impl LocalSymbolTable {
         Self { source_manager, symbols, items }
     }
 
-    #[inline(always)]
-    pub fn source_manager(&self) -> &dyn SourceManager {
-        &self.source_manager
-    }
-
-    #[inline(always)]
-    pub fn source_manager_arc(&self) -> Arc<dyn SourceManager> {
-        self.source_manager.clone()
+    pub fn new<S>(
+        iter: S,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self, SymbolResolutionError>
+    where
+        S: SymbolTable,
+    {
+        let symbols = iter.checked_symbols(source_manager.clone())?;
+        Ok(Self::build(symbols, source_manager))
     }
 }
 
@@ -486,6 +534,54 @@ mod tests {
         }
     }
 
+    #[test]
+    fn checked_symbols_rejects_oversized_module() {
+        let source_manager: Arc<dyn SourceManager> = Arc::new(DefaultSourceManager::default());
+        let mut module =
+            crate::ast::Module::new(crate::ast::ModuleKind::Library, crate::Path::new("::m::huge"));
+
+        for i in 0..=ItemIndex::MAX_ITEMS {
+            module.items.push(crate::ast::Export::Constant(crate::ast::Constant::new(
+                SourceSpan::UNKNOWN,
+                crate::ast::Visibility::Private,
+                crate::ast::Ident::new(format!("A{i}")).expect("valid identifier"),
+                crate::ast::ConstantExpr::Int(Span::unknown(crate::parser::IntValue::from(0u8))),
+            )));
+        }
+
+        let result = (&module).checked_symbols(source_manager);
+
+        assert!(matches!(result, Err(SymbolResolutionError::TooManyItemsInModule { .. })));
+    }
+
+    #[test]
+    fn checked_symbols_guard_custom_symbol_table_exact() {
+        struct ExactTooManySymbols;
+
+        impl SymbolTable for ExactTooManySymbols {
+            type SymbolIter = alloc::vec::IntoIter<LocalSymbol>;
+
+            fn symbols(&self, _source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter {
+                panic!("exact construction must not request unchecked symbols")
+            }
+
+            fn checked_symbols(
+                &self,
+                source_manager: Arc<dyn SourceManager>,
+            ) -> Result<Self::SymbolIter, SymbolResolutionError> {
+                Err(SymbolResolutionError::too_many_items_in_module(
+                    SourceSpan::UNKNOWN,
+                    &*source_manager,
+                ))
+            }
+        }
+
+        let source_manager: Arc<dyn SourceManager> = Arc::new(DefaultSourceManager::default());
+        let result = LocalSymbolTable::new(ExactTooManySymbols, source_manager);
+
+        assert!(matches!(result, Err(SymbolResolutionError::TooManyItemsInModule { .. })));
+    }
+
     #[cfg(test)]
     struct DuplicateSymbolsForInvariantTest;
 
@@ -529,7 +625,9 @@ mod tests {
                 "debug builds should panic when duplicates reach local resolver construction"
             );
         } else {
-            let table = result.expect("release builds should not panic on duplicate symbols");
+            let table = result
+                .expect("release builds should not panic on duplicate symbols")
+                .expect("release builds should still construct a table");
             let resolved = table
                 .get(Span::unknown("dup"))
                 .expect("release behavior should keep a deterministic symbol mapping");

--- a/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
+++ b/crates/assembly-syntax/src/ast/item/resolver/symbol_table.rs
@@ -149,10 +149,13 @@ impl LocalSymbolTable {
                 LocalSymbol::Import { name, .. } => name.clone().into_inner(),
             };
 
-            if let Some(prev) = symbols.insert(name.clone(), id) {
-                panic!(
+            if let Some(prev) = symbols.get(&name).copied() {
+                debug_assert!(
+                    false,
                     "duplicate symbol '{name}' reached local resolver construction (previous={prev:?}, current={id:?})"
                 );
+            } else {
+                symbols.insert(name.clone(), id);
             }
             items.push(symbol);
         }
@@ -503,10 +506,37 @@ mod tests {
         }
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "duplicate symbol 'dup' reached local resolver construction")]
     fn local_symbol_table_rejects_duplicate_symbols() {
         let source_manager: Arc<dyn SourceManager> = Arc::new(DefaultSourceManager::default());
         let _table = LocalSymbolTable::new(DuplicateSymbolsForInvariantTest, source_manager);
+    }
+
+    #[test]
+    fn local_symbol_table_duplicate_symbols_have_explicit_behavior() {
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        let source_manager: Arc<dyn SourceManager> = Arc::new(DefaultSourceManager::default());
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            LocalSymbolTable::new(DuplicateSymbolsForInvariantTest, source_manager)
+        }));
+
+        if cfg!(debug_assertions) {
+            assert!(
+                result.is_err(),
+                "debug builds should panic when duplicates reach local resolver construction"
+            );
+        } else {
+            let table = result.expect("release builds should not panic on duplicate symbols");
+            let resolved = table
+                .get(Span::unknown("dup"))
+                .expect("release behavior should keep a deterministic symbol mapping");
+            match resolved {
+                SymbolResolution::Local(id) => assert_eq!(id.into_inner(), ItemIndex::new(0)),
+                other => panic!("expected local symbol resolution, got {other:?}"),
+            }
+        }
     }
 }

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -293,17 +293,18 @@ impl Module {
     pub fn define_procedure(
         &mut self,
         procedure: Procedure,
-        source_manager: Arc<dyn SourceManager>,
+        _source_manager: Arc<dyn SourceManager>,
     ) -> Result<(), SemanticAnalysisError> {
-        let name = procedure.name();
-        let name = Span::new(name.span(), name.as_str());
-        if let Ok(prev) = self.resolve(name, source_manager) {
-            let prev_span = prev.span();
-            Err(SemanticAnalysisError::SymbolConflict { span: procedure.span(), prev_span })
-        } else {
-            self.items.push(Export::Procedure(procedure));
-            Ok(())
+        if let Some(prev) =
+            self.items.iter().find(|item| item.name().as_str() == procedure.name().as_str())
+        {
+            return Err(SemanticAnalysisError::SymbolConflict {
+                span: procedure.span(),
+                prev_span: prev.name().span(),
+            });
         }
+        self.items.push(Export::Procedure(procedure));
+        Ok(())
     }
 
     /// Defines an item alias, raising an error if the alias is invalid, or conflicts with a
@@ -311,20 +312,23 @@ impl Module {
     pub fn define_alias(
         &mut self,
         item: Alias,
-        source_manager: Arc<dyn SourceManager>,
+        _source_manager: Arc<dyn SourceManager>,
     ) -> Result<(), SemanticAnalysisError> {
         if self.is_kernel() && item.visibility().is_public() {
             return Err(SemanticAnalysisError::ReexportFromKernel { span: item.span() });
         }
-        let name = item.name();
-        let name = Span::new(name.span(), name.as_str());
-        if let Ok(prev) = self.resolve(name, source_manager) {
-            let prev_span = prev.span();
-            Err(SemanticAnalysisError::SymbolConflict { span: item.span(), prev_span })
-        } else {
-            self.items.push(Export::Alias(item));
-            Ok(())
+        if let Some(prev) = self
+            .items
+            .iter()
+            .find(|existing| existing.name().as_str() == item.name().as_str())
+        {
+            return Err(SemanticAnalysisError::SymbolConflict {
+                span: item.name().span(),
+                prev_span: prev.name().span(),
+            });
         }
+        self.items.push(Export::Alias(item));
+        Ok(())
     }
 }
 

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -18,7 +18,7 @@ use crate::{
     PathBuf,
     ast::{self, Ident, types},
     parser::ModuleParser,
-    sema::SemanticAnalysisError,
+    sema::{LimitKind, SemanticAnalysisError},
 };
 
 // MODULE KIND
@@ -198,6 +198,20 @@ impl Module {
         self.span = span;
     }
 
+    fn ensure_item_capacity(&self, span: SourceSpan) -> Result<(), SemanticAnalysisError> {
+        if self.items.len() >= ItemIndex::MAX_ITEMS {
+            return Err(SemanticAnalysisError::LimitExceeded { span, kind: LimitKind::Items });
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn push_export(&mut self, item: Export) -> Result<(), SemanticAnalysisError> {
+        self.ensure_item_capacity(item.span())?;
+        self.items.push(item);
+        Ok(())
+    }
+
     /// Defines a constant, raising an error if the constant conflicts with a previous definition
     pub fn define_constant(&mut self, constant: Constant) -> Result<(), SemanticAnalysisError> {
         if let Some(prev) = self.items.iter().find(|item| item.name() == &constant.name) {
@@ -206,7 +220,7 @@ impl Module {
                 prev_span: prev.span(),
             });
         }
-        self.items.push(Export::Constant(constant));
+        self.push_export(Export::Constant(constant))?;
         Ok(())
     }
 
@@ -218,7 +232,7 @@ impl Module {
                 prev_span: prev.span(),
             });
         }
-        self.items.push(Export::Type(ty.into()));
+        self.push_export(Export::Type(ty.into()))?;
         Ok(())
     }
 
@@ -283,7 +297,7 @@ impl Module {
             })?;
         }
 
-        self.items.push(Export::Type(alias.into()));
+        self.push_export(Export::Type(alias.into()))?;
 
         Ok(())
     }
@@ -303,7 +317,7 @@ impl Module {
                 prev_span: prev.name().span(),
             });
         }
-        self.items.push(Export::Procedure(procedure));
+        self.push_export(Export::Procedure(procedure))?;
         Ok(())
     }
 
@@ -327,7 +341,7 @@ impl Module {
                 prev_span: prev.name().span(),
             });
         }
-        self.items.push(Export::Alias(item));
+        self.push_export(Export::Alias(item))?;
         Ok(())
     }
 }
@@ -552,7 +566,7 @@ impl Module {
         name: Span<&str>,
         source_manager: Arc<dyn SourceManager>,
     ) -> Result<SymbolResolution, SymbolResolutionError> {
-        let resolver = self.resolver(source_manager);
+        let resolver = self.resolver(source_manager)?;
         resolver.resolve(name)
     }
 
@@ -562,13 +576,16 @@ impl Module {
         path: Span<&Path>,
         source_manager: Arc<dyn SourceManager>,
     ) -> Result<SymbolResolution, SymbolResolutionError> {
-        let resolver = self.resolver(source_manager);
+        let resolver = self.resolver(source_manager)?;
         resolver.resolve_path(path)
     }
 
     /// Construct a search structure that can resolve procedure names local to this module
     #[inline]
-    pub fn resolver(&self, source_manager: Arc<dyn SourceManager>) -> LocalSymbolResolver {
+    pub fn resolver(
+        &self,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<LocalSymbolResolver, SymbolResolutionError> {
         LocalSymbolResolver::new(self, source_manager)
     }
 
@@ -594,7 +611,7 @@ impl Module {
         ty: &ast::TypeExpr,
         source_manager: Arc<dyn SourceManager>,
     ) -> Result<Option<types::Type>, SymbolResolutionError> {
-        let type_resolver = ModuleTypeResolver::new(self, source_manager);
+        let type_resolver = self.type_resolver(source_manager)?;
         type_resolver.resolve(ty)
     }
 
@@ -602,7 +619,7 @@ impl Module {
     pub fn type_resolver(
         &self,
         source_manager: Arc<dyn SourceManager>,
-    ) -> impl TypeResolver<SymbolResolutionError> + '_ {
+    ) -> Result<impl TypeResolver<SymbolResolutionError> + '_, SymbolResolutionError> {
         ModuleTypeResolver::new(self, source_manager)
     }
 }
@@ -696,9 +713,12 @@ struct ModuleTypeResolver<'a> {
 }
 
 impl<'a> ModuleTypeResolver<'a> {
-    pub fn new(module: &'a Module, source_manager: Arc<dyn SourceManager>) -> Self {
-        let resolver = module.resolver(source_manager);
-        Self { module, resolver }
+    pub fn new(
+        module: &'a Module,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self, SymbolResolutionError> {
+        let resolver = module.resolver(source_manager)?;
+        Ok(Self { module, resolver })
     }
 }
 

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -200,15 +200,11 @@ impl Module {
 
     /// Defines a constant, raising an error if the constant conflicts with a previous definition
     pub fn define_constant(&mut self, constant: Constant) -> Result<(), SemanticAnalysisError> {
-        for item in self.items.iter() {
-            if let Export::Constant(c) = item
-                && c.name == constant.name
-            {
-                return Err(SemanticAnalysisError::SymbolConflict {
-                    span: constant.span,
-                    prev_span: c.span,
-                });
-            }
+        if let Some(prev) = self.items.iter().find(|item| item.name() == &constant.name) {
+            return Err(SemanticAnalysisError::SymbolConflict {
+                span: constant.span,
+                prev_span: prev.span(),
+            });
         }
         self.items.push(Export::Constant(constant));
         Ok(())
@@ -216,15 +212,11 @@ impl Module {
 
     /// Defines a type alias, raising an error if the alias conflicts with a previous definition
     pub fn define_type(&mut self, ty: TypeAlias) -> Result<(), SemanticAnalysisError> {
-        for item in self.items.iter() {
-            if let Export::Type(t) = item
-                && t.name() == ty.name()
-            {
-                return Err(SemanticAnalysisError::SymbolConflict {
-                    span: ty.span(),
-                    prev_span: t.span(),
-                });
-            }
+        if let Some(prev) = self.items.iter().find(|item| item.name() == ty.name()) {
+            return Err(SemanticAnalysisError::SymbolConflict {
+                span: ty.span(),
+                prev_span: prev.span(),
+            });
         }
         self.items.push(Export::Type(ty.into()));
         Ok(())

--- a/crates/assembly-syntax/src/ast/path/path.rs
+++ b/crates/assembly-syntax/src/ast/path/path.rs
@@ -477,6 +477,9 @@ impl Path {
     pub fn canonicalize(&self) -> Result<PathBuf, PathError> {
         let mut buf = PathBuf::with_capacity(self.byte_len());
         buf.extend_with_components(self.components())?;
+        if buf.byte_len() > u16::MAX as usize {
+            return Err(PathError::TooLong { max: u16::MAX as usize });
+        }
         Ok(buf)
     }
 }
@@ -667,5 +670,24 @@ mod tests {
         let expected = Path::new("foo::\"$bar\"");
         assert_eq!(canonicalized.as_path(), expected);
         Ok(())
+    }
+
+    #[test]
+    fn test_canonicalize_path_rejects_canonical_result_longer_than_u16_max() {
+        let component = alloc::format!("{}-", "a".repeat(254));
+        let mut source = alloc::string::String::new();
+        for i in 0..255 {
+            if i > 0 {
+                source.push_str("::");
+            }
+            source.push_str(&component);
+        }
+
+        let path = Path::validate(&source).expect("source path must be pre-canonicalization valid");
+        let err = path.canonicalize().expect_err(
+            "canonicalization must reject paths that exceed the serialization length bound",
+        );
+
+        assert!(matches!(err, PathError::TooLong { max } if max == u16::MAX as usize));
     }
 }

--- a/crates/assembly-syntax/src/ast/path/path_buf.rs
+++ b/crates/assembly-syntax/src/ast/path/path_buf.rs
@@ -341,11 +341,10 @@ impl Deserializable for PathBuf {
         let path = source.read_slice(len)?;
         let path =
             str::from_utf8(path).map_err(|e| DeserializationError::InvalidValue(e.to_string()))?;
-        Path::validate(path).map_err(|e| DeserializationError::InvalidValue(e.to_string()))?;
-        // We deserialize like this due to our deserialization tests expecting round-trips to be
-        // identical to what was serialized, though ideally we'd like to canonicalize paths that
-        // were deserialized. We should probably change how these tests work in the future.
-        Ok(PathBuf { inner: path.to_string() })
+        let path =
+            Path::validate(path).map_err(|e| DeserializationError::InvalidValue(e.to_string()))?;
+        path.canonicalize()
+            .map_err(|e| DeserializationError::InvalidValue(e.to_string()))
     }
 }
 
@@ -380,24 +379,20 @@ impl<'de> serde::Deserialize<'de> for PathBuf {
             where
                 E: serde::de::Error,
             {
-                Path::validate(v).map_err(serde::de::Error::custom)?;
-                // We deserialize like this due to our deserialization tests expecting round-trips
-                // to be identical to what was serialized, though ideally we'd like
-                // to canonicalize paths that were deserialized. We should probably
-                // change how these tests work in the future.
-                Ok(PathBuf { inner: v.to_string() })
+                Path::validate(v)
+                    .map_err(serde::de::Error::custom)?
+                    .canonicalize()
+                    .map_err(serde::de::Error::custom)
             }
 
             fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
             where
                 E: serde::de::Error,
             {
-                Path::validate(&v).map_err(serde::de::Error::custom)?;
-                // We deserialize like this due to our deserialization tests expecting round-trips
-                // to be identical to what was serialized, though ideally we'd like
-                // to canonicalize paths that were deserialized. We should probably
-                // change how these tests work in the future.
-                Ok(PathBuf { inner: v })
+                Path::validate(&v)
+                    .map_err(serde::de::Error::custom)?
+                    .canonicalize()
+                    .map_err(serde::de::Error::custom)
             }
         }
 
@@ -417,6 +412,8 @@ impl fmt::Display for PathBuf {
 /// Tests
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "serde")]
+    use alloc::string::String;
 
     use miden_core::assert_matches;
 
@@ -614,5 +611,41 @@ mod tests {
     fn invalid_path_invalid_character() {
         let result = Path::validate("#foo::bar");
         assert_matches!(result, Err(PathError::InvalidComponent(IdentError::InvalidChars { .. })));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_deserialize_path_buf_canonicalizes_redundant_quotes() {
+        let path: PathBuf = serde_json::from_str(r#""\"foo\"::\"bar\"""#)
+            .expect("path deserialization must succeed");
+        assert_eq!(path.as_str(), "foo::bar");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_deserialize_path_buf_preserves_required_quotes() {
+        let path: PathBuf = serde_json::from_value(serde_json::Value::String(String::from(
+            "::foo::\"miden::base/account@0.1.0\"",
+        )))
+        .expect("path deserialization must succeed");
+        assert_eq!(path.as_str(), "::foo::\"miden::base/account@0.1.0\"");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_deserialize_path_buf_rejects_overflow_after_canonicalization() {
+        let component = format!("{}-", "a".repeat(254));
+        let mut source = String::new();
+        for i in 0..255 {
+            if i > 0 {
+                source.push_str("::");
+            }
+            source.push_str(&component);
+        }
+
+        let err = serde_json::from_value::<PathBuf>(serde_json::Value::String(source))
+            .expect_err("deserialization must fail when canonicalization exceeds u16::MAX bytes");
+        let message = format!("{err}");
+        assert!(message.contains("too long"), "unexpected error: {message}");
     }
 }

--- a/crates/assembly-syntax/src/library/mod.rs
+++ b/crates/assembly-syntax/src/library/mod.rs
@@ -1051,6 +1051,7 @@ impl Arbitrary for Library {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "serde")]
     use super::*;
 
     #[cfg(feature = "serde")]

--- a/crates/assembly-syntax/src/library/mod.rs
+++ b/crates/assembly-syntax/src/library/mod.rs
@@ -3,9 +3,11 @@ use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 use miden_core::{
     Word,
     advice::AdviceMap,
-    mast::{MastForest, MastNodeExt, MastNodeId},
+    mast::{MastForest, MastNodeExt, MastNodeId, UntrustedMastForest},
     program::Kernel,
-    serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    serde::{
+        ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, SliceReader,
+    },
 };
 use midenc_hir_type::{FunctionType, Type};
 #[cfg(feature = "arbitrary")]
@@ -301,6 +303,108 @@ impl Library {
             ..self
         }
     }
+
+    fn read_mast_forest<R: ByteReader>(
+        source: &mut R,
+        validate_mast_forest: bool,
+    ) -> Result<Arc<MastForest>, DeserializationError> {
+        let mast_forest = if validate_mast_forest {
+            UntrustedMastForest::read_from(source)?.validate().map_err(|err| {
+                DeserializationError::InvalidValue(format!(
+                    "library contains an invalid untrusted MAST forest: {err}"
+                ))
+            })?
+        } else {
+            MastForest::read_from(source)?
+        };
+
+        Ok(Arc::new(mast_forest))
+    }
+
+    fn read_from_with_mast_forest<R: ByteReader>(
+        source: &mut R,
+        mast_forest: Arc<MastForest>,
+    ) -> Result<Self, DeserializationError> {
+        let num_exports = source.read_usize()?;
+        if num_exports == 0 {
+            return Err(DeserializationError::InvalidValue(String::from("No exported procedures")));
+        };
+        let mut exports = BTreeMap::new();
+        for _ in 0..num_exports {
+            let tag = source.read_u8()?;
+            let path: PathBuf = source.read()?;
+            let path = Arc::<Path>::from(path.into_boxed_path());
+            let export = match tag {
+                0 => {
+                    let node = MastNodeId::from_u32_safe(source.read_u32()?, &mast_forest)?;
+                    let signature = if source.read_bool()? {
+                        Some(FunctionTypeDeserializer::read_from(source)?.0)
+                    } else {
+                        None
+                    };
+                    let attributes = AttributeSet::read_from(source)?;
+                    LibraryExport::Procedure(ProcedureExport {
+                        node,
+                        path: path.clone(),
+                        signature,
+                        attributes,
+                    })
+                },
+                1 => {
+                    let value = crate::ast::ConstantValue::read_from(source)?;
+                    LibraryExport::Constant(ConstantExport { path: path.clone(), value })
+                },
+                2 => {
+                    let ty = TypeDeserializer::read_from(source)?.0;
+                    LibraryExport::Type(TypeExport { path: path.clone(), ty })
+                },
+                invalid => {
+                    return Err(DeserializationError::InvalidValue(format!(
+                        "unknown LibraryExport tag: '{invalid}'"
+                    )));
+                },
+            };
+            let (path, export) = normalize_export_for_deserialization(export)
+                .map_err(DeserializationError::InvalidValue)?;
+            if exports.insert(path.clone(), export).is_some() {
+                return Err(DeserializationError::InvalidValue(format!(
+                    "duplicate canonical export path in library artifact: '{path}'"
+                )));
+            }
+        }
+
+        let digest =
+            mast_forest.compute_nodes_commitment(exports.values().filter_map(|e| match e {
+                LibraryExport::Procedure(e) => Some(&e.node),
+                LibraryExport::Constant(_) | LibraryExport::Type(_) => None,
+            }));
+
+        Ok(Self { digest, exports, mast_forest })
+    }
+
+    /// Reads a library from `source` without validating the embedded MAST forest.
+    ///
+    /// This is only correct when serialization and deserialization happen within the same trust
+    /// domain. A typical use case is reloading bytes that were already validated before being
+    /// persisted to local storage controlled by the same trusted system.
+    ///
+    /// Do not use this for inbound artifact processing across a trust boundary, including bytes
+    /// received over the network or from another party. Authenticating the outer byte stream does
+    /// not prove that embedded MAST node digests are semantically valid.
+    pub fn read_from_unchecked<R: ByteReader>(
+        source: &mut R,
+    ) -> Result<Self, DeserializationError> {
+        let mast_forest = Self::read_mast_forest(source, false)?;
+        Self::read_from_with_mast_forest(source, mast_forest)
+    }
+
+    /// Reads a library from `bytes` without validating the embedded MAST forest.
+    ///
+    /// See [`Library::read_from_unchecked`].
+    pub fn read_from_bytes_unchecked(bytes: &[u8]) -> Result<Self, DeserializationError> {
+        let mut source = SliceReader::new(bytes);
+        Self::read_from_unchecked(&mut source)
+    }
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -486,6 +590,14 @@ impl AsRef<Library> for KernelLibrary {
 }
 
 impl KernelLibrary {
+    fn try_from_library(library: Library) -> Result<Self, DeserializationError> {
+        Self::try_from(library).map_err(|err| {
+            DeserializationError::InvalidValue(format!(
+                "Failed to deserialize kernel library: {err}"
+            ))
+        })
+    }
+
     /// Returns the [Kernel] for this kernel library.
     pub fn kernel(&self) -> &Kernel {
         &self.kernel
@@ -499,6 +611,30 @@ impl KernelLibrary {
     /// Destructures this kernel library into individual parts.
     pub fn into_parts(self) -> (Kernel, ModuleInfo, Arc<MastForest>) {
         (self.kernel, self.kernel_info, self.library.mast_forest)
+    }
+
+    /// Reads a kernel library from `source` without validating the embedded MAST forest.
+    ///
+    /// This is only correct when serialization and deserialization happen within the same trust
+    /// domain. A typical use case is reloading bytes that were already validated before being
+    /// persisted to local storage controlled by the same trusted system.
+    ///
+    /// Do not use this for inbound artifact processing across a trust boundary, including bytes
+    /// received over the network or from another party. Authenticating the outer byte stream does
+    /// not prove that embedded MAST node digests are semantically valid.
+    pub fn read_from_unchecked<R: ByteReader>(
+        source: &mut R,
+    ) -> Result<Self, DeserializationError> {
+        let library = Library::read_from_unchecked(source)?;
+        Self::try_from_library(library)
+    }
+
+    /// Reads a kernel library from `bytes` without validating the embedded MAST forest.
+    ///
+    /// See [`KernelLibrary::read_from_unchecked`].
+    pub fn read_from_bytes_unchecked(bytes: &[u8]) -> Result<Self, DeserializationError> {
+        let mut source = SliceReader::new(bytes);
+        Self::read_from_unchecked(&mut source)
     }
 }
 
@@ -634,63 +770,8 @@ impl Serializable for Library {
 /// NOTE: Serialization of libraries is likely to be deprecated in a future release
 impl Deserializable for Library {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let mast_forest = Arc::new(MastForest::read_from(source)?);
-
-        let num_exports = source.read_usize()?;
-        if num_exports == 0 {
-            return Err(DeserializationError::InvalidValue(String::from("No exported procedures")));
-        };
-        let mut exports = BTreeMap::new();
-        for _ in 0..num_exports {
-            let tag = source.read_u8()?;
-            let path: PathBuf = source.read()?;
-            let path = Arc::<Path>::from(path.into_boxed_path());
-            let export = match tag {
-                0 => {
-                    let node = MastNodeId::from_u32_safe(source.read_u32()?, &mast_forest)?;
-                    let signature = if source.read_bool()? {
-                        Some(FunctionTypeDeserializer::read_from(source)?.0)
-                    } else {
-                        None
-                    };
-                    let attributes = AttributeSet::read_from(source)?;
-                    LibraryExport::Procedure(ProcedureExport {
-                        node,
-                        path: path.clone(),
-                        signature,
-                        attributes,
-                    })
-                },
-                1 => {
-                    let value = crate::ast::ConstantValue::read_from(source)?;
-                    LibraryExport::Constant(ConstantExport { path: path.clone(), value })
-                },
-                2 => {
-                    let ty = TypeDeserializer::read_from(source)?.0;
-                    LibraryExport::Type(TypeExport { path: path.clone(), ty })
-                },
-                invalid => {
-                    return Err(DeserializationError::InvalidValue(format!(
-                        "unknown LibraryExport tag: '{invalid}'"
-                    )));
-                },
-            };
-            let (path, export) = normalize_export_for_deserialization(export)
-                .map_err(DeserializationError::InvalidValue)?;
-            if exports.insert(path.clone(), export).is_some() {
-                return Err(DeserializationError::InvalidValue(format!(
-                    "duplicate canonical export path in library artifact: '{path}'"
-                )));
-            }
-        }
-
-        let digest =
-            mast_forest.compute_nodes_commitment(exports.values().filter_map(|e| match e {
-                LibraryExport::Procedure(e) => Some(&e.node),
-                LibraryExport::Constant(_) | LibraryExport::Type(_) => None,
-            }));
-
-        Ok(Self { digest, exports, mast_forest })
+        let mast_forest = Self::read_mast_forest(source, true)?;
+        Self::read_from_with_mast_forest(source, mast_forest)
     }
 }
 
@@ -833,12 +914,7 @@ impl Serializable for KernelLibrary {
 impl Deserializable for KernelLibrary {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let library = Library::read_from(source)?;
-
-        Self::try_from(library).map_err(|err| {
-            DeserializationError::InvalidValue(format!(
-                "Failed to deserialize kernel library: {err}"
-            ))
-        })
+        Self::try_from_library(library)
     }
 }
 

--- a/crates/assembly-syntax/src/library/mod.rs
+++ b/crates/assembly-syntax/src/library/mod.rs
@@ -14,7 +14,7 @@ use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use crate::ast::{AttributeSet, Ident, Path, PathBuf, ProcedureName};
+use crate::ast::{AttributeSet, Ident, Path, PathBuf, PathComponent, ProcedureName};
 
 mod error;
 mod module;
@@ -575,6 +575,48 @@ impl KernelLibrary {
 // LIBRARY SERIALIZATION
 // ================================================================================================
 
+fn export_raw_leaf(path: &Path) -> Result<&str, String> {
+    match path.components().next_back() {
+        Some(Ok(PathComponent::Normal(leaf))) => Ok(leaf),
+        Some(Err(err)) => Err(format!("invalid export path '{path}': {err}")),
+        Some(Ok(PathComponent::Root)) | None => {
+            Err(format!("invalid export path (missing export leaf): '{path}'"))
+        },
+    }
+}
+
+fn canonicalize_export_path(path: &Path) -> Result<Arc<Path>, String> {
+    let canonical = path
+        .to_path_buf()
+        .canonicalize()
+        .map_err(|err| format!("invalid export path '{path}': {err}"))?;
+    Ok(Arc::<Path>::from(canonical.into_boxed_path()))
+}
+
+fn normalize_export_for_deserialization(
+    mut export: LibraryExport,
+) -> Result<(Arc<Path>, LibraryExport), String> {
+    let canonical_path = canonicalize_export_path(export.path().as_ref())?;
+
+    if matches!(export, LibraryExport::Procedure(_)) {
+        let leaf = export_raw_leaf(canonical_path.as_ref())?;
+        ProcedureName::new(leaf).map_err(|err| {
+            format!(
+                "invalid procedure export leaf name '{leaf}' in path '{}': {err}",
+                canonical_path
+            )
+        })?;
+    }
+
+    match &mut export {
+        LibraryExport::Procedure(export) => export.path = canonical_path.clone(),
+        LibraryExport::Constant(export) => export.path = canonical_path.clone(),
+        LibraryExport::Type(export) => export.path = canonical_path.clone(),
+    }
+
+    Ok((canonical_path, export))
+}
+
 /// NOTE: Serialization of libraries is likely to be deprecated in a future release
 impl Serializable for Library {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
@@ -633,7 +675,13 @@ impl Deserializable for Library {
                     )));
                 },
             };
-            exports.insert(path, export);
+            let (path, export) = normalize_export_for_deserialization(export)
+                .map_err(DeserializationError::InvalidValue)?;
+            if exports.insert(path.clone(), export).is_some() {
+                return Err(DeserializationError::InvalidValue(format!(
+                    "duplicate canonical export path in library artifact: '{path}'"
+                )));
+            }
         }
 
         let digest =
@@ -695,6 +743,28 @@ impl<'de> serde::Deserialize<'de> for Library {
 
         struct LibraryVisitor;
 
+        impl LibraryVisitor {
+            fn normalize_exports<E>(
+                items: Vec<LibraryExport>,
+            ) -> Result<BTreeMap<Arc<Path>, LibraryExport>, E>
+            where
+                E: serde::de::Error,
+            {
+                let mut exports = BTreeMap::new();
+                for export in items {
+                    let (path, export) = normalize_export_for_deserialization(export)
+                        .map_err(serde::de::Error::custom)?;
+                    if exports.insert(path.clone(), export).is_some() {
+                        return Err(serde::de::Error::custom(format!(
+                            "duplicate canonical export path in library artifact: '{path}'"
+                        )));
+                    }
+                }
+
+                Ok(exports)
+            }
+        }
+
         impl<'de> Visitor<'de> for LibraryVisitor {
             type Value = Library;
 
@@ -709,10 +779,10 @@ impl<'de> serde::Deserialize<'de> for Library {
                 let mast_forest = seq
                     .next_element()?
                     .ok_or_else(|| serde::de::Error::invalid_length(0, &self))?;
-                let exports: Vec<LibraryExport> = seq
+                let export_items: Vec<LibraryExport> = seq
                     .next_element()?
                     .ok_or_else(|| serde::de::Error::invalid_length(1, &self))?;
-                let exports = exports.into_iter().map(|export| (export.path(), export)).collect();
+                let exports = Self::normalize_exports(export_items)?;
                 Library::new(mast_forest, exports).map_err(serde::de::Error::custom)
             }
 
@@ -735,9 +805,7 @@ impl<'de> serde::Deserialize<'de> for Library {
                                 return Err(serde::de::Error::duplicate_field("exports"));
                             }
                             let items: Vec<LibraryExport> = map.next_value()?;
-                            exports = Some(
-                                items.into_iter().map(|export| (export.path(), export)).collect(),
-                            );
+                            exports = Some(Self::normalize_exports(items)?);
                         },
                     }
                 }
@@ -1274,5 +1342,65 @@ mod tests {
 
         let ty = TypeDeserializer::read_from(&mut SliceReader::new(&bytes)).unwrap();
         assert!(matches!(ty.0, Type::Function(_)));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_library_deserialization_rejects_duplicate_canonical_export_paths() {
+        let quoted = Arc::<Path>::from(Path::validate(r#"::foo::"bar""#).unwrap());
+        let unquoted = Arc::<Path>::from(Path::validate("::foo::bar").unwrap());
+
+        let mut exports = BTreeMap::new();
+        exports.insert(
+            quoted.clone(),
+            LibraryExport::Type(TypeExport { path: quoted, ty: Type::Felt }),
+        );
+        exports.insert(
+            unquoted.clone(),
+            LibraryExport::Type(TypeExport { path: unquoted, ty: Type::Felt }),
+        );
+
+        let lib =
+            Library::new(Arc::new(MastForest::new()), exports).expect("library must validate");
+        let json = serde_json::to_string(&lib).expect("library serialization must succeed");
+
+        let err = serde_json::from_str::<Library>(&json).expect_err(
+            "expected duplicate canonical export paths to be rejected during serde deserialization",
+        );
+        let message = alloc::format!("{err}");
+        assert!(
+            message.contains("duplicate canonical export path in library artifact"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_library_deserialization_rejects_malformed_quoted_procedure_leaf() {
+        use miden_core::{
+            mast::{BasicBlockNodeBuilder, MastForestContributor},
+            operations::Operation,
+        };
+
+        let mut mast_forest = MastForest::new();
+        let node = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+            .add_to_forest(&mut mast_forest)
+            .expect("must create MAST node");
+        mast_forest.make_root(node);
+
+        let bad = Arc::<Path>::from(Path::validate(r#"::foo::"bad name""#).unwrap());
+        let mut exports = BTreeMap::new();
+        exports.insert(bad.clone(), LibraryExport::Procedure(ProcedureExport::new(node, bad)));
+
+        let lib = Library::new(Arc::new(mast_forest), exports).expect("library must validate");
+        let json = serde_json::to_string(&lib).expect("library serialization must succeed");
+
+        let err = serde_json::from_str::<Library>(&json)
+            .expect_err("expected malformed procedure export leaf name rejection during serde");
+        let message = alloc::format!("{err}");
+        assert!(
+            message.contains("invalid procedure export leaf name"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/assembly-syntax/src/library/mod.rs
+++ b/crates/assembly-syntax/src/library/mod.rs
@@ -743,15 +743,21 @@ fn normalize_export_for_deserialization(
     mut export: LibraryExport,
 ) -> Result<(Arc<Path>, LibraryExport), String> {
     let canonical_path = canonicalize_export_path(export.path().as_ref())?;
+    let leaf = export_raw_leaf(canonical_path.as_ref())?;
 
-    if matches!(export, LibraryExport::Procedure(_)) {
-        let leaf = export_raw_leaf(canonical_path.as_ref())?;
-        ProcedureName::new(leaf).map_err(|err| {
-            format!(
-                "invalid procedure export leaf name '{leaf}' in path '{}': {err}",
-                canonical_path
-            )
-        })?;
+    match &export {
+        LibraryExport::Procedure(_) => {
+            ProcedureName::new(leaf).map_err(|err| {
+                format!(
+                    "invalid procedure export leaf name '{leaf}' in path '{canonical_path}': {err}"
+                )
+            })?;
+        },
+        LibraryExport::Constant(_) | LibraryExport::Type(_) => {
+            Ident::new(leaf).map_err(|err| {
+                format!("invalid export leaf name '{leaf}' in path '{canonical_path}': {err}")
+            })?;
+        },
     }
 
     match &mut export {
@@ -1040,7 +1046,7 @@ impl Arbitrary for Library {
             .boxed()
     }
 
-    type Strategy = proptest::prelude::BoxedStrategy<Self>;
+    type Strategy = BoxedStrategy<Self>;
 }
 
 #[cfg(test)]
@@ -1105,5 +1111,47 @@ mod tests {
             message.contains("invalid procedure export leaf name"),
             "unexpected error: {err}"
         );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_library_deserialization_rejects_malformed_quoted_constant_leaf() {
+        let bad = Arc::<Path>::from(Path::validate(r#"::foo::"bad name""#).unwrap());
+        let mut exports = BTreeMap::new();
+        exports.insert(
+            bad.clone(),
+            LibraryExport::Constant(ConstantExport {
+                path: bad,
+                value: ConstantValue::Int(miden_debug_types::Span::unknown(
+                    crate::parser::IntValue::from(1u8),
+                )),
+            }),
+        );
+
+        let lib =
+            Library::new(Arc::new(MastForest::new()), exports).expect("library must validate");
+        let json = serde_json::to_string(&lib).expect("library serialization must succeed");
+
+        let err = serde_json::from_str::<Library>(&json)
+            .expect_err("expected malformed constant export leaf name rejection during serde");
+        let message = alloc::format!("{err}");
+        assert!(message.contains("invalid export leaf name"), "unexpected error: {err}");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_library_deserialization_rejects_malformed_quoted_type_leaf() {
+        let bad = Arc::<Path>::from(Path::validate(r#"::foo::"bad name""#).unwrap());
+        let mut exports = BTreeMap::new();
+        exports.insert(bad.clone(), LibraryExport::Type(TypeExport { path: bad, ty: Type::Felt }));
+
+        let lib =
+            Library::new(Arc::new(MastForest::new()), exports).expect("library must validate");
+        let json = serde_json::to_string(&lib).expect("library serialization must succeed");
+
+        let err = serde_json::from_str::<Library>(&json)
+            .expect_err("expected malformed type export leaf name rejection during serde");
+        let message = alloc::format!("{err}");
+        assert!(message.contains("invalid export leaf name"), "unexpected error: {err}");
     }
 }

--- a/crates/assembly-syntax/src/library/module.rs
+++ b/crates/assembly-syntax/src/library/module.rs
@@ -18,6 +18,10 @@ pub struct ModuleInfo {
 }
 
 impl ModuleInfo {
+    pub(crate) fn raw_items(&self) -> &[ItemInfo] {
+        &self.items
+    }
+
     /// Returns a new [`ModuleInfo`] instantiated library path.
     pub fn new(path: Arc<Path>) -> Self {
         Self { path, items: Vec::new() }

--- a/crates/assembly-syntax/src/sema/context.rs
+++ b/crates/assembly-syntax/src/sema/context.rs
@@ -287,7 +287,7 @@ mod tests {
 
         fn get_source_file_for(
             &self,
-            span: crate::debuginfo::SourceSpan,
+            span: SourceSpan,
         ) -> Option<Arc<crate::debuginfo::SourceFile>> {
             <AnalysisContext as constants::ConstEnvironment>::get_source_file_for(self.inner, span)
         }
@@ -376,7 +376,7 @@ mod tests {
         let root_name = make_name(0);
         let mut env = CountingEnv::new(&mut context);
         let root = make_ref(root_name);
-        let result = crate::ast::constants::eval::expr(&root, &mut env)
+        let result = constants::eval::expr(&root, &mut env)
             .expect("shared-subexpression constant graph should evaluate");
 
         assert!(

--- a/crates/assembly-syntax/src/sema/context.rs
+++ b/crates/assembly-syntax/src/sema/context.rs
@@ -17,6 +17,7 @@ use crate::ast::{
 /// This maintains the state for semantic analysis of a single [Module].
 pub struct AnalysisContext {
     constants: BTreeMap<Ident, Constant>,
+    cached_constant_values: BTreeMap<Ident, ConstantValue>,
     imported: BTreeSet<Ident>,
     procedures: BTreeSet<ProcedureName>,
     errors: Vec<SemanticAnalysisError>,
@@ -37,7 +38,9 @@ impl constants::ConstEnvironment for AnalysisContext {
     }
     #[inline]
     fn get(&mut self, name: &Ident) -> Result<Option<CachedConstantValue<'_>>, Self::Error> {
-        if let Some(constant) = self.constants.get(name) {
+        if let Some(value) = self.cached_constant_values.get(name) {
+            Ok(Some(CachedConstantValue::Hit(value)))
+        } else if let Some(constant) = self.constants.get(name) {
             Ok(Some(CachedConstantValue::Miss(&constant.value)))
         } else if self.imported.contains(name) {
             // We don't have the definition available yet
@@ -61,12 +64,25 @@ impl constants::ConstEnvironment for AnalysisContext {
             Ok(None)
         }
     }
+
+    #[inline]
+    fn on_eval_completed(&mut self, name: Span<&Path>, value: &ConstantExpr) {
+        let Some(name) = name.as_ident() else {
+            return;
+        };
+        if let Some(value) = value.as_value() {
+            self.cached_constant_values.insert(name, value);
+        } else {
+            self.cached_constant_values.remove(&name);
+        }
+    }
 }
 
 impl AnalysisContext {
     pub fn new(source_file: Arc<SourceFile>, source_manager: Arc<dyn SourceManager>) -> Self {
         Self {
             constants: Default::default(),
+            cached_constant_values: Default::default(),
             imported: Default::default(),
             procedures: Default::default(),
             errors: Default::default(),
@@ -116,6 +132,7 @@ impl AnalysisContext {
     /// attempting to define the same constant twice.
     pub fn register_constant(&mut self, constant: Constant) {
         let name = constant.name.clone();
+        self.cached_constant_values.remove(&name);
         if let Some(prev) = self.constants.get(&name) {
             self.errors.push(SemanticAnalysisError::SymbolConflict {
                 span: constant.span,
@@ -130,6 +147,7 @@ impl AnalysisContext {
     ///
     /// This also has the effect of validating that the constant expressions themselves are valid.
     pub fn simplify_constants(&mut self) {
+        self.cached_constant_values.clear();
         let constants = self.constants.keys().cloned().collect::<Vec<_>>();
 
         for constant in constants.iter() {
@@ -139,9 +157,15 @@ impl AnalysisContext {
             ));
             match crate::ast::constants::eval::expr(&expr, self) {
                 Ok(value) => {
+                    if let Some(cached) = value.as_value() {
+                        self.cached_constant_values.insert(constant.clone(), cached);
+                    } else {
+                        self.cached_constant_values.remove(constant);
+                    }
                     self.constants.get_mut(constant).unwrap().value = value;
                 },
                 Err(err) => {
+                    self.cached_constant_values.remove(constant);
                     self.errors.push(err);
                 },
             }
@@ -213,4 +237,157 @@ impl AnalysisContext {
 
     #[cfg(not(feature = "std"))]
     fn emit_warnings(self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{boxed::Box, string::String, sync::Arc};
+    use core::cell::Cell;
+
+    use super::AnalysisContext;
+    use crate::{
+        Path, PathBuf,
+        ast::{
+            Constant, ConstantExpr, ConstantOp, ConstantValue, Ident, Visibility,
+            constants::{self, eval::CachedConstantValue},
+        },
+        debuginfo::{
+            DefaultSourceManager, SourceContent, SourceLanguage, SourceManager, SourceSpan, Span,
+            Uri,
+        },
+        parser::IntValue,
+    };
+
+    struct CountingEnv<'a> {
+        inner: &'a mut AnalysisContext,
+        hits: Cell<usize>,
+        misses: Cell<usize>,
+    }
+
+    impl<'a> CountingEnv<'a> {
+        fn new(inner: &'a mut AnalysisContext) -> Self {
+            Self {
+                inner,
+                hits: Cell::new(0),
+                misses: Cell::new(0),
+            }
+        }
+
+        fn hits(&self) -> usize {
+            self.hits.get()
+        }
+
+        fn misses(&self) -> usize {
+            self.misses.get()
+        }
+    }
+
+    impl constants::ConstEnvironment for CountingEnv<'_> {
+        type Error = super::SemanticAnalysisError;
+
+        fn get_source_file_for(
+            &self,
+            span: crate::debuginfo::SourceSpan,
+        ) -> Option<Arc<crate::debuginfo::SourceFile>> {
+            <AnalysisContext as constants::ConstEnvironment>::get_source_file_for(self.inner, span)
+        }
+
+        fn get(&mut self, name: &Ident) -> Result<Option<CachedConstantValue<'_>>, Self::Error> {
+            let value = <AnalysisContext as constants::ConstEnvironment>::get(self.inner, name)?;
+            if let Some(ref value) = value {
+                match value {
+                    CachedConstantValue::Hit(_) => self.hits.set(self.hits.get() + 1),
+                    CachedConstantValue::Miss(_) => self.misses.set(self.misses.get() + 1),
+                }
+            }
+            Ok(value)
+        }
+
+        fn get_by_path(
+            &mut self,
+            path: Span<&Path>,
+        ) -> Result<Option<CachedConstantValue<'_>>, Self::Error> {
+            if let Some(name) = path.as_ident() {
+                self.get(&name)
+            } else {
+                <AnalysisContext as constants::ConstEnvironment>::get_by_path(self.inner, path)
+            }
+        }
+
+        fn on_eval_completed(&mut self, name: Span<&Path>, value: &ConstantExpr) {
+            <AnalysisContext as constants::ConstEnvironment>::on_eval_completed(
+                self.inner, name, value,
+            );
+        }
+    }
+
+    fn make_name(i: usize) -> Ident {
+        format!("C{i:05}").parse().expect("generated constant name must be valid")
+    }
+
+    fn make_ref(name: Ident) -> ConstantExpr {
+        let path = Arc::<Path>::from(PathBuf::from(name));
+        ConstantExpr::Var(Span::new(SourceSpan::default(), path))
+    }
+
+    fn make_shared_subexpression_chain(context: &mut AnalysisContext, depth: usize) {
+        for i in 0..depth {
+            let name = make_name(i);
+            let next = make_name(i + 1);
+            context.register_constant(Constant::new(
+                SourceSpan::default(),
+                Visibility::Public,
+                name,
+                ConstantExpr::BinaryOp {
+                    span: SourceSpan::default(),
+                    op: ConstantOp::Add,
+                    lhs: Box::new(make_ref(next.clone())),
+                    rhs: Box::new(make_ref(next)),
+                },
+            ));
+        }
+
+        context.register_constant(Constant::new(
+            SourceSpan::default(),
+            Visibility::Public,
+            make_name(depth),
+            ConstantExpr::Int(Span::new(SourceSpan::default(), IntValue::from(1_u32))),
+        ));
+    }
+
+    #[test]
+    fn semantic_const_eval_memoizes_shared_subexpressions() {
+        let source_manager = Arc::new(DefaultSourceManager::default());
+        let uri =
+            Uri::from(String::from("mem://const-eval-shared-subexpressions").into_boxed_str());
+        let content = SourceContent::new(
+            SourceLanguage::Masm,
+            uri.clone(),
+            String::from("begin\n    nop\nend\n").into_boxed_str(),
+        );
+        let source_file = source_manager.load_from_raw_parts(uri, content);
+        let mut context = AnalysisContext::new(source_file, source_manager);
+
+        // Each Ci references C(i+1) twice, so without memoization the number of misses would
+        // grow exponentially with depth.
+        let depth = 24;
+        make_shared_subexpression_chain(&mut context, depth);
+
+        let root_name = make_name(0);
+        let mut env = CountingEnv::new(&mut context);
+        let root = make_ref(root_name);
+        let result = crate::ast::constants::eval::expr(&root, &mut env)
+            .expect("shared-subexpression constant graph should evaluate");
+
+        assert!(
+            matches!(result.as_value(), Some(ConstantValue::Int(_))),
+            "evaluation should produce a concrete integer constant value"
+        );
+        assert_eq!(env.misses(), depth + 1, "each constant in the chain should miss at most once");
+        assert_eq!(
+            env.hits(),
+            depth,
+            "the second reference to each dependency should be served from cache"
+        );
+    }
 }

--- a/crates/assembly-syntax/src/sema/errors.rs
+++ b/crates/assembly-syntax/src/sema/errors.rs
@@ -240,6 +240,8 @@ impl From<SymbolResolutionError> for SemanticAnalysisError {
 /// Represents a system limit that was exceeded
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LimitKind {
+    /// The total number of items in a module
+    Items,
     /// The total number of procedures in a module
     Procedures,
     /// The total number of procedure locals
@@ -257,6 +259,7 @@ pub enum LimitKind {
 impl fmt::Display for LimitKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Self::Items => f.write_str("too many items in module"),
             Self::Procedures => f.write_str("too many procedures in module"),
             Self::Locals => f.write_str("too many procedure locals"),
             Self::Imports => f.write_str("too many imported procedures"),

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -6,7 +6,8 @@ mod tests;
 
 use alloc::{
     boxed::Box,
-    collections::{BTreeSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    string::ToString,
     sync::Arc,
     vec::Vec,
 };
@@ -15,10 +16,11 @@ use miden_core::{Word, crypto::hash::Poseidon2};
 use miden_debug_types::{SourceFile, SourceManager, Span, Spanned};
 use smallvec::SmallVec;
 
+use self::passes::{LocalInvokeTarget, VerifyInvokeTargets};
 pub use self::{
     context::AnalysisContext,
-    errors::{SemanticAnalysisError, SyntaxError},
-    passes::{ConstEvalVisitor, VerifyInvokeTargets, VerifyRepeatCounts},
+    errors::{LimitKind, SemanticAnalysisError, SyntaxError},
+    passes::{ConstEvalVisitor, VerifyRepeatCounts},
 };
 use crate::{ast::*, parser::WordValue};
 
@@ -181,7 +183,13 @@ pub fn analyze(
 /// of a module graph and global program analysis to perform any remaining transformations.
 fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<(), SyntaxError> {
     let is_kernel = module.is_kernel();
-    let locals = BTreeSet::from_iter(module.items().iter().map(|p| p.name().clone()));
+    let locals = BTreeMap::from_iter(
+        module
+            .items()
+            .iter()
+            .map(|item| (item.name().as_str().to_string(), LocalInvokeTarget::from(item))),
+    );
+    let mut used_aliases = BTreeSet::default();
     let mut items = VecDeque::from(core::mem::take(&mut module.items));
     while let Some(item) = items.pop_front() {
         match item {
@@ -223,36 +231,69 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
                         analyzer,
                         module,
                         &locals,
+                        &mut used_aliases,
                         Some(procedure.name().clone()),
                     );
                     let _ = visitor.visit_mut_procedure(&mut procedure);
                 }
-                module.items.push(Export::Procedure(procedure));
+                if let Err(err) = module.push_export(Export::Procedure(procedure)) {
+                    analyzer.error(err);
+                }
             },
             Export::Alias(mut alias) => {
                 log::debug!(target: "verify-invoke", "visiting alias {}", alias.target());
                 {
-                    let mut visitor = VerifyInvokeTargets::new(analyzer, module, &locals, None);
+                    let mut visitor = VerifyInvokeTargets::new(
+                        analyzer,
+                        module,
+                        &locals,
+                        &mut used_aliases,
+                        None,
+                    );
                     let _ = visitor.visit_mut_alias(&mut alias);
                 }
-                module.items.push(Export::Alias(alias));
+                if let Err(err) = module.push_export(Export::Alias(alias)) {
+                    analyzer.error(err);
+                }
             },
             Export::Constant(mut constant) => {
                 log::debug!(target: "verify-invoke", "visiting constant {}", constant.name());
                 {
-                    let mut visitor = VerifyInvokeTargets::new(analyzer, module, &locals, None);
+                    let mut visitor = VerifyInvokeTargets::new(
+                        analyzer,
+                        module,
+                        &locals,
+                        &mut used_aliases,
+                        None,
+                    );
                     let _ = visitor.visit_mut_constant(&mut constant);
                 }
-                module.items.push(Export::Constant(constant));
+                if let Err(err) = module.push_export(Export::Constant(constant)) {
+                    analyzer.error(err);
+                }
             },
             Export::Type(mut ty) => {
                 log::debug!(target: "verify-invoke", "visiting type {}", ty.name());
                 {
-                    let mut visitor = VerifyInvokeTargets::new(analyzer, module, &locals, None);
+                    let mut visitor = VerifyInvokeTargets::new(
+                        analyzer,
+                        module,
+                        &locals,
+                        &mut used_aliases,
+                        None,
+                    );
                     let _ = visitor.visit_mut_type_decl(&mut ty);
                 }
-                module.items.push(Export::Type(ty));
+                if let Err(err) = module.push_export(Export::Type(ty)) {
+                    analyzer.error(err);
+                }
             },
+        }
+    }
+
+    for alias in module.aliases_mut() {
+        if alias.uses == 0 && used_aliases.contains(alias.name().as_str()) {
+            alias.uses = 1;
         }
     }
 

--- a/crates/assembly-syntax/src/sema/passes/mod.rs
+++ b/crates/assembly-syntax/src/sema/passes/mod.rs
@@ -2,7 +2,5 @@ mod const_eval;
 mod verify_invoke;
 mod verify_repeat;
 
-pub use self::{
-    const_eval::ConstEvalVisitor, verify_invoke::VerifyInvokeTargets,
-    verify_repeat::VerifyRepeatCounts,
-};
+pub(super) use self::verify_invoke::{LocalInvokeTarget, VerifyInvokeTargets};
+pub use self::{const_eval::ConstEvalVisitor, verify_repeat::VerifyRepeatCounts};

--- a/crates/assembly-syntax/src/sema/passes/verify_invoke.rs
+++ b/crates/assembly-syntax/src/sema/passes/verify_invoke.rs
@@ -1,4 +1,9 @@
-use alloc::{boxed::Box, collections::BTreeSet, sync::Arc};
+use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet},
+    string::{String, ToString},
+    sync::Arc,
+};
 use core::ops::ControlFlow;
 
 use miden_debug_types::{SourceSpan, Span, Spanned};
@@ -8,6 +13,25 @@ use crate::{
     ast::*,
     sema::{AnalysisContext, SemanticAnalysisError},
 };
+
+const MAX_ALIAS_EXPANSION_DEPTH: usize = 128;
+
+#[derive(Debug, Clone)]
+pub(crate) enum LocalInvokeTarget {
+    Procedure,
+    Alias(AliasTarget),
+    Other(SourceSpan),
+}
+
+impl From<&Export> for LocalInvokeTarget {
+    fn from(item: &Export) -> Self {
+        match item {
+            Export::Procedure(_) => Self::Procedure,
+            Export::Alias(alias) => Self::Alias(alias.target().clone()),
+            Export::Constant(_) | Export::Type(_) => Self::Other(item.span()),
+        }
+    }
+}
 
 /// This visitor visits every `exec`, `call`, `syscall`, and `procref`, and ensures that the
 /// invocation target for that call is resolvable to the extent possible within the current
@@ -20,25 +44,28 @@ use crate::{
 /// We attempt to apply as many call-related validations as we can here, however we are limited
 /// until later stages of compilation on what we can know in the context of a single module.
 /// As a result, more complex analyses are reserved until assembly.
-pub struct VerifyInvokeTargets<'a> {
+pub(crate) struct VerifyInvokeTargets<'a> {
     analyzer: &'a mut AnalysisContext,
     module: &'a mut Module,
-    procedures: &'a BTreeSet<Ident>,
+    locals: &'a BTreeMap<String, LocalInvokeTarget>,
+    used_aliases: &'a mut BTreeSet<String>,
     current_procedure: Option<ProcedureName>,
     invoked: BTreeSet<Invoke>,
 }
 
 impl<'a> VerifyInvokeTargets<'a> {
-    pub fn new(
+    pub(crate) fn new(
         analyzer: &'a mut AnalysisContext,
         module: &'a mut Module,
-        procedures: &'a BTreeSet<Ident>,
+        locals: &'a BTreeMap<String, LocalInvokeTarget>,
+        used_aliases: &'a mut BTreeSet<String>,
         current_procedure: Option<ProcedureName>,
     ) -> Self {
         Self {
             analyzer,
             module,
-            procedures,
+            locals,
+            used_aliases,
             current_procedure,
             invoked: Default::default(),
         }
@@ -46,12 +73,105 @@ impl<'a> VerifyInvokeTargets<'a> {
 }
 
 impl VerifyInvokeTargets<'_> {
+    fn track_used_alias_name(&mut self, name: &str) {
+        self.used_aliases.insert(name.to_string());
+    }
+
     fn resolve_local(&mut self, name: &Ident) -> ControlFlow<()> {
-        if !self.procedures.contains(name) {
+        let mut visited = BTreeSet::default();
+        self.resolve_local_name(name.span(), name.as_str(), &mut visited)
+    }
+
+    fn resolve_local_name(
+        &mut self,
+        span: SourceSpan,
+        name: &str,
+        visited: &mut BTreeSet<String>,
+    ) -> ControlFlow<()> {
+        if visited.len() > MAX_ALIAS_EXPANSION_DEPTH {
             self.analyzer.error(SemanticAnalysisError::SymbolResolutionError(Box::new(
-                SymbolResolutionError::undefined(name.span(), &self.analyzer.source_manager()),
+                SymbolResolutionError::alias_expansion_depth_exceeded(
+                    span,
+                    MAX_ALIAS_EXPANSION_DEPTH,
+                    &self.analyzer.source_manager(),
+                ),
             )));
+            return ControlFlow::Continue(());
         }
+
+        if self.current_procedure.as_ref().is_some_and(|curr| curr.as_str() == name) {
+            self.analyzer.error(SemanticAnalysisError::SelfRecursive { span });
+            return ControlFlow::Continue(());
+        }
+
+        let Some(item) = self.locals.get(name).cloned() else {
+            self.analyzer.error(SemanticAnalysisError::SymbolResolutionError(Box::new(
+                SymbolResolutionError::undefined(span, &self.analyzer.source_manager()),
+            )));
+            return ControlFlow::Continue(());
+        };
+
+        match &item {
+            LocalInvokeTarget::Procedure => ControlFlow::Continue(()),
+            LocalInvokeTarget::Other(actual) => {
+                self.analyzer.error(SemanticAnalysisError::SymbolResolutionError(Box::new(
+                    SymbolResolutionError::invalid_symbol_type(
+                        span,
+                        "procedure",
+                        *actual,
+                        &self.analyzer.source_manager(),
+                    ),
+                )));
+                ControlFlow::Continue(())
+            },
+            LocalInvokeTarget::Alias(target) => {
+                self.track_used_alias_name(name);
+
+                if !visited.insert(name.to_string()) {
+                    self.analyzer.error(SemanticAnalysisError::SymbolResolutionError(Box::new(
+                        SymbolResolutionError::alias_expansion_cycle(
+                            span,
+                            &self.analyzer.source_manager(),
+                        ),
+                    )));
+                    return ControlFlow::Continue(());
+                }
+
+                self.resolve_local_alias_target(span, target, visited)
+            },
+        }
+    }
+
+    fn resolve_local_alias_target(
+        &mut self,
+        span: SourceSpan,
+        target: &AliasTarget,
+        visited: &mut BTreeSet<String>,
+    ) -> ControlFlow<()> {
+        match target {
+            AliasTarget::MastRoot(_) => ControlFlow::Continue(()),
+            AliasTarget::Path(path) => self.resolve_invocation_path(span, path.inner(), visited),
+        }
+    }
+
+    fn resolve_invocation_path(
+        &mut self,
+        span: SourceSpan,
+        path: &Path,
+        visited: &mut BTreeSet<String>,
+    ) -> ControlFlow<()> {
+        if let Some(name) = path.as_ident() {
+            return self.resolve_local_name(span, name.as_str(), visited);
+        }
+
+        if path.parent().is_some_and(|parent| parent == self.module.path()) {
+            return self.resolve_local_name(span, path.last().unwrap(), visited);
+        }
+
+        if self.resolve_external(span, path).is_none() {
+            self.analyzer.error(SemanticAnalysisError::MissingImport { span });
+        }
+
         ControlFlow::Continue(())
     }
     fn resolve_external(&mut self, span: SourceSpan, path: &Path) -> Option<InvocationTarget> {
@@ -65,12 +185,16 @@ impl VerifyInvokeTargets<'_> {
             log::debug!(target: "verify-invoke", "found import '{}'", import.target());
             import.uses += 1;
             match import.target() {
-                AliasTarget::MastRoot(_) => {
-                    self.analyzer.error(SemanticAnalysisError::InvalidInvokeTargetViaImport {
-                        span,
-                        import: import.span(),
-                    });
-                    None
+                AliasTarget::MastRoot(digest) => {
+                    if rest.is_empty() {
+                        Some(InvocationTarget::MastRoot(*digest))
+                    } else {
+                        self.analyzer.error(SemanticAnalysisError::InvalidInvokeTargetViaImport {
+                            span,
+                            import: import.span(),
+                        });
+                        None
+                    }
                 },
                 // If we have an import like `use lib::lib`, the base `lib` has been shadowed, so
                 // we cannot attempt to resolve further. Instead, we use the target path we have.
@@ -86,13 +210,17 @@ impl VerifyInvokeTargets<'_> {
                     let resolved = self.resolve_external(path.span(), path.inner())?;
                     match resolved {
                         InvocationTarget::MastRoot(digest) => {
-                            self.analyzer.error(
-                                SemanticAnalysisError::InvalidInvokeTargetViaImport {
-                                    span,
-                                    import: digest.span(),
-                                },
-                            );
-                            None
+                            if rest.is_empty() {
+                                Some(InvocationTarget::MastRoot(digest))
+                            } else {
+                                self.analyzer.error(
+                                    SemanticAnalysisError::InvalidInvokeTargetViaImport {
+                                        span,
+                                        import: digest.span(),
+                                    },
+                                );
+                                None
+                            }
                         },
                         // We can consider this path fully-resolved, and mark it absolute, if it is
                         // not already
@@ -111,9 +239,7 @@ impl VerifyInvokeTargets<'_> {
         }
     }
     fn track_used_alias(&mut self, name: &Ident) {
-        if let Some(alias) = self.module.aliases_mut().find(|a| a.name() == name) {
-            alias.uses += 1;
-        }
+        self.track_used_alias_name(name.as_str());
     }
 }
 
@@ -211,10 +337,7 @@ impl VisitMut for VerifyInvokeTargets<'_> {
                     return ControlFlow::Continue(());
                 };
 
-                if let Some(via) = self.module.get_import_mut(ns) {
-                    via.uses += 1;
-                    assert!(via.is_used());
-                }
+                self.track_used_alias_name(ns);
                 ControlFlow::Continue(())
             },
         }
@@ -273,20 +396,16 @@ impl VisitMut for VerifyInvokeTargets<'_> {
     fn visit_mut_type_ref(&mut self, path: &mut Span<Arc<Path>>) -> ControlFlow<()> {
         if let Some(name) = path.as_ident() {
             self.track_used_alias(&name);
-        } else if let Some((module, _)) = path.split_first()
-            && let Some(alias) = self.module.aliases_mut().find(|a| a.name().as_str() == module)
-        {
-            alias.uses += 1;
+        } else if let Some((module, _)) = path.split_first() {
+            self.track_used_alias_name(module);
         }
         ControlFlow::Continue(())
     }
     fn visit_mut_constant_ref(&mut self, path: &mut Span<Arc<Path>>) -> ControlFlow<()> {
         if let Some(name) = path.as_ident() {
             self.track_used_alias(&name);
-        } else if let Some((module, _)) = path.split_first()
-            && let Some(alias) = self.module.aliases_mut().find(|a| a.name().as_str() == module)
-        {
-            alias.uses += 1;
+        } else if let Some((module, _)) = path.split_first() {
+            self.track_used_alias_name(module);
         }
         ControlFlow::Continue(())
     }

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -1,7 +1,17 @@
+use alloc::{
+    string::{String, ToString},
+    sync::Arc,
+};
+
+use miden_debug_types::{Span, Spanned};
+
 use crate::{
-    MAX_REPEAT_COUNT,
-    ast::{Constant, Export, Module},
+    MAX_REPEAT_COUNT, Path,
+    ast::{
+        Constant, ConstantExpr, Export, Module, ModuleKind, TypeAlias, TypeExpr, Visibility, types,
+    },
     diagnostics::reporting::PrintDiagnostic,
+    sema::SemanticAnalysisError,
     testing::SyntaxTestContext,
 };
 
@@ -57,6 +67,119 @@ fn assert_symbol_conflict(error: &miden_utils_diagnostics::Report, symbol: &str)
         prev_span_text.contains(symbol),
         "previous conflict span should include symbol '{symbol}', got: {prev_span_text:?}"
     );
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DefinitionKind {
+    Alias,
+    Procedure,
+    Constant,
+    Type,
+}
+
+impl DefinitionKind {
+    fn declaration(self, symbol: &str) -> String {
+        match self {
+            Self::Alias => format!("use ::dep::{}", quote_ident_if_needed(symbol)),
+            Self::Procedure => {
+                format!("proc {}\n    nop\nend", quote_ident_if_needed(symbol))
+            },
+            Self::Constant => format!("const {symbol} = 1"),
+            Self::Type => format!("type {} = felt", quote_ident_if_needed(symbol)),
+        }
+    }
+}
+
+fn quote_ident_if_needed(symbol: &str) -> String {
+    let is_bare_ident = symbol
+        .bytes()
+        .all(|b| b == b'_' || b.is_ascii_lowercase() || b.is_ascii_digit());
+    if is_bare_ident {
+        symbol.to_string()
+    } else {
+        format!("\"{symbol}\"")
+    }
+}
+
+fn assert_cross_kind_conflict(first: DefinitionKind, second: DefinitionKind) {
+    if is_constant_type_pair(first, second) {
+        assert_constant_type_conflict_via_module_api(first, second);
+        return;
+    }
+
+    let symbol = if matches!(first, DefinitionKind::Constant)
+        || matches!(second, DefinitionKind::Constant)
+    {
+        "THING"
+    } else {
+        "thing"
+    };
+    let context = SyntaxTestContext::default();
+    let source = format!("{}\n{}\n", first.declaration(symbol), second.declaration(symbol));
+    let message = format!("expected symbol conflict during analysis ({first:?} then {second:?})");
+    let error = context.parse_module(source).expect_err(&message);
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    if error.downcast_ref::<crate::sema::SyntaxError>().is_none() {
+        panic!("expected SyntaxError ({first:?} then {second:?}), got: {rendered}");
+    }
+    assert_symbol_conflict(&error, symbol);
+    assert!(rendered.contains("symbol conflict"));
+    assert!(rendered.contains(symbol));
+}
+
+fn is_constant_type_pair(first: DefinitionKind, second: DefinitionKind) -> bool {
+    matches!(
+        (first, second),
+        (DefinitionKind::Constant, DefinitionKind::Type)
+            | (DefinitionKind::Type, DefinitionKind::Constant)
+    )
+}
+
+fn assert_constant_type_conflict_via_module_api(first: DefinitionKind, second: DefinitionKind) {
+    let symbol = "dup";
+    let mut module = Module::new(ModuleKind::Library, Path::new("mod"));
+
+    match first {
+        DefinitionKind::Constant => module
+            .define_constant(constant_with_name(symbol))
+            .expect("expected initial constant definition to succeed"),
+        DefinitionKind::Type => module
+            .define_type(type_alias_with_name(symbol))
+            .expect("expected initial type definition to succeed"),
+        _ => unreachable!("only constant/type pairs should use this helper"),
+    }
+
+    let result = match second {
+        DefinitionKind::Constant => module.define_constant(constant_with_name(symbol)),
+        DefinitionKind::Type => module.define_type(type_alias_with_name(symbol)),
+        _ => unreachable!("only constant/type pairs should use this helper"),
+    };
+    assert!(
+        matches!(result, Err(SemanticAnalysisError::SymbolConflict { .. })),
+        "expected SymbolConflict when defining {second:?} after {first:?}, got {result:?}"
+    );
+}
+
+fn ident_with_name(name: &str) -> crate::ast::Ident {
+    crate::ast::Ident::from_raw_parts(Span::unknown(Arc::<str>::from(name)))
+}
+
+fn constant_with_name(name: &str) -> Constant {
+    let ident = ident_with_name(name);
+    Constant::new(
+        ident.span(),
+        Visibility::Private,
+        ident,
+        ConstantExpr::String(ident_with_name("value")),
+    )
+}
+
+fn type_alias_with_name(name: &str) -> TypeAlias {
+    TypeAlias::new(
+        Visibility::Private,
+        ident_with_name(name),
+        TypeExpr::Primitive(Span::unknown(types::Type::Felt)),
+    )
 }
 
 #[test]
@@ -145,73 +268,19 @@ pub const ACCOUNT_ID_SUFFIX_OFFSET = ACCOUNT_ID_AND_NONCE_OFFSET + 2
 }
 
 #[test]
-fn define_alias_detects_cross_kind_duplicate_with_type() {
-    let context = SyntaxTestContext::default();
-    let error = context
-        .parse_module(
-            r#"
-type thing = felt
-use ::dep::thing
-"#,
-        )
-        .expect_err("expected conflicting type/alias names to be rejected during analysis");
-    assert_symbol_conflict(&error, "thing");
-    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
-    assert!(rendered.contains("symbol conflict"));
-    assert!(rendered.contains("thing"));
-}
-
-#[test]
-fn define_procedure_detects_cross_kind_duplicate_with_type() {
-    let context = SyntaxTestContext::default();
-    let error = context
-        .parse_module(
-            r#"
-type thing = felt
-proc thing
-    nop
-end
-"#,
-        )
-        .expect_err("expected conflicting type/procedure names to be rejected during analysis");
-    assert_symbol_conflict(&error, "thing");
-    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
-    assert!(rendered.contains("symbol conflict"));
-    assert!(rendered.contains("thing"));
-}
-
-#[test]
-fn define_constant_detects_cross_kind_duplicate_with_alias() {
-    let context = SyntaxTestContext::default();
-    let error = context
-        .parse_module(
-            r#"
-use ::dep::"THING"
-const THING = 1
-"#,
-        )
-        .expect_err("expected conflicting alias/constant names to be rejected during analysis");
-    assert_symbol_conflict(&error, "THING");
-    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
-    assert!(rendered.contains("symbol conflict"));
-    assert!(rendered.contains("THING"));
-}
-
-#[test]
-fn define_type_detects_cross_kind_duplicate_with_procedure() {
-    let context = SyntaxTestContext::default();
-    let error = context
-        .parse_module(
-            r#"
-proc thing
-    nop
-end
-type thing = felt
-"#,
-        )
-        .expect_err("expected conflicting procedure/type names to be rejected during analysis");
-    assert_symbol_conflict(&error, "thing");
-    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
-    assert!(rendered.contains("symbol conflict"));
-    assert!(rendered.contains("thing"));
+fn define_items_detect_cross_kind_duplicates_for_all_pairs_and_orders() {
+    let kinds = [
+        DefinitionKind::Alias,
+        DefinitionKind::Procedure,
+        DefinitionKind::Constant,
+        DefinitionKind::Type,
+    ];
+    for first in kinds {
+        for second in kinds {
+            if first == second {
+                continue;
+            }
+            assert_cross_kind_conflict(first, second);
+        }
+    }
 }

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -36,9 +36,7 @@ fn assert_symbol_conflict(error: &miden_utils_diagnostics::Report, symbol: &str)
         .errors
         .iter()
         .find_map(|err| match err {
-            crate::sema::SemanticAnalysisError::SymbolConflict { span, prev_span } => {
-                Some((span, prev_span))
-            },
+            SemanticAnalysisError::SymbolConflict { span, prev_span } => Some((span, prev_span)),
             _ => None,
         })
         .expect("expected at least one SymbolConflict error");

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -1,5 +1,3 @@
-use miden_debug_types::Span;
-
 use crate::{
     MAX_REPEAT_COUNT,
     ast::{Constant, Export, Module},
@@ -17,6 +15,48 @@ fn exported_constant<'a>(module: &'a Module, name: &str) -> &'a Constant {
         Some(item) => panic!("expected exported constant named {name}, found {item:?}"),
         None => panic!("expected exported constant named {name}"),
     }
+}
+
+fn assert_symbol_conflict(error: &miden_utils_diagnostics::Report, symbol: &str) {
+    let syntax_error = error
+        .downcast_ref::<crate::sema::SyntaxError>()
+        .expect("expected SyntaxError report");
+
+    let (span, prev_span) = syntax_error
+        .errors
+        .iter()
+        .find_map(|err| match err {
+            crate::sema::SemanticAnalysisError::SymbolConflict { span, prev_span } => {
+                Some((span, prev_span))
+            },
+            _ => None,
+        })
+        .expect("expected at least one SymbolConflict error");
+
+    assert_ne!(span, prev_span, "conflicting definitions should point at distinct spans");
+    assert_eq!(
+        span.source_id(),
+        prev_span.source_id(),
+        "conflict spans should refer to the same source file"
+    );
+
+    let span_text = syntax_error
+        .source_file
+        .source_slice(*span)
+        .expect("conflict span should be valid");
+    let prev_span_text = syntax_error
+        .source_file
+        .source_slice(*prev_span)
+        .expect("previous conflict span should be valid");
+
+    assert!(
+        span_text.contains(symbol),
+        "conflict span should include symbol '{symbol}', got: {span_text:?}"
+    );
+    assert!(
+        prev_span_text.contains(symbol),
+        "previous conflict span should include symbol '{symbol}', got: {prev_span_text:?}"
+    );
 }
 
 #[test]
@@ -105,51 +145,73 @@ pub const ACCOUNT_ID_SUFFIX_OFFSET = ACCOUNT_ID_AND_NONCE_OFFSET + 2
 }
 
 #[test]
-fn alias_then_constant_name_conflict_can_reach_resolver_duplicate_error() {
+fn define_alias_detects_cross_kind_duplicate_with_type() {
     let context = SyntaxTestContext::default();
-    let module = context
+    let error = context
         .parse_module(
             r#"
-use ::dep::"EVENT_HASH"
-const EVENT_HASH = 1
+type thing = felt
+use ::dep::thing
 "#,
         )
-        .expect("expected module to parse and pass semantic analysis");
-
-    let err = module
-        .resolve(Span::unknown("EVENT_HASH"), context.source_manager())
-        .expect_err("expected duplicate symbol to be caught by resolver lookup");
-    assert!(
-        matches!(
-            &err,
-            crate::ast::SymbolResolutionError::DuplicateSymbol { symbol, .. }
-                if symbol.as_ref() == "EVENT_HASH"
-        ),
-        "unexpected error: {err}"
-    );
+        .expect_err("expected conflicting type/alias names to be rejected during analysis");
+    assert_symbol_conflict(&error, "thing");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("symbol conflict"));
+    assert!(rendered.contains("thing"));
 }
 
 #[test]
-fn alias_then_type_name_conflict_can_reach_resolver_duplicate_error() {
+fn define_procedure_detects_cross_kind_duplicate_with_type() {
     let context = SyntaxTestContext::default();
-    let module = context
+    let error = context
         .parse_module(
             r#"
-use ::dep::"Thing"
-type Thing = felt
+type thing = felt
+proc thing
+    nop
+end
 "#,
         )
-        .expect("expected module to parse and pass semantic analysis");
+        .expect_err("expected conflicting type/procedure names to be rejected during analysis");
+    assert_symbol_conflict(&error, "thing");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("symbol conflict"));
+    assert!(rendered.contains("thing"));
+}
 
-    let err = module
-        .resolve(Span::unknown("Thing"), context.source_manager())
-        .expect_err("expected duplicate symbol to be caught by resolver lookup");
-    assert!(
-        matches!(
-            &err,
-            crate::ast::SymbolResolutionError::DuplicateSymbol { symbol, .. }
-                if symbol.as_ref() == "Thing"
-        ),
-        "unexpected error: {err}"
-    );
+#[test]
+fn define_constant_detects_cross_kind_duplicate_with_alias() {
+    let context = SyntaxTestContext::default();
+    let error = context
+        .parse_module(
+            r#"
+use ::dep::"THING"
+const THING = 1
+"#,
+        )
+        .expect_err("expected conflicting alias/constant names to be rejected during analysis");
+    assert_symbol_conflict(&error, "THING");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("symbol conflict"));
+    assert!(rendered.contains("THING"));
+}
+
+#[test]
+fn define_type_detects_cross_kind_duplicate_with_procedure() {
+    let context = SyntaxTestContext::default();
+    let error = context
+        .parse_module(
+            r#"
+proc thing
+    nop
+end
+type thing = felt
+"#,
+        )
+        .expect_err("expected conflicting procedure/type names to be rejected during analysis");
+    assert_symbol_conflict(&error, "thing");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("symbol conflict"));
+    assert!(rendered.contains("thing"));
 }

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -1,3 +1,5 @@
+use miden_debug_types::Span;
+
 use crate::{
     MAX_REPEAT_COUNT,
     ast::{Constant, Export, Module},
@@ -99,5 +101,55 @@ pub const ACCOUNT_ID_SUFFIX_OFFSET = ACCOUNT_ID_AND_NONCE_OFFSET + 2
     assert!(
         exported.value.references().is_empty(),
         "expected semantic analysis to remove private local constant references from exported constants",
+    );
+}
+
+#[test]
+fn alias_then_constant_name_conflict_can_reach_resolver_duplicate_error() {
+    let context = SyntaxTestContext::default();
+    let module = context
+        .parse_module(
+            r#"
+use ::dep::"EVENT_HASH"
+const EVENT_HASH = 1
+"#,
+        )
+        .expect("expected module to parse and pass semantic analysis");
+
+    let err = module
+        .resolve(Span::unknown("EVENT_HASH"), context.source_manager())
+        .expect_err("expected duplicate symbol to be caught by resolver lookup");
+    assert!(
+        matches!(
+            &err,
+            crate::ast::SymbolResolutionError::DuplicateSymbol { symbol, .. }
+                if symbol.as_ref() == "EVENT_HASH"
+        ),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn alias_then_type_name_conflict_can_reach_resolver_duplicate_error() {
+    let context = SyntaxTestContext::default();
+    let module = context
+        .parse_module(
+            r#"
+use ::dep::"Thing"
+type Thing = felt
+"#,
+        )
+        .expect("expected module to parse and pass semantic analysis");
+
+    let err = module
+        .resolve(Span::unknown("Thing"), context.source_manager())
+        .expect_err("expected duplicate symbol to be caught by resolver lookup");
+    assert!(
+        matches!(
+            &err,
+            crate::ast::SymbolResolutionError::DuplicateSymbol { symbol, .. }
+                if symbol.as_ref() == "Thing"
+        ),
+        "unexpected error: {err}"
     );
 }

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -510,7 +510,12 @@ impl Assembler {
                         if !symbol.visibility().is_public() {
                             continue;
                         }
-                        module_path.join(symbol.name()).into()
+                        module_path
+                            .join(symbol.name())
+                            .canonicalize()
+                            .into_diagnostic()?
+                            .into_boxed_path()
+                            .into()
                     };
                     let export = self.export_symbol(
                         gid,

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -48,6 +48,9 @@ enum AssemblerError {
         source_file: Option<Arc<SourceFile>>,
         max_depth: usize,
     },
+    #[error("duplicate definition found for export path '{path}'")]
+    #[diagnostic()]
+    DuplicateExportPath { path: Arc<Path> },
 }
 
 // ASSEMBLER
@@ -523,7 +526,9 @@ impl Assembler {
                         path.clone(),
                         &mut mast_forest_builder,
                     )?;
-                    exports.insert(path, export);
+                    if exports.insert(path.clone(), export).is_some() {
+                        return Err(Report::new(AssemblerError::DuplicateExportPath { path }));
+                    }
                 }
             }
 

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -154,6 +154,39 @@ impl Assembler {
         self.warnings_as_errors = yes;
         self
     }
+
+    pub(crate) fn invalid_invoke_target_report(
+        &self,
+        kind: InvokeKind,
+        callee: &InvocationTarget,
+        caller: GlobalItemIndex,
+    ) -> Report {
+        let span = callee.span();
+        let source_file = self.source_manager.get(span.source_id()).ok();
+        let context = SymbolResolutionContext {
+            span,
+            module: caller.module,
+            kind: Some(kind),
+        };
+
+        let path = match self.linker.resolve_invoke_target(&context, callee) {
+            Ok(SymbolResolution::Exact { path, .. })
+            | Ok(SymbolResolution::Module { path, .. })
+            | Ok(SymbolResolution::External(path)) => Some(path.into_inner()),
+            Ok(SymbolResolution::Local(_)) | Ok(SymbolResolution::MastRoot(_)) => None,
+            Err(err) => return Report::new(err),
+        }
+        .or_else(|| match callee {
+            InvocationTarget::Symbol(symbol) => Some(Path::from_ident(symbol).into_owned().into()),
+            InvocationTarget::Path(path) => Some(path.clone().into_inner()),
+            InvocationTarget::MastRoot(_) => None,
+        });
+
+        match path {
+            Some(path) => Report::new(LinkerError::InvalidInvokeTarget { span, source_file, path }),
+            None => Report::msg("invalid procedure reference: target is not a procedure"),
+        }
+    }
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -652,11 +685,48 @@ impl Assembler {
             },
 
             SymbolItem::Alias { alias, resolved } => {
-                // All aliases should've been resolved by now
-                let resolved = resolved.get().unwrap_or_else(|| {
-                    panic!("unresolved alias {symbol_path} targeting: {}", alias.target())
-                });
-                return self.export_symbol(resolved, module_kind, symbol_path, mast_forest_builder);
+                if let Some(resolved) = resolved.get() {
+                    return self.export_symbol(
+                        resolved,
+                        module_kind,
+                        symbol_path,
+                        mast_forest_builder,
+                    );
+                }
+
+                let Some(ResolvedProcedure { node, signature }) = self.resolve_target(
+                    InvokeKind::ProcRef,
+                    &alias.target().into(),
+                    gid,
+                    mast_forest_builder,
+                )?
+                else {
+                    return Err(self.unresolved_alias_report("export", &symbol_path, alias));
+                };
+
+                let digest = mast_forest_builder
+                    .get_mast_node(node)
+                    .expect("resolved alias export node must exist")
+                    .digest();
+                let pctx = ProcedureContext::new(
+                    gid,
+                    /* is_program_entrypoint= */ false,
+                    symbol_path.clone(),
+                    Visibility::Public,
+                    signature.clone(),
+                    module_kind.is_kernel(),
+                    self.source_manager.clone(),
+                );
+                let procedure = pctx.into_procedure(digest, node);
+                self.linker.register_procedure_root(gid, digest)?;
+                mast_forest_builder.insert_procedure(gid, procedure)?;
+
+                return Ok(LibraryExport::Procedure(ProcedureExport {
+                    node,
+                    path: symbol_path,
+                    signature: signature.map(Arc::unwrap_or_clone),
+                    attributes: Default::default(),
+                }));
             },
         };
 
@@ -813,19 +883,27 @@ impl Assembler {
                     mast_forest_builder.insert_procedure(procedure_gid, procedure)?;
                 },
                 SymbolItem::Alias { alias, resolved } => {
-                    let procedure_gid = resolved.get().expect("resolved alias");
-                    match self.linker[procedure_gid].item() {
-                        SymbolItem::Procedure(_) | SymbolItem::Compiled(ItemInfo::Procedure(_)) => {
+                    let path: Arc<Path> = module_path.join(alias.name().as_str()).into();
+                    let procedure_gid = match resolved.get() {
+                        Some(procedure_gid) => {
+                            match self.linker[procedure_gid].item() {
+                                SymbolItem::Procedure(_)
+                                | SymbolItem::Compiled(ItemInfo::Procedure(_)) => {},
+                                SymbolItem::Constant(_)
+                                | SymbolItem::Type(_)
+                                | SymbolItem::Compiled(_) => {
+                                    continue;
+                                },
+                                // A resolved alias will always refer to a non-alias item, this is
+                                // because when aliases are resolved, they are resolved
+                                // recursively. Had the alias chain been cyclical, we would have
+                                // raised an error already.
+                                SymbolItem::Alias { .. } => unreachable!(),
+                            }
+                            procedure_gid
                         },
-                        SymbolItem::Constant(_) | SymbolItem::Type(_) | SymbolItem::Compiled(_) => {
-                            continue;
-                        },
-                        // A resolved alias will always refer to a non-alias item, this is because
-                        // when aliases are resolved, they are resolved recursively. Had the alias
-                        // chain been cyclical, we would have raised an error already.
-                        SymbolItem::Alias { .. } => unreachable!(),
-                    }
-                    let path = module_path.join(alias.name().as_str()).into();
+                        None => procedure_gid,
+                    };
                     // A program entrypoint is never an alias
                     let is_program_entrypoint = false;
                     let mut pctx = ProcedureContext::new(
@@ -872,6 +950,30 @@ impl Assembler {
         }
 
         Ok(())
+    }
+
+    fn unresolved_alias_report(
+        &self,
+        action: &'static str,
+        symbol_path: &Path,
+        alias: &ast::Alias,
+    ) -> Report {
+        let span = alias.target().span();
+        let reason = match alias.target() {
+            ast::AliasTarget::MastRoot(_) => {
+                "this digest target does not resolve to a known procedure"
+            },
+            ast::AliasTarget::Path(_) => "this alias target does not resolve to a concrete item",
+        };
+
+        RelatedLabel::error(format!(
+            "unable to {action} alias '{symbol_path}' targeting '{}'",
+            alias.target()
+        ))
+        .with_labeled_span(span, reason)
+        .with_help("aliases must resolve to a concrete item before they can be used")
+        .with_source_file(self.source_manager.get(span.source_id()).ok())
+        .into()
     }
 
     /// Compiles a single Miden Assembly procedure to its MAST representation.

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -184,10 +184,12 @@ impl Assembler {
         };
 
         let path = match self.linker.resolve_invoke_target(&context, callee) {
-            Ok(SymbolResolution::Exact { path, .. })
-            | Ok(SymbolResolution::Module { path, .. })
-            | Ok(SymbolResolution::External(path)) => Some(path.into_inner()),
-            Ok(SymbolResolution::Local(_)) | Ok(SymbolResolution::MastRoot(_)) => None,
+            Ok(
+                SymbolResolution::Exact { path, .. }
+                | SymbolResolution::Module { path, .. }
+                | SymbolResolution::External(path),
+            ) => Some(path.into_inner()),
+            Ok(SymbolResolution::Local(_) | SymbolResolution::MastRoot(_)) => None,
             Err(err) => return Report::new(err),
         }
         .or_else(|| match callee {

--- a/crates/assembly/src/instruction/procedures.rs
+++ b/crates/assembly/src/instruction/procedures.rs
@@ -33,7 +33,7 @@ impl Assembler {
     ) -> Result<MastNodeId, Report> {
         let resolved = self
             .resolve_target(kind, callee, caller, mast_forest_builder)?
-            .expect("invocation target is not a procedure");
+            .ok_or_else(|| self.invalid_invoke_target_report(kind, callee, caller))?;
 
         match kind {
             InvokeKind::ProcRef | InvokeKind::Exec => Ok(resolved.node),
@@ -82,7 +82,9 @@ impl Assembler {
                     caller,
                     block_builder.mast_forest_builder_mut(),
                 )?
-                .expect("invocation target is not a procedure");
+                .ok_or_else(|| {
+                    self.invalid_invoke_target_report(InvokeKind::ProcRef, callee, caller)
+                })?;
             // Note: it's ok to `unwrap()` here since `proc_body_id` was returned from
             // `mast_forest_builder`
             block_builder

--- a/crates/assembly/src/linker/callgraph.rs
+++ b/crates/assembly/src/linker/callgraph.rs
@@ -11,6 +11,10 @@ use crate::GlobalItemIndex;
 pub struct CycleError(BTreeSet<GlobalItemIndex>);
 
 impl CycleError {
+    pub fn new(nodes: impl IntoIterator<Item = GlobalItemIndex>) -> Self {
+        Self(nodes.into_iter().collect())
+    }
+
     pub fn into_node_ids(self) -> impl ExactSizeIterator<Item = GlobalItemIndex> {
         self.0.into_iter()
     }
@@ -60,11 +64,15 @@ impl CallGraph {
     /// introduce a cycle, or that [Self::toposort] is run once the graph is built, in order to
     /// verify that the graph is valid and has no cycles.
     ///
-    /// NOTE: This function will panic if you attempt to add an edge from a function to itself,
-    /// which trivially introduces a cycle. All other cycle-inducing edges must be caught by a
-    /// call to [Self::toposort].
-    pub fn add_edge(&mut self, caller: GlobalItemIndex, callee: GlobalItemIndex) {
-        assert_ne!(caller, callee, "a procedure cannot call itself");
+    /// Returns an error if adding the edge would introduce a trivial self-cycle.
+    pub fn add_edge(
+        &mut self,
+        caller: GlobalItemIndex,
+        callee: GlobalItemIndex,
+    ) -> Result<(), CycleError> {
+        if caller == callee {
+            return Err(CycleError::new([caller]));
+        }
 
         // Make sure the callee is in the graph
         self.get_or_insert_node(callee);
@@ -72,10 +80,11 @@ impl CallGraph {
         let callees = self.get_or_insert_node(caller);
         // If the caller already references the callee, we're done
         if callees.contains(&callee) {
-            return;
+            return Ok(());
         }
 
         callees.push(callee);
+        Ok(())
     }
 
     /// Removes the edge between `caller` and `callee` from the graph
@@ -113,15 +122,6 @@ impl CallGraph {
         let mut roots =
             VecDeque::from_iter(graph.nodes.keys().copied().filter(|n| !has_preds.contains(n)));
 
-        // If all nodes have predecessors, there must be a cycle, so just pick a node and let the
-        // algorithm find the cycle for that node so we have a useful error. Set a flag so that we
-        // can assert that the cycle was actually found as a sanity check
-        let mut expect_cycle = false;
-        if roots.is_empty() {
-            expect_cycle = true;
-            roots.extend(graph.nodes.keys().next());
-        }
-
         let mut successors = Vec::with_capacity(4);
         while let Some(id) = roots.pop_front() {
             output.push(id);
@@ -150,7 +150,6 @@ impl CallGraph {
             }
             Err(CycleError(in_cycle))
         } else {
-            assert!(!expect_cycle, "we expected a cycle to be found, but one was not identified");
             Ok(output)
         }
     }
@@ -326,6 +325,24 @@ mod tests {
         assert_eq!(err.0.into_iter().collect::<Vec<_>>(), &[A2, A3, B2, B3]);
     }
 
+    #[test]
+    fn callgraph_add_edge_with_self_cycle_is_error() {
+        let mut graph = CallGraph::default();
+
+        let err = graph.add_edge(A1, A1).expect_err("expected self-edge to be rejected");
+        assert_eq!(err.0.into_iter().collect::<Vec<_>>(), &[A1]);
+    }
+
+    #[test]
+    fn callgraph_rootless_cycle_toposort_is_error() {
+        let mut graph = CallGraph::default();
+        graph.add_edge(A1, B1).expect("A1 -> B1 must be accepted");
+        graph.add_edge(B1, A1).expect("B1 -> A1 must be accepted");
+
+        let err = graph.toposort().expect_err("expected topological sort to fail with cycle");
+        assert_eq!(err.0.into_iter().collect::<Vec<_>>(), &[A1, B1]);
+    }
+
     /// a::a1 -> a::a2 -> a::a3
     ///            |        ^
     ///            v        |
@@ -333,12 +350,12 @@ mod tests {
     fn callgraph_simple() -> CallGraph {
         // Construct the graph
         let mut graph = CallGraph::default();
-        graph.add_edge(A1, A2);
-        graph.add_edge(B1, B2);
-        graph.add_edge(A2, B2);
-        graph.add_edge(A2, A3);
-        graph.add_edge(B2, B3);
-        graph.add_edge(B3, A3);
+        graph.add_edge(A1, A2).expect("A1 -> A2 must be accepted");
+        graph.add_edge(B1, B2).expect("B1 -> B2 must be accepted");
+        graph.add_edge(A2, B2).expect("A2 -> B2 must be accepted");
+        graph.add_edge(A2, A3).expect("A2 -> A3 must be accepted");
+        graph.add_edge(B2, B3).expect("B2 -> B3 must be accepted");
+        graph.add_edge(B3, A3).expect("B3 -> A3 must be accepted");
 
         graph
     }
@@ -350,12 +367,12 @@ mod tests {
     fn callgraph_cycle() -> CallGraph {
         // Construct the graph
         let mut graph = CallGraph::default();
-        graph.add_edge(A1, A2);
-        graph.add_edge(B1, B2);
-        graph.add_edge(A2, B2);
-        graph.add_edge(B2, B3);
-        graph.add_edge(B3, A3);
-        graph.add_edge(A3, A2);
+        graph.add_edge(A1, A2).expect("A1 -> A2 must be accepted");
+        graph.add_edge(B1, B2).expect("B1 -> B2 must be accepted");
+        graph.add_edge(A2, B2).expect("A2 -> B2 must be accepted");
+        graph.add_edge(B2, B3).expect("B2 -> B3 must be accepted");
+        graph.add_edge(B3, A3).expect("B3 -> A3 must be accepted");
+        graph.add_edge(A3, A2).expect("A3 -> A2 must be accepted");
 
         graph
     }

--- a/crates/assembly/src/linker/errors.rs
+++ b/crates/assembly/src/linker/errors.rs
@@ -44,6 +44,16 @@ pub enum LinkerError {
     #[error("duplicate definition found for module '{path}'")]
     #[diagnostic()]
     DuplicateModule { path: Arc<Path> },
+    #[error("ambiguous module path resolution for '{path}'")]
+    #[diagnostic(help("matching module prefixes: {}", matches.join(", ")))]
+    AmbiguousModulePath {
+        #[label]
+        span: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+        path: Arc<Path>,
+        matches: Box<[String]>,
+    },
     #[error("undefined module '{path}'")]
     #[diagnostic()]
     UndefinedModule {

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -370,6 +370,17 @@ impl Linker {
 // ------------------------------------------------------------------------------------------------
 /// Analysis
 impl Linker {
+    fn cycle_error(&self, cycle: CycleError) -> LinkerError {
+        let iter = cycle.into_node_ids();
+        let mut nodes = Vec::with_capacity(iter.len());
+        for node in iter {
+            let module = self[node.module].path();
+            let item = self[node].name();
+            nodes.push(module.join(item).to_string());
+        }
+        LinkerError::Cycle { nodes: nodes.into() }
+    }
+
     /// Links `modules` using the current state of the linker.
     ///
     /// Returns the module indices corresponding to the provided modules, which are expected to
@@ -396,7 +407,18 @@ impl Linker {
         &mut self,
         mut kernel: Box<Module>,
     ) -> Result<Vec<ModuleIndex>, LinkerError> {
+        let original_module_len = self.modules.len();
+        let original_callgraph = self.callgraph.clone();
         let module_index = self.link_module(&mut kernel)?;
+        let original_kernel_index = self.kernel_index;
+        let original_module_kinds = self
+            .modules
+            .iter()
+            .enumerate()
+            .take(module_index.as_usize())
+            .filter(|(_, module)| matches!(module.source(), ModuleSource::Ast))
+            .map(|(module_index, module)| (module_index, module.kind()))
+            .collect::<Vec<_>>();
 
         // Set the module kind of all pending AST modules to Kernel, as we are linking a kernel
         for module in self.modules.iter_mut().take(module_index.as_usize()) {
@@ -407,7 +429,16 @@ impl Linker {
 
         self.kernel_index = Some(module_index);
 
-        self.link_and_rewrite()?;
+        if let Err(err) = self.link_and_rewrite() {
+            self.kernel_index = original_kernel_index;
+            self.callgraph = original_callgraph;
+            self.modules.truncate(original_module_len);
+            for (module_index, module_kind) in original_module_kinds {
+                self.modules[module_index].set_kind(module_kind);
+            }
+
+            return Err(err);
+        }
 
         Ok(vec![module_index])
     }
@@ -470,106 +501,124 @@ impl Linker {
 
         // Obtain a set of resolvers for the pending modules so that we can do name resolution
         // before they are added to the graph
-        let resolver = SymbolResolver::new(self);
-        let mut edges = Vec::new();
-        let mut cache = ResolverCache::default();
+        let pending_modules = self
+            .modules
+            .iter()
+            .enumerate()
+            .filter(|(_, module)| module.is_unlinked())
+            .map(|(module_index, module)| (module_index, module.clone()))
+            .collect::<Vec<_>>();
+        let original_callgraph = self.callgraph.clone();
 
-        for (module_index, module) in self.modules.iter().enumerate() {
-            if !module.is_unlinked() {
-                continue;
-            }
+        let result = {
+            let resolver = SymbolResolver::new(self);
+            let mut edges = Vec::new();
+            let mut cache = ResolverCache::default();
+            let mut linked_modules = Vec::new();
 
-            let module_index = ModuleIndex::new(module_index);
-
-            for (symbol_idx, symbol) in module.symbols().enumerate() {
-                assert!(
-                    symbol.is_unlinked(),
-                    "an unlinked module should only have unlinked symbols"
-                );
-
-                let gid = module_index + ItemIndex::new(symbol_idx);
-
-                // Perform any applicable rewrites to this item
-                rewrites::rewrite_symbol(gid, symbol, &resolver, &mut cache)?;
-
-                // Update the linker graph
-                match symbol.item() {
-                    SymbolItem::Compiled(_) | SymbolItem::Type(_) | SymbolItem::Constant(_) => (),
-                    SymbolItem::Alias { alias, resolved } => {
-                        if let Some(resolved) = resolved.get() {
-                            log::debug!(target: "linker", "  | resolved alias {} to item {resolved}", alias.target());
-                            if self[resolved].is_procedure() {
-                                edges.push((gid, resolved));
-                            }
-                        } else {
-                            log::debug!(target: "linker", "  | resolving alias {}..", alias.target());
-
-                            let context = SymbolResolutionContext {
-                                span: alias.target().span(),
-                                module: module_index,
-                                kind: None,
-                            };
-                            if let Some(callee) =
-                                resolver.resolve_alias_target(&context, alias)?.into_global_id()
-                            {
-                                log::debug!(
-                                    target: "linker",
-                                    "  | resolved alias to gid {:?}:{:?}",
-                                    callee.module,
-                                    callee.index
-                                );
-                                edges.push((gid, callee));
-                                resolved.set(Some(callee));
-                            }
-                        }
-                    },
-                    SymbolItem::Procedure(proc) => {
-                        // Add edges to all transitive dependencies of this item due to calls/symbol
-                        // refs
-                        let proc = proc.borrow();
-                        for invoke in proc.invoked() {
-                            log::debug!(target: "linker", "  | recording {} dependency on {}", invoke.kind, &invoke.target);
-
-                            let context = SymbolResolutionContext {
-                                span: invoke.span(),
-                                module: module_index,
-                                kind: None,
-                            };
-                            if let Some(callee) = resolver
-                                .resolve_invoke_target(&context, &invoke.target)?
-                                .into_global_id()
-                            {
-                                log::debug!(
-                                    target: "linker",
-                                    "  | resolved dependency to gid {}:{}",
-                                    callee.module.as_usize(),
-                                    callee.index.as_usize()
-                                );
-                                edges.push((gid, callee));
-                            }
-                        }
-                    },
+            for (module_index, module) in self.modules.iter().enumerate() {
+                if !module.is_unlinked() {
+                    continue;
                 }
+
+                let module_index = ModuleIndex::new(module_index);
+
+                for (symbol_idx, symbol) in module.symbols().enumerate() {
+                    let gid = module_index + ItemIndex::new(symbol_idx);
+
+                    // Perform any applicable rewrites to this item
+                    rewrites::rewrite_symbol(gid, symbol, &resolver, &mut cache)?;
+
+                    // Update the linker graph
+                    match symbol.item() {
+                        SymbolItem::Compiled(_) | SymbolItem::Type(_) | SymbolItem::Constant(_) => {
+                        },
+                        SymbolItem::Alias { alias, resolved } => {
+                            if let Some(resolved) = resolved.get() {
+                                log::debug!(target: "linker", "  | resolved alias {} to item {resolved}", alias.target());
+                                if self[resolved].is_procedure() {
+                                    edges.push((gid, resolved));
+                                }
+                            } else {
+                                log::debug!(target: "linker", "  | resolving alias {}..", alias.target());
+
+                                let context = SymbolResolutionContext {
+                                    span: alias.target().span(),
+                                    module: module_index,
+                                    kind: None,
+                                };
+                                if let Some(callee) =
+                                    resolver.resolve_alias_target(&context, alias)?.into_global_id()
+                                {
+                                    log::debug!(
+                                        target: "linker",
+                                        "  | resolved alias to gid {:?}:{:?}",
+                                        callee.module,
+                                        callee.index
+                                    );
+                                    edges.push((gid, callee));
+                                    resolved.set(Some(callee));
+                                }
+                            }
+                        },
+                        SymbolItem::Procedure(proc) => {
+                            // Add edges to all transitive dependencies of this item due to
+                            // calls/symbol refs
+                            let proc = proc.borrow();
+                            for invoke in proc.invoked() {
+                                log::debug!(target: "linker", "  | recording {} dependency on {}", invoke.kind, &invoke.target);
+
+                                let context = SymbolResolutionContext {
+                                    span: invoke.span(),
+                                    module: module_index,
+                                    kind: None,
+                                };
+                                if let Some(callee) = resolver
+                                    .resolve_invoke_target(&context, &invoke.target)?
+                                    .into_global_id()
+                                {
+                                    log::debug!(
+                                        target: "linker",
+                                        "  | resolved dependency to gid {}:{}",
+                                        callee.module.as_usize(),
+                                        callee.index.as_usize()
+                                    );
+                                    edges.push((gid, callee));
+                                }
+                            }
+                        },
+                    }
+                }
+
+                linked_modules.push(module_index);
             }
 
-            module.set_status(LinkStatus::Linked);
+            let mut callgraph = self.callgraph.clone();
+            for (caller, callee) in edges {
+                callgraph.add_edge(caller, callee).map_err(|cycle| self.cycle_error(cycle))?;
+            }
+
+            // Make sure the graph is free of cycles
+            callgraph.toposort().map_err(|cycle| self.cycle_error(cycle))?;
+
+            Ok::<_, LinkerError>((linked_modules, callgraph))
+        };
+
+        match result {
+            Ok((linked_modules, callgraph)) => {
+                self.callgraph = callgraph;
+                for module_index in linked_modules {
+                    self.modules[module_index.as_usize()].set_status(LinkStatus::Linked);
+                }
+            },
+            Err(err) => {
+                self.callgraph = original_callgraph;
+                for (module_index, module) in pending_modules {
+                    self.modules[module_index] = module;
+                }
+                return Err(err);
+            },
         }
-
-        edges
-            .into_iter()
-            .for_each(|(caller, callee)| self.callgraph.add_edge(caller, callee));
-
-        // Make sure the graph is free of cycles
-        self.callgraph.toposort().map_err(|cycle| {
-            let iter = cycle.into_node_ids();
-            let mut nodes = Vec::with_capacity(iter.len());
-            for node in iter {
-                let module = self[node.module].path();
-                let item = self[node].name();
-                nodes.push(module.join(item).to_string());
-            }
-            LinkerError::Cycle { nodes: nodes.into() }
-        })?;
 
         Ok(())
     }
@@ -847,5 +896,149 @@ impl Index<GlobalItemIndex> for Linker {
 
     fn index(&self, index: GlobalItemIndex) -> &Self::Output {
         &self.modules[index.module.as_usize()][index.index]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        string::String,
+        sync::Arc,
+    };
+
+    use miden_assembly_syntax::{
+        ast::{
+            Ident, InvocationTarget, InvokeKind, ItemIndex, Path, SymbolResolutionError,
+            Visibility, types,
+        },
+        debuginfo::{SourceSpan, Span},
+        library::{ItemInfo, TypeInfo},
+    };
+
+    use super::*;
+    use crate::testing::{TestContext, source_file};
+
+    #[test]
+    fn failed_kernel_link_restores_kernel_state() {
+        let context = TestContext::default();
+        let source_manager = context.source_manager();
+        let kernel_source = r#"
+                pub proc a
+                    call.b
+                end
+
+                proc b
+                    call.a
+                end
+                "#;
+
+        let userspace = context
+            .parse_module_with_path(
+                "userspace",
+                source_file!(
+                    &context,
+                    r#"
+                    pub proc helper
+                        push.1
+                    end
+                    "#
+                ),
+            )
+            .expect("userspace module parsing must succeed");
+
+        let mut linker = Linker::new(source_manager);
+        let userspace_index = linker
+            .link([userspace])
+            .expect("userspace module must link successfully")
+            .into_iter()
+            .next()
+            .expect("linked module index must be returned");
+
+        let first_err = linker
+            .link_kernel(
+                context
+                    .parse_kernel(source_file!(&context, kernel_source))
+                    .expect("kernel parsing must succeed"),
+            )
+            .expect_err("expected cyclic kernel to be rejected");
+
+        assert!(first_err.to_string().contains("found a cycle in the call graph"));
+        assert!(!linker.has_nonempty_kernel(), "failed kernel link must not leave a kernel set");
+        assert_eq!(linker[userspace_index].kind(), ast::ModuleKind::Library);
+
+        let second_err = linker
+            .link_kernel(
+                context
+                    .parse_kernel(source_file!(&context, kernel_source))
+                    .expect("kernel parsing must succeed"),
+            )
+            .expect_err("expected cyclic kernel retry to be rejected");
+        assert!(second_err.to_string().contains("found a cycle in the call graph"));
+        assert!(!second_err.to_string().contains("duplicate module"));
+
+        let syscall_context = SymbolResolutionContext {
+            span: SourceSpan::UNKNOWN,
+            module: userspace_index,
+            kind: Some(InvokeKind::SysCall),
+        };
+        let err = linker
+            .resolve_invoke_target(
+                &syscall_context,
+                &InvocationTarget::Symbol(Ident::new("a").expect("valid identifier")),
+            )
+            .expect_err("expected syscall without a linked kernel to be rejected");
+        assert!(matches!(err, LinkerError::InvalidSysCallTarget { .. }));
+    }
+
+    #[test]
+    fn oversized_link_module_resolution_returns_structured_error() {
+        let context = TestContext::default();
+        let mut linker = Linker::new(context.source_manager());
+        let module_id = ModuleIndex::new(0);
+        let path = Arc::<Path>::from(Path::new("::m::huge"));
+        let mut symbols = Vec::with_capacity(ItemIndex::MAX_ITEMS + 1);
+
+        for i in 0..=ItemIndex::MAX_ITEMS {
+            let name = Ident::new(format!("a{i}")).expect("valid identifier");
+            symbols.push(Symbol::new(
+                name.clone(),
+                Visibility::Private,
+                LinkStatus::Unlinked,
+                SymbolItem::Compiled(ItemInfo::Type(TypeInfo { name, ty: types::Type::Felt })),
+            ));
+        }
+
+        linker.modules.push(
+            LinkModule::new(
+                module_id,
+                ast::ModuleKind::Library,
+                LinkStatus::Unlinked,
+                ModuleSource::Mast,
+                path,
+            )
+            .with_symbols(symbols),
+        );
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            linker[module_id].resolve(Span::unknown("a0"), &SymbolResolver::new(&linker))
+        }));
+
+        let result = match result {
+            Ok(result) => result,
+            Err(panic) => {
+                let message = panic
+                    .downcast_ref::<&str>()
+                    .copied()
+                    .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+                    .expect("panic payload should be a string");
+                panic!("expected graceful error, got panic: {message}");
+            },
+        };
+
+        assert!(matches!(
+            result,
+            Err(err) if matches!(*err, SymbolResolutionError::TooManyItemsInModule { .. })
+        ));
     }
 }

--- a/crates/assembly/src/linker/module.rs
+++ b/crates/assembly/src/linker/module.rs
@@ -7,7 +7,7 @@ use miden_assembly_syntax::{
         self, AliasTarget, ItemIndex, LocalSymbol, LocalSymbolResolver, ModuleIndex, ModuleKind,
         SymbolResolution, SymbolResolutionError, SymbolTable,
     },
-    debuginfo::{SourceManager, Span, Spanned},
+    debuginfo::{SourceManager, SourceSpan, Span, Spanned},
 };
 
 use super::{AdviceMap, LinkStatus, Symbol, SymbolItem, SymbolResolver};
@@ -182,7 +182,8 @@ impl LinkModule {
         resolver: &SymbolResolver<'_>,
     ) -> Result<SymbolResolution, Box<SymbolResolutionError>> {
         let container = LinkModuleIter { resolver, module: self };
-        let local_resolver = LocalSymbolResolver::new(container, resolver.source_manager_arc());
+        let local_resolver =
+            LocalSymbolResolver::new(container, resolver.source_manager_arc()).map_err(Box::new)?;
         local_resolver.resolve(name).map_err(Box::new)
     }
 
@@ -193,7 +194,8 @@ impl LinkModule {
         resolver: &SymbolResolver<'_>,
     ) -> Result<SymbolResolution, Box<SymbolResolutionError>> {
         let container = LinkModuleIter { resolver, module: self };
-        let local_resolver = LocalSymbolResolver::new(container, resolver.source_manager_arc());
+        let local_resolver =
+            LocalSymbolResolver::new(container, resolver.source_manager_arc()).map_err(Box::new)?;
         local_resolver.resolve_path(path).map_err(Box::new)
     }
 }
@@ -216,68 +218,80 @@ impl<'a, 'b: 'a> SymbolTable for LinkModuleIter<'a, 'b> {
     type SymbolIter = alloc::vec::IntoIter<LocalSymbol>;
 
     fn symbols(&self, source_manager: Arc<dyn SourceManager>) -> Self::SymbolIter {
-        let symbols = self
-            .module
-            .symbols
-            .iter()
-            .enumerate()
-            .map(|(i, symbol)| {
-                let index = ItemIndex::new(i);
-                let gid = self.module.id + index;
-                match symbol.item() {
-                    SymbolItem::Compiled(_)
-                    | SymbolItem::Procedure(_)
-                    | SymbolItem::Constant(_)
-                    | SymbolItem::Type(_) => {
-                        let path = self.module.path.join(symbol.name());
-                        ast::LocalSymbol::Item {
-                            name: symbol.name().clone(),
-                            resolved: SymbolResolution::Exact {
-                                gid,
-                                path: Span::new(symbol.name().span(), path.into()),
+        let mut symbols = Vec::with_capacity(self.module.symbols.len());
+        for (i, symbol) in self.module.symbols.iter().enumerate() {
+            let index = ItemIndex::new(i);
+            let gid = self.module.id + index;
+            symbols.push(match symbol.item() {
+                SymbolItem::Compiled(_)
+                | SymbolItem::Procedure(_)
+                | SymbolItem::Constant(_)
+                | SymbolItem::Type(_) => {
+                    let path = self.module.path.join(symbol.name());
+                    ast::LocalSymbol::Item {
+                        name: symbol.name().clone(),
+                        resolved: SymbolResolution::Exact {
+                            gid,
+                            path: Span::new(symbol.name().span(), path.into()),
+                        },
+                    }
+                },
+                SymbolItem::Alias { alias, resolved } => {
+                    let name = alias.name().clone();
+                    let name = Span::new(name.span(), name.into_inner());
+                    if let Some(resolved) = resolved.get() {
+                        let path = self.resolver.item_path(gid);
+                        let span = name.span();
+                        ast::LocalSymbol::Import {
+                            name,
+                            resolution: Ok(SymbolResolution::Exact {
+                                gid: resolved,
+                                path: Span::new(span, path),
+                            }),
+                        }
+                    } else {
+                        match alias.target() {
+                            AliasTarget::MastRoot(root) => ast::LocalSymbol::Import {
+                                name,
+                                resolution: Ok(SymbolResolution::MastRoot(*root)),
+                            },
+                            AliasTarget::Path(path) => {
+                                let resolution = LocalSymbolResolver::expand(
+                                    |name| {
+                                        self.module.get(name).and_then(|sym| match sym.item() {
+                                            SymbolItem::Alias { alias, .. } => {
+                                                Some(alias.target().clone())
+                                            },
+                                            _ => None,
+                                        })
+                                    },
+                                    path.as_deref(),
+                                    &source_manager,
+                                );
+                                ast::LocalSymbol::Import { name, resolution }
                             },
                         }
-                    },
-                    SymbolItem::Alias { alias, resolved } => {
-                        let name = alias.name().clone();
-                        let name = Span::new(name.span(), name.into_inner());
-                        if let Some(resolved) = resolved.get() {
-                            let path = self.resolver.item_path(gid);
-                            let span = name.span();
-                            ast::LocalSymbol::Import {
-                                name,
-                                resolution: Ok(SymbolResolution::Exact {
-                                    gid: resolved,
-                                    path: Span::new(span, path),
-                                }),
-                            }
-                        } else {
-                            match alias.target() {
-                                AliasTarget::MastRoot(root) => ast::LocalSymbol::Import {
-                                    name,
-                                    resolution: Ok(SymbolResolution::MastRoot(*root)),
-                                },
-                                AliasTarget::Path(path) => {
-                                    let resolution = LocalSymbolResolver::expand(
-                                        |name| {
-                                            self.module.get(name).and_then(|sym| match sym.item() {
-                                                SymbolItem::Alias { alias, .. } => {
-                                                    Some(alias.target().clone())
-                                                },
-                                                _ => None,
-                                            })
-                                        },
-                                        path.as_deref(),
-                                        &source_manager,
-                                    );
-                                    ast::LocalSymbol::Import { name, resolution }
-                                },
-                            }
-                        }
-                    },
-                }
-            })
-            .collect::<Vec<_>>();
+                    }
+                },
+            });
+        }
         symbols.into_iter()
+    }
+
+    fn checked_symbols(
+        &self,
+        source_manager: Arc<dyn SourceManager>,
+    ) -> Result<Self::SymbolIter, SymbolResolutionError> {
+        if self.module.symbols.len() > ItemIndex::MAX_ITEMS {
+            let span = self
+                .module
+                .symbols
+                .first()
+                .map(|symbol| symbol.name().span())
+                .unwrap_or(SourceSpan::UNKNOWN);
+            Err(SymbolResolutionError::too_many_items_in_module(span, &*source_manager))
+        } else {
+            Ok(self.symbols(source_manager))
+        }
     }
 }

--- a/crates/assembly/src/linker/resolver/symbol_resolver.rs
+++ b/crates/assembly/src/linker/resolver/symbol_resolver.rs
@@ -301,8 +301,19 @@ impl<'a> SymbolResolver<'a> {
 
                     if path.starts_with_exactly(module_path.as_ref()) {
                         if let Some((_, prev)) = longest_prefix.as_ref() {
-                            if prev.components().count() < module_path.components().count() {
+                            let prev_len = prev.components().count();
+                            let module_len = module_path.components().count();
+                            if prev_len < module_len {
                                 longest_prefix = Some((module.id(), module_path));
+                            } else if prev_len == module_len && prev != &module_path {
+                                return Err(LinkerError::AmbiguousModulePath {
+                                    span,
+                                    source_file: self.source_manager().get(span.source_id()).ok(),
+                                    path: path.to_path_buf().into_boxed_path().into(),
+                                    matches:
+                                        alloc::vec![prev.to_string(), module_path.to_string(),]
+                                            .into_boxed_slice(),
+                                });
                             }
                         } else {
                             longest_prefix = Some((module.id(), module_path));

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -1,5 +1,5 @@
 use alloc::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     string::{String, ToString},
     vec::Vec,
 };
@@ -10,7 +10,10 @@ use std::{
 };
 
 use miden_assembly_syntax::{
-    MAX_REPEAT_COUNT, ast::Path, diagnostics::WrapErr, library::LibraryExport,
+    MAX_REPEAT_COUNT,
+    ast::Path,
+    diagnostics::WrapErr,
+    library::{LibraryExport, ProcedureExport},
 };
 use miden_core::{
     Felt, Word, assert_matches,
@@ -19,7 +22,7 @@ use miden_core::{
     mast::{MastNodeExt, MastNodeId},
     operations::Operation,
     program::Program,
-    serde::{Deserializable, Serializable},
+    serde::{Deserializable, DeserializationError, Serializable},
 };
 use miden_mast_package::{
     MastArtifact, MastForest, Package, PackageExport, PackageKind, PackageManifest,
@@ -5385,6 +5388,137 @@ fn test_cross_module_quoted_identifier_resolution() -> TestResult {
     let _ = assembler.assemble_library([module_a, module_b])?;
 
     Ok(())
+}
+
+#[test]
+fn regression_symbol_resolution_quoted_and_unquoted_module_paths_are_not_ambiguous_during_resolution()
+ {
+    use crate::{Parse, ParseOptions};
+
+    fn parse_library_module(
+        source_manager: Arc<dyn crate::SourceManager>,
+        path_str: &str,
+        source: &str,
+    ) -> alloc::boxed::Box<Module> {
+        let path = Path::validate(path_str).expect("path must validate");
+        let options = ParseOptions {
+            kind: ModuleKind::Library,
+            warnings_as_errors: false,
+            path: Some(Arc::<Path>::from(path)),
+        };
+        <&str as Parse>::parse_with_options(source, source_manager, options)
+            .expect("module must parse and analyse")
+    }
+
+    fn try_assemble_program_with_link_order(libs: &[Library]) -> Result<(), Report> {
+        let program_source = r#"
+begin
+    exec.::foo::bar::add
+end
+"#;
+
+        let mut assembler = Assembler::default();
+        for lib in libs {
+            assembler.link_static_library(lib)?;
+        }
+
+        assembler.assemble_program(program_source).map(|_| ())
+    }
+
+    let context = TestContext::default();
+    let source_manager = context.source_manager();
+
+    let legit_mod = parse_library_module(
+        source_manager.clone(),
+        "::foo::bar",
+        r#"
+pub proc add
+    add.1
+end
+"#,
+    );
+
+    let attacker_mod = parse_library_module(
+        source_manager.clone(),
+        r#"::foo::"bar""#,
+        r#"
+pub proc add
+    add.1
+    add.1
+end
+"#,
+    );
+
+    let legit_lib = Assembler::new(source_manager.clone())
+        .assemble_library([legit_mod])
+        .expect("library assembly must succeed");
+    let attacker_lib = Assembler::new(source_manager)
+        .assemble_library([attacker_mod])
+        .expect("library assembly must succeed");
+
+    let err = try_assemble_program_with_link_order(&[legit_lib.clone(), attacker_lib.clone()])
+        .expect_err("expected ambiguous quoted path shadowing to be rejected");
+    assert_diagnostic!(err, "ambiguous module path resolution for '::foo::bar::add'");
+
+    let err = try_assemble_program_with_link_order(&[attacker_lib, legit_lib])
+        .expect_err("expected ambiguous quoted path shadowing to be rejected");
+    assert_diagnostic!(err, "ambiguous module path resolution for '::foo::bar::add'");
+}
+
+#[test]
+fn regression_symbol_resolution_export_leaf_name_collision_should_be_rejected() {
+    let base = Assembler::default()
+        .assemble_library([r#"
+pub proc p
+    push.1
+end
+"#])
+        .expect("base library assembly must succeed");
+    let node = base
+        .exports()
+        .find_map(|e| e.as_procedure())
+        .expect("expected at least one procedure export")
+        .node;
+
+    let quoted = Arc::<Path>::from(Path::validate(r#"::foo::"bar""#).unwrap());
+    let unquoted = Arc::<Path>::from(Path::validate("::foo::bar").unwrap());
+
+    let mut exports = BTreeMap::new();
+    exports.insert(quoted.clone(), LibraryExport::Procedure(ProcedureExport::new(node, quoted)));
+    exports
+        .insert(unquoted.clone(), LibraryExport::Procedure(ProcedureExport::new(node, unquoted)));
+
+    let lib = Library::new(Arc::clone(base.mast_forest()), exports).expect("library must validate");
+    let err = Library::read_from_bytes(&lib.to_bytes()).expect_err(
+        "expected duplicate canonical export paths to be rejected during deserialization",
+    );
+    assert_matches!(err, DeserializationError::InvalidValue(_));
+}
+
+#[test]
+fn regression_symbol_resolution_malformed_quoted_export_leaf_should_return_error_not_panic() {
+    let base = Assembler::default()
+        .assemble_library([r#"
+pub proc p
+    push.1
+end
+"#])
+        .expect("base library assembly must succeed");
+    let node = base
+        .exports()
+        .find_map(|e| e.as_procedure())
+        .expect("expected at least one procedure export")
+        .node;
+
+    let bad = Arc::<Path>::from(Path::validate(r#"::foo::"bad name""#).unwrap());
+
+    let mut exports = BTreeMap::new();
+    exports.insert(bad.clone(), LibraryExport::Procedure(ProcedureExport::new(node, bad)));
+
+    let lib = Library::new(Arc::clone(base.mast_forest()), exports).expect("library must validate");
+    let err = Library::read_from_bytes(&lib.to_bytes())
+        .expect_err("expected malformed procedure export leaf names to be rejected");
+    assert_matches!(err, DeserializationError::InvalidValue(_));
 }
 
 #[test]

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5435,6 +5435,97 @@ fn test_issue_2696_imported_constant_with_private_dependency() -> TestResult {
 }
 
 #[test]
+fn imported_main_alias_self_call_is_structured_error() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let context = TestContext::new();
+    let program = r#"
+        use ::$exec::"$main"->alias_main
+
+        begin
+            call.alias_main
+        end
+    "#;
+
+    let assembled = catch_unwind(AssertUnwindSafe(|| {
+        Assembler::new(context.source_manager()).assemble_program(program)
+    }));
+
+    assert!(assembled.is_ok(), "assembler panicked during assembly");
+    let err = assembled
+        .unwrap()
+        .expect_err("expected self-referential alias call to be rejected");
+    assert_diagnostic!(&err, "invalid recursive procedure call");
+    assert_diagnostic!(&err, "this call is self-recursive");
+}
+
+#[test]
+fn rootless_call_cycle_is_structured_error() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let context = TestContext::new();
+    let program = r#"
+        begin
+            call.b
+        end
+
+        proc b
+            call."$main"
+        end
+    "#;
+
+    let assembled = catch_unwind(AssertUnwindSafe(|| {
+        Assembler::new(context.source_manager()).assemble_program(program)
+    }));
+
+    assert!(assembled.is_ok(), "assembler panicked during assembly");
+    let err = assembled.unwrap().expect_err("expected cyclic program to be rejected");
+    assert_diagnostic!(&err, "found a cycle in the call graph");
+    assert_diagnostic!(&err, "::$exec::$main");
+    assert_diagnostic!(&err, "b");
+}
+
+#[test]
+fn cyclic_link_retry_is_structured_error_without_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use crate::linker::Linker;
+
+    let context = TestContext::new();
+    let module = context
+        .parse_program(source_file!(
+            &context,
+            r#"
+                begin
+                    call.b
+                end
+
+                proc b
+                    call."$main"
+                end
+            "#
+        ))
+        .expect("program parsing must succeed");
+    let source_manager = context.source_manager();
+
+    let first_attempt = catch_unwind(AssertUnwindSafe(|| {
+        let mut linker = Linker::new(source_manager.clone());
+        let first_err = linker
+            .link([module.clone()])
+            .expect_err("expected cyclic program to be rejected on first link");
+        let second_err = linker
+            .link(core::iter::empty())
+            .expect_err("expected cyclic program to be rejected on second link");
+        (first_err, second_err)
+    }));
+
+    assert!(first_attempt.is_ok(), "linker panicked while retrying a cyclic link");
+    let (first_err, second_err) = first_attempt.unwrap();
+    assert!(first_err.to_string().contains("found a cycle in the call graph"));
+    assert!(second_err.to_string().contains("found a cycle in the call graph"));
+}
+
+#[test]
 fn test_cross_module_constant_cycle_in_procedure_scope_is_structured_error() {
     use std::panic::{AssertUnwindSafe, catch_unwind};
 
@@ -5515,6 +5606,269 @@ fn imported_error_message_cycle_is_rejected_without_panicking() {
     assert_diagnostic!(&err, "constant evaluation terminated due to infinite recursion");
     assert_diagnostic!(&err, "pub const ERR_A = b::ERR_B");
     assert_diagnostic!(&err, "pub const ERR_B = a::ERR_A");
+}
+
+#[test]
+fn exporting_unresolved_digest_alias_preserves_digest_without_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let context = TestContext::new();
+    let digest = Word::default();
+    let module = context
+        .parse_module_with_path(
+            "m::n",
+            source_file!(
+                &context,
+                "pub use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo\n"
+            ),
+        )
+        .expect("module parsing must succeed");
+
+    let assembled = catch_unwind(AssertUnwindSafe(|| {
+        Assembler::new(context.source_manager()).assemble_library([module])
+    }));
+
+    assert!(assembled.is_ok(), "assembly panicked, expected library assembly to succeed");
+    let library = assembled
+        .unwrap()
+        .expect("expected digest alias export to assemble successfully");
+    assert_eq!(library.get_procedure_root_by_path("m::n::foo"), Some(digest));
+}
+
+#[test]
+fn path_alias_chain_to_digest_assembles_without_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let context = TestContext::new();
+    let digest = Word::default();
+    let module = context
+        .parse_module_with_path(
+            "m::n",
+            source_file!(
+                &context,
+                r#"
+                    pub use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo
+                    pub use m::n::foo->bar
+
+                    pub proc calls_bar
+                        call.bar
+                    end
+                "#
+            ),
+        )
+        .expect("module parsing must succeed");
+
+    let assembled = catch_unwind(AssertUnwindSafe(|| {
+        Assembler::new(context.source_manager()).assemble_library([module])
+    }));
+
+    assert!(assembled.is_ok(), "assembly panicked, expected library assembly to succeed");
+    let library = assembled
+        .unwrap()
+        .expect("expected digest alias chain to assemble successfully");
+    assert_eq!(library.get_procedure_root_by_path("m::n::bar"), Some(digest));
+    assert!(library.get_procedure_root_by_path("m::n::calls_bar").is_some());
+}
+
+#[test]
+fn imported_digest_alias_invoke_assembles_without_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let program = r#"
+        use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo
+
+        begin
+            exec.foo
+        end
+    "#;
+
+    let assembled =
+        catch_unwind(AssertUnwindSafe(|| Assembler::default().assemble_program(program)));
+
+    assert!(
+        assembled.is_ok(),
+        "assembly panicked, expected opaque digest invoke to be allowed"
+    );
+    assembled
+        .unwrap()
+        .expect("expected digest-backed invoke alias to assemble successfully");
+}
+
+#[test]
+fn imported_digest_alias_invoke_is_not_reported_unused_when_warnings_are_errors() {
+    use std::sync::Arc;
+
+    use crate::{DefaultSourceManager, Parse, ParseOptions, ast::ModuleKind};
+
+    let source_manager: Arc<dyn crate::SourceManager> = Arc::new(DefaultSourceManager::default());
+    let program = r#"
+        use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo
+
+        begin
+            exec.foo
+        end
+    "#;
+
+    let mut options = ParseOptions::new(ModuleKind::Executable, "main");
+    options.warnings_as_errors = true;
+
+    <&str as Parse>::parse_with_options(program, source_manager, options)
+        .expect("expected digest-backed invoke alias to count as used");
+}
+
+#[test]
+fn imported_digest_alias_forward_decl_is_not_reported_unused_when_warnings_are_errors() {
+    use std::sync::Arc;
+
+    use crate::{DefaultSourceManager, Parse, ParseOptions, ast::ModuleKind};
+
+    let source_manager: Arc<dyn crate::SourceManager> = Arc::new(DefaultSourceManager::default());
+    let program = r#"
+        proc helper
+            exec.foo
+        end
+
+        use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo
+
+        begin
+            call.helper
+        end
+    "#;
+
+    let mut options = ParseOptions::new(ModuleKind::Executable, "main");
+    options.warnings_as_errors = true;
+
+    <&str as Parse>::parse_with_options(program, source_manager, options)
+        .expect("expected forward-declared digest alias to count as used");
+}
+
+#[test]
+fn forward_declared_import_used_by_alias_target_is_not_reported_unused_when_warnings_are_errors() {
+    use std::sync::Arc;
+
+    use crate::{DefaultSourceManager, Parse, ParseOptions, ast::ModuleKind};
+
+    let source_manager: Arc<dyn crate::SourceManager> = Arc::new(DefaultSourceManager::default());
+    let module = r#"
+        pub use foo::bar -> baz
+        use external::module -> foo
+    "#;
+
+    let mut options = ParseOptions::new(ModuleKind::Library, "m");
+    options.warnings_as_errors = true;
+
+    <&str as Parse>::parse_with_options(module, source_manager, options)
+        .expect("expected forward-declared import used by alias target to count as used");
+}
+
+#[test]
+fn forward_declared_import_used_by_type_ref_is_not_reported_unused_when_warnings_are_errors() {
+    use std::sync::Arc;
+
+    use crate::{DefaultSourceManager, Parse, ParseOptions, ast::ModuleKind};
+
+    let source_manager: Arc<dyn crate::SourceManager> = Arc::new(DefaultSourceManager::default());
+    let module = r#"
+        type Local = foo::Type
+        use external::module -> foo
+    "#;
+
+    let mut options = ParseOptions::new(ModuleKind::Library, "m");
+    options.warnings_as_errors = true;
+
+    <&str as Parse>::parse_with_options(module, source_manager, options)
+        .expect("expected forward-declared import used by type ref to count as used");
+}
+
+#[test]
+fn forward_declared_import_used_by_constant_ref_is_not_reported_unused_when_warnings_are_errors() {
+    use std::sync::Arc;
+
+    use crate::{DefaultSourceManager, Parse, ParseOptions, ast::ModuleKind};
+
+    let source_manager: Arc<dyn crate::SourceManager> = Arc::new(DefaultSourceManager::default());
+    let module = r#"
+        const LOCAL = foo::BAR
+        use external::module -> foo
+    "#;
+
+    let mut options = ParseOptions::new(ModuleKind::Library, "m");
+    options.warnings_as_errors = true;
+
+    <&str as Parse>::parse_with_options(module, source_manager, options)
+        .expect("expected forward-declared import used by constant ref to count as used");
+}
+
+#[test]
+fn imported_digest_alias_subpath_is_rejected_without_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let program = r#"
+        use 0x0000000000000000000000000000000000000000000000000000000000000000 -> foo
+
+        begin
+            exec.foo::bar
+        end
+    "#;
+
+    let assembled =
+        catch_unwind(AssertUnwindSafe(|| Assembler::default().assemble_program(program)));
+
+    assert!(assembled.is_ok(), "assembly panicked, expected a structured error");
+    let err = assembled
+        .unwrap()
+        .expect_err("expected digest-backed invoke subpath to be rejected");
+    assert_diagnostic!(&err, "invalid procedure path: not an item");
+}
+
+#[test]
+fn invoking_local_type_alias_returns_error_instead_of_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let masm = "type foo = u32\nbegin\n    exec.foo\nend\n";
+
+    let result = catch_unwind(AssertUnwindSafe(|| Assembler::default().assemble_program(masm)));
+
+    let result = result.expect("assembly panicked, expected a structured error");
+    let err = result.expect_err("assembly unexpectedly succeeded");
+    assert_diagnostic!(&err, "invalid symbol reference: wrong type");
+    assert_diagnostic!(&err, "expected this symbol to reference a procedure item");
+}
+
+#[test]
+fn invoking_local_type_alias_is_rejected_during_semantic_analysis() {
+    let context = TestContext::new();
+    let masm = source_file!(&context, "type foo = u32\nbegin\n    exec.foo\nend\n");
+
+    let err = context
+        .parse_program(masm)
+        .expect_err("semantic analysis unexpectedly accepted invoking a local type alias");
+    assert_diagnostic!(&err, "invalid symbol reference: wrong type");
+    assert_diagnostic!(&err, "expected this symbol to reference a procedure item");
+}
+
+#[test]
+fn invoking_imported_type_alias_returns_error_instead_of_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let context = TestContext::new();
+    let lib = context
+        .parse_module_with_path("test::types", source_file!(&context, "pub type foo = u32\n"))
+        .expect("library module parsing must succeed");
+    let library = Assembler::new(context.source_manager())
+        .assemble_library([lib])
+        .expect("library assembly must succeed");
+
+    let mut assembler = Assembler::new(context.source_manager());
+    assembler.link_dynamic_library(library).expect("library linking must succeed");
+
+    let program = "use test::types\nbegin\n    exec.types::foo\nend\n";
+    let result = catch_unwind(AssertUnwindSafe(|| assembler.assemble_program(program)));
+
+    let result = result.expect("assembly panicked, expected a structured error");
+    let err = result.expect_err("assembly unexpectedly succeeded");
+    assert_diagnostic!(&err, "invalid procedure reference: path refers to a non-procedure item");
+    assert_diagnostic!(&err, "test::types::foo");
 }
 
 #[test]

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5392,23 +5392,6 @@ fn test_cross_module_quoted_identifier_resolution() -> TestResult {
 
 #[test]
 fn regression_symbol_resolution_duplicate_module_paths_are_rejected_during_linking() {
-    use crate::{Parse, ParseOptions};
-
-    fn parse_library_module(
-        source_manager: Arc<dyn crate::SourceManager>,
-        path_str: &str,
-        source: &str,
-    ) -> alloc::boxed::Box<Module> {
-        let path = Path::validate(path_str).expect("path must validate");
-        let options = ParseOptions {
-            kind: ModuleKind::Library,
-            warnings_as_errors: false,
-            path: Some(Arc::<Path>::from(path)),
-        };
-        <&str as Parse>::parse_with_options(source, source_manager, options)
-            .expect("module must parse and analyse")
-    }
-
     fn try_assemble_program_with_link_order(libs: &[Library]) -> Result<(), Report> {
         let program_source = r#"
 begin
@@ -5427,18 +5410,20 @@ end
     let context = TestContext::default();
     let source_manager = context.source_manager();
 
-    let legit_mod = parse_library_module(
-        source_manager.clone(),
-        "::foo::bar",
-        r#"
+    let legit_mod = context
+        .parse_module_with_path(
+            "::foo::bar",
+            r#"
 pub proc add
     add.1
 end
 "#,
-    );
+        )
+        .expect("module must parse and analyse");
 
-    let attacker_mod =
-        parse_library_module(source_manager.clone(), r#"::foo::"bar""#, "pub proc add add.2 end");
+    let attacker_mod = context
+        .parse_module_with_path(r#"::foo::"bar""#, "pub proc add add.2 end")
+        .expect("module must parse and analyse");
 
     let legit_lib = Assembler::new(source_manager.clone())
         .assemble_library([legit_mod])
@@ -5458,29 +5443,14 @@ end
 
 #[test]
 fn regression_symbol_resolution_in_library_canonical_export_collision_is_rejected() {
-    use crate::{Parse, ParseOptions};
-
-    fn parse_library_module(
-        source_manager: Arc<dyn crate::SourceManager>,
-        path_str: &str,
-        source: &str,
-    ) -> alloc::boxed::Box<Module> {
-        let path = Path::validate(path_str).expect("path must validate");
-        let options = ParseOptions {
-            kind: ModuleKind::Library,
-            warnings_as_errors: false,
-            path: Some(Arc::<Path>::from(path)),
-        };
-        <&str as Parse>::parse_with_options(source, source_manager, options)
-            .expect("module must parse and analyse")
-    }
-
     let context = TestContext::default();
     let source_manager = context.source_manager();
-    let legit_mod =
-        parse_library_module(source_manager.clone(), "::foo::bar", "pub proc add add.1 end");
-    let attacker_mod =
-        parse_library_module(source_manager.clone(), r#"::foo::"bar""#, "pub proc add add.2 end");
+    let legit_mod = context
+        .parse_module_with_path("::foo::bar", "pub proc add add.1 end")
+        .expect("module must parse and analyse");
+    let attacker_mod = context
+        .parse_module_with_path(r#"::foo::"bar""#, "pub proc add add.2 end")
+        .expect("module must parse and analyse");
 
     let err = Assembler::new(source_manager)
         .assemble_library([legit_mod, attacker_mod])

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5391,8 +5391,7 @@ fn test_cross_module_quoted_identifier_resolution() -> TestResult {
 }
 
 #[test]
-fn regression_symbol_resolution_quoted_and_unquoted_module_paths_are_not_ambiguous_during_resolution()
- {
+fn regression_symbol_resolution_duplicate_module_paths_are_rejected_during_linking() {
     use crate::{Parse, ParseOptions};
 
     fn parse_library_module(
@@ -5438,16 +5437,8 @@ end
 "#,
     );
 
-    let attacker_mod = parse_library_module(
-        source_manager.clone(),
-        r#"::foo::"bar""#,
-        r#"
-pub proc add
-    add.1
-    add.1
-end
-"#,
-    );
+    let attacker_mod =
+        parse_library_module(source_manager.clone(), "::foo::bar", "pub proc add add.2 end");
 
     let legit_lib = Assembler::new(source_manager.clone())
         .assemble_library([legit_mod])
@@ -5457,12 +5448,12 @@ end
         .expect("library assembly must succeed");
 
     let err = try_assemble_program_with_link_order(&[legit_lib.clone(), attacker_lib.clone()])
-        .expect_err("expected ambiguous quoted path shadowing to be rejected");
-    assert_diagnostic!(err, "ambiguous module path resolution for '::foo::bar::add'");
+        .expect_err("expected duplicate canonical module namespace to be rejected");
+    assert_diagnostic!(err, "duplicate definition found for module '::foo::bar'");
 
     let err = try_assemble_program_with_link_order(&[attacker_lib, legit_lib])
-        .expect_err("expected ambiguous quoted path shadowing to be rejected");
-    assert_diagnostic!(err, "ambiguous module path resolution for '::foo::bar::add'");
+        .expect_err("expected duplicate canonical module namespace to be rejected");
+    assert_diagnostic!(err, "duplicate definition found for module '::foo::bar'");
 }
 
 #[test]

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -33,7 +33,7 @@ use proptest::{
 };
 
 use crate::{
-    Assembler, Library, ModuleParser, PathBuf,
+    Assembler, KernelLibrary, Library, ModuleParser, PathBuf,
     assembler::MAX_CONTROL_FLOW_NESTING,
     ast::{Module, ModuleKind, ProcedureName, QualifiedProcedureName},
     diagnostics::{IntoDiagnostic, Report},
@@ -409,6 +409,184 @@ fn library_serialization() -> Result<(), Report> {
     assert_eq!(bundle, deserialized);
 
     Ok(())
+}
+
+fn read_usize_vint64(bytes: &[u8], offset: &mut usize) -> usize {
+    // This test patches raw bytes in place, so it needs byte offsets that ByteReader::read_usize
+    // does not expose.
+    let first_byte = bytes.get(*offset).copied().expect("out-of-bounds vint64 peek");
+    let length = first_byte.trailing_zeros() as usize + 1;
+
+    if length == 9 {
+        *offset += 1;
+        let end = (*offset).checked_add(8).expect("offset overflow while reading vint64");
+        let chunk: [u8; 8] = bytes[*offset..end].try_into().expect("out-of-bounds vint64");
+        *offset = end;
+        let value = u64::from_le_bytes(chunk);
+        usize::try_from(value).expect("encoded usize does not fit host usize")
+    } else {
+        let end = (*offset).checked_add(length).expect("offset overflow while reading vint64");
+        let mut encoded = [0u8; 8];
+        encoded[..length].copy_from_slice(&bytes[*offset..end]);
+        *offset = end;
+        let value = u64::from_le_bytes(encoded) >> length;
+        usize::try_from(value).expect("encoded usize does not fit host usize")
+    }
+}
+
+fn locate_node_infos(bytes: &[u8]) -> (usize, usize) {
+    // Header: magic[4] + flags[1] + version[3]
+    let mut offset = 0usize;
+    offset += 4;
+    offset += 1;
+    offset += 3;
+
+    let node_count = read_usize_vint64(bytes, &mut offset);
+    let _decorator_count = read_usize_vint64(bytes, &mut offset);
+
+    // Roots: len (usize) + elements (u32 LE)
+    let roots_len = read_usize_vint64(bytes, &mut offset);
+    offset += roots_len * 4;
+
+    // Basic block data: len (usize) + bytes
+    let bb_len = read_usize_vint64(bytes, &mut offset);
+    offset += bb_len;
+
+    (offset, node_count)
+}
+
+fn build_library_bytes_with_spoofed_first_node_digest(
+    lib: &Library,
+    spoof_seed: &str,
+) -> (Vec<u8>, Word) {
+    use miden_core::serde::{ByteWriter, Serializable};
+
+    // Serialize the MastForest in stripped form so the byte layout is minimal and stable.
+    let forest = lib.mast_forest().as_ref();
+    let original_digest = forest[MastNodeId::new_unchecked(0)].digest();
+    let mut forest_bytes = Vec::new();
+    forest.write_stripped(&mut forest_bytes);
+
+    let (node_infos_start, node_count) = locate_node_infos(&forest_bytes);
+    assert!(node_count > 0, "expected at least one node info entry");
+
+    // Patch node 0 digest in-place.
+    let spoofed_digest = miden_core::utils::hash_string_to_word(spoof_seed);
+    assert_ne!(spoofed_digest, original_digest, "spoofed digest must differ");
+
+    let mut spoofed_digest_bytes = Vec::new();
+    spoofed_digest.write_into(&mut spoofed_digest_bytes);
+    assert_eq!(spoofed_digest_bytes.len(), 32, "Word must serialize to 32 bytes");
+
+    let node0_digest_offset = node_infos_start + 8;
+    forest_bytes[node0_digest_offset..node0_digest_offset + 32]
+        .copy_from_slice(&spoofed_digest_bytes);
+
+    // Re-encode a library byte stream using the spoofed forest bytes.
+    let mut bytes = forest_bytes;
+    bytes.write_usize(lib.exports().count());
+    for export in lib.exports() {
+        export.write_into(&mut bytes);
+    }
+    (bytes, spoofed_digest)
+}
+
+#[test]
+fn regression_library_deserialisation_rejects_spoofed_mast_node_digests() {
+    let lib_src = r#"
+pub proc p
+    push.1
+end
+"#;
+    let lib = Assembler::default()
+        .assemble_library([lib_src])
+        .expect("library assembly must succeed");
+
+    let (bytes, _) =
+        build_library_bytes_with_spoofed_first_node_digest(&lib, "spoofed-library-digest");
+    let err = Library::read_from_bytes(&bytes)
+        .expect_err("expected library deserialization to reject inconsistent node digests");
+    assert!(
+        err.to_string().contains("invalid untrusted MAST forest"),
+        "expected untrusted-MAST validation failure, got: {err}"
+    );
+    assert!(
+        err.to_string().contains("hash mismatch for node"),
+        "expected digest mismatch failure, got: {err}"
+    );
+}
+
+#[test]
+fn unchecked_library_deserialisation_accepts_spoofed_mast_node_digests() {
+    let lib_src = r#"
+pub proc p
+    push.1
+end
+"#;
+    let lib = Assembler::default()
+        .assemble_library([lib_src])
+        .expect("library assembly must succeed");
+
+    let (bytes, spoofed_digest) =
+        build_library_bytes_with_spoofed_first_node_digest(&lib, "spoofed-library-digest");
+    let deserialized = Library::read_from_bytes_unchecked(&bytes)
+        .expect("unchecked library deserialization must accept spoofed node digests");
+
+    assert_eq!(
+        deserialized.mast_forest()[MastNodeId::new_unchecked(0)].digest(),
+        spoofed_digest
+    );
+}
+
+#[test]
+fn regression_kernel_library_deserialisation_rejects_spoofed_mast_node_digests() {
+    let kernel_src = r#"
+pub proc k1
+    push.1
+end
+"#;
+    let kernel_lib = Assembler::default()
+        .assemble_kernel(kernel_src)
+        .expect("kernel assembly must succeed");
+
+    let (bytes, _) = build_library_bytes_with_spoofed_first_node_digest(
+        kernel_lib.as_ref(),
+        "spoofed-kernel-digest",
+    );
+    let err = KernelLibrary::read_from_bytes(&bytes)
+        .expect_err("expected kernel library deserialization to reject inconsistent node digests");
+    assert!(
+        err.to_string().contains("invalid untrusted MAST forest"),
+        "expected untrusted-MAST validation failure, got: {err}"
+    );
+    assert!(
+        err.to_string().contains("hash mismatch for node"),
+        "expected digest mismatch failure, got: {err}"
+    );
+}
+
+#[test]
+fn unchecked_kernel_library_deserialisation_accepts_spoofed_mast_node_digests() {
+    let kernel_src = r#"
+pub proc k1
+    push.1
+end
+"#;
+    let kernel_lib = Assembler::default()
+        .assemble_kernel(kernel_src)
+        .expect("kernel assembly must succeed");
+
+    let (bytes, spoofed_digest) = build_library_bytes_with_spoofed_first_node_digest(
+        kernel_lib.as_ref(),
+        "spoofed-kernel-digest",
+    );
+    let deserialized = KernelLibrary::read_from_bytes_unchecked(&bytes)
+        .expect("unchecked kernel deserialization must accept spoofed node digests");
+
+    assert_eq!(
+        deserialized.mast_forest()[MastNodeId::new_unchecked(0)].digest(),
+        spoofed_digest
+    );
 }
 
 #[test]

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5457,6 +5457,38 @@ end
 }
 
 #[test]
+fn regression_symbol_resolution_in_library_canonical_export_collision_is_rejected() {
+    use crate::{Parse, ParseOptions};
+
+    fn parse_library_module(
+        source_manager: Arc<dyn crate::SourceManager>,
+        path_str: &str,
+        source: &str,
+    ) -> alloc::boxed::Box<Module> {
+        let path = Path::validate(path_str).expect("path must validate");
+        let options = ParseOptions {
+            kind: ModuleKind::Library,
+            warnings_as_errors: false,
+            path: Some(Arc::<Path>::from(path)),
+        };
+        <&str as Parse>::parse_with_options(source, source_manager, options)
+            .expect("module must parse and analyse")
+    }
+
+    let context = TestContext::default();
+    let source_manager = context.source_manager();
+    let legit_mod =
+        parse_library_module(source_manager.clone(), "::foo::bar", "pub proc add add.1 end");
+    let attacker_mod =
+        parse_library_module(source_manager.clone(), r#"::foo::"bar""#, "pub proc add add.2 end");
+
+    let err = Assembler::new(source_manager)
+        .assemble_library([legit_mod, attacker_mod])
+        .expect_err("expected duplicate canonical export paths to be rejected during assembly");
+    assert_diagnostic!(err, "duplicate definition found for export path '::foo::bar::add'");
+}
+
+#[test]
 fn regression_symbol_resolution_export_leaf_name_collision_should_be_rejected() {
     let base = Assembler::default()
         .assemble_library([r#"

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -5438,7 +5438,7 @@ end
     );
 
     let attacker_mod =
-        parse_library_module(source_manager.clone(), "::foo::bar", "pub proc add add.2 end");
+        parse_library_module(source_manager.clone(), r#"::foo::"bar""#, "pub proc add add.2 end");
 
     let legit_lib = Assembler::new(source_manager.clone())
         .assemble_library([legit_mod])

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -5,11 +5,21 @@ mod section;
 mod seed_gen;
 mod serialization;
 
-use alloc::{format, string::String, sync::Arc, vec::Vec};
+use alloc::{
+    format,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
 
 use miden_assembly_syntax::{Library, Report, ast::QualifiedProcedureName};
 pub use miden_assembly_syntax::{Version, VersionError};
-use miden_core::{Word, program::Program};
+use miden_core::{
+    Word,
+    crypto::hash::Poseidon2,
+    program::Program,
+    serde::{ByteWriter, Serializable},
+};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -52,6 +62,49 @@ impl Package {
     /// Returns the digest of the package's MAST artifact
     pub fn digest(&self) -> Word {
         self.mast.digest()
+    }
+
+    /// Returns a digest of the package content relevant to assembly and dependency resolution.
+    ///
+    /// This is distinct from [`Self::digest`], which is only the digest of the underlying MAST
+    /// artifact. The content digest currently binds the MAST digest, package name, semantic
+    /// version, package kind, manifest, and any semantic package sections. Package descriptions
+    /// and opaque custom sections are intentionally excluded for now; kernel-section binding is
+    /// added separately.
+    pub fn content_digest(&self) -> Word {
+        let mut bytes = Vec::new();
+        self.write_content_digest_preimage(&mut bytes, None);
+        Poseidon2::hash(&bytes)
+    }
+
+    fn write_content_digest_preimage<W: ByteWriter>(
+        &self,
+        target: &mut W,
+        kernel_digest: Option<&Word>,
+    ) {
+        target.write_bytes(b"miden.package.content.v2");
+        self.digest().write_into(target);
+        self.name.write_into(target);
+        self.version.as_ref().map(|v| v.to_string()).write_into(target);
+        target.write_u8(self.kind.into());
+        self.manifest.write_into(target);
+        self.write_content_digest_sections(target);
+        target.write_bool(kernel_digest.is_some());
+        if let Some(kernel_digest) = kernel_digest {
+            kernel_digest.write_into(target);
+        }
+    }
+
+    fn write_content_digest_sections<W: ByteWriter>(&self, target: &mut W) {
+        let semantic_sections = self
+            .sections
+            .iter()
+            .filter(|section| section.id == SectionId::ACCOUNT_COMPONENT_METADATA)
+            .collect::<Vec<_>>();
+        target.write_usize(semantic_sections.len());
+        for section in semantic_sections {
+            section.write_into(target);
+        }
     }
 
     /// Returns the MastArtifact of the package

--- a/crates/mast-package/src/package/serialization.rs
+++ b/crates/mast-package/src/package/serialization.rs
@@ -435,6 +435,7 @@ mod tests {
         library::{LibraryExport, ProcedureExport as LibraryProcedureExport},
     };
     use miden_core::{
+        Word,
         mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, MastNodeExt, MastNodeId},
         operations::Operation,
         serde::{
@@ -444,9 +445,12 @@ mod tests {
     };
 
     use super::{
-        MAGIC_PACKAGE, MastArtifact, Package, PackageExport, PackageKind, PackageManifest, VERSION,
+        MAGIC_PACKAGE, MastArtifact, Package, PackageExport, PackageKind, PackageManifest, Section,
+        VERSION,
     };
-    use crate::package::manifest::ProcedureExport as PackageProcedureExport;
+    use crate::{
+        Dependency, SectionId, package::manifest::ProcedureExport as PackageProcedureExport,
+    };
 
     fn build_forest() -> (MastForest, MastNodeId) {
         let mut forest = MastForest::new();
@@ -515,6 +519,79 @@ mod tests {
         bytes.write_usize(count);
 
         bytes
+    }
+
+    #[test]
+    fn package_content_digest_changes_when_identity_fields_change() {
+        let package = build_package();
+        let digest = package.content_digest();
+
+        let renamed = Package {
+            name: String::from("renamed_pkg"),
+            ..package.clone()
+        };
+        assert_ne!(digest, renamed.content_digest());
+
+        let versioned = Package {
+            version: Some("1.2.3".parse().expect("valid semver")),
+            ..package.clone()
+        };
+        assert_ne!(digest, versioned.content_digest());
+
+        let executable = Package { kind: PackageKind::Executable, ..package };
+        assert_ne!(digest, executable.content_digest());
+    }
+
+    #[test]
+    fn package_content_digest_changes_when_manifest_changes() {
+        let package = build_package();
+        let digest = package.content_digest();
+
+        let mut with_dependency = package.clone();
+        with_dependency.manifest.add_dependency(Dependency {
+            name: String::from("dep_pkg").into(),
+            digest: Word::from([1_u32, 2, 3, 4]),
+        });
+        assert_ne!(digest, with_dependency.content_digest());
+    }
+
+    #[test]
+    fn package_content_digest_changes_when_account_component_metadata_changes() {
+        let package = build_package();
+        let digest = package.content_digest();
+
+        let with_metadata = Package {
+            sections: vec![Section::new(SectionId::ACCOUNT_COMPONENT_METADATA, vec![1, 2, 3, 4])],
+            ..package.clone()
+        };
+        assert_ne!(digest, with_metadata.content_digest());
+
+        let with_different_metadata = Package {
+            sections: vec![Section::new(SectionId::ACCOUNT_COMPONENT_METADATA, vec![4, 3, 2, 1])],
+            ..package
+        };
+        assert_ne!(with_metadata.content_digest(), with_different_metadata.content_digest());
+    }
+
+    #[test]
+    fn package_content_digest_ignores_description_and_opaque_custom_sections_for_now() {
+        let package = build_package();
+        let digest = package.content_digest();
+
+        let described = Package {
+            description: Some(String::from("human-facing package description")),
+            ..package.clone()
+        };
+        assert_eq!(digest, described.content_digest());
+
+        let with_section = Package {
+            sections: vec![Section::new(
+                SectionId::custom("opaque").expect("valid custom section id"),
+                vec![1, 2, 3, 4],
+            )],
+            ..package
+        };
+        assert_eq!(digest, with_section.content_digest());
     }
 
     #[test]

--- a/crates/mast-package/src/package/serialization.rs
+++ b/crates/mast-package/src/package/serialization.rs
@@ -513,7 +513,7 @@ mod tests {
         let package = build_package();
         let digest = package.content_digest();
 
-        let mut with_dependency = package.clone();
+        let mut with_dependency = package;
         with_dependency
             .manifest
             .add_dependency(Dependency {


### PR DESCRIPTION
This merges `audit-fixes-2026` into `next`, the number of commits being due to squash-merge of #2850 / #2823. This concludes the use of this audit branch.

The merge keeps the fixes from the audit branch while preserving the newer code already on `next`. It also avoids duplicate changelog entries for fixes that had already landed.

Notable points (mostly noted for when I tackle #2947):
- Library deserialization now validates constant and type export names, not only procedure names.
- Library deserialization keeps the existing `Library::new` export checks.
- Duplicate audit changelog entries were removed.
- The continuation stack changelog link now correctly points to `#2825`.