### PR TITLE
Grow FastProcessor stack up to a configured depth limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Hardened SHA256 message word range checks and U32ADD/U32ADD3 carry constraints, updating recursive verifier relation digest artifacts ([#3021](https://github.com/0xMiden/miden-vm/pull/3021)).
 - [BREAKING] Removed internal `_impl` precompile helpers from the core-lib API, hardened proof deserialization and debug storage errors, and added u256 regression vectors ([#3026](https://github.com/0xMiden/miden-vm/pull/3026)).
 - Fixed `u256::wrapping_mul` so it preserves caller stack values below its operands ([#3071](https://github.com/0xMiden/miden-vm/pull/3071)).
+- Fixed `FastProcessor` stack growth so operand stack depth is bounded by `ExecutionOptions::max_stack_depth` instead of the internal buffer size ([#3086](https://github.com/0xMiden/miden-vm/pull/3086)).
 - Fixed host event and advice-mutation diagnostics to point to the triggering `emit.event(...)` instruction ([#3042](https://github.com/0xMiden/miden-vm/pull/3042)).
 - Fixed debug-only underflow in memory range-check trace generation when the first memory access is at `clk = 0` ([#2976](https://github.com/0xMiden/miden-vm/pull/2976)).
 - Replaced unsound `ptr::read` with safe unbox in panic recovery, removing UB from potential double-drop ([#2934](https://github.com/0xMiden/miden-vm/pull/2934)).

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -58,6 +58,8 @@ pub enum ExecutionError {
     },
     #[error("failed to execute the program for internal reason: {0}")]
     Internal(&'static str),
+    #[error("operand stack depth {depth} exceeds the maximum of {max}")]
+    StackDepthLimitExceeded { depth: usize, max: usize },
     /// This means trace generation would go over the configured row limit.
     ///
     /// In parallel trace building, this is used for core-row prechecks and chiplet overflow.

--- a/processor/src/execution_options.rs
+++ b/processor/src/execution_options.rs
@@ -1,4 +1,5 @@
 use miden_air::trace::MIN_TRACE_LEN;
+use miden_core::program::MIN_STACK_DEPTH;
 
 // EXECUTION OPTIONS
 // ================================================================================================
@@ -24,6 +25,9 @@ pub struct ExecutionOptions {
     /// Maximum number of continuations allowed on the continuation stack at any point during
     /// execution.
     max_num_continuations: usize,
+    /// Maximum number of field elements allowed on the operand stack in the active execution
+    /// context.
+    max_stack_depth: usize,
 }
 
 impl Default for ExecutionOptions {
@@ -38,6 +42,7 @@ impl Default for ExecutionOptions {
             max_adv_map_elements: Self::DEFAULT_MAX_ADV_MAP_ELEMENTS,
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
             max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
+            max_stack_depth: Self::DEFAULT_MAX_STACK_DEPTH,
         }
     }
 }
@@ -69,6 +74,12 @@ impl ExecutionOptions {
     /// Default maximum number of continuations allowed on the continuation stack.
     /// Set to 2^16 (65536).
     pub const DEFAULT_MAX_NUM_CONTINUATIONS: usize = 1 << 16;
+
+    /// Default maximum number of field elements allowed on the operand stack.
+    ///
+    /// This preserves the effective stack depth ceiling imposed by the previous fixed
+    /// `FastProcessor` stack buffer.
+    pub const DEFAULT_MAX_STACK_DEPTH: usize = 6615;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -133,6 +144,7 @@ impl ExecutionOptions {
             max_adv_map_elements: Self::DEFAULT_MAX_ADV_MAP_ELEMENTS,
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
             max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
+            max_stack_depth: Self::DEFAULT_MAX_STACK_DEPTH,
         })
     }
 
@@ -246,10 +258,33 @@ impl ExecutionOptions {
         self.max_num_continuations
     }
 
+    /// Returns the maximum number of field elements allowed on the operand stack in the active
+    /// execution context.
+    #[inline]
+    pub fn max_stack_depth(&self) -> usize {
+        self.max_stack_depth
+    }
+
     /// Sets the maximum number of continuations allowed on the continuation stack.
     pub fn with_max_num_continuations(mut self, max_num_continuations: usize) -> Self {
         self.max_num_continuations = max_num_continuations;
         self
+    }
+
+    /// Sets the maximum number of field elements allowed on the operand stack in the active
+    /// execution context.
+    pub fn with_max_stack_depth(
+        mut self,
+        max_stack_depth: usize,
+    ) -> Result<Self, ExecutionOptionsError> {
+        if max_stack_depth < MIN_STACK_DEPTH {
+            return Err(ExecutionOptionsError::MaxStackDepthTooSmall {
+                max_stack_depth,
+                min_stack_depth: MIN_STACK_DEPTH,
+            });
+        }
+        self.max_stack_depth = max_stack_depth;
+        Ok(self)
     }
 }
 
@@ -268,6 +303,11 @@ pub enum ExecutionOptionsError {
     MaxCycleNumTooBig { max_cycles: u32, max_cycles_limit: u32 },
     #[error("core trace fragment size must be greater than 0")]
     CoreTraceFragmentSizeTooSmall,
+    #[error("maximum stack depth {max_stack_depth} must be at least {min_stack_depth}")]
+    MaxStackDepthTooSmall {
+        max_stack_depth: usize,
+        min_stack_depth: usize,
+    },
 }
 
 // TESTS
@@ -325,5 +365,21 @@ mod tests {
         let opts = ExecutionOptions::new(Some(100), 64, 1024, false, false);
         assert!(opts.is_ok());
         assert_eq!(opts.unwrap().expected_cycles(), 64);
+    }
+
+    #[test]
+    fn max_stack_depth_validates_minimum_depth() {
+        let result = ExecutionOptions::default().with_max_stack_depth(MIN_STACK_DEPTH - 1);
+        assert!(matches!(
+            result,
+            Err(ExecutionOptionsError::MaxStackDepthTooSmall {
+                max_stack_depth,
+                min_stack_depth: MIN_STACK_DEPTH,
+            }) if max_stack_depth == MIN_STACK_DEPTH - 1
+        ));
+
+        let result = ExecutionOptions::default().with_max_stack_depth(MIN_STACK_DEPTH);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().max_stack_depth(), MIN_STACK_DEPTH);
     }
 }

--- a/processor/src/fast/call_and_dyn.rs
+++ b/processor/src/fast/call_and_dyn.rs
@@ -4,7 +4,7 @@ use miden_core::{ZERO, program::MIN_STACK_DEPTH, utils::range};
 
 use crate::{
     errors::OperationError,
-    fast::{ExecutionContextInfo, FastProcessor, INITIAL_STACK_TOP_IDX, STACK_BUFFER_SIZE},
+    fast::{ExecutionContextInfo, FastProcessor, INITIAL_STACK_TOP_IDX},
 };
 
 impl FastProcessor {
@@ -80,8 +80,8 @@ impl FastProcessor {
             // location of the stack in the buffer. We reset it so that after restoring the overflow
             // stack, the stack_bot_idx is at its original position (i.e. INITIAL_STACK_TOP_IDX -
             // 16).
-            let new_stack_top_idx =
-                core::cmp::min(INITIAL_STACK_TOP_IDX + target_overflow_len, STACK_BUFFER_SIZE - 1);
+            let new_stack_top_idx = INITIAL_STACK_TOP_IDX + target_overflow_len;
+            self.ensure_stack_capacity_for_top_idx(new_stack_top_idx);
 
             self.reset_stack_in_buffer(new_stack_top_idx);
         }

--- a/processor/src/fast/call_and_dyn.rs
+++ b/processor/src/fast/call_and_dyn.rs
@@ -73,6 +73,10 @@ impl FastProcessor {
     #[inline(always)]
     fn restore_overflow_stack(&mut self, ctx_info: &ExecutionContextInfo) {
         let target_overflow_len = ctx_info.overflow_stack.len();
+        debug_assert!(
+            MIN_STACK_DEPTH.saturating_add(target_overflow_len) <= self.options.max_stack_depth(),
+            "suspended caller stacks are checked against the operand stack depth limit before being saved"
+        );
 
         // Check if there's enough room to restore the overflow stack in the current stack buffer.
         if target_overflow_len > self.stack_bot_idx {

--- a/processor/src/fast/execution_api.rs
+++ b/processor/src/fast/execution_api.rs
@@ -72,7 +72,10 @@ impl FastProcessor {
         program: &Program,
         host: &mut impl SyncHost,
     ) -> Result<TraceBuildInputs, ExecutionError> {
-        let mut tracer = ExecutionTracer::new(self.options.core_trace_fragment_size());
+        let mut tracer = ExecutionTracer::new(
+            self.options.core_trace_fragment_size(),
+            self.options.max_stack_depth(),
+        );
         let execution_output = self.execute_with_tracer_sync(program, host, &mut tracer)?;
         Ok(Self::trace_build_inputs_from_parts(program, execution_output, tracer))
     }
@@ -85,7 +88,10 @@ impl FastProcessor {
         program: &Program,
         host: &mut impl Host,
     ) -> Result<TraceBuildInputs, ExecutionError> {
-        let mut tracer = ExecutionTracer::new(self.options.core_trace_fragment_size());
+        let mut tracer = ExecutionTracer::new(
+            self.options.core_trace_fragment_size(),
+            self.options.max_stack_depth(),
+        );
         let execution_output = self.execute_with_tracer(program, host, &mut tracer).await?;
         Ok(Self::trace_build_inputs_from_parts(program, execution_output, tracer))
     }

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -642,7 +642,7 @@ impl FastProcessor {
         }
     }
 
-    fn grow_stack_buffer(&mut self, min_len: usize) {
+    fn grow_stack_buffer(&mut self, requested_min_len: usize) {
         // The maximum allocation is tied to the logical operand stack depth, not to the current
         // buffer position. Using `stack_bot_idx` here would make the allocation ceiling drift when
         // the live stack has moved away from the initial base.
@@ -655,18 +655,19 @@ impl FastProcessor {
         // behavior close to the fixed-buffer layout and avoids carrying unused prefix cells into
         // the new allocation. The extra slot is for the next checked push that triggered growth.
         let recentered_min_len = STACK_BUFFER_BASE_IDX.saturating_add(live_len).saturating_add(2);
-        let required_len = min_len.min(max_len).max(recentered_min_len);
-        debug_assert!(required_len <= max_len);
+        debug_assert!(requested_min_len <= max_len);
+        debug_assert!(recentered_min_len <= max_len);
 
-        let mut new_len = self.stack.len();
-        while new_len < required_len {
-            let next_len = new_len.saturating_mul(2);
-            if next_len <= new_len {
-                new_len = required_len;
-                break;
-            }
-            new_len = next_len.min(max_len);
-        }
+        // Allocation growth is based on the stack's post-recentered live range, not the previous
+        // buffer length. This preserves the same VM-visible outcome as growing from the old buffer:
+        // the requested index is covered, the live stack is restored at `STACK_BUFFER_BASE_IDX`,
+        // and allocation remains capped by the configured stack depth. The allocation size
+        // can differ, though. Normal push growth may allocate a couple of extra cells
+        // because of the spare push slot, while restoring a deep caller from a shallow
+        // callee may allocate only the requested restored range instead of doubling the old
+        // buffer. That smaller restore allocation is intentional, but it means future
+        // pushes can grow again sooner and should stay covered by benchmarks.
+        let new_len = recentered_min_len.saturating_mul(2).max(requested_min_len).min(max_len);
         debug_assert!(new_len <= max_len);
 
         let mut new_stack = vec![ZERO; new_len].into_boxed_slice();

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -655,18 +655,19 @@ impl FastProcessor {
         // behavior close to the fixed-buffer layout and avoids carrying unused prefix cells into
         // the new allocation. The extra slot is for the next checked push that triggered growth.
         let recentered_min_len = STACK_BUFFER_BASE_IDX.saturating_add(live_len).saturating_add(2);
-        debug_assert!(requested_min_len <= max_len);
         debug_assert!(recentered_min_len <= max_len);
 
         // Allocation growth is based on the stack's post-recentered live range, not the previous
-        // buffer length. This preserves the same VM-visible outcome as growing from the old buffer:
-        // the requested index is covered, the live stack is restored at `STACK_BUFFER_BASE_IDX`,
-        // and allocation remains capped by the configured stack depth. The allocation size
-        // can differ, though. Normal push growth may allocate a couple of extra cells
-        // because of the spare push slot, while restoring a deep caller from a shallow
-        // callee may allocate only the requested restored range instead of doubling the old
-        // buffer. That smaller restore allocation is intentional, but it means future
-        // pushes can grow again sooner and should stay covered by benchmarks.
+        // buffer length. The `requested_min_len` may be beyond the allocation cap when a shallow
+        // context is still positioned near the end of the old buffer; recentering the live stack is
+        // what makes that valid. The VM-visible requirements are that the live stack is restored at
+        // `STACK_BUFFER_BASE_IDX`, the post-recentered push slot is available, and allocation stays
+        // capped by the configured stack depth. The allocation size can differ from the previous
+        // doubling policy: normal push growth may allocate a couple of extra cells because of the
+        // spare push slot, while restoring a deep caller from a shallow callee may allocate only
+        // the requested restored range instead of doubling the old buffer. That smaller
+        // restore allocation is intentional, but it means future pushes can grow again
+        // sooner and should stay covered by benchmarks.
         let new_len = recentered_min_len.saturating_mul(2).max(requested_min_len).min(max_len);
         debug_assert!(new_len <= max_len);
 

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 use alloc::rc::Rc;
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
 #[cfg(test)]
 use core::cell::Cell;
 use core::{cmp::min, ops::ControlFlow};
@@ -42,7 +42,7 @@ mod tests;
 // CONSTANTS
 // ================================================================================================
 
-/// The size of the stack buffer.
+/// The initial size of the stack buffer.
 ///
 /// Note: This value is much larger than it needs to be for the majority of programs. However, some
 /// existing programs need it, so we're forced to push it up (though this should be double-checked).
@@ -50,7 +50,7 @@ mod tests;
 /// example, the blake3 benchmark went from 285 MHz to 250 MHz (~10% degradation). Perhaps a better
 /// solution would be to make this value much smaller (~1000), and then fallback to a `Vec` if the
 /// stack overflows.
-const STACK_BUFFER_SIZE: usize = 6850;
+const INITIAL_STACK_BUFFER_SIZE: usize = 6850;
 
 /// The initial position of the top of the stack in the stack buffer.
 ///
@@ -59,6 +59,10 @@ const STACK_BUFFER_SIZE: usize = 6850;
 /// 0's that were generated automatically to keep the stack depth at 16. In practice, if this
 /// occurs, it is most likely a bug.
 const INITIAL_STACK_TOP_IDX: usize = 250;
+
+/// Default maximum operand stack depth preserving the previous fixed-buffer ceiling.
+const DEFAULT_MAX_STACK_DEPTH: usize =
+    INITIAL_STACK_BUFFER_SIZE - INITIAL_STACK_TOP_IDX - 1 + MIN_STACK_DEPTH;
 
 // FAST PROCESSOR
 // ================================================================================================
@@ -72,7 +76,7 @@ const INITIAL_STACK_TOP_IDX: usize = 250;
 /// # Stack Management
 /// A few key points about how the stack was designed for maximum performance:
 ///
-/// - The stack has a fixed buffer size defined by `STACK_BUFFER_SIZE`.
+/// - The stack starts with a fixed buffer size defined by `INITIAL_STACK_BUFFER_SIZE`.
 ///     - This was observed to increase performance by at least 2x compared to using a `Vec` with
 ///       `push()` & `pop()`.
 ///     - We track the stack top and bottom using indices `stack_top_idx` and `stack_bot_idx`,
@@ -97,7 +101,7 @@ const INITIAL_STACK_TOP_IDX: usize = 250;
 #[derive(Debug)]
 pub struct FastProcessor {
     /// The stack is stored in reverse order, so that the last element is at the top of the stack.
-    stack: Box<[Felt; STACK_BUFFER_SIZE]>,
+    stack: Box<[Felt]>,
     /// The index of the top of the stack.
     stack_top_idx: usize,
     /// The index of the bottom of the stack.
@@ -264,8 +268,9 @@ impl FastProcessor {
             // Note: we use `Vec::into_boxed_slice()` here, since `Box::new([T; N])` first allocates
             // the array on the stack, and then moves it to the heap. This might cause a
             // stack overflow on some systems.
-            let mut stack: Box<[Felt; STACK_BUFFER_SIZE]> =
-                vec![ZERO; STACK_BUFFER_SIZE].into_boxed_slice().try_into().unwrap();
+            debug_assert_eq!(ExecutionOptions::DEFAULT_MAX_STACK_DEPTH, DEFAULT_MAX_STACK_DEPTH);
+
+            let mut stack = vec![ZERO; INITIAL_STACK_BUFFER_SIZE].into_boxed_slice();
 
             // Copy inputs in reverse order so first element ends up at top of stack
             for (i, &input) in stack_inputs.iter().enumerate() {
@@ -601,6 +606,52 @@ impl FastProcessor {
     #[inline(always)]
     fn increment_stack_size(&mut self) {
         self.stack_top_idx += 1;
+    }
+
+    /// Ensures the internal stack storage can accommodate one additional logical stack element.
+    ///
+    /// The operand stack depth limit is the semantic resource bound; the buffer is only an
+    /// implementation detail. We therefore check the logical depth before allocating so a program
+    /// cannot force memory growth beyond `ExecutionOptions::max_stack_depth()`. When storage does
+    /// need to grow, it grows geometrically and remains heap-allocated as a boxed slice. A
+    /// `SmallVec` would put a useful inline buffer inside `FastProcessor`, and preallocating the
+    /// full limit would penalize ordinary programs. This policy is performance-sensitive and should
+    /// be benchmarked against the fixed-buffer baseline.
+    #[inline(always)]
+    fn ensure_stack_capacity_for_push(&mut self) -> Result<(), ExecutionError> {
+        let depth = self.stack_size() + 1;
+        let max = self.options.max_stack_depth();
+        if depth > max {
+            return Err(ExecutionError::StackDepthLimitExceeded { depth, max });
+        }
+
+        if self.stack_top_idx >= self.stack.len() - 1 {
+            self.grow_stack_buffer(self.stack_top_idx + 2);
+        }
+
+        Ok(())
+    }
+
+    fn ensure_stack_capacity_for_top_idx(&mut self, top_idx: usize) {
+        if top_idx >= self.stack.len() {
+            self.grow_stack_buffer(top_idx + 1);
+        }
+    }
+
+    fn grow_stack_buffer(&mut self, min_len: usize) {
+        let max_len = self
+            .stack_bot_idx
+            .saturating_add(self.options.max_stack_depth())
+            .saturating_add(1);
+        let mut new_len = self.stack.len();
+        while new_len < min_len {
+            new_len = new_len.saturating_mul(2);
+        }
+        new_len = new_len.min(max_len).max(min_len);
+
+        let mut new_stack = vec![ZERO; new_len].into_boxed_slice();
+        new_stack[..self.stack.len()].copy_from_slice(&self.stack);
+        self.stack = new_stack;
     }
 
     /// Decrements the stack top pointer by 1.

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -64,6 +64,12 @@ const INITIAL_STACK_TOP_IDX: usize = 250;
 const DEFAULT_MAX_STACK_DEPTH: usize =
     INITIAL_STACK_BUFFER_SIZE - INITIAL_STACK_TOP_IDX - 1 + MIN_STACK_DEPTH;
 
+const _: [(); 1] =
+    [(); (ExecutionOptions::DEFAULT_MAX_STACK_DEPTH == DEFAULT_MAX_STACK_DEPTH) as usize];
+
+/// The stack buffer index where the logical operand stack starts after reset/recenter.
+const STACK_BUFFER_BASE_IDX: usize = INITIAL_STACK_TOP_IDX - MIN_STACK_DEPTH;
+
 // FAST PROCESSOR
 // ================================================================================================
 
@@ -268,8 +274,6 @@ impl FastProcessor {
             // Note: we use `Vec::into_boxed_slice()` here, since `Box::new([T; N])` first allocates
             // the array on the stack, and then moves it to the heap. This might cause a
             // stack overflow on some systems.
-            debug_assert_eq!(ExecutionOptions::DEFAULT_MAX_STACK_DEPTH, DEFAULT_MAX_STACK_DEPTH);
-
             let mut stack = vec![ZERO; INITIAL_STACK_BUFFER_SIZE].into_boxed_slice();
 
             // Copy inputs in reverse order so first element ends up at top of stack
@@ -639,19 +643,45 @@ impl FastProcessor {
     }
 
     fn grow_stack_buffer(&mut self, min_len: usize) {
-        let max_len = self
-            .stack_bot_idx
+        // The maximum allocation is tied to the logical operand stack depth, not to the current
+        // buffer position. Using `stack_bot_idx` here would make the allocation ceiling drift when
+        // the live stack has moved away from the initial base.
+        let max_len = STACK_BUFFER_BASE_IDX
             .saturating_add(self.options.max_stack_depth())
             .saturating_add(1);
+        let live_len = self.stack_size();
+
+        // Growth also recenters the live stack at the normal base. This keeps future push/drop
+        // behavior close to the fixed-buffer layout and avoids carrying unused prefix cells into
+        // the new allocation. The extra slot is for the next checked push that triggered growth.
+        let recentered_min_len = STACK_BUFFER_BASE_IDX.saturating_add(live_len).saturating_add(2);
+        let required_len = min_len.min(max_len).max(recentered_min_len);
+        debug_assert!(required_len <= max_len);
+
         let mut new_len = self.stack.len();
-        while new_len < min_len {
-            new_len = new_len.saturating_mul(2);
+        while new_len < required_len {
+            let next_len = new_len.saturating_mul(2);
+            if next_len <= new_len {
+                new_len = required_len;
+                break;
+            }
+            new_len = next_len.min(max_len);
         }
-        new_len = new_len.min(max_len).max(min_len);
+        debug_assert!(new_len <= max_len);
 
         let mut new_stack = vec![ZERO; new_len].into_boxed_slice();
-        new_stack[..self.stack.len()].copy_from_slice(&self.stack);
+        let new_stack_bot_idx = STACK_BUFFER_BASE_IDX;
+        let new_stack_top_idx = new_stack_bot_idx + live_len;
+
+        // Only the active stack range carries VM state. Prefix/suffix cells are scratch storage and
+        // stay zeroed, which keeps growth proportional to the live depth instead of the old buffer
+        // length.
+        new_stack[new_stack_bot_idx..new_stack_top_idx]
+            .copy_from_slice(&self.stack[self.stack_bot_idx..self.stack_top_idx]);
+
         self.stack = new_stack;
+        self.stack_bot_idx = new_stack_bot_idx;
+        self.stack_top_idx = new_stack_top_idx;
     }
 
     /// Decrements the stack top pointer by 1.

--- a/processor/src/fast/operation.rs
+++ b/processor/src/fast/operation.rs
@@ -16,7 +16,7 @@ use super::step::BreakReason;
 use crate::{
     AdviceProvider, BaseHost, ContextId, ExecutionError,
     errors::OperationError,
-    fast::{FastProcessor, STACK_BUFFER_SIZE, memory::Memory},
+    fast::{FastProcessor, memory::Memory},
     processor::{HasherInterface, Processor, StackInterface, SystemInterface},
 };
 
@@ -309,12 +309,9 @@ impl StackInterface for FastProcessor {
 
     #[inline(always)]
     fn increment_size(&mut self) -> Result<(), ExecutionError> {
-        if self.stack_top_idx < STACK_BUFFER_SIZE - 1 {
-            self.increment_stack_size();
-            Ok(())
-        } else {
-            Err(ExecutionError::Internal("stack overflow"))
-        }
+        self.ensure_stack_capacity_for_push()?;
+        self.increment_stack_size();
+        Ok(())
     }
 
     #[inline(always)]

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -763,6 +763,31 @@ fn stack_buffer_is_not_preallocated_to_operand_stack_depth_limit() {
     );
 }
 
+#[test]
+fn stack_growth_recenters_shallow_context_when_requested_len_exceeds_allocation_cap() {
+    let options = ExecutionOptions::default()
+        .with_max_stack_depth(DEFAULT_MAX_STACK_DEPTH)
+        .unwrap();
+    let mut processor =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits");
+
+    // This models a callee that has only the minimum live stack depth, but is still positioned at
+    // the end of the current stack buffer after the caller filled the buffer and entered a new
+    // context. The next push requests one slot past the allocation cap using the old position, but
+    // growth can still succeed because it recenters the live stack before the push.
+    processor.stack_top_idx = INITIAL_STACK_BUFFER_SIZE - 1;
+    processor.stack_bot_idx = processor.stack_top_idx - MIN_STACK_DEPTH;
+
+    processor
+        .ensure_stack_capacity_for_push()
+        .expect("recentered shallow context push should fit within the stack depth limit");
+
+    assert_eq!(processor.stack_bot_idx, STACK_BUFFER_BASE_IDX);
+    assert_eq!(processor.stack_top_idx, STACK_BUFFER_BASE_IDX + MIN_STACK_DEPTH);
+    assert_eq!(processor.stack.len(), INITIAL_STACK_BUFFER_SIZE);
+}
+
 fn previous_growth_len(
     stack_len: usize,
     live_len: usize,

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -576,6 +576,43 @@ fn test_external_node_decorator_sequencing() {
     );
 }
 
+#[test]
+fn issue_2818_2834_fast_processor_stack_grows_past_initial_buffer() {
+    let mut host = DefaultHost::default();
+
+    let pushes_past_initial_buffer = DEFAULT_MAX_STACK_DEPTH - MIN_STACK_DEPTH + 1;
+    let mut ops = vec![Operation::Pad; pushes_past_initial_buffer];
+    ops.extend(vec![Operation::Drop; pushes_past_initial_buffer]);
+    let program = simple_program_with_ops(ops);
+    let options = ExecutionOptions::default()
+        .with_max_stack_depth(DEFAULT_MAX_STACK_DEPTH + 1)
+        .unwrap();
+
+    FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+        .execute_sync(&program, &mut host)
+        .expect("stack growth past the initial fast-processor buffer should succeed");
+}
+
+#[test]
+fn stack_depth_limit_exceeded() {
+    let mut host = DefaultHost::default();
+    let program = simple_program_with_ops(vec![Operation::Pad]);
+    let options = ExecutionOptions::default().with_max_stack_depth(MIN_STACK_DEPTH).unwrap();
+
+    let err =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .execute_sync(&program, &mut host)
+            .expect_err("pushing past the configured stack depth should fail");
+
+    assert_matches!(
+        err,
+        ExecutionError::StackDepthLimitExceeded {
+            depth,
+            max: MIN_STACK_DEPTH,
+        } if depth == MIN_STACK_DEPTH + 1
+    );
+}
+
 /// Tests that `ExecutionError::Internal` is correctly emitted when the continuation stack grows
 /// past the maximum allowed size.
 #[test]

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -577,20 +577,183 @@ fn test_external_node_decorator_sequencing() {
 }
 
 #[test]
-fn issue_2818_2834_fast_processor_stack_grows_past_initial_buffer() {
+fn stack_depth_default_limit_exact_boundary_succeeds() {
     let mut host = DefaultHost::default();
 
-    let pushes_past_initial_buffer = DEFAULT_MAX_STACK_DEPTH - MIN_STACK_DEPTH + 1;
-    let mut ops = vec![Operation::Pad; pushes_past_initial_buffer];
-    ops.extend(vec![Operation::Drop; pushes_past_initial_buffer]);
-    let program = simple_program_with_ops(ops);
+    let pushes_to_default_limit = DEFAULT_MAX_STACK_DEPTH - MIN_STACK_DEPTH;
+    let program = simple_program_with_ops(pad_then_drop_ops(pushes_to_default_limit));
+
+    FastProcessor::new(StackInputs::default())
+        .execute_sync(&program, &mut host)
+        .expect("using the full default stack depth limit should succeed");
+}
+
+#[test]
+fn stack_depth_default_limit_exceeded_returns_typed_error() {
+    let mut host = DefaultHost::default();
+
+    let pushes_past_default_limit = DEFAULT_MAX_STACK_DEPTH - MIN_STACK_DEPTH + 1;
+    let program = simple_program_with_ops(vec![Operation::Pad; pushes_past_default_limit]);
+
+    let err = FastProcessor::new(StackInputs::default())
+        .execute_sync(&program, &mut host)
+        .expect_err("pushing past the default stack depth limit should fail");
+
+    assert_matches!(
+        err,
+        ExecutionError::StackDepthLimitExceeded {
+            depth,
+            max: DEFAULT_MAX_STACK_DEPTH,
+        } if depth == DEFAULT_MAX_STACK_DEPTH + 1
+    );
+}
+
+#[test]
+fn stack_depth_small_custom_limit_fails_before_buffer_growth() {
+    let mut host = DefaultHost::default();
+    let max_stack_depth = MIN_STACK_DEPTH + 1;
+    let program = simple_program_with_ops(vec![Operation::Pad; 2]);
+    let options = ExecutionOptions::default().with_max_stack_depth(max_stack_depth).unwrap();
+
+    let err =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .execute_sync(&program, &mut host)
+            .expect_err("small configured stack depth limit should fail before buffer growth");
+
+    assert_matches!(
+        err,
+        ExecutionError::StackDepthLimitExceeded {
+            depth,
+            max,
+        } if depth == max_stack_depth + 1 && max == max_stack_depth
+    );
+}
+
+#[test]
+fn issue_2818_fast_processor_stack_grows_past_initial_buffer_by_multiple_elements() {
+    const GROWTH_MARGIN: usize = 4;
+
+    let mut host = DefaultHost::default();
+
+    let pushes_past_initial_buffer = DEFAULT_MAX_STACK_DEPTH - MIN_STACK_DEPTH + GROWTH_MARGIN;
+    let program = simple_program_with_ops(pad_then_drop_ops(pushes_past_initial_buffer));
     let options = ExecutionOptions::default()
-        .with_max_stack_depth(DEFAULT_MAX_STACK_DEPTH + 1)
+        .with_max_stack_depth(DEFAULT_MAX_STACK_DEPTH + GROWTH_MARGIN)
         .unwrap();
 
     FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
         .execute_sync(&program, &mut host)
-        .expect("stack growth past the initial fast-processor buffer should succeed");
+        .expect("stack growth multiple elements past the initial buffer should succeed");
+}
+
+#[test]
+fn issue_2818_traced_execution_stack_grows_past_initial_buffer() {
+    const GROWTH_MARGIN: usize = 2;
+
+    let mut host = DefaultHost::default();
+
+    let pushes_past_initial_buffer = DEFAULT_MAX_STACK_DEPTH - MIN_STACK_DEPTH + GROWTH_MARGIN;
+    let program = simple_program_with_ops(pad_then_drop_ops(pushes_past_initial_buffer));
+    let options = ExecutionOptions::default()
+        .with_max_stack_depth(DEFAULT_MAX_STACK_DEPTH + GROWTH_MARGIN)
+        .unwrap();
+
+    let trace_inputs =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .execute_trace_inputs_sync(&program, &mut host)
+            .expect("traced execution should grow the stack buffer past the initial buffer");
+
+    crate::trace::build_trace(trace_inputs)
+        .expect("trace replay should accept the same operand stack depth limit");
+}
+
+#[test]
+fn issue_2818_step_execution_stack_grows_past_initial_buffer() {
+    const GROWTH_MARGIN: usize = 2;
+
+    let mut host = DefaultHost::default();
+
+    let pushes_past_initial_buffer = DEFAULT_MAX_STACK_DEPTH - MIN_STACK_DEPTH + GROWTH_MARGIN;
+    let program = simple_program_with_ops(pad_then_drop_ops(pushes_past_initial_buffer));
+    let options = ExecutionOptions::default()
+        .with_max_stack_depth(DEFAULT_MAX_STACK_DEPTH + GROWTH_MARGIN)
+        .unwrap();
+
+    FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+        .execute_by_step_sync(&program, &mut host)
+        .expect("step execution should grow the stack buffer past the initial buffer");
+}
+
+#[test]
+fn issue_2818_restore_context_grows_stack_buffer_for_suspended_caller() {
+    let caller_overflow_len = DEFAULT_MAX_STACK_DEPTH - MIN_STACK_DEPTH + 1;
+    let options = ExecutionOptions::default()
+        .with_max_stack_depth(DEFAULT_MAX_STACK_DEPTH + 1)
+        .unwrap();
+    let mut processor =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+
+    assert_eq!(processor.stack.len(), INITIAL_STACK_BUFFER_SIZE);
+    processor.call_stack.push(ExecutionContextInfo {
+        overflow_stack: vec![Felt::from_u32(42); caller_overflow_len],
+        ctx: processor.ctx,
+        fn_hash: processor.caller_hash,
+    });
+
+    // The active callee context is still at the minimum stack depth and the storage has not grown.
+    // Restoring this suspended caller is what requires moving the active stack and growing storage.
+    processor
+        .restore_context()
+        .expect("restoring a suspended caller should grow the stack buffer when needed");
+    assert!(
+        processor.stack.len() > INITIAL_STACK_BUFFER_SIZE,
+        "context restore should have grown the stack buffer"
+    );
+    assert_eq!(processor.stack_size(), MIN_STACK_DEPTH + caller_overflow_len);
+}
+
+#[test]
+fn stack_buffer_is_not_preallocated_to_operand_stack_depth_limit() {
+    const GROWTH_MARGIN: usize = 2;
+
+    let options = ExecutionOptions::default()
+        .with_max_stack_depth(DEFAULT_MAX_STACK_DEPTH + GROWTH_MARGIN)
+        .unwrap();
+    let mut processor =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+
+    assert_eq!(
+        processor.stack.len(),
+        INITIAL_STACK_BUFFER_SIZE,
+        "processor should start with the initial stack buffer, not the full depth limit"
+    );
+
+    let mut host = DefaultHost::default();
+    processor
+        .execute_mut_sync(
+            &simple_program_with_ops(vec![Operation::Pad, Operation::Drop]),
+            &mut host,
+        )
+        .expect("ordinary shallow stack use should succeed");
+    assert_eq!(
+        processor.stack.len(),
+        INITIAL_STACK_BUFFER_SIZE,
+        "ordinary shallow stack use should not grow the buffer"
+    );
+
+    let pushes_past_initial_buffer = DEFAULT_MAX_STACK_DEPTH - MIN_STACK_DEPTH + GROWTH_MARGIN;
+    let program = simple_program_with_ops(pad_then_drop_ops(pushes_past_initial_buffer));
+    let mut processor =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+    let mut host = DefaultHost::default();
+
+    processor
+        .execute_mut_sync(&program, &mut host)
+        .expect("deep stack use should grow the buffer on demand");
+    assert!(
+        processor.stack.len() > INITIAL_STACK_BUFFER_SIZE,
+        "deep stack use should grow the buffer only when needed"
+    );
 }
 
 #[test]
@@ -696,4 +859,10 @@ fn simple_program_with_ops(ops: Vec<Operation>) -> Program {
     };
 
     program
+}
+
+fn pad_then_drop_ops(num_pads: usize) -> Vec<Operation> {
+    let mut ops = vec![Operation::Pad; num_pads];
+    ops.extend(vec![Operation::Drop; num_pads]);
+    ops
 }

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -617,6 +617,7 @@ fn stack_depth_small_custom_limit_fails_before_buffer_growth() {
 
     let err =
         FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits")
             .execute_sync(&program, &mut host)
             .expect_err("small configured stack depth limit should fail before buffer growth");
 
@@ -642,6 +643,7 @@ fn issue_2818_fast_processor_stack_grows_past_initial_buffer_by_multiple_element
         .unwrap();
 
     FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+        .expect("processor advice inputs should fit advice map limits")
         .execute_sync(&program, &mut host)
         .expect("stack growth multiple elements past the initial buffer should succeed");
 }
@@ -660,6 +662,7 @@ fn issue_2818_traced_execution_stack_grows_past_initial_buffer() {
 
     let trace_inputs =
         FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits")
             .execute_trace_inputs_sync(&program, &mut host)
             .expect("traced execution should grow the stack buffer past the initial buffer");
 
@@ -680,6 +683,7 @@ fn issue_2818_step_execution_stack_grows_past_initial_buffer() {
         .unwrap();
 
     FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+        .expect("processor advice inputs should fit advice map limits")
         .execute_by_step_sync(&program, &mut host)
         .expect("step execution should grow the stack buffer past the initial buffer");
 }
@@ -691,7 +695,8 @@ fn issue_2818_restore_context_grows_stack_buffer_for_suspended_caller() {
         .with_max_stack_depth(DEFAULT_MAX_STACK_DEPTH + 1)
         .unwrap();
     let mut processor =
-        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits");
 
     assert_eq!(processor.stack.len(), INITIAL_STACK_BUFFER_SIZE);
     processor.call_stack.push(ExecutionContextInfo {
@@ -720,7 +725,8 @@ fn stack_buffer_is_not_preallocated_to_operand_stack_depth_limit() {
         .with_max_stack_depth(DEFAULT_MAX_STACK_DEPTH + GROWTH_MARGIN)
         .unwrap();
     let mut processor =
-        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits");
 
     assert_eq!(
         processor.stack.len(),
@@ -744,7 +750,8 @@ fn stack_buffer_is_not_preallocated_to_operand_stack_depth_limit() {
     let pushes_past_initial_buffer = DEFAULT_MAX_STACK_DEPTH - MIN_STACK_DEPTH + GROWTH_MARGIN;
     let program = simple_program_with_ops(pad_then_drop_ops(pushes_past_initial_buffer));
     let mut processor =
-        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options);
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits");
     let mut host = DefaultHost::default();
 
     processor
@@ -921,6 +928,7 @@ fn stack_depth_limit_exceeded() {
 
     let err =
         FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits")
             .execute_sync(&program, &mut host)
             .expect_err("pushing past the configured stack depth should fail");
 

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -756,6 +756,163 @@ fn stack_buffer_is_not_preallocated_to_operand_stack_depth_limit() {
     );
 }
 
+fn previous_growth_len(
+    stack_len: usize,
+    live_len: usize,
+    requested_min_len: usize,
+    max_len: usize,
+) -> usize {
+    let recentered_min_len = STACK_BUFFER_BASE_IDX.saturating_add(live_len).saturating_add(2);
+    let required_len = requested_min_len.min(max_len).max(recentered_min_len);
+
+    let mut new_len = stack_len;
+    while new_len < required_len {
+        let next_len = new_len.saturating_mul(2);
+        if next_len <= new_len {
+            return required_len;
+        }
+        new_len = next_len.min(max_len);
+    }
+
+    new_len
+}
+
+fn new_growth_len(live_len: usize, requested_min_len: usize, max_len: usize) -> usize {
+    let target_len = STACK_BUFFER_BASE_IDX
+        .saturating_add(live_len)
+        .saturating_add(2)
+        .saturating_mul(2);
+
+    target_len.max(requested_min_len).min(max_len)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct GrowthSemantics {
+    new_stack_bot_idx: usize,
+    new_stack_top_idx: usize,
+    covers_requested_len: bool,
+    covers_recentered_len: bool,
+    within_max_len: bool,
+}
+
+fn growth_semantics(
+    new_len: usize,
+    live_len: usize,
+    requested_min_len: usize,
+    max_len: usize,
+) -> GrowthSemantics {
+    let recentered_min_len = STACK_BUFFER_BASE_IDX.saturating_add(live_len).saturating_add(2);
+
+    GrowthSemantics {
+        new_stack_bot_idx: STACK_BUFFER_BASE_IDX,
+        new_stack_top_idx: STACK_BUFFER_BASE_IDX + live_len,
+        covers_requested_len: new_len >= requested_min_len,
+        covers_recentered_len: new_len >= recentered_min_len,
+        within_max_len: new_len <= max_len,
+    }
+}
+
+#[test]
+fn new_stack_growth_algorithm_is_vm_equivalent_to_previous_algorithm() {
+    let max_depth = DEFAULT_MAX_STACK_DEPTH * 4;
+    let max_len = STACK_BUFFER_BASE_IDX.saturating_add(max_depth).saturating_add(1);
+
+    for stack_len in [INITIAL_STACK_BUFFER_SIZE, INITIAL_STACK_BUFFER_SIZE * 2] {
+        // Push growth is called when the next push would need one slot past the current buffer.
+        let live_len = stack_len - STACK_BUFFER_BASE_IDX - 1;
+        let requested_min_len = stack_len + 1;
+
+        let previous_len = previous_growth_len(stack_len, live_len, requested_min_len, max_len);
+        let new_len = new_growth_len(live_len, requested_min_len, max_len);
+
+        assert_eq!(
+            growth_semantics(previous_len, live_len, requested_min_len, max_len),
+            growth_semantics(new_len, live_len, requested_min_len, max_len)
+        );
+    }
+
+    for overflow_len in 0..=(max_depth - MIN_STACK_DEPTH) {
+        // Restore growth is called from a callee with only the minimum live stack, but the
+        // requested length must cover the caller overflow stack being restored.
+        let requested_min_len =
+            INITIAL_STACK_TOP_IDX.saturating_add(overflow_len).saturating_add(1);
+        let previous_len = previous_growth_len(
+            INITIAL_STACK_BUFFER_SIZE,
+            MIN_STACK_DEPTH,
+            requested_min_len,
+            max_len,
+        );
+        let new_len = new_growth_len(MIN_STACK_DEPTH, requested_min_len, max_len);
+
+        assert_eq!(
+            growth_semantics(previous_len, MIN_STACK_DEPTH, requested_min_len, max_len),
+            growth_semantics(new_len, MIN_STACK_DEPTH, requested_min_len, max_len)
+        );
+    }
+}
+
+#[test]
+fn new_stack_growth_algorithm_allocation_differences_are_intentional() {
+    let max_depth = DEFAULT_MAX_STACK_DEPTH * 4;
+    let max_len = STACK_BUFFER_BASE_IDX.saturating_add(max_depth).saturating_add(1);
+
+    let push_live_len = INITIAL_STACK_BUFFER_SIZE - STACK_BUFFER_BASE_IDX - 1;
+    let push_requested_min_len = INITIAL_STACK_BUFFER_SIZE + 1;
+    assert_eq!(
+        previous_growth_len(
+            INITIAL_STACK_BUFFER_SIZE,
+            push_live_len,
+            push_requested_min_len,
+            max_len,
+        ),
+        INITIAL_STACK_BUFFER_SIZE * 2
+    );
+    assert_eq!(
+        new_growth_len(push_live_len, push_requested_min_len, max_len),
+        INITIAL_STACK_BUFFER_SIZE * 2 + 2
+    );
+
+    let restore_requested_min_len = INITIAL_STACK_BUFFER_SIZE + 1;
+    assert_eq!(
+        previous_growth_len(
+            INITIAL_STACK_BUFFER_SIZE,
+            MIN_STACK_DEPTH,
+            restore_requested_min_len,
+            max_len,
+        ),
+        INITIAL_STACK_BUFFER_SIZE * 2
+    );
+    assert_eq!(
+        new_growth_len(MIN_STACK_DEPTH, restore_requested_min_len, max_len),
+        restore_requested_min_len
+    );
+}
+
+#[test]
+fn new_stack_growth_algorithm_preserves_required_bounds() {
+    let max_depth = DEFAULT_MAX_STACK_DEPTH * 4;
+    let max_len = STACK_BUFFER_BASE_IDX.saturating_add(max_depth).saturating_add(1);
+
+    for live_len in MIN_STACK_DEPTH..max_depth {
+        let recentered_min_len = STACK_BUFFER_BASE_IDX.saturating_add(live_len).saturating_add(2);
+        let requested_min_len = recentered_min_len.max(INITIAL_STACK_BUFFER_SIZE + 1);
+        let new_len = new_growth_len(live_len, requested_min_len, max_len);
+
+        assert!(new_len >= requested_min_len);
+        assert!(new_len >= recentered_min_len);
+        assert!(new_len <= max_len);
+    }
+
+    for overflow_len in 0..=(max_depth - MIN_STACK_DEPTH) {
+        let requested_min_len =
+            INITIAL_STACK_TOP_IDX.saturating_add(overflow_len).saturating_add(1);
+        let new_len = new_growth_len(MIN_STACK_DEPTH, requested_min_len, max_len);
+
+        assert!(new_len >= requested_min_len);
+        assert!(new_len <= max_len);
+    }
+}
+
 #[test]
 fn stack_depth_limit_exceeded() {
     let mut host = DefaultHost::default();

--- a/processor/src/trace/execution_tracer.rs
+++ b/processor/src/trace/execution_tracer.rs
@@ -61,6 +61,10 @@ pub struct TraceGenerationContext {
     /// The number of rows per core trace fragment, except for the last fragment which may be
     /// shorter.
     pub fragment_size: usize,
+
+    /// The maximum number of field elements allowed on the operand stack in an active execution
+    /// context.
+    pub max_stack_depth: usize,
 }
 
 /// Builder for recording the context to generate trace fragments during execution.
@@ -113,6 +117,10 @@ pub struct ExecutionTracer {
     /// The number of rows per core trace fragment.
     fragment_size: usize,
 
+    /// The maximum number of field elements allowed on the operand stack in an active execution
+    /// context.
+    max_stack_depth: usize,
+
     /// Flag set in `start_clock_cycle` when a Call/Syscall/Dyncall END is encountered, consumed
     /// in `finalize_clock_cycle` to call `overflow_table.restore_context()`. This is deferred to
     /// `finalize_clock_cycle` because `finalize_clock_cycle` is only called when the operation
@@ -127,7 +135,7 @@ pub struct ExecutionTracer {
 impl ExecutionTracer {
     /// Creates a new `ExecutionTracer` with the given fragment size.
     #[inline(always)]
-    pub fn new(fragment_size: usize) -> Self {
+    pub fn new(fragment_size: usize, max_stack_depth: usize) -> Self {
         Self {
             state_snapshot: None,
             overflow_table: OverflowTable::default(),
@@ -147,6 +155,7 @@ impl ExecutionTracer {
             external: MastForestResolutionReplay::default(),
             fragment_contexts: Vec::new(),
             fragment_size,
+            max_stack_depth,
             pending_restore_context: false,
             is_eval_circuit_op: false,
         }
@@ -168,6 +177,7 @@ impl ExecutionTracer {
             hasher_for_chiplet: self.hasher_for_chiplet,
             ace_replay: self.ace,
             fragment_size: self.fragment_size,
+            max_stack_depth: self.max_stack_depth,
         }
     }
 

--- a/processor/src/trace/parallel/mod.rs
+++ b/processor/src/trace/parallel/mod.rs
@@ -115,6 +115,7 @@ pub fn build_trace_with_max_len(
         hasher_for_chiplet,
         ace_replay,
         fragment_size,
+        max_stack_depth,
     } = trace_generation_context;
 
     // Before any trace generation, check that the number of core trace rows doesn't exceed the
@@ -155,6 +156,7 @@ pub fn build_trace_with_max_len(
         core_trace_contexts,
         program_info.kernel().clone(),
         fragment_size,
+        max_stack_depth,
     )?;
 
     let core_trace_len = core_trace_data.len() / CORE_TRACE_WIDTH;
@@ -220,6 +222,7 @@ fn generate_core_trace_row_major(
     core_trace_contexts: Vec<CoreTraceFragmentContext>,
     kernel: Kernel,
     fragment_size: usize,
+    max_stack_depth: usize,
 ) -> Result<Vec<Felt>, ExecutionError> {
     let num_fragments = core_trace_contexts.len();
     let total_allocated_rows = num_fragments * fragment_size;
@@ -244,7 +247,7 @@ fn generate_core_trace_row_major(
         .zip(writers.into_par_iter())
         .map(|(trace_state, writer)| {
             let (mut processor, mut tracer, mut continuation_stack, mut current_forest) =
-                split_trace_fragment_context(trace_state, writer, fragment_size);
+                split_trace_fragment_context(trace_state, writer, fragment_size, max_stack_depth);
 
             processor.execute(
                 &mut continuation_stack,
@@ -662,6 +665,7 @@ fn split_trace_fragment_context<'a>(
     fragment_context: CoreTraceFragmentContext,
     writer: RowMajorTraceWriter<'a, Felt>,
     fragment_size: usize,
+    max_stack_depth: usize,
 ) -> (
     ReplayProcessor,
     CoreTraceGenerationTracer<'a>,
@@ -694,6 +698,7 @@ fn split_trace_fragment_context<'a>(
         memory_reads_replay,
         hasher_response_replay,
         mast_forest_resolution_replay,
+        max_stack_depth,
         fragment_size.into(),
     );
     let tracer =

--- a/processor/src/trace/parallel/processor.rs
+++ b/processor/src/trace/parallel/processor.rs
@@ -54,6 +54,10 @@ pub(crate) struct ReplayProcessor {
     pub hasher_response_replay: HasherResponseReplay,
     pub mast_forest_resolution_replay: MastForestResolutionReplay,
 
+    /// The maximum number of field elements allowed on the operand stack in an active execution
+    /// context.
+    pub max_stack_depth: usize,
+
     /// The maximum clock cycle at which this processor should stop execution.
     pub maximum_clock: RowIndex,
 }
@@ -73,6 +77,7 @@ impl ReplayProcessor {
         memory_reads_replay: MemoryReadsReplay,
         hasher_response_replay: HasherResponseReplay,
         mast_forest_resolution_replay: MastForestResolutionReplay,
+        max_stack_depth: usize,
         num_clocks_to_execute: RowIndex,
     ) -> Self {
         let maximum_clock = initial_system.clk + num_clocks_to_execute.as_usize();
@@ -86,6 +91,7 @@ impl ReplayProcessor {
             memory_reads_replay,
             hasher_response_replay,
             mast_forest_resolution_replay,
+            max_stack_depth,
             maximum_clock,
         }
     }
@@ -335,6 +341,12 @@ impl StackInterface for ReplayProcessor {
 
     fn increment_size(&mut self) -> Result<(), ExecutionError> {
         const SENTINEL_VALUE: Felt = Felt::new_unchecked(Felt::ORDER_U64 - 1);
+
+        let depth = self.depth() as usize + 1;
+        let max = self.max_stack_depth;
+        if depth > max {
+            return Err(ExecutionError::StackDepthLimitExceeded { depth, max });
+        }
 
         // push the last element on the overflow table
         {

--- a/processor/src/trace/parallel/tracer/mod.rs
+++ b/processor/src/trace/parallel/tracer/mod.rs
@@ -704,6 +704,7 @@ mod tests {
             MemoryReadsReplay::default(),
             HasherResponseReplay::default(),
             MastForestResolutionReplay::default(),
+            crate::ExecutionOptions::DEFAULT_MAX_STACK_DEPTH,
             1u32.into(),
         );
 


### PR DESCRIPTION
Closes #2818, closes #2834.

`FastProcessor` used a fixed stack buffer as both storage and an implicit stack limit. Other execution paths treated stack depth as a VM rule, so the limit was not enforced in one clear place.

This adds `ExecutionOptions::max_stack_depth` as the operand stack depth limit. The fast stack now grows on demand, but only up to that limit. When the limit is exceeded, execution returns `StackDepthLimitExceeded` instead of an internal stack overflow.

The same limit is passed into trace replay, so fast execution, traced execution, step execution, and replay use the same rule.
