### PR TITLE
Bound live advice map size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [BREAKING] Reject non-procedure invoke targets during semantic analysis, and return an assembly error instead of panicking if one still reaches assembly ([#2899](https://github.com/0xMiden/miden-vm/pull/2899)).
 - Added `Package::content_digest()` to identify package contents without changing the MAST digest, including manifest data and semantic package metadata ([#2909](https://github.com/0xMiden/miden-vm/pull/2909)).
 - Hardened MAST forest and package byte-slice deserialization against fuzzed length fields ([#3088](https://github.com/0xMiden/miden-vm/pull/3088)).
+- [BREAKING] Bounded the live advice map by total field elements during execution; advice-provider setup now returns an error when initial advice exceeds this limit ([#3085](https://github.com/0xMiden/miden-vm/pull/3085)).
 
 #### Changes
 

--- a/benches/synthetic-bench/benches/synthetic_bench.rs
+++ b/benches/synthetic-bench/benches/synthetic_bench.rs
@@ -42,7 +42,8 @@ fn processor_inputs(program: &Program) -> (DefaultHost, Program, FastProcessor) 
         StackInputs::default(),
         AdviceInputs::default(),
         ExecutionOptions::default(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     (host, program.clone(), processor)
 }
 

--- a/core/src/advice/map.rs
+++ b/core/src/advice/map.rs
@@ -23,6 +23,10 @@ use crate::{
 /// Each key maps to one or more field element. To access the elements, the VM can move the values
 /// associated with a given key onto the advice stack using `adv.push_mapval` instruction. The VM
 /// can also insert new values into the advice map during execution.
+///
+/// This type is a policy-free container. Execution-specific size limits for live advice map state
+/// are enforced by the processor's `AdviceProvider`, which owns the active execution options and
+/// live resource accounting.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]

--- a/core/src/advice/map.rs
+++ b/core/src/advice/map.rs
@@ -11,7 +11,7 @@ use alloc::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    Felt, Word,
+    Felt, WORD_SIZE, Word,
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 
@@ -82,6 +82,18 @@ impl AdviceMap {
             }
         }
         size
+    }
+
+    /// Returns the total number of field elements stored in this advice map's keys and values.
+    ///
+    /// Each key is a word, so every entry contributes [`WORD_SIZE`] key elements plus the number
+    /// of value elements associated with that key. Returns `None` if the count overflows `usize`.
+    pub fn total_element_count(&self) -> Option<usize> {
+        self.0.values().try_fold(0usize, |total, values| {
+            WORD_SIZE
+                .checked_add(values.len())
+                .and_then(|entry_elements| total.checked_add(entry_elements))
+        })
     }
 
     /// Gets the given key's corresponding entry in the map for in-place manipulation.

--- a/crates/lib/core/tests/crypto/falcon.rs
+++ b/crates/lib/core/tests/crypto/falcon.rs
@@ -512,6 +512,7 @@ fn falcon_prove_verify() {
 
     let trace_inputs =
         FastProcessor::new_with_options(stack_inputs, advice_inputs, Default::default())
+            .expect("processor advice inputs should fit advice map limits")
             .execute_trace_inputs_sync(&program, &mut host)
             .expect("failed to execute");
     let trace = miden_processor::trace::build_trace(trace_inputs).expect("failed to build trace");

--- a/crates/lib/core/tests/crypto/keccak256.rs
+++ b/crates/lib/core/tests/crypto/keccak256.rs
@@ -349,7 +349,8 @@ fn run_keccak_with_max_hash_len(
 
     let options = ExecutionOptions::default().with_max_hash_len_bytes(max_hash_len_bytes);
     let processor =
-        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .map_err(ExecutionError::advice_error_no_context)?;
 
     processor.execute_sync(&program, &mut host)?;
     Ok(())

--- a/crates/lib/core/tests/crypto/sha512.rs
+++ b/crates/lib/core/tests/crypto/sha512.rs
@@ -233,7 +233,8 @@ fn run_sha512_with_max_hash_len(
 
     let options = ExecutionOptions::default().with_max_hash_len_bytes(max_hash_len_bytes);
     let processor =
-        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .map_err(ExecutionError::advice_error_no_context)?;
 
     processor.execute_sync(&program, &mut host)?;
     Ok(())

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -369,6 +369,7 @@ impl Test {
         // execute the test
         let processor = FastProcessor::new(self.stack_inputs)
             .with_advice(self.advice_inputs.clone())
+            .expect("test advice inputs should fit default advice map limits")
             .with_debugging(self.in_debug_mode)
             .with_tracing(self.in_debug_mode);
         let execution_output = processor.execute_sync(&program, &mut host).unwrap();
@@ -546,7 +547,8 @@ impl Test {
                     .with_debugging(self.in_debug_mode)
                     .with_core_trace_fragment_size(FRAGMENT_SIZE)
                     .unwrap(),
-            );
+            )
+            .map_err(ExecutionError::advice_error_no_context)?;
             fast_processor.execute_trace_inputs_sync(&program, &mut host)
         };
 
@@ -571,6 +573,7 @@ impl Test {
 
         let processor = FastProcessor::new(self.stack_inputs)
             .with_advice(self.advice_inputs.clone())
+            .map_err(ExecutionError::advice_error_no_context)?
             .with_debugging(true)
             .with_tracing(true);
 
@@ -592,6 +595,7 @@ impl Test {
 
         let processor = FastProcessor::new(self.stack_inputs)
             .with_advice(self.advice_inputs.clone())
+            .map_err(ExecutionError::advice_error_no_context)?
             .with_debugging(true)
             .with_tracing(true);
 
@@ -757,6 +761,7 @@ impl Test {
         let fast_result_by_step = {
             let fast_process = FastProcessor::new(stack_inputs)
                 .with_advice(self.advice_inputs.clone())
+                .expect("test advice inputs should fit default advice map limits")
                 .with_debugging(self.in_debug_mode)
                 .with_tracing(self.in_debug_mode);
             fast_process.execute_by_step_sync(&program, &mut host)

--- a/miden-vm/benches/build_trace.rs
+++ b/miden-vm/benches/build_trace.rs
@@ -72,7 +72,8 @@ fn build_trace(c: &mut Criterion) {
                                 ExecutionOptions::default()
                                     .with_core_trace_fragment_size(TRACE_FRAGMENT_SIZE)
                                     .unwrap(),
-                            );
+                            )
+                            .expect("processor advice inputs should fit advice map limits");
 
                             (host, program.clone(), processor)
                         },

--- a/miden-vm/benches/program_execution_fast.rs
+++ b/miden-vm/benches/program_execution_fast.rs
@@ -56,8 +56,9 @@ fn program_execution_fast(c: &mut Criterion) {
                                 .with_library(&CoreLibrary::default())
                                 .unwrap();
 
-                            let processor =
-                                FastProcessor::new(stack_inputs).with_advice(advice_inputs.clone());
+                            let processor = FastProcessor::new(stack_inputs)
+                                .with_advice(advice_inputs.clone())
+                                .expect("advice inputs should fit advice map limits");
 
                             (host, program.clone(), processor)
                         },

--- a/miden-vm/benches/program_execution_for_trace.rs
+++ b/miden-vm/benches/program_execution_for_trace.rs
@@ -68,7 +68,8 @@ fn program_execution_for_trace(c: &mut Criterion) {
                                 ExecutionOptions::default()
                                     .with_core_trace_fragment_size(TRACE_FRAGMENT_SIZE)
                                     .unwrap(),
-                            );
+                            )
+                            .expect("processor advice inputs should fit advice map limits");
 
                             (host, program.clone(), processor)
                         },

--- a/miden-vm/src/cli/run.rs
+++ b/miden-vm/src/cli/run.rs
@@ -152,9 +152,8 @@ fn run_masp_program(params: &RunCmd) -> Result<(ExecutionTrace, [u8; 32]), Repor
     )
     .map_err(|err| Report::msg(format!("{err}")))?;
 
-    let processor = FastProcessor::new(stack_inputs)
-        .with_advice(advice_inputs)
-        .with_options(exec_options);
+    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, exec_options)
+        .map_err(|err| Report::msg(format!("{err}")))?;
 
     let trace_inputs = processor
         .execute_trace_inputs_sync(&program, &mut host)
@@ -219,9 +218,8 @@ fn run_masm_program(params: &RunCmd) -> Result<(ExecutionTrace, [u8; 32]), Repor
     )
     .map_err(|err| Report::msg(format!("{err}")))?;
 
-    let processor = FastProcessor::new(stack_inputs)
-        .with_advice(advice_inputs)
-        .with_options(exec_options);
+    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, exec_options)
+        .map_err(|err| Report::msg(format!("{err}")))?;
 
     let trace_inputs = processor
         .execute_trace_inputs_sync(&program, &mut host)

--- a/miden-vm/tests/integration/prove_verify.rs
+++ b/miden-vm/tests/integration/prove_verify.rs
@@ -457,6 +457,7 @@ mod fast_parallel {
         host: &mut DefaultHost,
     ) -> TraceBuildInputs {
         FastProcessor::new_with_options(stack_inputs, advice_inputs, parallel_execution_options())
+            .expect("processor advice inputs should fit advice map limits")
             .execute_trace_inputs_sync(program, host)
             .expect("Fast processor execution failed")
     }

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -108,6 +108,17 @@ pub enum ExecutionError {
     HostError(#[from] HostError),
 }
 
+impl ExecutionError {
+    /// Wraps an advice error without source-location context.
+    pub fn advice_error_no_context(err: AdviceError) -> Self {
+        Self::AdviceError {
+            label: SourceSpan::UNKNOWN,
+            source_file: None,
+            err,
+        }
+    }
+}
+
 impl AsRef<dyn Diagnostic> for ExecutionError {
     fn as_ref(&self) -> &(dyn Diagnostic + 'static) {
         self

--- a/processor/src/execution/operations/crypto_ops/tests.rs
+++ b/processor/src/execution/operations/crypto_ops/tests.rs
@@ -562,7 +562,7 @@ proptest! {
             ZERO,                  // position 15 (bottom)
         ];
         let mut processor = FastProcessor::new(StackInputs::new(&stack_inputs).unwrap())
-            .with_advice(advice_inputs);
+            .with_advice(advice_inputs).expect("advice inputs should fit advice map limits");
         let mut tracer = NoopTracer;
         let program = MastForest::default();
 
@@ -658,7 +658,7 @@ proptest! {
             ZERO,                     // position 15 (bottom)
         ];
         let mut processor = FastProcessor::new(StackInputs::new(&stack_inputs).unwrap())
-            .with_advice(advice_inputs);
+            .with_advice(advice_inputs).expect("advice inputs should fit advice map limits");
         let mut tracer = NoopTracer;
 
         // Execute the operation
@@ -762,8 +762,9 @@ fn test_op_mrupdate_merge_subtree() {
         ZERO,                              // position 14
         ZERO,                              // position 15 (bottom)
     ];
-    let mut processor =
-        FastProcessor::new(StackInputs::new(&stack_inputs).unwrap()).with_advice(advice_inputs);
+    let mut processor = FastProcessor::new(StackInputs::new(&stack_inputs).unwrap())
+        .with_advice(advice_inputs)
+        .expect("advice inputs should fit advice map limits");
     let mut tracer = NoopTracer;
 
     // Execute the operation

--- a/processor/src/execution/operations/io_ops/tests.rs
+++ b/processor/src/execution/operations/io_ops/tests.rs
@@ -23,7 +23,9 @@ fn test_op_advpop() {
     // popping from the advice stack should push the value onto the operand stack
     let advice_stack: Vec<u64> = vec![3];
     let advice_inputs = AdviceInputs::default().with_stack_values(advice_stack).unwrap();
-    let mut processor = FastProcessor::new(StackInputs::default()).with_advice(advice_inputs);
+    let mut processor = FastProcessor::new(StackInputs::default())
+        .with_advice(advice_inputs)
+        .expect("advice inputs should fit advice map limits");
     let mut tracer = NoopTracer;
 
     op_push(&mut processor, Felt::new_unchecked(1)).unwrap();
@@ -46,7 +48,9 @@ fn test_op_advpopw() {
     // word[0]=3 goes to stack position 0 (top), so result is [3, 4, 5, 6, 1].
     let advice_stack: Vec<u64> = vec![3, 4, 5, 6];
     let advice_inputs = AdviceInputs::default().with_stack_values(advice_stack).unwrap();
-    let mut processor = FastProcessor::new(StackInputs::default()).with_advice(advice_inputs);
+    let mut processor = FastProcessor::new(StackInputs::default())
+        .with_advice(advice_inputs)
+        .expect("advice inputs should fit advice map limits");
     let mut tracer = NoopTracer;
 
     op_push(&mut processor, Felt::new_unchecked(1)).unwrap();
@@ -390,7 +394,9 @@ fn test_op_pipe() {
     // pop_stack_dword pops: 30, 29, 28, 27 -> words[0], then 26, 25, 24, 23 -> words[1]
     let advice_stack: Vec<u64> = vec![30, 29, 28, 27, 26, 25, 24, 23];
     let advice_inputs = AdviceInputs::default().with_stack_values(advice_stack).unwrap();
-    let mut processor = FastProcessor::new(StackInputs::default()).with_advice(advice_inputs);
+    let mut processor = FastProcessor::new(StackInputs::default())
+        .with_advice(advice_inputs)
+        .expect("advice inputs should fit advice map limits");
     let mut tracer = NoopTracer;
 
     // arrange the stack such that:

--- a/processor/src/execution_options.rs
+++ b/processor/src/execution_options.rs
@@ -17,6 +17,8 @@ pub struct ExecutionOptions {
     /// Maximum number of field elements that can be inserted into the advice map in a single
     /// `adv.insert_mem` operation.
     max_adv_map_value_size: usize,
+    /// Maximum total number of field elements allowed in live advice map keys and values.
+    max_adv_map_elements: usize,
     /// Maximum number of input bytes allowed for a single hash precompile invocation.
     max_hash_len_bytes: usize,
     /// Maximum number of continuations allowed on the continuation stack at any point during
@@ -33,6 +35,7 @@ impl Default for ExecutionOptions {
             enable_tracing: false,
             enable_debugging: false,
             max_adv_map_value_size: Self::DEFAULT_MAX_ADV_MAP_VALUE_SIZE,
+            max_adv_map_elements: Self::DEFAULT_MAX_ADV_MAP_ELEMENTS,
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
             max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
         }
@@ -50,8 +53,14 @@ impl ExecutionOptions {
     pub const DEFAULT_CORE_TRACE_FRAGMENT_SIZE: usize = 4096; // 2^12
 
     /// Default maximum number of field elements in a single advice map value inserted via
-    /// `adv.insert_mem`. Set to 2^17 (~1 MB given 8-byte field elements).
+    /// execution-time advice map mutations. Set to 2^17 (~1 MB given 8-byte field elements).
     pub const DEFAULT_MAX_ADV_MAP_VALUE_SIZE: usize = 1 << 17;
+
+    /// Default maximum total number of field elements in live advice map keys and values.
+    ///
+    /// Set to 2^20 so the default allows multiple maximum-sized entries while still providing a
+    /// finite host-memory backstop. Each entry contributes 4 key elements plus its value length.
+    pub const DEFAULT_MAX_ADV_MAP_ELEMENTS: usize = 1 << 20;
 
     /// Default maximum number of input bytes for a single hash precompile invocation (e.g.
     /// keccak256, sha512, etc.). Set to 2^20 (1 MB).
@@ -121,6 +130,7 @@ impl ExecutionOptions {
             enable_tracing,
             enable_debugging,
             max_adv_map_value_size: Self::DEFAULT_MAX_ADV_MAP_VALUE_SIZE,
+            max_adv_map_elements: Self::DEFAULT_MAX_ADV_MAP_ELEMENTS,
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
             max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
         })
@@ -193,11 +203,17 @@ impl ExecutionOptions {
         self.enable_debugging
     }
 
-    /// Returns the maximum number of field elements allowed in a single advice map value
-    /// inserted via `adv.insert_mem`.
+    /// Returns the maximum number of field elements allowed in a single live advice map value.
     #[inline]
     pub fn max_adv_map_value_size(&self) -> usize {
         self.max_adv_map_value_size
+    }
+
+    /// Returns the maximum total number of field elements allowed in live advice map keys and
+    /// values.
+    #[inline]
+    pub fn max_adv_map_elements(&self) -> usize {
+        self.max_adv_map_elements
     }
 
     /// Returns the maximum number of input bytes allowed for a single hash precompile invocation.
@@ -206,10 +222,15 @@ impl ExecutionOptions {
         self.max_hash_len_bytes
     }
 
-    /// Sets the maximum number of field elements allowed in a single advice map value
-    /// inserted via `adv.insert_mem`.
+    /// Sets the maximum number of field elements allowed in a single live advice map value.
     pub fn with_max_adv_map_value_size(mut self, size: usize) -> Self {
         self.max_adv_map_value_size = size;
+        self
+    }
+
+    /// Sets the maximum total number of field elements allowed in live advice map keys and values.
+    pub fn with_max_adv_map_elements(mut self, size: usize) -> Self {
+        self.max_adv_map_elements = size;
         self
     }
 

--- a/processor/src/fast/basic_block/sys_event_handlers.rs
+++ b/processor/src/fast/basic_block/sys_event_handlers.rs
@@ -540,7 +540,7 @@ mod tests {
     use miden_core::{Felt, ZERO, crypto::hash::Poseidon2};
 
     use super::*;
-    use crate::{StackInputs, fast::FastProcessor};
+    use crate::{ExecutionOptions, StackInputs, fast::FastProcessor};
 
     /// Tests that `insert_hperm_into_adv_map` produces the same key as applying
     /// `Poseidon2::apply_permutation` directly to the same state, and stores the rate portion
@@ -576,5 +576,73 @@ mod tests {
             .get_mapped_values(&expected_key)
             .expect("key should be present in advice map");
         assert_eq!(stored_values, expected_values.as_slice());
+    }
+
+    #[test]
+    fn insert_hdword_into_adv_map_respects_max_adv_map_value_size() {
+        let stack_values = stack_with_values(8, 1);
+        let options = ExecutionOptions::default().with_max_adv_map_value_size(7);
+        let mut processor = FastProcessor::new(StackInputs::new(&stack_values).unwrap())
+            .with_options(options)
+            .expect("test advice inputs should fit advice map limits");
+
+        let err = insert_hdword_into_adv_map(&mut processor, ZERO).unwrap_err();
+        assert!(matches!(
+            err,
+            SystemEventError::Advice(AdviceError::AdvMapValueSizeExceeded { size: 8, max: 7 })
+        ));
+    }
+
+    #[test]
+    fn insert_hqword_into_adv_map_respects_max_adv_map_value_size() {
+        let stack_values = stack_with_values(15, 1);
+        let options = ExecutionOptions::default().with_max_adv_map_value_size(15);
+        let mut processor = FastProcessor::new(StackInputs::new(&stack_values).unwrap())
+            .with_options(options)
+            .expect("test advice inputs should fit advice map limits");
+
+        let err = insert_hqword_into_adv_map(&mut processor).unwrap_err();
+        assert!(matches!(
+            err,
+            SystemEventError::Advice(AdviceError::AdvMapValueSizeExceeded { size: 16, max: 15 })
+        ));
+    }
+
+    #[test]
+    fn repeated_hdword_insertions_respect_adv_map_element_budget() {
+        let stack_values = stack_with_values(8, 1);
+        let options = ExecutionOptions::default().with_max_adv_map_elements(24);
+        let mut processor = FastProcessor::new(StackInputs::new(&stack_values).unwrap())
+            .with_options(options)
+            .expect("test advice inputs should fit advice map limits");
+
+        for i in 0..2 {
+            write_stack_values(&mut processor, 8, i * 8 + 1);
+            insert_hdword_into_adv_map(&mut processor, ZERO).unwrap();
+        }
+
+        write_stack_values(&mut processor, 8, 17);
+        let err = insert_hdword_into_adv_map(&mut processor, ZERO).unwrap_err();
+        let SystemEventError::Advice(AdviceError::AdvMapElementBudgetExceeded {
+            current,
+            added: 12,
+            max: 24,
+        }) = err
+        else {
+            panic!("expected advice map element budget error, got {err:?}");
+        };
+        assert_eq!(current, 2 * (WORD_SIZE + 2 * WORD_SIZE));
+    }
+
+    fn stack_with_values(count: usize, start: u64) -> Vec<Felt> {
+        let mut stack_values = vec![ZERO];
+        stack_values.extend((0..count).map(|idx| Felt::new_unchecked(start + idx as u64)));
+        stack_values
+    }
+
+    fn write_stack_values(processor: &mut FastProcessor, count: usize, start: u64) {
+        for idx in 0..count {
+            processor.stack_write(idx + 1, Felt::new_unchecked(start + idx as u64));
+        }
     }
 }

--- a/processor/src/fast/execution_api.rs
+++ b/processor/src/fast/execution_api.rs
@@ -529,7 +529,7 @@ impl FastProcessor {
         program: &Program,
         host: &mut impl SyncHost,
     ) -> Result<StackOutputs, ExecutionError> {
-        let mut current_resume_ctx = self.get_initial_resume_context(program).unwrap();
+        let mut current_resume_ctx = self.get_initial_resume_context(program)?;
 
         loop {
             match self.step_sync(host, current_resume_ctx)? {
@@ -548,7 +548,7 @@ impl FastProcessor {
         program: &Program,
         host: &mut impl Host,
     ) -> Result<StackOutputs, ExecutionError> {
-        let mut current_resume_ctx = self.get_initial_resume_context(program).unwrap();
+        let mut current_resume_ctx = self.get_initial_resume_context(program)?;
         let mut processor = self;
 
         loop {

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -18,6 +18,7 @@ use miden_core::{
 use crate::{
     AdviceInputs, AdviceProvider, BaseHost, ContextId, ExecutionError, ExecutionOptions,
     ProcessorState,
+    advice::AdviceError,
     continuation_stack::{Continuation, ContinuationStack},
     errors::MapExecErrNoCtx,
     tracer::{OperationHelperRegisters, Tracer},
@@ -198,25 +199,40 @@ impl FastProcessor {
     ///
     /// let processor = FastProcessor::new(stack_inputs)
     ///     .with_advice(advice_inputs)
+    ///     .expect("advice inputs should fit advice map limits")
     ///     .with_debugging(true)
     ///     .with_tracing(true);
     /// ```
+    ///
+    /// When using non-default advice map limits, prefer [`Self::new_with_options`] so the advice
+    /// inputs are validated against the intended execution options.
     pub fn new(stack_inputs: StackInputs) -> Self {
         Self::new_with_options(stack_inputs, AdviceInputs::default(), ExecutionOptions::default())
+            .expect("empty advice inputs should fit default advice map limits")
     }
 
     /// Sets the advice inputs for the processor.
-    pub fn with_advice(mut self, advice_inputs: AdviceInputs) -> Self {
-        self.advice = advice_inputs.into();
-        self
+    ///
+    /// Advice inputs are loaded into the live advice provider immediately and are validated against
+    /// the processor's current [`ExecutionOptions`]. If the advice map needs non-default limits,
+    /// construct the processor with [`Self::new_with_options`] or call [`Self::with_options`]
+    /// before calling this method.
+    pub fn with_advice(mut self, advice_inputs: AdviceInputs) -> Result<Self, AdviceError> {
+        self.advice = AdviceProvider::new(advice_inputs, &self.options)?;
+        Ok(self)
     }
 
     /// Sets the execution options for the processor.
     ///
     /// This will override any previously set debugging or tracing settings.
-    pub fn with_options(mut self, options: ExecutionOptions) -> Self {
+    ///
+    /// Existing advice inputs are revalidated against the new options before they are applied. To
+    /// load advice inputs that require non-default advice map limits, call this before
+    /// [`Self::with_advice`] or use [`Self::new_with_options`].
+    pub fn with_options(mut self, options: ExecutionOptions) -> Result<Self, AdviceError> {
+        self.advice.set_options(&options)?;
         self.options = options;
-        self
+        Ok(self)
     }
 
     /// Enables or disables debugging mode.
@@ -242,7 +258,7 @@ impl FastProcessor {
         stack_inputs: StackInputs,
         advice_inputs: AdviceInputs,
         options: ExecutionOptions,
-    ) -> Self {
+    ) -> Result<Self, AdviceError> {
         let stack_top_idx = INITIAL_STACK_TOP_IDX;
         let stack = {
             // Note: we use `Vec::into_boxed_slice()` here, since `Box::new([T; N])` first allocates
@@ -258,8 +274,8 @@ impl FastProcessor {
             stack
         };
 
-        Self {
-            advice: advice_inputs.into(),
+        Ok(Self {
+            advice: AdviceProvider::new(advice_inputs, &options)?,
             stack,
             stack_top_idx,
             stack_bot_idx: stack_top_idx - MIN_STACK_DEPTH,
@@ -272,7 +288,7 @@ impl FastProcessor {
             pc_transcript: PrecompileTranscript::new(),
             #[cfg(test)]
             decorator_retrieval_count: Rc::new(Cell::new(0)),
-        }
+        })
     }
 
     /// Returns the resume context to be used with the first call to `step_sync()`.

--- a/processor/src/fast/tests/advice_provider.rs
+++ b/processor/src/fast/tests/advice_provider.rs
@@ -148,6 +148,7 @@ fn test_advice_provider() {
     let mut fast_host = TestHost::with_kernel_forest(kernel_lib.mast_forest().clone());
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
     let fast_stack_outputs = processor.execute_sync(&program, &mut fast_host).unwrap().stack;

--- a/processor/src/fast/tests/fast_decorator_execution_tests.rs
+++ b/processor/src/fast/tests/fast_decorator_execution_tests.rs
@@ -51,6 +51,7 @@ fn test_before_enter_decorator_executed_once_fast() {
     let mut host = TestHost::new();
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
 
@@ -103,6 +104,7 @@ fn test_multiple_before_enter_decorators_each_once_fast() {
     let mut host = TestHost::new();
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
 
@@ -149,6 +151,7 @@ fn test_multiple_after_exit_decorators_each_once_fast() {
     let mut host = TestHost::new();
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
 
@@ -201,6 +204,7 @@ fn test_decorator_execution_order_fast() {
     let mut host = TestHost::new();
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
 
@@ -251,6 +255,7 @@ fn test_processor_decorator_execution() {
     let mut host = TestHost::new();
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
 
@@ -294,6 +299,7 @@ fn test_no_duplication_between_inner_and_before_exit_decorators_fast() {
     let mut host = TestHost::new();
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
 
@@ -374,6 +380,7 @@ fn test_decorator_bypass_in_debug_mode() {
         create_test_program(&[Decorator::Trace(1)], &[Decorator::Trace(2)], &[Operation::Noop]);
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
     let counter = processor.decorator_retrieval_count.clone();

--- a/processor/src/fast/tests/fast_decorator_execution_tests.rs
+++ b/processor/src/fast/tests/fast_decorator_execution_tests.rs
@@ -80,6 +80,7 @@ fn test_after_exit_trace_executes_with_tracing_only_fast() {
     let mut host = TestHost::new();
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_tracing(true);
 
     let result = processor.execute_sync(&program, &mut host);

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -232,7 +232,8 @@ fn test_cycle_limit_exceeded() {
     let program = simple_program_with_ops(vec![Operation::Swap; MIN_TRACE_LEN]);
 
     let processor =
-        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits");
     let err = processor.execute_sync(&program, &mut host).unwrap_err();
 
     assert_matches!(err, ExecutionError::CycleLimitExceeded(max_cycles) if max_cycles == MIN_TRACE_LEN as u32);
@@ -265,7 +266,8 @@ fn test_cycle_limit_exactly_max_cycles_succeeds() {
     .unwrap();
 
     let processor =
-        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits");
     let result = processor.execute_sync(&program, &mut host);
 
     // The program should succeed since it uses exactly max_cycles cycles.
@@ -540,6 +542,7 @@ fn test_external_node_decorator_sequencing() {
     let mut host = crate::test_utils::TestHost::with_kernel_forest(Arc::new(lib_forest));
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
 
@@ -607,7 +610,8 @@ fn test_continuation_stack_limit_exceeded() {
     let options = ExecutionOptions::default().with_max_num_continuations(3);
 
     let processor =
-        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits");
     let err = processor.execute_sync(&program, &mut host).unwrap_err();
 
     assert_matches!(err, ExecutionError::Internal(msg) if msg.contains("continuation stack"));
@@ -635,7 +639,8 @@ fn test_continuation_stack_limit_exactly_max_continuations_succeeds() {
     let options = ExecutionOptions::default().with_max_num_continuations(3);
 
     let processor =
-        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits");
 
     processor.execute_sync(&program, &mut host).unwrap();
 }

--- a/processor/src/host/advice/errors.rs
+++ b/processor/src/host/advice/errors.rs
@@ -29,6 +29,10 @@ pub enum AdviceError {
     #[error("advice map value size of {size} exceeds the maximum of {max}")]
     AdvMapValueSizeExceeded { size: usize, max: usize },
     #[error(
+        "advice map element budget exceeded: adding {added} elements to the current {current} would exceed the maximum of {max}"
+    )]
+    AdvMapElementBudgetExceeded { current: usize, added: usize, max: usize },
+    #[error(
         "provided merkle tree {depth} is out of bounds and cannot be represented as an unsigned 8-bit integer"
     )]
     InvalidMerkleTreeDepth { depth: Felt },

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -27,6 +27,10 @@ const MAX_ADVICE_STACK_SIZE: usize = 1 << 17;
 /// the host (i.e., result of a computation performed outside of the VM), as well as insert new data
 /// into the advice provider to be recovered by the host after the program has finished executing.
 ///
+/// Advice map size limits are enforced here, rather than by `AdviceMap`, because they are part of
+/// execution policy. The provider owns the active `ExecutionOptions` and tracks the live advice map
+/// budget across initial advice, host mutations, and system-event inserts.
+///
 /// An advice provider consists of the following components:
 /// 1. Advice stack, which is a LIFO data structure. The processor can move the elements from the
 ///    advice stack onto the operand stack, as well as push new elements onto the advice stack. The

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -1,10 +1,7 @@
-use alloc::{
-    collections::{VecDeque, btree_map::Entry},
-    vec::Vec,
-};
+use alloc::{collections::VecDeque, vec::Vec};
 
 use miden_core::{
-    Felt, Word,
+    Felt, WORD_SIZE, Word,
     advice::{AdviceInputs, AdviceMap},
     crypto::merkle::{InnerNodeInfo, MerklePath, MerkleStore, NodeIndex},
     precompile::PrecompileRequest,
@@ -15,7 +12,7 @@ use miden_core::{crypto::hash::Blake3_256, serde::Serializable};
 mod errors;
 pub use errors::AdviceError;
 
-use crate::{host::AdviceMutation, processor::AdviceProviderInterface};
+use crate::{ExecutionOptions, host::AdviceMutation, processor::AdviceProviderInterface};
 
 // CONSTANTS
 // ================================================================================================
@@ -48,15 +45,70 @@ const MAX_ADVICE_STACK_SIZE: usize = 1 << 17;
 ///      or,
 ///    - used to produce a STARK proof using a precompile VM, which can be verified in the epilog of
 ///      the program.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AdviceProvider {
     stack: VecDeque<Felt>,
     map: AdviceMap,
+    map_element_count: usize,
+    max_map_value_size: usize,
+    max_map_elements: usize,
     store: MerkleStore,
     pc_requests: Vec<PrecompileRequest>,
 }
 
+impl Default for AdviceProvider {
+    fn default() -> Self {
+        Self::empty(&ExecutionOptions::default())
+    }
+}
+
 impl AdviceProvider {
+    /// Creates a new advice provider from the provided inputs and execution options.
+    ///
+    /// The advice map limits in `options` are enforced while loading the initial advice inputs.
+    pub fn new(inputs: AdviceInputs, options: &ExecutionOptions) -> Result<Self, AdviceError> {
+        let AdviceInputs { stack, map, store } = inputs;
+        let mut provider = Self::empty(options);
+        provider.extend_stack(stack)?;
+        provider.extend_merkle_store(store.inner_nodes());
+        provider.extend_map(&map)?;
+        Ok(provider)
+    }
+
+    fn empty(options: &ExecutionOptions) -> Self {
+        Self {
+            stack: VecDeque::new(),
+            map: AdviceMap::default(),
+            map_element_count: 0,
+            max_map_value_size: options.max_adv_map_value_size(),
+            max_map_elements: options.max_adv_map_elements(),
+            store: MerkleStore::default(),
+            pc_requests: Vec::new(),
+        }
+    }
+
+    pub(crate) fn set_options(&mut self, options: &ExecutionOptions) -> Result<(), AdviceError> {
+        Self::validate_map_values(&self.map, options.max_adv_map_value_size())?;
+        let map_element_count =
+            self.map.total_element_count().ok_or(AdviceError::AdvMapElementBudgetExceeded {
+                current: self.map_element_count,
+                added: usize::MAX,
+                max: options.max_adv_map_elements(),
+            })?;
+        if map_element_count > options.max_adv_map_elements() {
+            return Err(AdviceError::AdvMapElementBudgetExceeded {
+                current: 0,
+                added: map_element_count,
+                max: options.max_adv_map_elements(),
+            });
+        }
+
+        self.map_element_count = map_element_count;
+        self.max_map_value_size = options.max_adv_map_value_size();
+        self.max_map_elements = options.max_adv_map_elements();
+        Ok(())
+    }
+
     #[cfg(test)]
     #[expect(dead_code)]
     pub(crate) fn merkle_store(&self) -> &MerkleStore {
@@ -304,6 +356,51 @@ impl AdviceProvider {
         self.map.get(key).map(AsRef::as_ref)
     }
 
+    fn validate_map_values(map: &AdviceMap, max_value_size: usize) -> Result<(), AdviceError> {
+        for (_, values) in map.iter() {
+            if values.len() > max_value_size {
+                return Err(AdviceError::AdvMapValueSizeExceeded {
+                    size: values.len(),
+                    max: max_value_size,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn entry_element_count(value_len: usize) -> Option<usize> {
+        WORD_SIZE.checked_add(value_len)
+    }
+
+    fn check_map_value_size(&self, size: usize) -> Result<(), AdviceError> {
+        if size > self.max_map_value_size {
+            return Err(AdviceError::AdvMapValueSizeExceeded {
+                size,
+                max: self.max_map_value_size,
+            });
+        }
+        Ok(())
+    }
+
+    fn check_map_element_budget(&self, added: usize) -> Result<(), AdviceError> {
+        let Some(new_total) = self.map_element_count.checked_add(added) else {
+            return Err(AdviceError::AdvMapElementBudgetExceeded {
+                current: self.map_element_count,
+                added,
+                max: self.max_map_elements,
+            });
+        };
+
+        if new_total > self.max_map_elements {
+            return Err(AdviceError::AdvMapElementBudgetExceeded {
+                current: self.map_element_count,
+                added,
+                max: self.max_map_elements,
+            });
+        }
+        Ok(())
+    }
+
     /// Inserts the provided value into the advice map under the specified key.
     ///
     /// The values in the advice map can be moved onto the advice stack by invoking
@@ -311,12 +408,9 @@ impl AdviceProvider {
     ///
     /// Returns an error if the specified key is already present in the advice map.
     pub fn insert_into_map(&mut self, key: Word, values: Vec<Felt>) -> Result<(), AdviceError> {
-        match self.map.entry(key) {
-            Entry::Vacant(entry) => {
-                entry.insert(values.into());
-            },
-            Entry::Occupied(entry) => {
-                let existing_values = entry.get().as_ref();
+        match self.map.get(&key) {
+            Some(existing_values) => {
+                let existing_values = existing_values.as_ref();
                 if existing_values != values {
                     return Err(AdviceError::MapKeyAlreadyPresent {
                         key,
@@ -324,6 +418,19 @@ impl AdviceProvider {
                         new_values: values,
                     });
                 }
+            },
+            None => {
+                self.check_map_value_size(values.len())?;
+                let added = Self::entry_element_count(values.len()).ok_or(
+                    AdviceError::AdvMapElementBudgetExceeded {
+                        current: self.map_element_count,
+                        added: usize::MAX,
+                        max: self.max_map_elements,
+                    },
+                )?;
+                self.check_map_element_budget(added)?;
+                self.map.insert(key, values);
+                self.map_element_count += added;
             },
         }
         Ok(())
@@ -334,13 +441,46 @@ impl AdviceProvider {
     /// Returns an error if any new entry already exists with the same key but a different value
     /// than the one currently stored. The current map remains unchanged.
     pub fn extend_map(&mut self, other: &AdviceMap) -> Result<(), AdviceError> {
+        let mut added = 0usize;
+        for (key, values) in other.iter() {
+            if let Some(existing_values) = self.map.get(key) {
+                if existing_values.as_ref() != values.as_ref() {
+                    return Err(AdviceError::MapKeyAlreadyPresent {
+                        key: *key,
+                        prev_values: existing_values.to_vec(),
+                        new_values: values.to_vec(),
+                    });
+                }
+                continue;
+            }
+
+            self.check_map_value_size(values.len())?;
+            let entry_elements = Self::entry_element_count(values.len()).ok_or(
+                AdviceError::AdvMapElementBudgetExceeded {
+                    current: self.map_element_count,
+                    added: usize::MAX,
+                    max: self.max_map_elements,
+                },
+            )?;
+            added = added.checked_add(entry_elements).ok_or(
+                AdviceError::AdvMapElementBudgetExceeded {
+                    current: self.map_element_count,
+                    added: usize::MAX,
+                    max: self.max_map_elements,
+                },
+            )?;
+        }
+        self.check_map_element_budget(added)?;
+
         self.map.merge(other).map_err(|((key, prev_values), new_values)| {
             AdviceError::MapKeyAlreadyPresent {
                 key,
                 prev_values: prev_values.to_vec(),
                 new_values: new_values.to_vec(),
             }
-        })
+        })?;
+        self.map_element_count += added;
+        Ok(())
     }
 
     // MERKLE STORE
@@ -498,18 +638,6 @@ impl AdviceProvider {
     }
 }
 
-impl From<AdviceInputs> for AdviceProvider {
-    fn from(inputs: AdviceInputs) -> Self {
-        let AdviceInputs { stack, map, store } = inputs;
-        Self {
-            stack: VecDeque::from(stack),
-            map,
-            store,
-            pc_requests: Vec::new(),
-        }
-    }
-}
-
 // ADVICE PROVIDER INTERFACE IMPLEMENTATION
 // ================================================================================================
 
@@ -553,9 +681,14 @@ impl AdviceProviderInterface for AdviceProvider {
 
 #[cfg(test)]
 mod tests {
+    use alloc::{collections::BTreeMap, vec, vec::Vec};
+
+    use miden_core::WORD_SIZE;
+
     use super::AdviceProvider;
     use crate::{
-        AdviceInputs, Felt, Word,
+        AdviceInputs, ExecutionOptions, Felt, Word,
+        advice::{AdviceError, AdviceMap},
         crypto::merkle::{MerkleStore, MerkleTree},
     };
 
@@ -586,10 +719,102 @@ mod tests {
 
         assert_eq!(store_a, store_b);
 
-        let provider_a = AdviceProvider::from(AdviceInputs::default().with_merkle_store(store_a));
-        let provider_b = AdviceProvider::from(AdviceInputs::default().with_merkle_store(store_b));
+        let provider_a = AdviceProvider::new(
+            AdviceInputs::default().with_merkle_store(store_a),
+            &Default::default(),
+        )
+        .unwrap();
+        let provider_b = AdviceProvider::new(
+            AdviceInputs::default().with_merkle_store(store_b),
+            &Default::default(),
+        )
+        .unwrap();
 
         assert_eq!(provider_a, provider_b);
         assert_eq!(provider_a.fingerprint(), provider_b.fingerprint());
+    }
+
+    #[test]
+    fn advice_map_insert_respects_element_budget() {
+        let options = ExecutionOptions::default().with_max_adv_map_elements(WORD_SIZE + 1);
+        let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
+
+        provider.insert_into_map(make_leaf(0), vec![Felt::ONE]).unwrap();
+
+        let err = provider.insert_into_map(make_leaf(1), vec![Felt::ONE]).unwrap_err();
+        assert!(matches!(
+            err,
+            AdviceError::AdvMapElementBudgetExceeded { current: 5, added: 5, max: 5 }
+        ));
+
+        assert_eq!(provider.map.len(), 1);
+        assert!(provider.contains_map_key(&make_leaf(0)));
+        assert!(!provider.contains_map_key(&make_leaf(1)));
+    }
+
+    #[test]
+    fn advice_map_insert_respects_value_limit() {
+        let options = ExecutionOptions::default().with_max_adv_map_value_size(1);
+        let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
+        let values = vec![Felt::ONE, Felt::new_unchecked(2)];
+
+        let err = provider.insert_into_map(make_leaf(0), values).unwrap_err();
+        assert!(matches!(err, AdviceError::AdvMapValueSizeExceeded { size: 2, max: 1 }));
+
+        assert_eq!(provider.map.len(), 0);
+    }
+
+    #[test]
+    fn advice_map_extend_respects_element_budget_atomically() {
+        let options = ExecutionOptions::default().with_max_adv_map_elements(2 * (WORD_SIZE + 1));
+        let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
+        provider.insert_into_map(make_leaf(0), vec![Felt::ONE]).unwrap();
+        let other = advice_map_from_entries(1..3, 1);
+
+        let err = provider.extend_map(&other).unwrap_err();
+        assert!(matches!(
+            err,
+            AdviceError::AdvMapElementBudgetExceeded { current: 5, added: 10, max: 10 }
+        ));
+
+        assert_eq!(provider.map.len(), 1);
+        assert!(provider.contains_map_key(&make_leaf(0)));
+        assert!(!provider.contains_map_key(&make_leaf(1)));
+        assert!(!provider.contains_map_key(&make_leaf(2)));
+    }
+
+    #[test]
+    fn advice_map_extend_respects_value_limit_atomically() {
+        let options = ExecutionOptions::default().with_max_adv_map_value_size(1);
+        let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
+        let other = advice_map_from_entries(0..2, 2);
+
+        let err = provider.extend_map(&other).unwrap_err();
+        assert!(matches!(err, AdviceError::AdvMapValueSizeExceeded { size: 2, max: 1 }));
+
+        assert_eq!(provider.map.len(), 0);
+    }
+
+    #[test]
+    fn initial_advice_map_respects_element_budget() {
+        let options = ExecutionOptions::default().with_max_adv_map_elements(WORD_SIZE);
+        let inputs = AdviceInputs::default().with_map([(make_leaf(0), vec![Felt::ONE])]);
+
+        let err = AdviceProvider::new(inputs, &options).unwrap_err();
+        assert!(matches!(
+            err,
+            AdviceError::AdvMapElementBudgetExceeded { current: 0, added: 5, max: 4 }
+        ));
+    }
+
+    fn advice_map_from_entries(keys: impl Iterator<Item = u64>, value_len: usize) -> AdviceMap {
+        keys.map(|key| {
+            let values = (0..value_len)
+                .map(|offset| Felt::new_unchecked(key + offset as u64))
+                .collect::<Vec<_>>();
+            (make_leaf(key), values)
+        })
+        .collect::<BTreeMap<_, _>>()
+        .into()
     }
 }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -28,7 +28,7 @@ mod tracer;
 use crate::{
     advice::{AdviceInputs, AdviceProvider},
     continuation_stack::ContinuationStack,
-    errors::MapExecErr,
+    errors::{MapExecErr, MapExecErrNoCtx},
     processor::{Processor, SystemInterface},
     trace::RowIndex,
 };
@@ -107,7 +107,8 @@ pub async fn execute(
     host: &mut impl Host,
     options: ExecutionOptions,
 ) -> Result<ExecutionOutput, ExecutionError> {
-    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, options);
+    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, options)
+        .map_exec_err_no_ctx()?;
     processor.execute(program, host).await
 }
 
@@ -128,7 +129,8 @@ pub fn execute_sync(
     host: &mut impl SyncHost,
     options: ExecutionOptions,
 ) -> Result<ExecutionOutput, ExecutionError> {
-    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, options);
+    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, options)
+        .map_exec_err_no_ctx()?;
     processor.execute_sync(program, host)
 }
 

--- a/processor/src/tests/debug_mode_decorator_tests.rs
+++ b/processor/src/tests/debug_mode_decorator_tests.rs
@@ -59,6 +59,7 @@ fn test_decorators_only_execute_in_debug_mode() {
     let mut host_debug_on = TestHost::new();
     let process_debug_on = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
 
@@ -110,6 +111,7 @@ fn test_decorators_only_execute_in_debug_mode_on() {
     // Create processor with debug mode ON (tracing enabled)
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
 
@@ -174,6 +176,7 @@ fn test_zero_overhead_when_debug_off() {
     let mut host_on = TestHost::new();
     let processor_on = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
 

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -183,6 +183,7 @@ fn test_diagnostic_host_event_error_uses_emit_location() {
 
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
     let err = processor.execute_sync(&program, &mut host).expect_err("expected error");
@@ -216,6 +217,7 @@ fn test_diagnostic_host_event_advice_error_uses_emit_location() {
 
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default().with_map([(Word::default(), vec![ZERO])]))
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
     let err = processor.execute_sync(&program, &mut host).expect_err("expected error");
@@ -839,6 +841,7 @@ fn test_diagnostic_procedure_not_found_call() {
 
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
     let err = processor.execute_sync(&program, &mut host).unwrap_err();
@@ -898,6 +901,7 @@ fn test_diagnostic_procedure_not_found_join() {
 
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
     let err = processor.execute_sync(&program, &mut host).unwrap_err();
@@ -961,6 +965,7 @@ fn test_diagnostic_procedure_not_found_loop() {
 
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
     let err = processor.execute_sync(&program, &mut host).unwrap_err();
@@ -1025,6 +1030,7 @@ fn test_diagnostic_procedure_not_found_split() {
 
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
     let err = processor.execute_sync(&program, &mut host).unwrap_err();
@@ -1252,6 +1258,7 @@ fn test_diagnostic_syscall_target_not_in_kernel() {
 
     let processor = FastProcessor::new(StackInputs::default())
         .with_advice(AdviceInputs::default())
+        .expect("advice inputs should fit advice map limits")
         .with_debugging(true)
         .with_tracing(true);
     let err = processor.execute_sync(&program, &mut host).unwrap_err();

--- a/processor/src/trace/chiplets/tests.rs
+++ b/processor/src/trace/chiplets/tests.rs
@@ -181,7 +181,8 @@ fn build_trace(
         StackInputs::new(&stack_inputs).unwrap(),
         AdviceInputs::default(),
         ExecutionOptions::default().with_core_trace_fragment_size(1 << 10).unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
 
     let mut host = DefaultHost::default();
     let program = {

--- a/processor/src/trace/parallel/core_trace_fragment/tests.rs
+++ b/processor/src/trace/parallel/core_trace_fragment/tests.rs
@@ -1601,7 +1601,8 @@ fn build_trace_helper(stack_inputs: &[u64], program: &Program) -> (DecoderTrace,
         ExecutionOptions::default()
             .with_core_trace_fragment_size(MAX_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
     host.register_handler(EMIT_EVENT, Arc::new(NoopEventHandler)).unwrap();
 
@@ -1631,7 +1632,8 @@ fn build_call_trace_helper(program: &Program) -> (SystemTrace, DecoderTrace, usi
         ExecutionOptions::default()
             .with_core_trace_fragment_size(MAX_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
 
     let trace_inputs = processor.execute_trace_inputs_sync(program, &mut host).unwrap();

--- a/processor/src/trace/parallel/tests.rs
+++ b/processor/src/trace/parallel/tests.rs
@@ -331,7 +331,8 @@ fn test_trace_generation_at_fragment_boundaries(
             ExecutionOptions::default()
                 .with_core_trace_fragment_size(fragment_size)
                 .unwrap(),
-        );
+        )
+        .expect("processor advice inputs should fit advice map limits");
         let mut host = DefaultHost::default();
         host.load_library(create_simple_library()).unwrap();
         let trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
@@ -345,7 +346,8 @@ fn test_trace_generation_at_fragment_boundaries(
             ExecutionOptions::default()
                 .with_core_trace_fragment_size(MAX_FRAGMENT_SIZE)
                 .unwrap(),
-        );
+        )
+        .expect("processor advice inputs should fit advice map limits");
         let mut host = DefaultHost::default();
         host.load_library(create_simple_library()).unwrap();
         let trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
@@ -515,7 +517,8 @@ fn test_partial_last_fragment_exists_for_h0_inversion_path() {
         ExecutionOptions::default()
             .with_core_trace_fragment_size(FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
     host.load_library(create_simple_library()).unwrap();
 
@@ -550,7 +553,8 @@ fn miri_repro_uninitialized_tail_read_during_h0_inversion() {
         ExecutionOptions::default()
             .with_core_trace_fragment_size(FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
     host.load_library(create_simple_library()).unwrap();
     let trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
@@ -926,7 +930,8 @@ fn test_build_trace_returns_err_on_empty_memory_reads_replay() {
         ExecutionOptions::default()
             .with_core_trace_fragment_size(MAX_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
     let mut trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
 
@@ -958,7 +963,8 @@ fn test_build_trace_returns_err_on_bad_node_id_in_hasher_replay() {
         ExecutionOptions::default()
             .with_core_trace_fragment_size(MAX_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
     let mut trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
 
@@ -996,7 +1002,8 @@ fn test_build_trace_rejects_mismatched_precompile_requests() {
         ExecutionOptions::default()
             .with_core_trace_fragment_size(MAX_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
     let trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
     let (trace_output, trace_generation_context, program_info) = trace_inputs.into_parts();
@@ -1049,7 +1056,8 @@ fn test_build_trace_with_max_len_corner_cases(
         ExecutionOptions::default()
             .with_core_trace_fragment_size(MAX_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
     let trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
 
@@ -1095,7 +1103,8 @@ fn test_build_trace_returns_err_on_fragment_size_overflow() {
         ExecutionOptions::default()
             .with_core_trace_fragment_size(MAX_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
     let mut trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
 
@@ -1126,7 +1135,8 @@ fn test_build_trace_returns_err_when_chiplets_trace_exceeds_max_len() {
         ExecutionOptions::default()
             .with_core_trace_fragment_size(MAX_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
     let mut trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
 
@@ -1173,7 +1183,8 @@ fn test_build_trace_returns_err_on_empty_core_trace_contexts() {
         ExecutionOptions::default()
             .with_core_trace_fragment_size(MAX_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
     let mut trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
 
@@ -1208,7 +1219,8 @@ fn build_trace_for_program(
         ExecutionOptions::default()
             .with_core_trace_fragment_size(fragment_size)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
     host.load_library(create_simple_library()).unwrap();
     let trace_inputs = processor.execute_trace_inputs_sync(program, &mut host).unwrap();

--- a/processor/src/trace/tests/mod.rs
+++ b/processor/src/trace/tests/mod.rs
@@ -58,7 +58,8 @@ pub fn build_trace_from_program_with_stack(
         ExecutionOptions::default()
             .with_core_trace_fragment_size(TEST_TRACE_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let trace_inputs = processor.execute_trace_inputs_sync(program, &mut host).unwrap();
     build_trace(trace_inputs).unwrap()
 }

--- a/processor/src/trace/tests/mod.rs
+++ b/processor/src/trace/tests/mod.rs
@@ -36,7 +36,8 @@ pub fn build_trace_from_program(program: &Program, stack_inputs: &[u64]) -> Exec
         ExecutionOptions::default()
             .with_core_trace_fragment_size(TEST_TRACE_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let trace_inputs = processor.execute_trace_inputs_sync(program, &mut host).unwrap();
     build_trace(trace_inputs).unwrap()
 }
@@ -99,7 +100,8 @@ pub fn build_trace_from_ops_with_inputs(
         ExecutionOptions::default()
             .with_core_trace_fragment_size(TEST_TRACE_FRAGMENT_SIZE)
             .unwrap(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
     let trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
     build_trace(trace_inputs).unwrap()
 }

--- a/processor/tests/eval_circuit_overflow.rs
+++ b/processor/tests/eval_circuit_overflow.rs
@@ -29,7 +29,8 @@ fn eval_circuit_overflow_panic_check() {
         stack_inputs,
         AdviceInputs::default(),
         miden_processor::ExecutionOptions::default(),
-    );
+    )
+    .expect("processor advice inputs should fit advice map limits");
 
     // Namely, this checks that execution doesn't panic due to an overflow.
     assert!(matches!(

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -75,7 +75,8 @@ pub async fn prove(
     proving_options: ProvingOptions,
 ) -> Result<(StackOutputs, ExecutionProof), ExecutionError> {
     // execute the program to create an execution trace using FastProcessor
-    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, execution_options);
+    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, execution_options)
+        .map_err(ExecutionError::advice_error_no_context)?;
 
     let trace_inputs = processor.execute_trace_inputs(program, host).await?;
     prove_from_trace_sync(TraceProvingInputs::new(trace_inputs, proving_options))
@@ -91,7 +92,8 @@ pub fn prove_sync(
     execution_options: ExecutionOptions,
     proving_options: ProvingOptions,
 ) -> Result<(StackOutputs, ExecutionProof), ExecutionError> {
-    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, execution_options);
+    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, execution_options)
+        .map_err(ExecutionError::advice_error_no_context)?;
 
     let trace_inputs = processor.execute_trace_inputs_sync(program, host)?;
     prove_from_trace_sync(TraceProvingInputs::new(trace_inputs, proving_options))


### PR DESCRIPTION
This caps the live advice map used during execution.

Advice map entries could grow without a total limit. Some paths also inserted fixed-size values without checking the per-entry value limit.

The fix adds one shared limit for the total number of field elements in live advice map keys and values. `AdviceProvider` enforces both the per-entry value limit and the total element limit for initial advice, host map extensions, and system-event inserts.

`FastProcessor` advice setup is now fallible because loading advice creates bounded live state. Call sites now return the validation error instead of panicking.

Fixes #2806. Fixes 0xmiden/security-issues#13. Fixes 0xmiden/security-issues#17.