### PR TITLE
fix(syntax): align Path::MAX_COMPONENT_LENGTH with maximum Path length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.22.3 (2026-05-01)
+
+- Change value of `Path::MAX_COMPONENT_LENGTH` to `u16::MAX - 2` [#3087](https://github.com/0xMiden/miden-vm/pull/3087)
+
 ## 0.22.2 (2026-04-028)
 
 - Improve debug var loc tracking ([#2955](https://github.com/0xMiden/miden-vm/pull/2955)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1248,7 +1248,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1260,7 +1260,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "env_logger",
  "insta",
@@ -1279,7 +1279,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "aho-corasick",
  "env_logger",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "criterion",
  "derive_more",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "criterion",
  "env_logger",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "derive_more",
  "miden-assembly-syntax",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "insta",
  "itertools 0.14.0",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "bincode",
  "miden-air",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "miden-crypto",
  "serde",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "lock_api",
  "loom",
@@ -1658,7 +1658,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "bincode",
  "miden-air",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "assert_cmd",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ homepage = "https://miden.xyz"
 repository = "https://github.com/0xMiden/miden-vm"
 exclude = [".github/"]
 rust-version = "1.90"
-version = "0.22.2"
+version = "0.22.3"
 
 [profile.optimized]
 inherits = "release"

--- a/crates/assembly-syntax/src/ast/path/path.rs
+++ b/crates/assembly-syntax/src/ast/path/path.rs
@@ -129,8 +129,12 @@ impl From<&Path> for alloc::sync::Arc<Path> {
 
 /// Conversions
 impl Path {
-    /// Path components  must be 255 bytes or less
-    pub const MAX_COMPONENT_LENGTH: usize = u8::MAX as usize;
+    /// Path components must be no larger than the maximum valid path length, which is u16::MAX
+    /// bytes, minus 2 bytes for the optional absolute path prefix `::`.
+    ///
+    /// While path components of this size are unlikely, it keeps the `Path` API consistent in cases
+    /// where a path is long simply due to a single component.
+    pub const MAX_COMPONENT_LENGTH: usize = (u16::MAX as usize) - 2;
 
     /// An empty path for use as a default value, placeholder, comparisons, etc.
     pub const EMPTY: &Path = unsafe { &*("" as *const str as *const Path) };
@@ -609,6 +613,17 @@ impl fmt::Display for Path {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_path_split_with_quotes_and_large_components() -> Result<(), PathError> {
+        let path = Path::new(
+            "::\"miden:counter-contract/counter-contract@0.1.0\"::counter_contract::_RNvXsg_NtNtCseaniv3neBPi_10miden_base5types7storageINtB5_10StorageMapNtNtCscxjsWiPtnzN_11miden_field4word4WordNtNtB19_10wasm_miden4FeltEINtNtCs3NSMmx5ugmE_4core7convert4FromNtNtNtCs52sTGLXFK3W_14miden_base_sys8bindings5types13StorageSlotIdE4fromCsanZ5gV8dMQ0_16counter_contract",
+        );
+        let canonicalized = path.canonicalize()?;
+
+        assert_eq!(canonicalized.as_path(), path);
+        Ok(())
+    }
 
     #[test]
     fn test_canonicalize_path_identity() -> Result<(), PathError> {

--- a/crates/assembly-syntax/src/parser/mod.rs
+++ b/crates/assembly-syntax/src/parser/mod.rs
@@ -469,7 +469,7 @@ end
             parse::{Parse, ParseOptions},
         };
 
-        let big_component = "a".repeat(256);
+        let big_component = "a".repeat(u16::MAX as usize);
         let source = format!("begin\n    exec.{big_component}::x::foo\nend\n");
 
         let source_manager = Arc::new(DefaultSourceManager::default());


### PR DESCRIPTION
After updating the Rust toolchain the compiler uses, and enabling LTO to shrink the size of the programs we assemble, we immediately hit an error during assembly that is caused due to some Rust symbols to result in paths where the leaf component exceeds `Path::MAX_COMPONENT_LENGTH`, which previously was set to `255`. Fundamentally, we need to bump the limit just due to that issue alone.

However, I chose here to bump the limit to the maximum valid path length (currently `u16::MAX`), but reserve 2 bytes for the absolute path prefix, giving us a new `MAX_COMPONENT_LENGTH` of `u16::MAX - 2`. This ensures that a single-component path can make full use of the maximum valid path length, where before, even though a path could be `u16::MAX` bytes, we were not allowing individual components to use that space if needed. I think this makes the API a bit more consistent, while addressing the issue we hit in the compiler.

This is targeted against `main` so that we can do a point release (i.e. `0.22.3`) containing this fix, as it is a critical blocker for the compiler. This is not a breaking change, we are simply more permissive than we were previously, and can be trivially merged with `next`.