### PR TITLE
ci: extend comparative benches to the Synthetic Tx bench

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,5 @@
 # Allow actionlint to recognize the org's custom Warp runner label used by the
-# blake3 non-regression workflow.
+# non-regression benchmark workflows.
 self-hosted-runner:
   labels:
     - warp-ubuntu-latest-x64-8x

--- a/.github/workflows/synthetic-tx-nonregression.yml
+++ b/.github/workflows/synthetic-tx-nonregression.yml
@@ -65,7 +65,7 @@ jobs:
           rustup toolchain install "${toolchain}" --profile minimal --target wasm32-unknown-unknown
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        uses: WarpBuilds/rust-cache@9d0cc3090d9c87de74ea67617b246e978735b1a1 # v2.9.1
 
       - name: Prepare benchmark directories
         id: dirs

--- a/.github/workflows/synthetic-tx-nonregression.yml
+++ b/.github/workflows/synthetic-tx-nonregression.yml
@@ -1,0 +1,387 @@
+name: synthetic tx kernel non-regression
+
+on:
+  push:
+    branches:
+      - main
+      - next
+  workflow_dispatch:
+    inputs:
+      baseline_ref:
+        description: Commit or ref to use as the baseline. Defaults to the current ref's first parent.
+        required: false
+        type: string
+      current_ref:
+        description: Commit or ref to benchmark. Defaults to the workflow ref.
+        required: false
+        type: string
+      regression_threshold_pct:
+        description: Allowed slowdown before the workflow fails.
+        required: false
+        default: "5"
+        type: string
+      rayon_num_threads:
+        description: RAYON_NUM_THREADS value used for the benchmark.
+        required: false
+        default: "8"
+        type: string
+      scenario_filter:
+        description: Optional SYNTH_SCENARIO filter for the synthetic benchmark.
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Benchmark baseline vs current
+    runs-on: warp-ubuntu-latest-x64-8x
+    timeout-minutes: 240
+    permissions:
+      contents: read
+    outputs:
+      summary: ${{ steps.summary.outputs.summary }}
+      regression: ${{ steps.compare.outputs.regression }}
+      status: ${{ steps.compare.outputs.status }}
+      baseline_sha: ${{ steps.compare.outputs.baseline_sha }}
+      current_sha: ${{ steps.compare.outputs.current_sha }}
+      max_delta_metric: ${{ steps.compare.outputs.max_delta_metric }}
+      max_delta_pct: ${{ steps.compare.outputs.max_delta_pct }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          toolchain="$(sed -n 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)"
+          rustup toolchain install "${toolchain}" --profile minimal --target wasm32-unknown-unknown
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Prepare benchmark directories
+        id: dirs
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_root="${RUNNER_TEMP}/synthetic-tx-nonregression-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_dir="${run_root}/artifacts"
+          worktree_dir="${run_root}/worktrees"
+          mkdir -p "${artifact_dir}" "${worktree_dir}"
+          {
+            echo "run_root=${run_root}"
+            echo "artifact_dir=${artifact_dir}"
+            echo "worktree_dir=${worktree_dir}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Resolve benchmark refs
+        id: refs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          INPUT_BASELINE_REF: ${{ inputs.baseline_ref }}
+          INPUT_CURRENT_REF: ${{ inputs.current_ref }}
+          INPUT_THRESHOLD_PCT: ${{ inputs.regression_threshold_pct }}
+          INPUT_RAYON_THREADS: ${{ inputs.rayon_num_threads }}
+          INPUT_SCENARIO_FILTER: ${{ inputs.scenario_filter }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          resolve_commit() {
+            local ref="$1"
+            git rev-parse --verify --end-of-options "${ref}^{commit}"
+          }
+
+          fetch_commit_if_needed() {
+            local ref="$1"
+            local fetch_log
+            if resolve_commit "${ref}" >/dev/null 2>&1; then
+              return 0
+            fi
+            fetch_log="$(mktemp)"
+            if git fetch --no-tags --depth=1 origin "${ref}" >"${fetch_log}" 2>&1; then
+              rm -f "${fetch_log}"
+              resolve_commit "${ref}" >/dev/null 2>&1
+              return $?
+            fi
+            if grep -Eqi "couldn't find remote ref|not our ref|unadvertised object|reference is not a tree|no such remote ref" "${fetch_log}"; then
+              rm -f "${fetch_log}"
+              return 2
+            fi
+            cat "${fetch_log}" >&2
+            rm -f "${fetch_log}"
+            return 1
+          }
+
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            current_ref="${GITHUB_SHA}"
+            baseline_ref="${BEFORE_SHA}"
+            threshold_pct="5"
+            rayon_threads="8"
+            scenario_filter=""
+          else
+            baseline_ref="${INPUT_BASELINE_REF}"
+            current_ref="${INPUT_CURRENT_REF}"
+            threshold_pct="${INPUT_THRESHOLD_PCT}"
+            rayon_threads="${INPUT_RAYON_THREADS}"
+            scenario_filter="${INPUT_SCENARIO_FILTER}"
+          fi
+
+          if [[ -z "${current_ref}" ]]; then
+            current_ref="${GITHUB_SHA}"
+          fi
+
+          if [[ -z "${threshold_pct}" ]]; then
+            threshold_pct="5"
+          fi
+
+          if [[ -z "${rayon_threads}" ]]; then
+            rayon_threads="8"
+          fi
+
+          if [[ ! "${threshold_pct}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+            echo "regression_threshold_pct must be numeric" >&2
+            exit 1
+          fi
+
+          if [[ ! "${rayon_threads}" =~ ^[0-9]+$ ]]; then
+            echo "rayon_num_threads must be an integer" >&2
+            exit 1
+          fi
+
+          if [[ -z "${baseline_ref}" || "${baseline_ref}" == "0000000000000000000000000000000000000000" ]]; then
+            baseline_ref="${current_ref}^"
+          fi
+
+          current_sha="$(resolve_commit "${current_ref}")"
+          fetch_status=0
+
+          if [[ "${EVENT_NAME}" == "push" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]]; then
+            if fetch_commit_if_needed "${baseline_ref}"; then
+              fetch_status=0
+            else
+              fetch_status=$?
+            fi
+          fi
+
+          if [[ "${EVENT_NAME}" == "push" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" && ${fetch_status} -eq 0 ]]; then
+            baseline_sha="$(resolve_commit "${baseline_ref}")"
+          elif [[ "${EVENT_NAME}" == "push" && "${BEFORE_SHA}" != "0000000000000000000000000000000000000000" && ${fetch_status} -eq 2 ]]; then
+            echo "push baseline ${baseline_ref} is no longer available; refusing to compare against current_sha^" >&2
+            exit 1
+          elif resolve_commit "${baseline_ref}" >/dev/null 2>&1; then
+            baseline_sha="$(resolve_commit "${baseline_ref}")"
+          elif [[ "${EVENT_NAME}" == "push" && "${BEFORE_SHA}" == "0000000000000000000000000000000000000000" ]]; then
+            baseline_ref="${current_sha}^"
+            baseline_sha="$(resolve_commit "${current_sha}^")"
+          elif [[ "${EVENT_NAME}" == "workflow_dispatch" && -z "${INPUT_BASELINE_REF}" ]]; then
+            baseline_ref="${current_sha}^"
+            baseline_sha="$(resolve_commit "${current_sha}^")"
+          else
+            echo "baseline_ref must resolve to a commit: ${baseline_ref}" >&2
+            exit 1
+          fi
+
+          baseline_ref="${baseline_sha}"
+
+          {
+            echo "baseline_ref=${baseline_ref}"
+            echo "current_ref=${current_ref}"
+            echo "baseline_sha=${baseline_sha}"
+            echo "current_sha=${current_sha}"
+            echo "threshold_pct=${threshold_pct}"
+            echo "rayon_threads=${rayon_threads}"
+            echo "scenario_filter=${scenario_filter}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Create worktrees
+        env:
+          WORKTREE_DIR: ${{ steps.dirs.outputs.worktree_dir }}
+          BASELINE_SHA: ${{ steps.refs.outputs.baseline_sha }}
+          CURRENT_SHA: ${{ steps.refs.outputs.current_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git worktree add --detach "${WORKTREE_DIR}/baseline" "${BASELINE_SHA}"
+          git worktree add --detach "${WORKTREE_DIR}/current" "${CURRENT_SHA}"
+
+      - name: Run baseline benchmark
+        env:
+          GITHUB_WORKSPACE_PATH: ${{ github.workspace }}
+          WORKTREE_DIR: ${{ steps.dirs.outputs.worktree_dir }}
+          ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
+          RAYON_THREADS: ${{ steps.refs.outputs.rayon_threads }}
+          SCENARIO_FILTER: ${{ steps.refs.outputs.scenario_filter }}
+          BASELINE_SHA: ${{ steps.refs.outputs.baseline_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 "${GITHUB_WORKSPACE_PATH}/scripts/synthetic_tx_nonregression.py" run \
+            --repo-root "${WORKTREE_DIR}/baseline" \
+            --output-dir "${ARTIFACT_DIR}/baseline" \
+            --rayon-num-threads "${RAYON_THREADS}" \
+            --scenario-filter "${SCENARIO_FILTER}" \
+            --git-ref "${BASELINE_SHA}"
+
+      - name: Run current benchmark
+        env:
+          GITHUB_WORKSPACE_PATH: ${{ github.workspace }}
+          WORKTREE_DIR: ${{ steps.dirs.outputs.worktree_dir }}
+          ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
+          RAYON_THREADS: ${{ steps.refs.outputs.rayon_threads }}
+          SCENARIO_FILTER: ${{ steps.refs.outputs.scenario_filter }}
+          CURRENT_SHA: ${{ steps.refs.outputs.current_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 "${GITHUB_WORKSPACE_PATH}/scripts/synthetic_tx_nonregression.py" run \
+            --repo-root "${WORKTREE_DIR}/current" \
+            --output-dir "${ARTIFACT_DIR}/current" \
+            --rayon-num-threads "${RAYON_THREADS}" \
+            --scenario-filter "${SCENARIO_FILTER}" \
+            --git-ref "${CURRENT_SHA}"
+
+      - name: Compare baseline and current results
+        id: compare
+        env:
+          GITHUB_WORKSPACE_PATH: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
+          THRESHOLD_PCT: ${{ steps.refs.outputs.threshold_pct }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 "${GITHUB_WORKSPACE_PATH}/scripts/synthetic_tx_nonregression.py" compare \
+            --baseline "${ARTIFACT_DIR}/baseline/result.json" \
+            --current "${ARTIFACT_DIR}/current/result.json" \
+            --summary-out "${ARTIFACT_DIR}/summary.md" \
+            --json-out "${ARTIFACT_DIR}/comparison.json" \
+            --threshold-pct "${THRESHOLD_PCT}" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Publish job summary
+        if: always()
+        env:
+          ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -f "${ARTIFACT_DIR}/summary.md" ]]; then
+            cat "${ARTIFACT_DIR}/summary.md" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Expose summary for downstream jobs
+        if: always()
+        id: summary
+        env:
+          ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! -f "${ARTIFACT_DIR}/summary.md" ]]; then
+            exit 0
+          fi
+          {
+            echo "summary<<EOF"
+            cat "${ARTIFACT_DIR}/summary.md"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: synthetic-tx-kernel-nonregression
+          path: ${{ steps.dirs.outputs.artifact_dir }}
+          if-no-files-found: warn
+
+      - name: Remove worktrees
+        if: always()
+        env:
+          RUN_ROOT: ${{ steps.dirs.outputs.run_root }}
+          WORKTREE_DIR: ${{ steps.dirs.outputs.worktree_dir }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git worktree remove --force "${WORKTREE_DIR}/baseline" || true
+          git worktree remove --force "${WORKTREE_DIR}/current" || true
+          rm -rf "${RUN_ROOT}"
+
+      - name: Fail on regression
+        if: steps.compare.outputs.regression == 'true'
+        env:
+          MAX_DELTA_METRIC: ${{ steps.compare.outputs.max_delta_metric }}
+          MAX_DELTA_PCT: ${{ steps.compare.outputs.max_delta_pct }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "synthetic transaction kernel benchmark ${MAX_DELTA_METRIC} regressed by ${MAX_DELTA_PCT}%"
+          exit 1
+
+  comment:
+    name: Comment on pushed commit
+    runs-on: ubuntu-latest
+    needs:
+      - benchmark
+    if: always() && github.event_name == 'push' && needs.benchmark.outputs.current_sha != '' && needs.benchmark.outputs.summary != ''
+    permissions:
+      contents: write
+    steps:
+      - name: Create or update commit comment
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        env:
+          CURRENT_SHA: ${{ needs.benchmark.outputs.current_sha }}
+          MARKER: "<!-- synthetic-tx-kernel-nonregression -->"
+          BODY: ${{ needs.benchmark.outputs.summary }}
+        with:
+          script: |
+            const body = [
+              process.env.MARKER,
+              process.env.BODY,
+              '',
+              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const commitSha = process.env.CURRENT_SHA;
+            const marker = process.env.MARKER;
+
+            const comments = await github.paginate(
+              github.rest.repos.listCommentsForCommit,
+              {
+                owner,
+                repo,
+                commit_sha: commitSha,
+                per_page: 100,
+              },
+            );
+
+            const existing = comments.find(comment =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.repos.updateCommitComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.repos.createCommitComment({
+              owner,
+              repo,
+              commit_sha: commitSha,
+              body,
+            });

--- a/scripts/blake3_nonregression.py
+++ b/scripts/blake3_nonregression.py
@@ -368,6 +368,8 @@ def summary_markdown(result: dict[str, Any]) -> str:
     top_slowdowns = result["top_slowdowns"]
 
     lines = [
+        "# BENCHMARK REPORT: blake3-1to1-nonregression",
+        "",
         "## Blake3 1-to-1 Non-Regression",
         "",
         f"Status: **{status_word}**",

--- a/scripts/synthetic_tx_nonregression.py
+++ b/scripts/synthetic_tx_nonregression.py
@@ -88,14 +88,27 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def parse_criterion_estimate_path(criterion_root: Path, estimates_path: Path) -> tuple[str, str, str]:
+    relative_parts = estimates_path.relative_to(criterion_root).parts
+    if len(relative_parts) == 5 and relative_parts[-2:] == ("new", "estimates.json"):
+        producer, scenario, axis = relative_parts[:3]
+        return producer, scenario, axis
+
+    if len(relative_parts) == 4 and relative_parts[-2:] == ("new", "estimates.json"):
+        group, axis = relative_parts[:2]
+        producer, separator, scenario = group.partition("_")
+        if separator and scenario:
+            return producer, scenario, axis
+
+    raise ValueError(f"Unexpected synthetic benchmark estimate path: {estimates_path}")
+
+
 def collect_criterion_metrics(repo_root: Path, *, estimate: str = "mean") -> dict[str, dict[str, Any]]:
     criterion_root = repo_root / "target" / "criterion"
     metrics: dict[str, dict[str, Any]] = {}
 
-    for estimates_path in sorted(criterion_root.glob("bench-tx/*/*/new/estimates.json")):
-        axis = estimates_path.parents[1].name
-        scenario = estimates_path.parents[2].name
-        producer = estimates_path.parents[3].name
+    for estimates_path in sorted(criterion_root.glob("**/new/estimates.json")):
+        producer, scenario, axis = parse_criterion_estimate_path(criterion_root, estimates_path)
         name = f"{producer}/{scenario}/{axis}"
         estimate_data = json.loads(estimates_path.read_text(encoding="utf-8"))[estimate]
         metrics[name] = {
@@ -395,6 +408,34 @@ class Tests(unittest.TestCase):
             try:
                 metrics = collect_criterion_metrics(root)
                 self.assertEqual(metrics["bench-tx/consume-single-p2id-note/prove"]["estimate_ms"], 1.5)
+            finally:
+                subprocess.run(["rm", "-rf", str(root)], check=False)
+
+    def test_collect_criterion_estimate_from_sanitized_group_dir(self) -> None:
+        with mock.patch("subprocess.check_output", return_value="abc\n"):
+            root = Path(self.id().replace("/", "_"))
+            estimates = (
+                root
+                / "target"
+                / "criterion"
+                / "bench-tx_create-single-p2id-note"
+                / "prove"
+                / "new"
+                / "estimates.json"
+            )
+            estimates.parent.mkdir(parents=True, exist_ok=True)
+            write_json(
+                estimates,
+                {
+                    "mean": {
+                        "point_estimate": 1_500_000.0,
+                        "confidence_interval": {"lower_bound": 1_000_000.0, "upper_bound": 2_000_000.0},
+                    }
+                },
+            )
+            try:
+                metrics = collect_criterion_metrics(root)
+                self.assertEqual(metrics["bench-tx/create-single-p2id-note/prove"]["estimate_ms"], 1.5)
             finally:
                 subprocess.run(["rm", "-rf", str(root)], check=False)
 

--- a/scripts/synthetic_tx_nonregression.py
+++ b/scripts/synthetic_tx_nonregression.py
@@ -88,20 +88,14 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def split_criterion_group(group: str) -> tuple[str, str]:
-    producer, separator, scenario = group.partition("_")
-    if not separator or not scenario:
-        raise ValueError(f"Unexpected synthetic benchmark group directory: {group}")
-    return producer, scenario
-
-
 def collect_criterion_metrics(repo_root: Path, *, estimate: str = "mean") -> dict[str, dict[str, Any]]:
     criterion_root = repo_root / "target" / "criterion"
     metrics: dict[str, dict[str, Any]] = {}
 
-    for estimates_path in sorted(criterion_root.glob("bench-tx_*/*/new/estimates.json")):
+    for estimates_path in sorted(criterion_root.glob("bench-tx/*/*/new/estimates.json")):
         axis = estimates_path.parents[1].name
-        producer, scenario = split_criterion_group(estimates_path.parents[2].name)
+        scenario = estimates_path.parents[2].name
+        producer = estimates_path.parents[3].name
         name = f"{producer}/{scenario}/{axis}"
         estimate_data = json.loads(estimates_path.read_text(encoding="utf-8"))[estimate]
         metrics[name] = {
@@ -364,7 +358,8 @@ class Tests(unittest.TestCase):
                 root
                 / "target"
                 / "criterion"
-                / "bench-tx_consume-single-p2id-note"
+                / "bench-tx"
+                / "consume-single-p2id-note"
                 / "prove"
                 / "new"
                 / "estimates.json"

--- a/scripts/synthetic_tx_nonregression.py
+++ b/scripts/synthetic_tx_nonregression.py
@@ -268,30 +268,48 @@ def summary_markdown(result: dict[str, Any]) -> str:
         if result["baseline_bench_wall_ms"] is None or result["current_bench_wall_ms"] is None
         else result["current_bench_wall_ms"] - result["baseline_bench_wall_ms"]
     )
+    wall_delta_pct = percent_delta(result["current_bench_wall_ms"], result["baseline_bench_wall_ms"])
+    over_threshold = [
+        row
+        for row in result["metric_rows"]
+        if row["delta_pct"] is not None and row["delta_pct"] > result["threshold_pct"]
+    ]
+    metric_rows = result["metric_rows"]
     lines = [
         "# BENCHMARK REPORT: synthetic-tx-kernel-nonregression",
         "",
         "## Synthetic Transaction Kernel Non-Regression",
         "",
-        f"Status: **{status}**",
-        f"Threshold: `{result['threshold_pct']:.2f}%`",
-        f"Baseline: `{baseline}`",
-        f"Current: `{current}`",
-        (
-            "Worst slowdown: "
-            f"`{result['max_delta_metric']}` moved by "
-            f"`{fmt_delta(result['max_delta_ms'])}` ({fmt_pct(result['max_delta_pct'])})"
-        ),
+        "### Run",
         "",
-        "| Metric | Baseline | Current | Delta | Delta % |",
-        "| --- | ---: | ---: | ---: | ---: |",
-        (
-            "| bench wall | "
-            f"{fmt_ms(result['baseline_bench_wall_ms'])} | "
-            f"{fmt_ms(result['current_bench_wall_ms'])} | "
-            f"{fmt_delta(wall_delta)} | "
-            f"{fmt_pct(percent_delta(result['current_bench_wall_ms'], result['baseline_bench_wall_ms']))} |"
-        ),
+        f"- Baseline: `{baseline}`",
+        f"- Current: `{current}`",
+        f"- Threshold: `{result['threshold_pct']:.2f}%`",
+        "- Bench wall: "
+        f"{fmt_ms(result['baseline_bench_wall_ms'])} -> "
+        f"{fmt_ms(result['current_bench_wall_ms'])} "
+        f"({fmt_delta(wall_delta)}, {fmt_pct(wall_delta_pct)})",
+        "",
+        "### Result",
+        "",
+        f"- Status: **{status}**",
+        "- Worst regression: "
+        f"`{result['max_delta_metric']}` moved by "
+        f"`{fmt_delta(result['max_delta_ms'])}` ({fmt_pct(result['max_delta_pct'])})",
+        "",
+        "### Metrics over threshold",
+        "",
+    ]
+    if over_threshold:
+        lines.extend(
+            f"- `{row['name']}`: {fmt_delta(row['delta_ms'])} ({fmt_pct(row['delta_pct'])})"
+            for row in over_threshold
+        )
+    else:
+        lines.append("- None")
+    lines += [
+        "",
+        f"### Per-benchmark results ({len(metric_rows)} of {len(metric_rows)})",
         "",
         "| Benchmark | Baseline | Current | Delta | Delta % |",
         "| --- | ---: | ---: | ---: | ---: |",
@@ -301,7 +319,7 @@ def summary_markdown(result: dict[str, Any]) -> str:
             f"| {row['name']} | {fmt_ms(row['baseline_ms'])} | {fmt_ms(row['current_ms'])} | "
             f"{fmt_delta(row['delta_ms'])} | {fmt_pct(row['delta_pct'])} |"
         )
-        for row in result["metric_rows"][:20]
+        for row in metric_rows
     ]
     if result["missing_in_current"] or result["missing_in_baseline"]:
         lines.append("\nMetric set changed:")
@@ -386,6 +404,49 @@ class Tests(unittest.TestCase):
         result = compare_results(baseline, current, 5.0)
         self.assertTrue(result["regression"])
         self.assertEqual(result["max_delta_metric"], "bench-tx/a/verify")
+
+    def test_summary_markdown_uses_requested_report_shape(self) -> None:
+        result = compare_results(
+            {
+                "git_sha": "1764d66ca1c6deadbeef",
+                "bench_wall_ms": 145_000.0,
+                "metrics": {
+                    "bench-tx/consume-b2agg-note-bridge-out/exec": {"estimate_ms": 23.96},
+                    "bench-tx/consume-single-p2id-note/prove": {"estimate_ms": 1_987.33},
+                },
+            },
+            {
+                "git_sha": "1234567890abcdef",
+                "bench_wall_ms": 152_000.0,
+                "metrics": {
+                    "bench-tx/consume-b2agg-note-bridge-out/exec": {"estimate_ms": 23.96},
+                    "bench-tx/consume-single-p2id-note/prove": {"estimate_ms": 2_132.40},
+                },
+            },
+            5.0,
+        )
+
+        summary = summary_markdown(result)
+
+        self.assertIn("# BENCHMARK REPORT: synthetic-tx-kernel-nonregression", summary)
+        self.assertIn("### Run", summary)
+        self.assertIn("- Baseline: `1764d66ca1c6`", summary)
+        self.assertIn("- Current: `1234567890ab`", summary)
+        self.assertIn("- Threshold: `5.00%`", summary)
+        self.assertIn("- Bench wall: 145,000.00 ms -> 152,000.00 ms (+7,000.00 ms, +4.83%)", summary)
+        self.assertIn("### Result", summary)
+        self.assertIn("- Status: **REGRESSION**", summary)
+        self.assertIn(
+            "- Worst regression: `bench-tx/consume-single-p2id-note/prove` moved by `+145.07 ms` (+7.30%)",
+            summary,
+        )
+        self.assertIn("### Metrics over threshold", summary)
+        self.assertIn("- `bench-tx/consume-single-p2id-note/prove`: +145.07 ms (+7.30%)", summary)
+        self.assertIn("### Per-benchmark results (2 of 2)", summary)
+        self.assertIn(
+            "| bench-tx/consume-single-p2id-note/prove | 1,987.33 ms | 2,132.40 ms | +145.07 ms | +7.30% |",
+            summary,
+        )
 
 
 def cmd_self_test(args: argparse.Namespace) -> int:

--- a/scripts/synthetic_tx_nonregression.py
+++ b/scripts/synthetic_tx_nonregression.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import textwrap
+import time
+import unittest
+from pathlib import Path
+from typing import Any
+
+ANSI_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+TIME_RE = re.compile(
+    r"^(?:(?P<name>[A-Za-z0-9_.-][^\s]*)\s+)?"
+    r"time:\s*\[\s*"
+    r"(?P<low>[0-9]+(?:\.[0-9]+)?)\s*(?P<low_unit>ps|ns|us|\u00b5s|\u03bcs|ms|s)\s+"
+    r"(?P<estimate>[0-9]+(?:\.[0-9]+)?)\s*(?P<estimate_unit>ps|ns|us|\u00b5s|\u03bcs|ms|s)\s+"
+    r"(?P<high>[0-9]+(?:\.[0-9]+)?)\s*(?P<high_unit>ps|ns|us|\u00b5s|\u03bcs|ms|s)\s*"
+    r"\]"
+)
+BENCH_LINE_RE = re.compile(r"^[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+$")
+BENCHMARKING_RE = re.compile(r"^Benchmarking (?P<name>[^:]+)(?::|$)")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run and compare the synthetic transaction kernel non-regression benchmark."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parse_log = subparsers.add_parser("parse-log", help="Parse Criterion output into JSON.")
+    parse_log.add_argument("--log", required=True, type=Path)
+    parse_log.add_argument("--output", required=True, type=Path)
+    parse_log.add_argument("--repo-root", type=Path)
+    parse_log.add_argument("--bench-wall-ms", type=float)
+    parse_log.add_argument("--rayon-num-threads", type=int)
+    parse_log.add_argument("--scenario-filter", default="")
+    parse_log.add_argument("--git-ref", default="")
+
+    run = subparsers.add_parser("run", help="Build from clean state and run the benchmark.")
+    run.add_argument("--repo-root", required=True, type=Path)
+    run.add_argument("--output-dir", required=True, type=Path)
+    run.add_argument("--rayon-num-threads", type=int, default=8)
+    run.add_argument("--scenario-filter", default="")
+    run.add_argument("--sample-size", type=int)
+    run.add_argument("--measurement-time-secs", type=int)
+    run.add_argument("--warm-up-time-secs", type=int)
+    run.add_argument("--git-ref", default="")
+
+    compare = subparsers.add_parser(
+        "compare", help="Compare two parsed benchmark result JSON files."
+    )
+    compare.add_argument("--baseline", required=True, type=Path)
+    compare.add_argument("--current", required=True, type=Path)
+    compare.add_argument("--summary-out", required=True, type=Path)
+    compare.add_argument("--json-out", required=True, type=Path)
+    compare.add_argument("--threshold-pct", required=True, type=float)
+    compare.add_argument("--github-output", type=Path)
+
+    self_test = subparsers.add_parser("self-test", help="Run parser and comparison tests.")
+    self_test.add_argument("--runs", type=int, default=1)
+
+    return parser.parse_args()
+
+
+def strip_ansi(text: str) -> str:
+    return ANSI_RE.sub("", text)
+
+
+def parse_duration_ms(value: str, unit: str) -> float:
+    amount = float(value)
+    if unit == "ps":
+        return amount / 1_000_000_000.0
+    if unit == "ns":
+        return amount / 1_000_000.0
+    if unit in ("us", "\u00b5s", "\u03bcs"):
+        return amount / 1000.0
+    if unit == "ms":
+        return amount
+    if unit == "s":
+        return amount * 1000.0
+    raise ValueError(f"Unsupported duration unit: {unit}")
+
+
+def run_logged_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None,
+    log_path: Path,
+) -> float:
+    start = time.perf_counter()
+    with log_path.open("w", encoding="utf-8") as handle:
+        handle.write(f"$ {' '.join(command)}\n")
+        handle.flush()
+
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        assert process.stdout is not None
+
+        for line in process.stdout:
+            sys.stdout.write(line)
+            handle.write(line)
+
+        code = process.wait()
+        if code != 0:
+            raise subprocess.CalledProcessError(code, command)
+
+    return (time.perf_counter() - start) * 1000.0
+
+
+def current_sha(repo_root: Path) -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repo_root, text=True
+    ).strip()
+
+
+def parse_criterion_log(contents: str) -> dict[str, Any]:
+    metrics: dict[str, dict[str, Any]] = {}
+    pending_name: str | None = None
+
+    for line_number, raw_line in enumerate(contents.splitlines(), start=1):
+        line = strip_ansi(raw_line).strip()
+        if not line:
+            continue
+
+        benchmarking = BENCHMARKING_RE.match(line)
+        if benchmarking:
+            name = benchmarking.group("name").strip()
+            if BENCH_LINE_RE.match(name):
+                pending_name = name
+            continue
+
+        match = TIME_RE.match(line)
+        if match:
+            name = match.group("name") or pending_name
+            if name is None:
+                raise ValueError(f"Criterion timing without benchmark name on line {line_number}")
+            estimate_ms = parse_duration_ms(
+                match.group("estimate"), match.group("estimate_unit")
+            )
+            low_ms = parse_duration_ms(match.group("low"), match.group("low_unit"))
+            high_ms = parse_duration_ms(match.group("high"), match.group("high_unit"))
+            parts = name.split("/")
+            metrics[name] = {
+                "name": name,
+                "producer": parts[0] if len(parts) >= 3 else "",
+                "scenario": "/".join(parts[1:-1]) if len(parts) >= 3 else "",
+                "axis": parts[-1],
+                "low_ms": low_ms,
+                "estimate_ms": estimate_ms,
+                "high_ms": high_ms,
+                "line": line_number,
+            }
+            pending_name = None
+            continue
+
+        if BENCH_LINE_RE.match(line):
+            pending_name = line
+
+    if not metrics:
+        raise ValueError("Could not find any Criterion timing rows in the benchmark log.")
+
+    return {"metrics": dict(sorted(metrics.items()))}
+
+
+def parse_log_file(
+    log_path: Path,
+    *,
+    repo_root: Path | None,
+    git_ref: str,
+    bench_wall_ms: float | None,
+    rayon_num_threads: int | None,
+    scenario_filter: str,
+) -> dict[str, Any]:
+    parsed = parse_criterion_log(log_path.read_text(encoding="utf-8"))
+    metadata = {
+        "log_path": str(log_path),
+        "git_ref": git_ref,
+        "bench_wall_ms": bench_wall_ms,
+        "rayon_num_threads": rayon_num_threads,
+        "scenario_filter": scenario_filter,
+    }
+    if repo_root is not None:
+        metadata["repo_root"] = str(repo_root)
+        metadata["git_sha"] = current_sha(repo_root)
+    return {**metadata, **parsed}
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    repo_root = args.repo_root.resolve()
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env["RAYON_NUM_THREADS"] = str(args.rayon_num_threads)
+    if args.scenario_filter:
+        env["SYNTH_SCENARIO"] = args.scenario_filter
+
+    run_logged_command(
+        ["cargo", "clean"], cwd=repo_root, env=env, log_path=output_dir / "clean.log"
+    )
+
+    bench_command = [
+        "cargo",
+        "bench",
+        "--profile",
+        "optimized",
+        "-p",
+        "miden-vm-synthetic-bench",
+        "--bench",
+        "synthetic_bench",
+        "--",
+        "--noplot",
+    ]
+    if args.sample_size is not None:
+        bench_command.extend(["--sample-size", str(args.sample_size)])
+    if args.measurement_time_secs is not None:
+        bench_command.extend(["--measurement-time", str(args.measurement_time_secs)])
+    if args.warm_up_time_secs is not None:
+        bench_command.extend(["--warm-up-time", str(args.warm_up_time_secs)])
+
+    bench_log = output_dir / "bench.log"
+    bench_wall_ms = run_logged_command(bench_command, cwd=repo_root, env=env, log_path=bench_log)
+
+    payload = parse_log_file(
+        bench_log,
+        repo_root=repo_root,
+        git_ref=args.git_ref,
+        bench_wall_ms=bench_wall_ms,
+        rayon_num_threads=args.rayon_num_threads,
+        scenario_filter=args.scenario_filter,
+    )
+    write_json(output_dir / "result.json", payload)
+    return 0
+
+
+def percent_delta(current: float | None, baseline: float | None) -> float | None:
+    if baseline in (None, 0) or current is None:
+        return None
+    return ((current - baseline) / baseline) * 100.0
+
+
+def format_ms(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:,.2f} ms"
+
+
+def format_delta(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    sign = "+" if value >= 0 else ""
+    return f"{sign}{value:,.2f} ms"
+
+
+def format_pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    sign = "+" if value >= 0 else ""
+    return f"{sign}{value:.2f}%"
+
+
+def compare_results(
+    baseline: dict[str, Any],
+    current: dict[str, Any],
+    threshold_pct: float,
+) -> dict[str, Any]:
+    baseline_metrics = baseline.get("metrics", {})
+    current_metrics = current.get("metrics", {})
+    missing_in_current = sorted(set(baseline_metrics) - set(current_metrics))
+    missing_in_baseline = sorted(set(current_metrics) - set(baseline_metrics))
+    shared = sorted(set(baseline_metrics) & set(current_metrics))
+    if not shared:
+        raise ValueError("Baseline and current benchmark results have no metric names in common.")
+
+    rows: list[dict[str, Any]] = []
+    for name in shared:
+        baseline_ms = baseline_metrics[name]["estimate_ms"]
+        current_ms = current_metrics[name]["estimate_ms"]
+        delta_ms = current_ms - baseline_ms
+        delta_pct = percent_delta(current_ms, baseline_ms)
+        rows.append(
+            {
+                "name": name,
+                "producer": current_metrics[name].get("producer", ""),
+                "scenario": current_metrics[name].get("scenario", ""),
+                "axis": current_metrics[name].get("axis", ""),
+                "baseline_ms": baseline_ms,
+                "current_ms": current_ms,
+                "delta_ms": delta_ms,
+                "delta_pct": delta_pct,
+            }
+        )
+
+    rows.sort(
+        key=lambda row: row["delta_pct"] if row["delta_pct"] is not None else float("-inf"),
+        reverse=True,
+    )
+    worst = rows[0]
+    regression = bool(worst["delta_pct"] is not None and worst["delta_pct"] > threshold_pct)
+
+    return {
+        "status": "regression" if regression else "ok",
+        "regression": regression,
+        "threshold_pct": threshold_pct,
+        "baseline_sha": baseline.get("git_sha", ""),
+        "current_sha": current.get("git_sha", ""),
+        "baseline_ref": baseline.get("git_ref", ""),
+        "current_ref": current.get("git_ref", ""),
+        "baseline_bench_wall_ms": baseline.get("bench_wall_ms"),
+        "current_bench_wall_ms": current.get("bench_wall_ms"),
+        "max_delta_metric": worst["name"],
+        "max_delta_ms": worst["delta_ms"],
+        "max_delta_pct": worst["delta_pct"],
+        "metric_rows": rows,
+        "missing_in_current": missing_in_current,
+        "missing_in_baseline": missing_in_baseline,
+    }
+
+
+def summary_markdown(result: dict[str, Any]) -> str:
+    status_word = "REGRESSION" if result["regression"] else "OK"
+    baseline_sha = result["baseline_sha"][:12] or result["baseline_ref"] or "baseline"
+    current_sha = result["current_sha"][:12] or result["current_ref"] or "current"
+
+    lines = [
+        "# BENCHMARK REPORT: synthetic-tx-kernel-nonregression",
+        "",
+        "## Synthetic Transaction Kernel Non-Regression",
+        "",
+        f"Status: **{status_word}**",
+        f"Threshold: `{result['threshold_pct']:.2f}%`",
+        f"Baseline: `{baseline_sha}`",
+        f"Current: `{current_sha}`",
+        (
+            "Worst slowdown: "
+            f"`{result['max_delta_metric']}` moved by "
+            f"`{format_delta(result['max_delta_ms'])}` ({format_pct(result['max_delta_pct'])})"
+        ),
+        "",
+        "| Metric | Baseline | Current | Delta | Delta % |",
+        "| --- | ---: | ---: | ---: | ---: |",
+        (
+            "| bench wall | "
+            f"{format_ms(result['baseline_bench_wall_ms'])} | "
+            f"{format_ms(result['current_bench_wall_ms'])} | "
+            f"{format_delta(None if result['baseline_bench_wall_ms'] is None or result['current_bench_wall_ms'] is None else result['current_bench_wall_ms'] - result['baseline_bench_wall_ms'])} | "
+            f"{format_pct(percent_delta(result['current_bench_wall_ms'], result['baseline_bench_wall_ms']))} |"
+        ),
+    ]
+
+    lines.extend(
+        [
+            "",
+            "| Benchmark | Baseline | Current | Delta | Delta % |",
+            "| --- | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for row in result["metric_rows"][:20]:
+        lines.append(
+            "| "
+            f"{row['name']} | "
+            f"{format_ms(row['baseline_ms'])} | "
+            f"{format_ms(row['current_ms'])} | "
+            f"{format_delta(row['delta_ms'])} | "
+            f"{format_pct(row['delta_pct'])} |"
+        )
+
+    if result["missing_in_current"] or result["missing_in_baseline"]:
+        lines.extend(["", "Metric set changed:"])
+        if result["missing_in_current"]:
+            lines.append(
+                "- Missing in current: "
+                + ", ".join(f"`{name}`" for name in result["missing_in_current"][:10])
+            )
+        if result["missing_in_baseline"]:
+            lines.append(
+                "- Missing in baseline: "
+                + ", ".join(f"`{name}`" for name in result["missing_in_baseline"][:10])
+            )
+
+    return "\n".join(lines) + "\n"
+
+
+def write_github_output(path: Path, result: dict[str, Any]) -> None:
+    lines = [
+        f"status={result['status']}",
+        f"regression={'true' if result['regression'] else 'false'}",
+        f"baseline_sha={result['baseline_sha']}",
+        f"current_sha={result['current_sha']}",
+        f"max_delta_metric={result['max_delta_metric']}",
+        f"max_delta_ms={result['max_delta_ms']:.6f}",
+        f"max_delta_pct={result['max_delta_pct']:.6f}",
+    ]
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+def cmd_parse_log(args: argparse.Namespace) -> int:
+    payload = parse_log_file(
+        args.log,
+        repo_root=args.repo_root,
+        git_ref=args.git_ref,
+        bench_wall_ms=args.bench_wall_ms,
+        rayon_num_threads=args.rayon_num_threads,
+        scenario_filter=args.scenario_filter,
+    )
+    write_json(args.output, payload)
+    return 0
+
+
+def cmd_compare(args: argparse.Namespace) -> int:
+    baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+    current = json.loads(args.current.read_text(encoding="utf-8"))
+    result = compare_results(baseline, current, args.threshold_pct)
+    write_json(args.json_out, result)
+    args.summary_out.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_out.write_text(summary_markdown(result), encoding="utf-8")
+    if args.github_output is not None:
+        write_github_output(args.github_output, result)
+    return 0
+
+
+class ParserTests(unittest.TestCase):
+    def test_parse_split_criterion_rows(self) -> None:
+        payload = parse_criterion_log(
+            textwrap.dedent(
+                """
+                Benchmarking bench-tx/consume-single-p2id-note/prove: Warming up for 1.0000 s
+                bench-tx/consume-single-p2id-note/prove
+                                        time:   [1.2345 s 1.3456 s 1.4567 s]
+                Found 3 outliers among 30 measurements
+                bench-tx/consume-single-p2id-note/verify
+                                        time:   [997.00 us 1.0000 ms 1.0130 ms]
+                """
+            )
+        )
+        self.assertAlmostEqual(
+            payload["metrics"]["bench-tx/consume-single-p2id-note/prove"]["estimate_ms"],
+            1345.6,
+        )
+        self.assertAlmostEqual(
+            payload["metrics"]["bench-tx/consume-single-p2id-note/verify"]["estimate_ms"],
+            1.0,
+        )
+
+    def test_parse_inline_colored_row(self) -> None:
+        payload = parse_criterion_log(
+            "\x1b[32mbench-tx/foo/exec time: [10.00 ms 11.50 ms 13.00 ms]\x1b[0m\n"
+        )
+        self.assertAlmostEqual(payload["metrics"]["bench-tx/foo/exec"]["estimate_ms"], 11.5)
+
+    def test_compare_uses_worst_positive_delta(self) -> None:
+        baseline = {
+            "metrics": {
+                "bench-tx/a/prove": {"estimate_ms": 100.0},
+                "bench-tx/a/verify": {"estimate_ms": 50.0},
+            }
+        }
+        current = {
+            "metrics": {
+                "bench-tx/a/prove": {"estimate_ms": 104.0},
+                "bench-tx/a/verify": {"estimate_ms": 60.0},
+            }
+        }
+        result = compare_results(baseline, current, 5.0)
+        self.assertTrue(result["regression"])
+        self.assertEqual(result["max_delta_metric"], "bench-tx/a/verify")
+
+    def test_empty_log_fails(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_criterion_log("running 0 tests\n")
+
+
+def cmd_self_test(args: argparse.Namespace) -> int:
+    for run in range(args.runs):
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(ParserTests)
+        result = unittest.TextTestRunner(verbosity=1, stream=sys.stderr).run(suite)
+        if not result.wasSuccessful():
+            return 1
+        if args.runs > 1:
+            print(f"parser self-test run {run + 1}/{args.runs} passed")
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "parse-log":
+        return cmd_parse_log(args)
+    if args.command == "run":
+        return cmd_run(args)
+    if args.command == "compare":
+        return cmd_compare(args)
+    if args.command == "self-test":
+        return cmd_self_test(args)
+    raise ValueError(f"Unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/synthetic_tx_nonregression.py
+++ b/scripts/synthetic_tx_nonregression.py
@@ -5,44 +5,22 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
 import subprocess
 import sys
-import textwrap
 import time
 import unittest
+import unittest.mock as mock
 from pathlib import Path
 from typing import Any
-
-ANSI_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
-TIME_RE = re.compile(
-    r"^(?:(?P<name>[A-Za-z0-9_.-][^\s]*)\s+)?"
-    r"time:\s*\[\s*"
-    r"(?P<low>[0-9]+(?:\.[0-9]+)?)\s*(?P<low_unit>ps|ns|us|\u00b5s|\u03bcs|ms|s)\s+"
-    r"(?P<estimate>[0-9]+(?:\.[0-9]+)?)\s*(?P<estimate_unit>ps|ns|us|\u00b5s|\u03bcs|ms|s)\s+"
-    r"(?P<high>[0-9]+(?:\.[0-9]+)?)\s*(?P<high_unit>ps|ns|us|\u00b5s|\u03bcs|ms|s)\s*"
-    r"\]"
-)
-BENCH_LINE_RE = re.compile(r"^[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+$")
-BENCHMARKING_RE = re.compile(r"^Benchmarking (?P<name>[^:]+)(?::|$)")
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run and compare the synthetic transaction kernel non-regression benchmark."
     )
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    commands = parser.add_subparsers(dest="command", required=True)
 
-    parse_log = subparsers.add_parser("parse-log", help="Parse Criterion output into JSON.")
-    parse_log.add_argument("--log", required=True, type=Path)
-    parse_log.add_argument("--output", required=True, type=Path)
-    parse_log.add_argument("--repo-root", type=Path)
-    parse_log.add_argument("--bench-wall-ms", type=float)
-    parse_log.add_argument("--rayon-num-threads", type=int)
-    parse_log.add_argument("--scenario-filter", default="")
-    parse_log.add_argument("--git-ref", default="")
-
-    run = subparsers.add_parser("run", help="Build from clean state and run the benchmark.")
+    run = commands.add_parser("run", help="Build from clean state and run the benchmark.")
     run.add_argument("--repo-root", required=True, type=Path)
     run.add_argument("--output-dir", required=True, type=Path)
     run.add_argument("--rayon-num-threads", type=int, default=8)
@@ -52,9 +30,15 @@ def parse_args() -> argparse.Namespace:
     run.add_argument("--warm-up-time-secs", type=int)
     run.add_argument("--git-ref", default="")
 
-    compare = subparsers.add_parser(
-        "compare", help="Compare two parsed benchmark result JSON files."
-    )
+    collect = commands.add_parser("collect", help="Collect Criterion estimates into JSON.")
+    collect.add_argument("--repo-root", required=True, type=Path)
+    collect.add_argument("--output", required=True, type=Path)
+    collect.add_argument("--bench-wall-ms", type=float)
+    collect.add_argument("--rayon-num-threads", type=int)
+    collect.add_argument("--scenario-filter", default="")
+    collect.add_argument("--git-ref", default="")
+
+    compare = commands.add_parser("compare", help="Compare two benchmark result JSON files.")
     compare.add_argument("--baseline", required=True, type=Path)
     compare.add_argument("--current", required=True, type=Path)
     compare.add_argument("--summary-out", required=True, type=Path)
@@ -62,38 +46,13 @@ def parse_args() -> argparse.Namespace:
     compare.add_argument("--threshold-pct", required=True, type=float)
     compare.add_argument("--github-output", type=Path)
 
-    self_test = subparsers.add_parser("self-test", help="Run parser and comparison tests.")
+    self_test = commands.add_parser("self-test", help="Run parser and comparison tests.")
     self_test.add_argument("--runs", type=int, default=1)
 
     return parser.parse_args()
 
 
-def strip_ansi(text: str) -> str:
-    return ANSI_RE.sub("", text)
-
-
-def parse_duration_ms(value: str, unit: str) -> float:
-    amount = float(value)
-    if unit == "ps":
-        return amount / 1_000_000_000.0
-    if unit == "ns":
-        return amount / 1_000_000.0
-    if unit in ("us", "\u00b5s", "\u03bcs"):
-        return amount / 1000.0
-    if unit == "ms":
-        return amount
-    if unit == "s":
-        return amount * 1000.0
-    raise ValueError(f"Unsupported duration unit: {unit}")
-
-
-def run_logged_command(
-    command: list[str],
-    *,
-    cwd: Path,
-    env: dict[str, str] | None,
-    log_path: Path,
-) -> float:
+def run_logged_command(command: list[str], *, cwd: Path, env: dict[str, str], log_path: Path) -> float:
     start = time.perf_counter()
     with log_path.open("w", encoding="utf-8") as handle:
         handle.write(f"$ {' '.join(command)}\n")
@@ -109,7 +68,6 @@ def run_logged_command(
             bufsize=1,
         )
         assert process.stdout is not None
-
         for line in process.stdout:
             sys.stdout.write(line)
             handle.write(line)
@@ -122,86 +80,62 @@ def run_logged_command(
 
 
 def current_sha(repo_root: Path) -> str:
-    return subprocess.check_output(
-        ["git", "rev-parse", "HEAD"], cwd=repo_root, text=True
-    ).strip()
-
-
-def parse_criterion_log(contents: str) -> dict[str, Any]:
-    metrics: dict[str, dict[str, Any]] = {}
-    pending_name: str | None = None
-
-    for line_number, raw_line in enumerate(contents.splitlines(), start=1):
-        line = strip_ansi(raw_line).strip()
-        if not line:
-            continue
-
-        benchmarking = BENCHMARKING_RE.match(line)
-        if benchmarking:
-            name = benchmarking.group("name").strip()
-            if BENCH_LINE_RE.match(name):
-                pending_name = name
-            continue
-
-        match = TIME_RE.match(line)
-        if match:
-            name = match.group("name") or pending_name
-            if name is None:
-                raise ValueError(f"Criterion timing without benchmark name on line {line_number}")
-            estimate_ms = parse_duration_ms(
-                match.group("estimate"), match.group("estimate_unit")
-            )
-            low_ms = parse_duration_ms(match.group("low"), match.group("low_unit"))
-            high_ms = parse_duration_ms(match.group("high"), match.group("high_unit"))
-            parts = name.split("/")
-            metrics[name] = {
-                "name": name,
-                "producer": parts[0] if len(parts) >= 3 else "",
-                "scenario": "/".join(parts[1:-1]) if len(parts) >= 3 else "",
-                "axis": parts[-1],
-                "low_ms": low_ms,
-                "estimate_ms": estimate_ms,
-                "high_ms": high_ms,
-                "line": line_number,
-            }
-            pending_name = None
-            continue
-
-        if BENCH_LINE_RE.match(line):
-            pending_name = line
-
-    if not metrics:
-        raise ValueError("Could not find any Criterion timing rows in the benchmark log.")
-
-    return {"metrics": dict(sorted(metrics.items()))}
-
-
-def parse_log_file(
-    log_path: Path,
-    *,
-    repo_root: Path | None,
-    git_ref: str,
-    bench_wall_ms: float | None,
-    rayon_num_threads: int | None,
-    scenario_filter: str,
-) -> dict[str, Any]:
-    parsed = parse_criterion_log(log_path.read_text(encoding="utf-8"))
-    metadata = {
-        "log_path": str(log_path),
-        "git_ref": git_ref,
-        "bench_wall_ms": bench_wall_ms,
-        "rayon_num_threads": rayon_num_threads,
-        "scenario_filter": scenario_filter,
-    }
-    if repo_root is not None:
-        metadata["repo_root"] = str(repo_root)
-        metadata["git_sha"] = current_sha(repo_root)
-    return {**metadata, **parsed}
+    return subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_root, text=True).strip()
 
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def split_criterion_group(group: str) -> tuple[str, str]:
+    producer, separator, scenario = group.partition("_")
+    if not separator or not scenario:
+        raise ValueError(f"Unexpected synthetic benchmark group directory: {group}")
+    return producer, scenario
+
+
+def collect_criterion_metrics(repo_root: Path, *, estimate: str = "mean") -> dict[str, dict[str, Any]]:
+    criterion_root = repo_root / "target" / "criterion"
+    metrics: dict[str, dict[str, Any]] = {}
+
+    for estimates_path in sorted(criterion_root.glob("bench-tx_*/*/new/estimates.json")):
+        axis = estimates_path.parents[1].name
+        producer, scenario = split_criterion_group(estimates_path.parents[2].name)
+        name = f"{producer}/{scenario}/{axis}"
+        estimate_data = json.loads(estimates_path.read_text(encoding="utf-8"))[estimate]
+        metrics[name] = {
+            "name": name,
+            "producer": producer,
+            "scenario": scenario,
+            "axis": axis,
+            "estimate_ms": float(estimate_data["point_estimate"]) / 1_000_000.0,
+            "low_ms": float(estimate_data["confidence_interval"]["lower_bound"]) / 1_000_000.0,
+            "high_ms": float(estimate_data["confidence_interval"]["upper_bound"]) / 1_000_000.0,
+        }
+
+    if not metrics:
+        raise ValueError(f"No Criterion estimates found under {criterion_root}")
+    return dict(sorted(metrics.items()))
+
+
+def collect_result(
+    repo_root: Path,
+    *,
+    git_ref: str,
+    bench_wall_ms: float | None,
+    rayon_num_threads: int | None,
+    scenario_filter: str,
+) -> dict[str, Any]:
+    return {
+        "repo_root": str(repo_root),
+        "git_ref": git_ref,
+        "git_sha": current_sha(repo_root),
+        "bench_wall_ms": bench_wall_ms,
+        "rayon_num_threads": rayon_num_threads,
+        "scenario_filter": scenario_filter,
+        "metrics": collect_criterion_metrics(repo_root),
+    }
 
 
 def cmd_run(args: argparse.Namespace) -> int:
@@ -214,9 +148,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     if args.scenario_filter:
         env["SYNTH_SCENARIO"] = args.scenario_filter
 
-    run_logged_command(
-        ["cargo", "clean"], cwd=repo_root, env=env, log_path=output_dir / "clean.log"
-    )
+    run_logged_command(["cargo", "clean"], cwd=repo_root, env=env, log_path=output_dir / "clean.log")
 
     bench_command = [
         "cargo",
@@ -237,18 +169,33 @@ def cmd_run(args: argparse.Namespace) -> int:
     if args.warm_up_time_secs is not None:
         bench_command.extend(["--warm-up-time", str(args.warm_up_time_secs)])
 
-    bench_log = output_dir / "bench.log"
-    bench_wall_ms = run_logged_command(bench_command, cwd=repo_root, env=env, log_path=bench_log)
-
-    payload = parse_log_file(
-        bench_log,
-        repo_root=repo_root,
-        git_ref=args.git_ref,
-        bench_wall_ms=bench_wall_ms,
-        rayon_num_threads=args.rayon_num_threads,
-        scenario_filter=args.scenario_filter,
+    bench_wall_ms = run_logged_command(
+        bench_command, cwd=repo_root, env=env, log_path=output_dir / "bench.log"
     )
-    write_json(output_dir / "result.json", payload)
+    write_json(
+        output_dir / "result.json",
+        collect_result(
+            repo_root,
+            git_ref=args.git_ref,
+            bench_wall_ms=bench_wall_ms,
+            rayon_num_threads=args.rayon_num_threads,
+            scenario_filter=args.scenario_filter,
+        ),
+    )
+    return 0
+
+
+def cmd_collect(args: argparse.Namespace) -> int:
+    write_json(
+        args.output,
+        collect_result(
+            args.repo_root.resolve(),
+            git_ref=args.git_ref,
+            bench_wall_ms=args.bench_wall_ms,
+            rayon_num_threads=args.rayon_num_threads,
+            scenario_filter=args.scenario_filter,
+        ),
+    )
     return 0
 
 
@@ -258,65 +205,47 @@ def percent_delta(current: float | None, baseline: float | None) -> float | None
     return ((current - baseline) / baseline) * 100.0
 
 
-def format_ms(value: float | None) -> str:
+def fmt_ms(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:,.2f} ms"
+
+
+def fmt_delta(value: float | None) -> str:
     if value is None:
         return "n/a"
-    return f"{value:,.2f} ms"
+    return f"{'+' if value >= 0 else ''}{value:,.2f} ms"
 
 
-def format_delta(value: float | None) -> str:
+def fmt_pct(value: float | None) -> str:
     if value is None:
         return "n/a"
-    sign = "+" if value >= 0 else ""
-    return f"{sign}{value:,.2f} ms"
-
-
-def format_pct(value: float | None) -> str:
-    if value is None:
-        return "n/a"
-    sign = "+" if value >= 0 else ""
-    return f"{sign}{value:.2f}%"
+    return f"{'+' if value >= 0 else ''}{value:.2f}%"
 
 
 def compare_results(
-    baseline: dict[str, Any],
-    current: dict[str, Any],
-    threshold_pct: float,
+    baseline: dict[str, Any], current: dict[str, Any], threshold_pct: float
 ) -> dict[str, Any]:
     baseline_metrics = baseline.get("metrics", {})
     current_metrics = current.get("metrics", {})
-    missing_in_current = sorted(set(baseline_metrics) - set(current_metrics))
-    missing_in_baseline = sorted(set(current_metrics) - set(baseline_metrics))
     shared = sorted(set(baseline_metrics) & set(current_metrics))
     if not shared:
         raise ValueError("Baseline and current benchmark results have no metric names in common.")
 
-    rows: list[dict[str, Any]] = []
+    rows = []
     for name in shared:
         baseline_ms = baseline_metrics[name]["estimate_ms"]
         current_ms = current_metrics[name]["estimate_ms"]
-        delta_ms = current_ms - baseline_ms
-        delta_pct = percent_delta(current_ms, baseline_ms)
         rows.append(
             {
                 "name": name,
-                "producer": current_metrics[name].get("producer", ""),
-                "scenario": current_metrics[name].get("scenario", ""),
-                "axis": current_metrics[name].get("axis", ""),
                 "baseline_ms": baseline_ms,
                 "current_ms": current_ms,
-                "delta_ms": delta_ms,
-                "delta_pct": delta_pct,
+                "delta_ms": current_ms - baseline_ms,
+                "delta_pct": percent_delta(current_ms, baseline_ms),
             }
         )
-
-    rows.sort(
-        key=lambda row: row["delta_pct"] if row["delta_pct"] is not None else float("-inf"),
-        reverse=True,
-    )
+    rows.sort(key=lambda r: r["delta_pct"] if r["delta_pct"] is not None else float("-inf"), reverse=True)
     worst = rows[0]
     regression = bool(worst["delta_pct"] is not None and worst["delta_pct"] > threshold_pct)
-
     return {
         "status": "regression" if regression else "ok",
         "regression": regression,
@@ -331,61 +260,57 @@ def compare_results(
         "max_delta_ms": worst["delta_ms"],
         "max_delta_pct": worst["delta_pct"],
         "metric_rows": rows,
-        "missing_in_current": missing_in_current,
-        "missing_in_baseline": missing_in_baseline,
+        "missing_in_current": sorted(set(baseline_metrics) - set(current_metrics)),
+        "missing_in_baseline": sorted(set(current_metrics) - set(baseline_metrics)),
     }
 
 
 def summary_markdown(result: dict[str, Any]) -> str:
-    status_word = "REGRESSION" if result["regression"] else "OK"
-    baseline_sha = result["baseline_sha"][:12] or result["baseline_ref"] or "baseline"
-    current_sha = result["current_sha"][:12] or result["current_ref"] or "current"
-
+    status = "REGRESSION" if result["regression"] else "OK"
+    baseline = result["baseline_sha"][:12] or result["baseline_ref"] or "baseline"
+    current = result["current_sha"][:12] or result["current_ref"] or "current"
+    wall_delta = (
+        None
+        if result["baseline_bench_wall_ms"] is None or result["current_bench_wall_ms"] is None
+        else result["current_bench_wall_ms"] - result["baseline_bench_wall_ms"]
+    )
     lines = [
         "# BENCHMARK REPORT: synthetic-tx-kernel-nonregression",
         "",
         "## Synthetic Transaction Kernel Non-Regression",
         "",
-        f"Status: **{status_word}**",
+        f"Status: **{status}**",
         f"Threshold: `{result['threshold_pct']:.2f}%`",
-        f"Baseline: `{baseline_sha}`",
-        f"Current: `{current_sha}`",
+        f"Baseline: `{baseline}`",
+        f"Current: `{current}`",
         (
             "Worst slowdown: "
             f"`{result['max_delta_metric']}` moved by "
-            f"`{format_delta(result['max_delta_ms'])}` ({format_pct(result['max_delta_pct'])})"
+            f"`{fmt_delta(result['max_delta_ms'])}` ({fmt_pct(result['max_delta_pct'])})"
         ),
         "",
         "| Metric | Baseline | Current | Delta | Delta % |",
         "| --- | ---: | ---: | ---: | ---: |",
         (
             "| bench wall | "
-            f"{format_ms(result['baseline_bench_wall_ms'])} | "
-            f"{format_ms(result['current_bench_wall_ms'])} | "
-            f"{format_delta(None if result['baseline_bench_wall_ms'] is None or result['current_bench_wall_ms'] is None else result['current_bench_wall_ms'] - result['baseline_bench_wall_ms'])} | "
-            f"{format_pct(percent_delta(result['current_bench_wall_ms'], result['baseline_bench_wall_ms']))} |"
+            f"{fmt_ms(result['baseline_bench_wall_ms'])} | "
+            f"{fmt_ms(result['current_bench_wall_ms'])} | "
+            f"{fmt_delta(wall_delta)} | "
+            f"{fmt_pct(percent_delta(result['current_bench_wall_ms'], result['baseline_bench_wall_ms']))} |"
         ),
+        "",
+        "| Benchmark | Baseline | Current | Delta | Delta % |",
+        "| --- | ---: | ---: | ---: | ---: |",
     ]
-
-    lines.extend(
-        [
-            "",
-            "| Benchmark | Baseline | Current | Delta | Delta % |",
-            "| --- | ---: | ---: | ---: | ---: |",
-        ]
-    )
-    for row in result["metric_rows"][:20]:
-        lines.append(
-            "| "
-            f"{row['name']} | "
-            f"{format_ms(row['baseline_ms'])} | "
-            f"{format_ms(row['current_ms'])} | "
-            f"{format_delta(row['delta_ms'])} | "
-            f"{format_pct(row['delta_pct'])} |"
+    lines += [
+        (
+            f"| {row['name']} | {fmt_ms(row['baseline_ms'])} | {fmt_ms(row['current_ms'])} | "
+            f"{fmt_delta(row['delta_ms'])} | {fmt_pct(row['delta_pct'])} |"
         )
-
+        for row in result["metric_rows"][:20]
+    ]
     if result["missing_in_current"] or result["missing_in_baseline"]:
-        lines.extend(["", "Metric set changed:"])
+        lines.append("\nMetric set changed:")
         if result["missing_in_current"]:
             lines.append(
                 "- Missing in current: "
@@ -396,41 +321,33 @@ def summary_markdown(result: dict[str, Any]) -> str:
                 "- Missing in baseline: "
                 + ", ".join(f"`{name}`" for name in result["missing_in_baseline"][:10])
             )
-
     return "\n".join(lines) + "\n"
 
 
 def write_github_output(path: Path, result: dict[str, Any]) -> None:
-    lines = [
-        f"status={result['status']}",
-        f"regression={'true' if result['regression'] else 'false'}",
-        f"baseline_sha={result['baseline_sha']}",
-        f"current_sha={result['current_sha']}",
-        f"max_delta_metric={result['max_delta_metric']}",
-        f"max_delta_ms={result['max_delta_ms']:.6f}",
-        f"max_delta_pct={result['max_delta_pct']:.6f}",
-    ]
     with path.open("a", encoding="utf-8") as handle:
-        handle.write("\n".join(lines) + "\n")
-
-
-def cmd_parse_log(args: argparse.Namespace) -> int:
-    payload = parse_log_file(
-        args.log,
-        repo_root=args.repo_root,
-        git_ref=args.git_ref,
-        bench_wall_ms=args.bench_wall_ms,
-        rayon_num_threads=args.rayon_num_threads,
-        scenario_filter=args.scenario_filter,
-    )
-    write_json(args.output, payload)
-    return 0
+        handle.write(
+            "\n".join(
+                [
+                    f"status={result['status']}",
+                    f"regression={'true' if result['regression'] else 'false'}",
+                    f"baseline_sha={result['baseline_sha']}",
+                    f"current_sha={result['current_sha']}",
+                    f"max_delta_metric={result['max_delta_metric']}",
+                    f"max_delta_ms={result['max_delta_ms']:.6f}",
+                    f"max_delta_pct={result['max_delta_pct']:.6f}",
+                ]
+            )
+            + "\n"
+        )
 
 
 def cmd_compare(args: argparse.Namespace) -> int:
-    baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
-    current = json.loads(args.current.read_text(encoding="utf-8"))
-    result = compare_results(baseline, current, args.threshold_pct)
+    result = compare_results(
+        json.loads(args.baseline.read_text(encoding="utf-8")),
+        json.loads(args.current.read_text(encoding="utf-8")),
+        args.threshold_pct,
+    )
     write_json(args.json_out, result)
     args.summary_out.parent.mkdir(parents=True, exist_ok=True)
     args.summary_out.write_text(summary_markdown(result), encoding="utf-8")
@@ -439,74 +356,61 @@ def cmd_compare(args: argparse.Namespace) -> int:
     return 0
 
 
-class ParserTests(unittest.TestCase):
-    def test_parse_split_criterion_rows(self) -> None:
-        payload = parse_criterion_log(
-            textwrap.dedent(
-                """
-                Benchmarking bench-tx/consume-single-p2id-note/prove: Warming up for 1.0000 s
-                bench-tx/consume-single-p2id-note/prove
-                                        time:   [1.2345 s 1.3456 s 1.4567 s]
-                Found 3 outliers among 30 measurements
-                bench-tx/consume-single-p2id-note/verify
-                                        time:   [997.00 us 1.0000 ms 1.0130 ms]
-                """
+class Tests(unittest.TestCase):
+    def test_collect_criterion_estimate(self) -> None:
+        with mock.patch("subprocess.check_output", return_value="abc\n"):
+            root = Path(self.id().replace("/", "_"))
+            estimates = (
+                root
+                / "target"
+                / "criterion"
+                / "bench-tx_consume-single-p2id-note"
+                / "prove"
+                / "new"
+                / "estimates.json"
             )
-        )
-        self.assertAlmostEqual(
-            payload["metrics"]["bench-tx/consume-single-p2id-note/prove"]["estimate_ms"],
-            1345.6,
-        )
-        self.assertAlmostEqual(
-            payload["metrics"]["bench-tx/consume-single-p2id-note/verify"]["estimate_ms"],
-            1.0,
-        )
-
-    def test_parse_inline_colored_row(self) -> None:
-        payload = parse_criterion_log(
-            "\x1b[32mbench-tx/foo/exec time: [10.00 ms 11.50 ms 13.00 ms]\x1b[0m\n"
-        )
-        self.assertAlmostEqual(payload["metrics"]["bench-tx/foo/exec"]["estimate_ms"], 11.5)
+            estimates.parent.mkdir(parents=True, exist_ok=True)
+            write_json(
+                estimates,
+                {
+                    "mean": {
+                        "point_estimate": 1_500_000.0,
+                        "confidence_interval": {"lower_bound": 1_000_000.0, "upper_bound": 2_000_000.0},
+                    }
+                },
+            )
+            try:
+                metrics = collect_criterion_metrics(root)
+                self.assertEqual(metrics["bench-tx/consume-single-p2id-note/prove"]["estimate_ms"], 1.5)
+            finally:
+                subprocess.run(["rm", "-rf", str(root)], check=False)
 
     def test_compare_uses_worst_positive_delta(self) -> None:
-        baseline = {
-            "metrics": {
-                "bench-tx/a/prove": {"estimate_ms": 100.0},
-                "bench-tx/a/verify": {"estimate_ms": 50.0},
-            }
-        }
-        current = {
-            "metrics": {
-                "bench-tx/a/prove": {"estimate_ms": 104.0},
-                "bench-tx/a/verify": {"estimate_ms": 60.0},
-            }
-        }
+        baseline = {"metrics": {"bench-tx/a/prove": {"estimate_ms": 100.0}, "bench-tx/a/verify": {"estimate_ms": 50.0}}}
+        current = {"metrics": {"bench-tx/a/prove": {"estimate_ms": 104.0}, "bench-tx/a/verify": {"estimate_ms": 60.0}}}
         result = compare_results(baseline, current, 5.0)
         self.assertTrue(result["regression"])
         self.assertEqual(result["max_delta_metric"], "bench-tx/a/verify")
 
-    def test_empty_log_fails(self) -> None:
-        with self.assertRaises(ValueError):
-            parse_criterion_log("running 0 tests\n")
-
 
 def cmd_self_test(args: argparse.Namespace) -> int:
     for run in range(args.runs):
-        suite = unittest.defaultTestLoader.loadTestsFromTestCase(ParserTests)
-        result = unittest.TextTestRunner(verbosity=1, stream=sys.stderr).run(suite)
+        result = unittest.TextTestRunner(verbosity=1, stream=sys.stderr).run(
+            unittest.defaultTestLoader.loadTestsFromTestCase(Tests)
+        )
         if not result.wasSuccessful():
             return 1
         if args.runs > 1:
-            print(f"parser self-test run {run + 1}/{args.runs} passed")
+            print(f"self-test run {run + 1}/{args.runs} passed")
     return 0
 
 
 def main() -> int:
     args = parse_args()
-    if args.command == "parse-log":
-        return cmd_parse_log(args)
     if args.command == "run":
         return cmd_run(args)
+    if args.command == "collect":
+        return cmd_collect(args)
     if args.command == "compare":
         return cmd_compare(args)
     if args.command == "self-test":


### PR DESCRIPTION
This extends the per-commit comment introduced in #2992 to the benchmark introduced in #3024, and normalizes the headers of the bench so the comments are easily grepped for (BENCHMARK REPORT is the string).

## Example Comment Output

The example below is generated from a real full synthetic benchmark run, with one metric faked to demonstrate the regression rendering:

```md
# BENCHMARK REPORT: synthetic-tx-kernel-nonregression

## Synthetic Transaction Kernel Non-Regression

Status: **REGRESSION**
Threshold: `5.00%`
Baseline: `1764d66ca1c6`
Current: `1234567890ab`
Worst slowdown: `bench-tx/consume-single-p2id-note/prove` moved by `+145.07 ms` (+7.30%)

| Metric | Baseline | Current | Delta | Delta % |
| --- | ---: | ---: | ---: | ---: |
| bench wall | n/a | n/a | n/a | n/a |

| Benchmark | Baseline | Current | Delta | Delta % |
| --- | ---: | ---: | ---: | ---: |
| bench-tx/consume-single-p2id-note/prove | 1,987.33 ms | 2,132.40 ms | +145.07 ms | +7.30% |
| bench-tx/consume-b2agg-note-bridge-out/exec | 23.96 ms | 23.96 ms | +0.00 ms | +0.00% |
| bench-tx/consume-b2agg-note-bridge-out/prove | 16,246.29 ms | 16,246.29 ms | +0.00 ms | +0.00% |
| bench-tx/consume-b2agg-note-bridge-out/trace_prep | 25.76 ms | 25.76 ms | +0.00 ms | +0.00% |
| bench-tx/consume-b2agg-note-bridge-out/verify | 3.27 ms | 3.27 ms | +0.00 ms | +0.00% |
| bench-tx/consume-claim-note-l1-to-miden/prove | 3,874.57 ms | 3,874.57 ms | +0.00 ms | +0.00% |
| bench-tx/consume-claim-note-l2-to-miden/prove | 3,962.15 ms | 3,962.15 ms | +0.00 ms | +0.00% |
| bench-tx/consume-two-p2id-notes/prove | 3,977.85 ms | 3,977.85 ms | +0.00 ms | +0.00% |
```

## Notes

- The synthetic benchmark script intentionally reads Criterion JSON artifacts,
- The table is sorted by slowdown percentage, so the most relevant regression appears first,
- Missing or newly added metric names are reported separately in the comment body.

Closes #2256 