### PR TITLE
Fix: mast_forest_validate fuzz target inference

### DIFF
--- a/miden-core-fuzz/fuzz_targets/mast_forest_validate.rs
+++ b/miden-core-fuzz/fuzz_targets/mast_forest_validate.rs
@@ -13,19 +13,20 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use miden_core::mast::UntrustedMastForest;
+use miden_core::{mast::UntrustedMastForest, serde::DeserializationError};
 
 fuzz_target!(|data: &[u8]| {
-    let validate_untrusted = |result| {
+    let validate_untrusted = |result: Result<UntrustedMastForest, DeserializationError>| {
         if let Ok(untrusted) = result {
             let _ = untrusted.validate();
         }
     };
-    let validate_untrusted_with_flags = |result| {
-        if let Ok((untrusted, _flags)) = result {
-            let _ = untrusted.validate();
-        }
-    };
+    let validate_untrusted_with_flags =
+        |result: Result<(UntrustedMastForest, u8), DeserializationError>| {
+            if let Ok((untrusted, _flags)) = result {
+                let _ = untrusted.validate();
+            }
+        };
 
     // Test the full untrusted deserialization + validation pipeline
     let Ok(untrusted) = UntrustedMastForest::read_from_bytes(data) else {


### PR DESCRIPTION
Fixes the `mast_forest_validate` fuzz target build failure from the latest daily fuzz job.

The helper closures used for validating `UntrustedMastForest` results were missing explicit parameter types, which caused Rust to fail inference with `E0282` when compiling the fuzz target. This annotates the closures with the concrete `Result` types returned by the untrusted deserialization helpers.