### PR TITLE
Hperm to map comment semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Documented non-overlap requirement for `memcopy_words`, `memcopy_elements`, and AEAD encrypt/decrypt procedures ([#2941](https://github.com/0xMiden/miden-vm/pull/2941)).
 - Aligned AEAD key/nonce stack-order documentation and handler comments with the runtime contract ([#3036](https://github.com/0xMiden/miden-vm/pull/3036)).
 - Aligned `core_lib::math::u256` user docs with unified LE stack limb ordering (`a0/b0` on top), removing conflicting `[b7..b0, a7..a0]` notation ([#3066](https://github.com/0xMiden/miden-vm/pull/3066)).
+- Aligned `SystemEvent::HpermToMap` comments with runtime state semantics (`[R0, R1, C]`) to remove stale `hperm([C, A, B])` wording ([#3079](https://github.com/0xMiden/miden-vm/pull/3079)).
 - Added chainable `Test` builders for common test setup in `miden-utils-testing` ([#2957](https://github.com/0xMiden/miden-vm/pull/2957)).
 - Added fuzz coverage for package semantic deserialization and project parsing, loading, and assembly ([#3015](https://github.com/0xMiden/miden-vm/pull/3015)).
 - Made serde opt-in for package crates, and added macro-based binary and serde roundtrip tests for Arbitrary serialization types ([#3058](https://github.com/0xMiden/miden-vm/pull/3058)).

--- a/core/src/events/sys_events.rs
+++ b/core/src/events/sys_events.rs
@@ -278,19 +278,19 @@ pub enum SystemEvent {
     ///   absorption; two rounds for four words).
     HqwordToMap,
 
-    /// Reads three words from the operand stack and inserts the top two words into the advice map
-    /// under the key defined by applying a Poseidon2 permutation to all three words.
+    /// Reads a hasher state from the operand stack and inserts the two rate words into the advice
+    /// map under the key defined by applying a Poseidon2 permutation to the full state.
     ///
     /// Inputs:
-    ///   Operand stack: [A, B, C, ...]
+    ///   Operand stack: [R0, R1, C, ...]
     ///   Advice map: {...}
     ///
     /// Outputs:
-    ///   Operand stack: [A, B, C, ...]
-    ///   Advice map: {KEY: [a0, a1, a2, a3, b0, b1, b2, b3]}
+    ///   Operand stack: [R0, R1, C, ...]
+    ///   Advice map: {KEY: [r00, r01, r02, r03, r10, r11, r12, r13]}
     ///
-    /// Where KEY is computed by extracting the digest elements from hperm([C, A, B]). For example,
-    /// if C is [0, d, 0, 0], KEY will be set as hash(A || B, d).
+    /// Where KEY is computed by extracting the digest elements from hperm([R0, R1, C]). For
+    /// example, if C is [0, d, 0, 0], KEY will be set as hash(R0 || R1, d).
     HpermToMap,
 }
 


### PR DESCRIPTION
  ## Describe your changes
                                                                                                                                                                                                     
  This PR fixes a semantic drift in `SystemEvent::HpermToMap` documentation comments.                                                                                                                
                                                                                                                                                                                                     
  ### What changed                                                                                                                                                                                   
  - Updated `core/src/events/sys_events.rs` comments for `HpermToMap`:                                                                                                                               
    - stack/state notation from legacy `[A, B, C]` to `[R0, R1, C]`                                                                                                                                  
    - key derivation wording from `hperm([C, A, B])` to `hperm([R0, R1, C])`                                                                                                                         
    - example wording from `hash(A || B, d)` to `hash(R0 || R1, d)`                                                                                                                                  

  ### Why                                                                                                                                                                                            
  The runtime implementation and user/core docs already use `[R0, R1, C]`.                                                                                                                           
  This change removes contradictory wording that could mislead future maintenance, audits, and follow-up fixes.                                                                                      
                                                                                                                                                                                                     
  ### Scope                                                                                                                                                                                          
  - Comment-only change.                                                                                                                                                                             
  - No runtime behavior changes.                                                                                                                                                                     
                                                                                                                                                                                                     
  ### Related context                                                                                                                                                                                
  - `SystemEvent::HpermToMap` handler fix: [#2801](https://github.com/0xMiden/miden-vm/pull/2801)                                                                                                    
                                                                                                                                                                                                     
  ## Checklist before requesting a review                                                                                                                                                            
  - [x] Repo forked and branch created from `next` according to naming convention.                                                                                                                   
  - [x] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).                                                                                                                      
  - [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).                                                                      
  - [x] Relevant issues are linked in the PR description.                                                                                                                                            
  - [x] Tests added for new functionality. (N/A: comment-only change, no new runtime functionality)
  - [x] Documentation/comments updated according to changes.                                                                                                                                         
  - [ ] Updated `CHANGELOG.md`.