### PR TITLE
Fix miden-project release dry-run

### DIFF
--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -33,7 +33,7 @@ proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde-untagged = { workspace = true, optional = true }
 thiserror.workspace = true
-toml = { workspace = true }
+toml = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 miden-core.workspace = true


### PR DESCRIPTION
Fixes the workspace-release CI:  `miden-project` uses `toml::Value`, but `toml` only exposes it with its `serde` feature.
This enables `toml/serde` for `miden-project`, so the crate builds in the release dry-run.

Checked with `./scripts/check-msrv.sh` and `cargo publish --workspace --dry-run`.