### PR TITLE
Fix local registry persistence

### DIFF
--- a/crates/assembly/src/project.rs
+++ b/crates/assembly/src/project.rs
@@ -11,7 +11,7 @@ use miden_assembly_syntax::{
 };
 use miden_core::serde::{Deserializable, Serializable};
 use miden_mast_package::{Package as MastPackage, Section, SectionId, TargetType};
-use miden_package_registry::{PackageId, PackageStore, Version as PackageVersion};
+use miden_package_registry::{PackageCache, PackageId, Version as PackageVersion};
 use miden_project::{
     Linkage, Package as ProjectPackage, PreassembledDependencyMetadata, Profile,
     ProjectDependencyNodeProvenance, ProjectSource, ProjectSourceOrigin, Target,
@@ -45,7 +45,7 @@ impl Assembler {
         store: &'a mut S,
     ) -> Result<ProjectAssembler<'a, S>, Report>
     where
-        S: PackageStore + ?Sized,
+        S: PackageCache + ?Sized,
     {
         let manifest_path = manifest_path.as_ref();
         let source_manager = self.source_manager();
@@ -69,7 +69,7 @@ impl Assembler {
         store: &'a mut S,
     ) -> Result<ProjectAssembler<'a, S>, Report>
     where
-        S: PackageStore + ?Sized,
+        S: PackageCache + ?Sized,
     {
         let source_manager = self.source_manager();
         let dependency_graph =
@@ -91,7 +91,7 @@ pub struct ProjectSourceInputs {
     pub support: Vec<Box<Module>>,
 }
 
-pub struct ProjectAssembler<'a, S: PackageStore + ?Sized> {
+pub struct ProjectAssembler<'a, S: PackageCache + ?Sized> {
     assembler: Assembler,
     project: Arc<ProjectPackage>,
     dependency_graph: DependencyGraph,
@@ -100,7 +100,7 @@ pub struct ProjectAssembler<'a, S: PackageStore + ?Sized> {
 
 impl<'a, S> ProjectAssembler<'a, S>
 where
-    S: PackageStore + ?Sized,
+    S: PackageCache + ?Sized,
 {
     pub fn project(&self) -> &ProjectPackage {
         self.project.as_ref()
@@ -317,7 +317,7 @@ where
         let node = self.dependency_graph.get(package_id)?;
         let node_version = node.version.clone();
 
-        let package = match &node.provenance {
+        let (package, should_cache) = match &node.provenance {
             ProjectDependencyNodeProvenance::Source(ProjectSource::Virtual { .. }) => {
                 return Err(Report::msg(format!(
                     "package '{package_id}' is missing a manifest path",
@@ -353,11 +353,14 @@ where
                     manifest_path,
                     workspace_root.as_deref(),
                 )? {
-                    RegisteredSourcePackage::Loaded(package) => ResolvedPackage {
-                        linked_kernel_package: self
-                            .resolve_linked_kernel_package(package.clone())?,
-                        package,
-                    },
+                    RegisteredSourcePackage::Loaded(package) => (
+                        ResolvedPackage {
+                            linked_kernel_package: self
+                                .resolve_linked_kernel_package(package.clone())?,
+                            package,
+                        },
+                        false,
+                    ),
                     reuse => {
                         let package = self.assemble_source_package(
                             package_id.clone(),
@@ -369,9 +372,7 @@ where
                             cache,
                         )?;
                         match reuse {
-                            RegisteredSourcePackage::Missing => {
-                                self.publish_source_dependency(package.package.clone())?;
-                            },
+                            RegisteredSourcePackage::Missing => (),
                             RegisteredSourcePackage::IndexedButUnreadable(expected) => {
                                 let actual = PackageVersion::new(
                                     package.package.version.clone(),
@@ -385,7 +386,7 @@ where
                             },
                             RegisteredSourcePackage::Loaded(_) => unreachable!(),
                         }
-                        package
+                        (package, true)
                     },
                 }
             },
@@ -396,17 +397,25 @@ where
                             "dependency '{package_id}' version '{node_version}' was not found in the package registry"
                         ))
                     })?;
-                ResolvedPackage {
-                    linked_kernel_package: self.resolve_linked_kernel_package(package.clone())?,
-                    package,
-                }
+                (
+                    ResolvedPackage {
+                        linked_kernel_package: self
+                            .resolve_linked_kernel_package(package.clone())?,
+                        package,
+                    },
+                    false,
+                )
             },
             ProjectDependencyNodeProvenance::Registry { selected, .. } => {
                 let package = self.store.load_package(package_id, selected)?;
-                ResolvedPackage {
-                    linked_kernel_package: self.resolve_linked_kernel_package(package.clone())?,
-                    package,
-                }
+                (
+                    ResolvedPackage {
+                        linked_kernel_package: self
+                            .resolve_linked_kernel_package(package.clone())?,
+                        package,
+                    },
+                    false,
+                )
             },
             ProjectDependencyNodeProvenance::Preassembled {
                 path,
@@ -421,13 +430,21 @@ where
                     *kind,
                     requirements,
                 )?;
-                ResolvedPackage {
-                    linked_kernel_package: self.resolve_linked_kernel_package(package.clone())?,
-                    package,
-                }
+                let should_cache = self.should_cache_preassembled_package(package_id, selected)?;
+                (
+                    ResolvedPackage {
+                        linked_kernel_package: self
+                            .resolve_linked_kernel_package(package.clone())?,
+                        package,
+                    },
+                    should_cache,
+                )
             },
         };
 
+        if should_cache {
+            self.cache_resolved_package(&package)?;
+        }
         cache.insert(package_id.clone(), package.clone());
         Ok(package)
     }
@@ -536,9 +553,52 @@ where
         Ok(RegisteredSourcePackage::Loaded(package))
     }
 
-    fn publish_source_dependency(&mut self, package: Arc<MastPackage>) -> Result<(), Report> {
+    fn should_cache_preassembled_package(
+        &self,
+        package_id: &PackageId,
+        selected: &PackageVersion,
+    ) -> Result<bool, Report> {
+        let Some(record) = self.store.get_by_semver(package_id, &selected.version) else {
+            return Ok(true);
+        };
+        if record.version() != selected {
+            return Ok(false);
+        }
+
+        match self.store.load_package(package_id, selected) {
+            Ok(_) => Ok(false),
+            Err(_) => Ok(true),
+        }
+    }
+
+    fn cache_resolved_package(&mut self, package: &ResolvedPackage) -> Result<(), Report> {
+        self.cache_package(package.package.clone())?;
+        if let Some(kernel_package) = package.linked_kernel_package.clone()
+            && self.should_cache_linked_kernel_package(kernel_package.as_ref())?
+        {
+            self.cache_package(kernel_package)?;
+        }
+        Ok(())
+    }
+
+    fn should_cache_linked_kernel_package(&self, package: &MastPackage) -> Result<bool, Report> {
+        let version = PackageVersion::new(package.version.clone(), package.digest());
+        let Some(record) = self.store.get_by_semver(&package.name, &package.version) else {
+            return Ok(true);
+        };
+        if record.version() != &version {
+            return Ok(false);
+        }
+
+        match self.store.load_package(&package.name, &version) {
+            Ok(_) => Ok(false),
+            Err(_) => Ok(true),
+        }
+    }
+
+    fn cache_package(&mut self, package: Arc<MastPackage>) -> Result<(), Report> {
         self.store
-            .publish_package(package)
+            .cache_package(package)
             .map(|_| ())
             .map_err(|error| Report::msg(error.to_string()))
     }

--- a/crates/assembly/src/project/dependency_graph.rs
+++ b/crates/assembly/src/project/dependency_graph.rs
@@ -8,7 +8,7 @@ use std::path::Path as FsPath;
 
 use miden_assembly_syntax::diagnostics::Report;
 use miden_core::{Word, utils::hash_string_to_word};
-use miden_package_registry::{PackageId, PackageStore};
+use miden_package_registry::{PackageId, PackageRegistry};
 use miden_project::{
     Package as ProjectPackage, ProjectDependencyGraph, ProjectDependencyGraphBuilder,
     ProjectDependencyNode, ProjectDependencyNodeProvenance, ProjectSource, ProjectSourceOrigin,
@@ -30,7 +30,7 @@ impl DependencyGraph {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    pub fn from_project_path<S: PackageStore + ?Sized>(
+    pub fn from_project_path<S: PackageRegistry + ?Sized>(
         manifest_path: impl AsRef<FsPath>,
         store: &S,
         source_manager: Arc<dyn SourceManager>,
@@ -42,7 +42,7 @@ impl DependencyGraph {
         Ok(Self { dependency_graph, source_manager })
     }
 
-    pub fn from_project<S: PackageStore + ?Sized>(
+    pub fn from_project<S: PackageRegistry + ?Sized>(
         project: Arc<ProjectPackage>,
         store: &S,
         source_manager: Arc<dyn SourceManager>,

--- a/crates/assembly/src/project/tests.rs
+++ b/crates/assembly/src/project/tests.rs
@@ -457,6 +457,12 @@ end
             format!("regdep@1.0.0#{regdep_digest}")
         ]
     );
+    let cached_packages = context.registry().cached_packages();
+    assert!(cached_packages.iter().any(|entry| entry.starts_with("pathdep@1.0.0#")));
+    assert!(cached_packages.iter().any(|entry| entry.starts_with("gitdep@1.0.0#")));
+    assert!(cached_packages.iter().any(|entry| entry.starts_with("predep@1.0.0#")));
+    assert!(!cached_packages.iter().any(|entry| entry.starts_with("runtime@")));
+    assert!(!cached_packages.iter().any(|entry| entry.starts_with("regdep@")));
     assert!(!dependency_names.iter().any(|name| name == "pathdep"));
     assert_eq!(package.kind, TargetType::Library);
     assert_eq!(
@@ -482,6 +488,270 @@ end
         context
             .registry()
             .is_semver_available(&PackageId::from("gitdep"), &"1.0.0".parse().unwrap())
+    );
+}
+
+#[test]
+fn source_dependency_with_preassembled_dependency_does_not_require_registry_entry() {
+    let tempdir = TempDir::new().unwrap();
+    let context = TestContext::new();
+
+    let predep =
+        context.assemble_library_package_with_export("predep", "1.0.0", "deps::predep::leaf", []);
+    let predep_path = tempdir.path().join("predep.masp");
+    predep.write_to_file(&predep_path).unwrap();
+
+    let pathdep_dir = tempdir.path().join("pathdep");
+    write_file(
+        &pathdep_dir.join("miden-project.toml"),
+        r#"[package]
+name = "pathdep"
+version = "1.0.0"
+
+[lib]
+path = "lib.masm"
+namespace = "deps::pathdep"
+
+[dependencies]
+predep = { path = "../predep.masp" }
+"#,
+    );
+    write_file(
+        &pathdep_dir.join("lib.masm"),
+        r#"use ::deps::predep
+
+pub proc call_predep
+    exec.predep::leaf
+end
+"#,
+    );
+
+    let root_dir = tempdir.path().join("root");
+    let root_manifest = root_dir.join("miden-project.toml");
+    write_file(
+        &root_manifest,
+        r#"[package]
+name = "root"
+version = "1.0.0"
+
+[lib]
+path = "lib.masm"
+
+[dependencies]
+pathdep = { path = "../pathdep" }
+"#,
+    );
+    write_file(
+        &root_dir.join("lib.masm"),
+        r#"use ::deps::pathdep
+
+pub proc entry
+    exec.pathdep::call_predep
+end
+"#,
+    );
+
+    let mut context = context;
+    let package = context
+        .assemble_library_package(&root_manifest, None)
+        .expect("source dependency with preassembled dependency should assemble");
+
+    assert_eq!(&package.name, "root");
+}
+
+#[test]
+fn preassembled_dependency_bypasses_registry_semver_collision() {
+    let tempdir = TempDir::new().unwrap();
+    let mut context = TestContext::new();
+
+    let registered_module = Module::parse(
+        "deps::predep",
+        ModuleKind::Library,
+        source_file!(
+            context,
+            r#"pub proc leaf
+    push.1
+    drop
+end
+"#
+        ),
+        context.source_manager(),
+    )
+    .unwrap();
+    let registered_library = context.assemble_library([registered_module]).unwrap();
+    let registered = MastPackage::from_library(
+        "predep".into(),
+        "1.0.0".parse().unwrap(),
+        TargetType::Library,
+        registered_library,
+        std::iter::empty::<miden_mast_package::Dependency>(),
+    );
+    let registered_digest = registered.digest();
+    context.registry_mut().add_package(registered.into());
+
+    let predep =
+        context.assemble_library_package_with_export("predep", "1.0.0", "deps::predep::leaf", []);
+    let predep_digest = predep.digest();
+    assert_ne!(registered_digest, predep_digest);
+    let predep_path = tempdir.path().join("predep.masp");
+    predep.write_to_file(&predep_path).unwrap();
+
+    let root_dir = tempdir.path().join("root");
+    let root_manifest = root_dir.join("miden-project.toml");
+    write_file(
+        &root_manifest,
+        r#"[package]
+name = "root"
+version = "1.0.0"
+
+[lib]
+path = "lib.masm"
+
+[dependencies]
+predep = { path = "../predep.masp" }
+"#,
+    );
+    write_file(
+        &root_dir.join("lib.masm"),
+        r#"use ::deps::predep
+
+pub proc entry
+    exec.predep::leaf
+end
+"#,
+    );
+
+    let package = context
+        .assemble_library_package(&root_manifest, None)
+        .expect("explicit preassembled path should bypass registry semver collisions");
+
+    assert_eq!(&package.name, "root");
+    assert_eq!(
+        package
+            .manifest
+            .dependencies()
+            .find(|dependency| &dependency.name == "predep")
+            .unwrap()
+            .digest,
+        predep_digest
+    );
+    assert!(
+        !context
+            .registry()
+            .cached_packages()
+            .iter()
+            .any(|entry| entry.starts_with("predep@"))
+    );
+}
+
+#[test]
+fn preassembled_dependency_repairs_unreadable_exact_registry_artifact() {
+    let tempdir = TempDir::new().unwrap();
+    let mut context = TestContext::new();
+
+    let predep =
+        context.assemble_library_package_with_export("predep", "1.0.0", "deps::predep::leaf", []);
+    let selected = context.registry_mut().add_package(predep.clone().into());
+    context
+        .registry_mut()
+        .remove_package(&predep.name, &selected)
+        .expect("test should leave an indexed package without an artifact");
+
+    let predep_path = tempdir.path().join("predep.masp");
+    predep.write_to_file(&predep_path).unwrap();
+
+    let root_dir = tempdir.path().join("root");
+    let root_manifest = root_dir.join("miden-project.toml");
+    write_file(
+        &root_manifest,
+        r#"[package]
+name = "root"
+version = "1.0.0"
+
+[lib]
+path = "lib.masm"
+
+[dependencies]
+predep = { path = "../predep.masp" }
+"#,
+    );
+    write_file(
+        &root_dir.join("lib.masm"),
+        r#"use ::deps::predep
+
+pub proc entry
+    exec.predep::leaf
+end
+"#,
+    );
+
+    context
+        .assemble_library_package(&root_manifest, None)
+        .expect("preassembled dependency should repair unreadable exact registry artifact");
+
+    assert!(
+        context
+            .registry()
+            .cached_packages()
+            .iter()
+            .any(|entry| entry == &format!("predep@{selected}"))
+    );
+}
+
+#[test]
+fn preassembled_dependency_does_not_repair_readable_exact_registry_artifact() {
+    let tempdir = TempDir::new().unwrap();
+    let mut context = TestContext::new();
+
+    let predep =
+        context.assemble_library_package_with_export("predep", "1.0.0", "deps::predep::leaf", []);
+    let selected = context.registry_mut().add_package(predep.clone().into());
+
+    let mut path_predep = MastPackage::read_from_bytes(&predep.to_bytes()).unwrap();
+    path_predep.sections.push(Section::new(
+        SectionId::custom("preassembled-test").unwrap(),
+        Vec::from([1, 2, 3]),
+    ));
+    assert_eq!(path_predep.digest(), predep.digest());
+
+    let predep_path = tempdir.path().join("predep.masp");
+    path_predep.write_to_file(&predep_path).unwrap();
+
+    let root_dir = tempdir.path().join("root");
+    let root_manifest = root_dir.join("miden-project.toml");
+    write_file(
+        &root_manifest,
+        r#"[package]
+name = "root"
+version = "1.0.0"
+
+[lib]
+path = "lib.masm"
+
+[dependencies]
+predep = { path = "../predep.masp" }
+"#,
+    );
+    write_file(
+        &root_dir.join("lib.masm"),
+        r#"use ::deps::predep
+
+pub proc entry
+    exec.predep::leaf
+end
+"#,
+    );
+
+    context
+        .assemble_library_package(&root_manifest, None)
+        .expect("preassembled dependency should use path artifact when exact registry entry loads");
+
+    assert!(
+        !context
+            .registry()
+            .cached_packages()
+            .iter()
+            .any(|entry| entry == &format!("predep@{selected}"))
     );
 }
 
@@ -2031,7 +2301,14 @@ fn preassembled_libraries_fall_back_to_embedded_kernel_when_store_artifact_is_un
     assert_eq!(embedded_kernel_package.digest(), kernel_package.digest());
     assert_eq!(
         context.registry().loaded_packages(),
-        vec![format!("kernelpkg@{kernel_version}")]
+        vec![format!("kernelpkg@{kernel_version}"), format!("kernelpkg@{kernel_version}")]
+    );
+    assert!(
+        context
+            .registry()
+            .cached_packages()
+            .iter()
+            .any(|entry| entry == &format!("kernelpkg@{kernel_version}"))
     );
 
     let round_tripped_program = MastPackage::read_from_bytes(&package.to_bytes())
@@ -2039,6 +2316,75 @@ fn preassembled_libraries_fall_back_to_embedded_kernel_when_store_artifact_is_un
         .try_into_program()
         .expect("program reconstruction should use the embedded fallback kernel");
     assert_eq!(round_tripped_program.kernel(), &expected_kernel);
+}
+
+#[test]
+fn preassembled_libraries_skip_embedded_kernel_cache_on_semver_collision() {
+    let tempdir = TempDir::new().unwrap();
+    let (_, kernel_manifest) = write_transitive_kernel_program_project(tempdir.path());
+    let mid_manifest = tempdir.path().join("mid").join("miden-project.toml");
+    let mid_package_path = tempdir.path().join("mid-embedded.masp");
+
+    let mut build_context = TestContext::new();
+    let kernel_package = build_context
+        .assemble_library_package(&kernel_manifest, None)
+        .expect("kernel package build should succeed");
+    let mut mid_package = MastPackage::read_from_bytes(
+        &build_context
+            .assemble_library_package(&mid_manifest, None)
+            .expect("mid package build should succeed")
+            .to_bytes(),
+    )
+    .expect("mid package should deserialize");
+    mid_package
+        .sections
+        .push(Section::new(SectionId::KERNEL, kernel_package.to_bytes()));
+    mid_package.write_to_file(&mid_package_path).unwrap();
+
+    let conflicting_kernel_manifest = tempdir.path().join("conflicting-kernel/miden-project.toml");
+    write_file(
+        &conflicting_kernel_manifest,
+        r#"[package]
+name = "kernelpkg"
+version = "1.0.0"
+
+[lib]
+kind = "kernel"
+path = "kernel.masm"
+"#,
+    );
+    write_file(
+        &conflicting_kernel_manifest.parent().unwrap().join("kernel.masm"),
+        r#"pub proc foo
+    push.1
+    drop
+end
+"#,
+    );
+    let conflicting_kernel = build_context
+        .assemble_library_package(&conflicting_kernel_manifest, None)
+        .expect("conflicting kernel package build should succeed");
+    assert_ne!(conflicting_kernel.digest(), kernel_package.digest());
+
+    let root_manifest =
+        write_preassembled_kernel_executable_project(tempdir.path(), &mid_package_path);
+    let mut context = TestContext::new();
+    context.registry_mut().add_package(kernel_package);
+    let mut project_assembler = context
+        .project_assembler_for_path(&root_manifest)
+        .expect("dependency graph should build");
+    project_assembler.store.replace_semver_package(conflicting_kernel);
+
+    project_assembler
+        .assemble(ProjectTargetSelector::Executable("main"), "dev")
+        .expect("embedded kernel fallback should not try to cache over a semver collision");
+    assert!(
+        !project_assembler
+            .store
+            .cached_packages()
+            .iter()
+            .any(|entry| entry.starts_with("kernelpkg@"))
+    );
 }
 
 #[test]

--- a/crates/assembly/src/testing.rs
+++ b/crates/assembly/src/testing.rs
@@ -243,7 +243,7 @@ mod package_features {
 
     use miden_mast_package::{Package, PackageId};
     use miden_package_registry::{
-        PackageIndex, PackageProvider, PackageRecord, PackageRegistry, PackageStore,
+        PackageCache, PackageIndex, PackageProvider, PackageRecord, PackageRegistry, PackageStore,
         PackageVersions, Version, VersionRequirement,
     };
 
@@ -256,6 +256,7 @@ mod package_features {
         index: BTreeMap<PackageId, PackageVersions>,
         packages: BTreeMap<(PackageId, Version), Arc<Package>>,
         loads: Mutex<Vec<String>>,
+        caches: Mutex<Vec<String>>,
     }
 
     impl TestRegistry {
@@ -269,6 +270,10 @@ mod package_features {
             self.loads.lock().unwrap().clone()
         }
 
+        pub fn cached_packages(&self) -> Vec<String> {
+            self.caches.lock().unwrap().clone()
+        }
+
         pub fn clear_loaded_packages(&self) {
             self.loads.lock().unwrap().clear();
         }
@@ -279,6 +284,26 @@ mod package_features {
             version: &Version,
         ) -> Option<Arc<Package>> {
             self.packages.remove(&(package.clone(), version.clone()))
+        }
+
+        pub fn replace_semver_package(&mut self, package: Arc<Package>) -> Version {
+            let version = Version::new(package.version.clone(), package.digest());
+            self.packages.retain(|(name, existing), _| {
+                name != &package.name || existing.version != package.version
+            });
+
+            let dependencies = package.manifest.dependencies().map(|dependency| {
+                let version = Version::new(dependency.version.clone(), dependency.digest);
+                (dependency.name.clone(), VersionRequirement::Exact(version))
+            });
+            let record = PackageRecord::new(version.clone(), dependencies)
+                .with_description(package.description.clone().unwrap_or_default());
+            self.index
+                .entry(package.name.clone())
+                .or_default()
+                .insert(package.version.clone(), record);
+            self.packages.insert((package.name.clone(), version.clone()), package);
+            version
         }
     }
 
@@ -320,9 +345,35 @@ mod package_features {
         }
     }
 
-    impl PackageStore for TestRegistry {
+    impl PackageCache for TestRegistry {
         type Error = Report;
 
+        fn cache_package(&mut self, package: Arc<Package>) -> Result<Version, Self::Error> {
+            let version = Version::new(package.version.clone(), package.digest());
+            self.caches.lock().unwrap().push(format!("{}@{version}", package.name));
+            if let Some(record) = self.get_by_semver(&package.name, &package.version) {
+                if record.version() == &version {
+                    self.packages.insert((package.name.clone(), version.clone()), package);
+                    return Ok(version);
+                }
+                return Err(Report::msg(format!(
+                    "package '{}' version '{}' is already registered",
+                    package.name, package.version
+                )));
+            }
+            let dependencies = package.manifest.dependencies().map(|dependency| {
+                let version = Version::new(dependency.version.clone(), dependency.digest);
+                (dependency.name.clone(), VersionRequirement::Exact(version))
+            });
+            let record = PackageRecord::new(version.clone(), dependencies)
+                .with_description(package.description.clone().unwrap_or_default());
+            self.register(package.name.clone(), record)?;
+            self.packages.insert((package.name.clone(), version.clone()), package);
+            Ok(version)
+        }
+    }
+
+    impl PackageStore for TestRegistry {
         fn publish_package(&mut self, package: Arc<Package>) -> Result<Version, Self::Error> {
             let version = Version::new(package.version.clone(), package.digest());
             let dependencies = package

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -13,7 +13,7 @@ use miden_core::{
 };
 use miden_mast_package::Package as MastPackage;
 use miden_package_registry::{
-    InMemoryPackageRegistry, PackageId, PackageIndex, PackageProvider, PackageRecord,
+    InMemoryPackageRegistry, PackageCache, PackageId, PackageIndex, PackageProvider, PackageRecord,
     PackageRegistry, PackageStore, PackageVersions, Version, VersionRequirement,
 };
 use serde::{Deserialize, Serialize};
@@ -448,6 +448,98 @@ impl LocalPackageRegistry {
         }
     }
 
+    fn record_for_package(
+        package: &MastPackage,
+        version: Version,
+    ) -> (PackageRecord, Vec<(PackageId, Version, VersionRequirement)>) {
+        let dependencies = package
+            .manifest
+            .dependencies()
+            .map(|dependency| {
+                let dependency_name = dependency.id().clone();
+                let dependency_version =
+                    Version::new(dependency.version.clone(), dependency.digest);
+                (
+                    dependency_name,
+                    dependency_version.clone(),
+                    VersionRequirement::Exact(dependency_version),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let record = match package.description.clone() {
+            Some(description) => PackageRecord::new(
+                version,
+                dependencies
+                    .iter()
+                    .map(|(name, _version, requirement)| (name.clone(), requirement.clone())),
+            )
+            .with_description(description),
+            None => PackageRecord::new(
+                version,
+                dependencies
+                    .iter()
+                    .map(|(name, _version, requirement)| (name.clone(), requirement.clone())),
+            ),
+        };
+
+        (record, dependencies)
+    }
+
+    fn cache_package_with_bytes(
+        &mut self,
+        package: Arc<MastPackage>,
+        bytes: Vec<u8>,
+    ) -> Result<PublishedPackage, LocalRegistryError> {
+        let digest = package.digest();
+        let version = Version::new(package.version.clone(), digest);
+        let (record, _dependencies) = Self::record_for_package(&package, version.clone());
+        let artifact_path = self.artifact_path_for_package(&package.name, &package.version, digest);
+
+        if let Some(existing) = self.index.get_by_semver(&package.name, &package.version) {
+            if existing.version() != &version || existing != &record {
+                return Err(LocalRegistryError::DuplicateSemanticVersion {
+                    package: package.name.clone(),
+                    version: package.version.clone(),
+                });
+            }
+
+            let should_write_artifact = match fs::read(&artifact_path) {
+                Ok(existing_bytes) => match MastPackage::read_from_bytes(&existing_bytes) {
+                    Ok(existing_package) if &existing_package == package.as_ref() => false,
+                    Ok(_) => {
+                        return Err(LocalRegistryError::DuplicateSemanticVersion {
+                            package: package.name.clone(),
+                            version: package.version.clone(),
+                        });
+                    },
+                    Err(_) => true,
+                },
+                Err(_) => true,
+            };
+
+            if should_write_artifact {
+                fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)?;
+            }
+            self.save()?;
+            return Ok(PublishedPackage {
+                name: package.name.clone(),
+                version,
+                artifact_path,
+            });
+        }
+
+        fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)?;
+        self.register(package.name.clone(), record)?;
+        self.save()?;
+
+        Ok(PublishedPackage {
+            name: package.name.clone(),
+            version,
+            artifact_path,
+        })
+    }
+
     /// Publish `package`, with `bytes` representing the serialized form of `package` which
     /// determines its provenance, i.e. if we deserialized `package` from `bytes`, then `bytes`
     /// is those exact bytes, not the bytes we would get by serializing `package`, which might
@@ -459,28 +551,17 @@ impl LocalPackageRegistry {
     ) -> Result<PublishedPackage, LocalRegistryError> {
         let digest = package.digest();
         let version = Version::new(package.version.clone(), digest);
-        let mut dependencies = Vec::new();
-        for dependency in package.manifest.dependencies() {
-            let dependency_name = dependency.id().clone();
-            let dependency_version = Version::new(dependency.version.clone(), dependency.digest);
-            let requirement = VersionRequirement::Exact(dependency_version.clone());
-            if self.index.get_exact_version(&dependency_name, &dependency_version).is_none() {
+        let (record, dependencies) = Self::record_for_package(&package, version.clone());
+
+        for (dependency_name, dependency_version, _requirement) in dependencies.iter() {
+            if self.index.get_exact_version(dependency_name, dependency_version).is_none() {
                 return Err(LocalRegistryError::MissingDependency {
                     package: package.name.clone(),
-                    dependency: dependency_name,
-                    version: dependency_version,
+                    dependency: dependency_name.clone(),
+                    version: dependency_version.clone(),
                 });
             }
-
-            dependencies.push((dependency_name, requirement));
         }
-
-        let record = match package.description.clone() {
-            Some(description) => {
-                PackageRecord::new(version.clone(), dependencies).with_description(description)
-            },
-            None => PackageRecord::new(version.clone(), dependencies),
-        };
 
         // Write the package artifact to the registry
         let artifact_path = self.artifact_path_for_package(&package.name, &package.version, digest);
@@ -527,9 +608,16 @@ impl PackageProvider for LocalPackageRegistry {
     }
 }
 
-impl PackageStore for LocalPackageRegistry {
+impl PackageCache for LocalPackageRegistry {
     type Error = LocalRegistryError;
 
+    fn cache_package(&mut self, package: Arc<MastPackage>) -> Result<Version, Self::Error> {
+        let bytes = package.to_bytes();
+        self.cache_package_with_bytes(package, bytes).map(|published| published.version)
+    }
+}
+
+impl PackageStore for LocalPackageRegistry {
     fn publish_package(&mut self, package: Arc<MastPackage>) -> Result<Version, Self::Error> {
         let bytes = package.to_bytes();
         self.publish_package_with_bytes(package, bytes)
@@ -539,7 +627,7 @@ impl PackageStore for LocalPackageRegistry {
 
 #[cfg(test)]
 mod tests {
-    use miden_mast_package::{Dependency, Package, TargetType};
+    use miden_mast_package::{Dependency, Package, Section, SectionId, TargetType};
     use tempfile::TempDir;
 
     use super::*;
@@ -621,6 +709,54 @@ mod tests {
 
         let error = registry.publish(&package_path).expect_err("publish should fail");
         assert!(matches!(error, LocalRegistryError::MissingDependency { .. }));
+    }
+
+    #[test]
+    fn cache_persists_packages_with_missing_dependencies() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let dependency_digest = miden_core::utils::hash_string_to_word("dep");
+        let package = build_package(
+            "pkg",
+            "1.0.0",
+            [("dep", "1.0.0", TargetType::Library, dependency_digest)],
+        );
+        let version = registry
+            .cache_package(Arc::from(package))
+            .expect("cache should accept unresolved dependencies");
+
+        let reloaded = load_registry(&tempdir);
+        let shown = reloaded
+            .show(&PackageId::from("pkg"), Some(&version))
+            .expect("cached package should be indexed");
+        assert_eq!(shown.dependencies.len(), 1);
+        assert!(reloaded.load_package(&PackageId::from("pkg"), &version).is_ok());
+    }
+
+    #[test]
+    fn cache_rejects_different_artifact_for_existing_exact_version() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let package_path = tempdir.path().join("pkg.masp");
+        build_package("pkg", "1.0.0", []).write_to_file(&package_path).unwrap();
+        let published = registry.publish(&package_path).unwrap();
+
+        let mut conflicting_package = build_package("pkg", "1.0.0", []);
+        conflicting_package
+            .sections
+            .push(Section::new(SectionId::custom("cache-test").unwrap(), Vec::from([1, 2, 3])));
+        assert_eq!(Some(conflicting_package.digest()), published.version.digest);
+
+        let error = registry
+            .cache_package(Arc::from(conflicting_package))
+            .expect_err("cache should reject conflicting package artifacts");
+        assert!(matches!(error, LocalRegistryError::DuplicateSemanticVersion { .. }));
+
+        let loaded = registry.load_package(&PackageId::from("pkg"), &published.version).unwrap();
+        assert_eq!(loaded.manifest.dependencies().count(), 0);
+        assert!(loaded.sections.is_empty());
     }
 
     #[test]

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -61,6 +61,16 @@ pub enum LocalRegistryError {
         path: PathBuf,
     },
     #[error(
+        "package artifact at '{path}' does not match requested package '{expected_package}' version '{expected_version}' (found '{actual_package}' version '{actual_version}')"
+    )]
+    ArtifactMismatch {
+        path: PathBuf,
+        expected_package: PackageId,
+        expected_version: Box<Version>,
+        actual_package: PackageId,
+        actual_version: Box<Version>,
+    },
+    #[error(
         "package '{package}' depends on unpublished package '{dependency}' with version '{version}'"
     )]
     MissingDependency {
@@ -257,9 +267,35 @@ impl LocalPackageRegistry {
         Some(self.package_summary(package.clone(), version, record))
     }
 
-    /// Get the path in the artifact store for `version`
-    pub fn artifact_path(&self, version: &Version) -> Option<PathBuf> {
-        version.digest.as_ref().map(|digest| self.artifact_path_for_digest(*digest))
+    /// Get the path in the artifact store for `package` at `version`
+    pub fn artifact_path(&self, package: &PackageId, version: &Version) -> Option<PathBuf> {
+        self.artifact_path_for_summary(package, version)
+    }
+
+    fn artifact_path_for_summary(&self, package: &PackageId, version: &Version) -> Option<PathBuf> {
+        let digest = *version.digest.as_ref()?;
+        let artifact_path = self.artifact_path_for_package(package, &version.version, digest);
+        if artifact_path.exists() {
+            return Some(artifact_path);
+        }
+
+        let legacy_path = self.legacy_artifact_path_for_digest(digest);
+        if self.legacy_artifact_matches(package, version, &legacy_path) {
+            Some(legacy_path)
+        } else {
+            Some(artifact_path)
+        }
+    }
+
+    fn legacy_artifact_matches(&self, package: &PackageId, version: &Version, path: &Path) -> bool {
+        let Ok(bytes) = fs::read(path) else {
+            return false;
+        };
+        let Ok(loaded) = MastPackage::read_from_bytes(&bytes) else {
+            return false;
+        };
+        let actual_version = Version::new(loaded.version.clone(), loaded.digest());
+        loaded.name == *package && actual_version == *version
     }
 
     /// Loads the given version of `package` from the artifact store.
@@ -277,28 +313,46 @@ impl LocalPackageRegistry {
             }
         })?;
 
-        let path = self.artifact_path(version).ok_or_else(|| {
-            LocalRegistryError::MissingArtifactDigest {
-                package: package.clone(),
-                version: version.clone(),
-            }
+        let digest = version.digest.ok_or_else(|| LocalRegistryError::MissingArtifactDigest {
+            package: package.clone(),
+            version: version.clone(),
         })?;
-        if !path.exists() {
-            return Err(LocalRegistryError::MissingArtifact {
-                package: package.clone(),
-                version: version.clone(),
-                path,
-            });
-        }
+        let path = self.artifact_path_for_package(package, &version.version, digest);
+        let path = if path.exists() {
+            path
+        } else {
+            let legacy_path = self.legacy_artifact_path_for_digest(digest);
+            if legacy_path.exists() {
+                legacy_path
+            } else {
+                return Err(LocalRegistryError::MissingArtifact {
+                    package: package.clone(),
+                    version: version.clone(),
+                    path,
+                });
+            }
+        };
 
         let bytes = fs::read(&path).map_err(LocalRegistryError::IndexRead)?;
-        let package = MastPackage::read_from_bytes(&bytes).map_err(|error| {
+        let loaded = MastPackage::read_from_bytes(&bytes).map_err(|error| {
             LocalRegistryError::PackageDecode {
                 path: path.clone(),
                 error: error.to_string(),
             }
         })?;
-        Ok(Arc::new(package))
+
+        let actual_version = Version::new(loaded.version.clone(), loaded.digest());
+        if loaded.name != *package || actual_version != *version {
+            return Err(LocalRegistryError::ArtifactMismatch {
+                path,
+                expected_package: package.clone(),
+                expected_version: Box::new(version.clone()),
+                actual_package: loaded.name,
+                actual_version: Box::new(actual_version),
+            });
+        }
+
+        Ok(Arc::new(loaded))
     }
 
     /// Persist the state of the index to disk
@@ -351,9 +405,25 @@ impl LocalPackageRegistry {
 
     /// Derive the path in the artifact store for a package with `digest`
     ///
-    /// The file name of the resulting path is the hexadecimal encoding of the digest, with the
-    /// `.masp` extension.
-    fn artifact_path_for_digest(&self, digest: miden_core::Word) -> PathBuf {
+    /// The file name includes the package name and semantic version to avoid collisions between
+    /// package identities that share the same underlying MAST digest.
+    fn artifact_path_for_package(
+        &self,
+        package: &PackageId,
+        version: &miden_package_registry::SemVer,
+        digest: miden_core::Word,
+    ) -> PathBuf {
+        let package_id = DisplayHex(package.as_bytes());
+        let semantic_version = version.to_string();
+        let semantic_version = DisplayHex(semantic_version.as_bytes());
+        let digest_bytes = digest.as_bytes();
+        let digest = DisplayHex::new(&digest_bytes);
+        let filename = format!("{package_id}-{semantic_version}-0x{digest}.masp");
+        self.artifact_dir.join(filename)
+    }
+
+    /// Derive the artifact path used before filenames included package identity.
+    fn legacy_artifact_path_for_digest(&self, digest: miden_core::Word) -> PathBuf {
         let filename = format!("0x{}.masp", DisplayHex::new(&digest.as_bytes()));
         self.artifact_dir.join(filename)
     }
@@ -366,7 +436,7 @@ impl LocalPackageRegistry {
         record: &PackageRecord,
     ) -> PackageSummary {
         PackageSummary {
-            artifact_path: self.artifact_path(&version),
+            artifact_path: self.artifact_path_for_summary(&name, &version),
             dependencies: record
                 .dependencies()
                 .iter()
@@ -413,7 +483,7 @@ impl LocalPackageRegistry {
         };
 
         // Write the package artifact to the registry
-        let artifact_path = self.artifact_path_for_digest(digest);
+        let artifact_path = self.artifact_path_for_package(&package.name, &package.version, digest);
         fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)?;
 
         // Record the new package to the in-memory registry index
@@ -630,5 +700,105 @@ mod tests {
         let reloaded = load_registry(&tempdir);
         assert!(reloaded.show(&PackageId::from("a"), None).is_some());
         assert!(reloaded.show(&PackageId::from("longer-package-name"), None).is_some());
+    }
+
+    #[test]
+    fn load_package_rejects_artifact_that_does_not_match_requested_identity() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let package_path = tempdir.path().join("pkg.masp");
+        build_package("pkg", "1.0.0", []).write_to_file(&package_path).unwrap();
+        let published = registry.publish(&package_path).unwrap();
+
+        build_package("other", "1.0.0", [])
+            .write_to_file(&published.artifact_path)
+            .unwrap();
+
+        let error = registry
+            .load_package(&PackageId::from("pkg"), &published.version)
+            .expect_err("artifact mismatch should be rejected");
+        assert!(matches!(error, LocalRegistryError::ArtifactMismatch { .. }));
+    }
+
+    #[test]
+    fn load_package_accepts_legacy_digest_only_artifact_path() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let package = build_package("pkg", "1.0.0", []);
+        let package_path = tempdir.path().join("pkg.masp");
+        package.write_to_file(&package_path).unwrap();
+        let published = registry.publish(&package_path).unwrap();
+        let legacy_path =
+            registry.legacy_artifact_path_for_digest(published.version.digest.unwrap());
+        assert_ne!(published.artifact_path, legacy_path);
+        fs::rename(&published.artifact_path, &legacy_path).unwrap();
+
+        let shown = registry.show(&PackageId::from("pkg"), Some(&published.version)).unwrap();
+        assert_eq!(shown.artifact_path.as_ref(), Some(&legacy_path));
+        assert_eq!(
+            registry.artifact_path(&PackageId::from("pkg"), &published.version),
+            Some(legacy_path.clone())
+        );
+        let listed = registry.list();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].artifact_path.as_ref(), Some(&legacy_path));
+
+        let loaded = registry.load_package(&PackageId::from("pkg"), &published.version).unwrap();
+        assert_eq!(loaded.as_ref(), package.as_ref());
+    }
+
+    #[test]
+    fn summaries_do_not_report_legacy_artifact_for_different_package_identity() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let first = build_package("first", "1.0.0", []);
+        let second = build_package("second", "1.0.0", []);
+        assert_eq!(first.digest(), second.digest());
+
+        let first_path = tempdir.path().join("first.masp");
+        let second_path = tempdir.path().join("second.masp");
+        first.write_to_file(&first_path).unwrap();
+        second.write_to_file(&second_path).unwrap();
+
+        let first = registry.publish(&first_path).unwrap();
+        let second = registry.publish(&second_path).unwrap();
+        let legacy_path = registry.legacy_artifact_path_for_digest(first.version.digest.unwrap());
+        fs::rename(&first.artifact_path, &legacy_path).unwrap();
+        fs::remove_file(&second.artifact_path).unwrap();
+
+        let first_summary = registry.show(&PackageId::from("first"), Some(&first.version)).unwrap();
+        assert_eq!(first_summary.artifact_path.as_ref(), Some(&legacy_path));
+        let second_summary =
+            registry.show(&PackageId::from("second"), Some(&second.version)).unwrap();
+        assert_eq!(second_summary.artifact_path.as_ref(), Some(&second.artifact_path));
+    }
+
+    #[test]
+    fn artifact_paths_distinguish_packages_with_same_mast_digest() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let first = build_package("first", "1.0.0", []);
+        let second = build_package("second", "1.0.0", []);
+        assert_eq!(first.digest(), second.digest());
+
+        let first_path = tempdir.path().join("first.masp");
+        let second_path = tempdir.path().join("second.masp");
+        first.write_to_file(&first_path).unwrap();
+        second.write_to_file(&second_path).unwrap();
+
+        let first = registry.publish(&first_path).unwrap();
+        let second = registry.publish(&second_path).unwrap();
+        assert_ne!(first.artifact_path, second.artifact_path);
+
+        let first_loaded =
+            registry.load_package(&PackageId::from("first"), &first.version).unwrap();
+        let second_loaded =
+            registry.load_package(&PackageId::from("second"), &second.version).unwrap();
+        assert_eq!(first_loaded.name, PackageId::from("first"));
+        assert_eq!(second_loaded.name, PackageId::from("second"));
     }
 }

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -357,6 +357,13 @@ impl LocalPackageRegistry {
 
     /// Persist the state of the index to disk
     fn save(&mut self) -> Result<(), LocalRegistryError> {
+        self.save_with_locked_operation(|| Ok(()))
+    }
+
+    fn save_with_locked_operation(
+        &mut self,
+        operation: impl FnOnce() -> Result<(), LocalRegistryError>,
+    ) -> Result<(), LocalRegistryError> {
         let persisted = PersistedIndex { packages: self.index.packages().clone() };
         let contents = toml::to_string_pretty(&persisted)?;
         let mut file = fs::File::options()
@@ -387,6 +394,8 @@ impl LocalPackageRegistry {
             }
         }
 
+        operation()?;
+
         // Compute the new checksum of the updated index contents before we write, but do not
         // update the in-memory state until we've successfully persisted the index
         let new_checksum = miden_core::crypto::hash::Sha256::hash(contents.as_bytes().trim_ascii());
@@ -401,6 +410,23 @@ impl LocalPackageRegistry {
         self.index_checksum = *new_checksum.as_bytes();
 
         Ok(())
+    }
+
+    fn register_and_save_with_locked_operation(
+        &mut self,
+        name: PackageId,
+        record: PackageRecord,
+        operation: impl FnOnce() -> Result<(), LocalRegistryError>,
+    ) -> Result<(), LocalRegistryError> {
+        let previous_packages = self.index.packages().clone();
+        self.register(name, record)?;
+        match self.save_with_locked_operation(operation) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.index = InMemoryPackageRegistry::from_packages(previous_packages);
+                Err(error)
+            },
+        }
     }
 
     /// Derive the path in the artifact store for a package with `digest`
@@ -519,9 +545,12 @@ impl LocalPackageRegistry {
             };
 
             if should_write_artifact {
-                fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)?;
+                self.save_with_locked_operation(|| {
+                    fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)
+                })?;
+            } else {
+                self.save()?;
             }
-            self.save()?;
             return Ok(PublishedPackage {
                 name: package.name.clone(),
                 version,
@@ -529,9 +558,9 @@ impl LocalPackageRegistry {
             });
         }
 
-        fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)?;
-        self.register(package.name.clone(), record)?;
-        self.save()?;
+        self.register_and_save_with_locked_operation(package.name.clone(), record, || {
+            fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)
+        })?;
 
         Ok(PublishedPackage {
             name: package.name.clone(),
@@ -565,13 +594,17 @@ impl LocalPackageRegistry {
 
         // Write the package artifact to the registry
         let artifact_path = self.artifact_path_for_package(&package.name, &package.version, digest);
-        fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)?;
+        if self.index.get_by_semver(&package.name, &package.version).is_some() {
+            return Err(LocalRegistryError::DuplicateSemanticVersion {
+                package: package.name.clone(),
+                version: package.version.clone(),
+            });
+        }
 
-        // Record the new package to the in-memory registry index
-        self.register(package.name.clone(), record)?;
-
-        // Persist the updated registry index
-        self.save()?;
+        // Persist the updated registry index and artifact under the index write lock.
+        self.register_and_save_with_locked_operation(package.name.clone(), record, || {
+            fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)
+        })?;
 
         Ok(PublishedPackage {
             name: package.name.clone(),
@@ -760,6 +793,31 @@ mod tests {
     }
 
     #[test]
+    fn stale_cache_does_not_overwrite_artifact() {
+        let tempdir = TempDir::new().unwrap();
+        let mut stale_registry = load_registry(&tempdir);
+        let mut current_registry = load_registry(&tempdir);
+
+        let package_path = tempdir.path().join("pkg.masp");
+        build_package("pkg", "1.0.0", []).write_to_file(&package_path).unwrap();
+        let published = current_registry.publish(&package_path).unwrap();
+        let original_bytes = fs::read(&published.artifact_path).unwrap();
+
+        let mut conflicting_package = build_package("pkg", "1.0.0", []);
+        conflicting_package.sections.push(Section::new(
+            SectionId::custom("stale-cache-test").unwrap(),
+            Vec::from([1, 2, 3]),
+        ));
+        assert_eq!(Some(conflicting_package.digest()), published.version.digest);
+
+        let error = stale_registry
+            .cache_package(conflicting_package.into())
+            .expect_err("stale cache should fail before writing artifact bytes");
+        assert!(matches!(error, LocalRegistryError::WriteToStaleIndex));
+        assert_eq!(fs::read(&published.artifact_path).unwrap(), original_bytes);
+    }
+
+    #[test]
     fn list_and_show_include_multiple_versions() {
         let tempdir = TempDir::new().unwrap();
         let mut registry = load_registry(&tempdir);
@@ -811,6 +869,88 @@ mod tests {
             .publish(&package_path)
             .expect_err("duplicate semver should fail even for identical bytes");
         assert!(matches!(error, LocalRegistryError::DuplicateSemanticVersion { .. }));
+    }
+
+    #[test]
+    fn publish_duplicate_semver_does_not_overwrite_artifact() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let package_path = tempdir.path().join("pkg.masp");
+        build_package("pkg", "1.0.0", []).write_to_file(&package_path).unwrap();
+        let published = registry.publish(&package_path).unwrap();
+        let original_bytes = fs::read(&published.artifact_path).unwrap();
+
+        let mut conflicting_package = build_package("pkg", "1.0.0", []);
+        conflicting_package
+            .sections
+            .push(Section::new(SectionId::custom("publish-test").unwrap(), Vec::from([1, 2, 3])));
+        assert_eq!(Some(conflicting_package.digest()), published.version.digest);
+        let conflicting_path = tempdir.path().join("pkg-conflicting.masp");
+        conflicting_package.write_to_file(&conflicting_path).unwrap();
+
+        let error = registry
+            .publish(&conflicting_path)
+            .expect_err("duplicate semver should fail before writing artifact bytes");
+        assert!(matches!(error, LocalRegistryError::DuplicateSemanticVersion { .. }));
+        assert_eq!(fs::read(&published.artifact_path).unwrap(), original_bytes);
+
+        let loaded = registry.load_package(&PackageId::from("pkg"), &published.version).unwrap();
+        assert!(loaded.sections.is_empty());
+    }
+
+    #[test]
+    fn stale_publish_duplicate_semver_does_not_overwrite_artifact() {
+        let tempdir = TempDir::new().unwrap();
+        let mut stale_registry = load_registry(&tempdir);
+        let mut current_registry = load_registry(&tempdir);
+
+        let package_path = tempdir.path().join("pkg.masp");
+        build_package("pkg", "1.0.0", []).write_to_file(&package_path).unwrap();
+        let published = current_registry.publish(&package_path).unwrap();
+        let original_bytes = fs::read(&published.artifact_path).unwrap();
+
+        let mut conflicting_package = build_package("pkg", "1.0.0", []);
+        conflicting_package.sections.push(Section::new(
+            SectionId::custom("stale-publish-test").unwrap(),
+            Vec::from([1, 2, 3]),
+        ));
+        assert_eq!(Some(conflicting_package.digest()), published.version.digest);
+        let conflicting_path = tempdir.path().join("pkg-conflicting.masp");
+        conflicting_package.write_to_file(&conflicting_path).unwrap();
+
+        let error = stale_registry
+            .publish(&conflicting_path)
+            .expect_err("stale publish should fail before writing artifact bytes");
+        assert!(matches!(error, LocalRegistryError::WriteToStaleIndex));
+        assert_eq!(fs::read(&published.artifact_path).unwrap(), original_bytes);
+    }
+
+    #[test]
+    fn failed_publish_artifact_write_does_not_persist_index_on_later_save() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let package = build_package("pkg", "1.0.0", []);
+        let package_path = tempdir.path().join("pkg.masp");
+        package.write_to_file(&package_path).unwrap();
+        let artifact_path =
+            registry.artifact_path_for_package(&package.name, &package.version, package.digest());
+        fs::create_dir(&artifact_path).unwrap();
+
+        let error = registry
+            .publish(&package_path)
+            .expect_err("artifact write should fail while the artifact path is a directory");
+        assert!(matches!(error, LocalRegistryError::IndexWrite(_)));
+        fs::remove_dir(&artifact_path).unwrap();
+
+        let other_path = tempdir.path().join("other.masp");
+        build_package("other", "1.0.0", []).write_to_file(&other_path).unwrap();
+        registry.publish(&other_path).expect("later publish should succeed");
+
+        let reloaded = load_registry(&tempdir);
+        assert!(reloaded.show(&PackageId::from("pkg"), None).is_none());
+        assert!(reloaded.show(&PackageId::from("other"), None).is_some());
     }
 
     #[test]

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -355,11 +355,6 @@ impl LocalPackageRegistry {
         Ok(Arc::new(loaded))
     }
 
-    /// Persist the state of the index to disk
-    fn save(&mut self) -> Result<(), LocalRegistryError> {
-        self.save_with_locked_operation(|| Ok(()))
-    }
-
     fn save_with_locked_operation(
         &mut self,
         operation: impl FnOnce() -> Result<(), LocalRegistryError>,
@@ -426,6 +421,70 @@ impl LocalPackageRegistry {
                 self.index = InMemoryPackageRegistry::from_packages(previous_packages);
                 Err(error)
             },
+        }
+    }
+
+    fn write_cache_artifact_from_legacy_or_bytes(
+        artifact_path: &Path,
+        legacy_path: &Path,
+        package: &MastPackage,
+        version: &Version,
+        bytes: &[u8],
+    ) -> Result<(), LocalRegistryError> {
+        match fs::read(legacy_path) {
+            Ok(existing_bytes) => match MastPackage::read_from_bytes(&existing_bytes) {
+                Ok(existing_package) => {
+                    let existing_version =
+                        Version::new(existing_package.version.clone(), existing_package.digest());
+                    if existing_package.name == package.name && existing_version == *version {
+                        if &existing_package == package {
+                            fs::write(artifact_path, existing_bytes)
+                                .map_err(LocalRegistryError::IndexWrite)
+                        } else {
+                            Err(LocalRegistryError::DuplicateSemanticVersion {
+                                package: package.name.clone(),
+                                version: package.version.clone(),
+                            })
+                        }
+                    } else {
+                        fs::write(artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)
+                    }
+                },
+                Err(_) => fs::write(artifact_path, bytes).map_err(LocalRegistryError::IndexWrite),
+            },
+            Err(_) => fs::write(artifact_path, bytes).map_err(LocalRegistryError::IndexWrite),
+        }
+    }
+
+    fn repair_cache_artifact(
+        artifact_path: &Path,
+        legacy_path: &Path,
+        package: &MastPackage,
+        version: &Version,
+        bytes: &[u8],
+    ) -> Result<(), LocalRegistryError> {
+        match fs::read(artifact_path) {
+            Ok(existing_bytes) => match MastPackage::read_from_bytes(&existing_bytes) {
+                Ok(existing_package) if &existing_package == package => Ok(()),
+                Ok(_) => Err(LocalRegistryError::DuplicateSemanticVersion {
+                    package: package.name.clone(),
+                    version: package.version.clone(),
+                }),
+                Err(_) => Self::write_cache_artifact_from_legacy_or_bytes(
+                    artifact_path,
+                    legacy_path,
+                    package,
+                    version,
+                    bytes,
+                ),
+            },
+            Err(_) => Self::write_cache_artifact_from_legacy_or_bytes(
+                artifact_path,
+                legacy_path,
+                package,
+                version,
+                bytes,
+            ),
         }
     }
 
@@ -530,27 +589,16 @@ impl LocalPackageRegistry {
                 });
             }
 
-            let should_write_artifact = match fs::read(&artifact_path) {
-                Ok(existing_bytes) => match MastPackage::read_from_bytes(&existing_bytes) {
-                    Ok(existing_package) if &existing_package == package.as_ref() => false,
-                    Ok(_) => {
-                        return Err(LocalRegistryError::DuplicateSemanticVersion {
-                            package: package.name.clone(),
-                            version: package.version.clone(),
-                        });
-                    },
-                    Err(_) => true,
-                },
-                Err(_) => true,
-            };
-
-            if should_write_artifact {
-                self.save_with_locked_operation(|| {
-                    fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)
-                })?;
-            } else {
-                self.save()?;
-            }
+            let legacy_path = self.legacy_artifact_path_for_digest(digest);
+            self.save_with_locked_operation(|| {
+                Self::repair_cache_artifact(
+                    &artifact_path,
+                    &legacy_path,
+                    package.as_ref(),
+                    &version,
+                    &bytes,
+                )
+            })?;
             return Ok(PublishedPackage {
                 name: package.name.clone(),
                 version,
@@ -815,6 +863,95 @@ mod tests {
             .expect_err("stale cache should fail before writing artifact bytes");
         assert!(matches!(error, LocalRegistryError::WriteToStaleIndex));
         assert_eq!(fs::read(&published.artifact_path).unwrap(), original_bytes);
+    }
+
+    #[test]
+    fn concurrent_cache_repair_does_not_overwrite_existing_artifact() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let package_path = tempdir.path().join("pkg.masp");
+        build_package("pkg", "1.0.0", []).write_to_file(&package_path).unwrap();
+        let published = registry.publish(&package_path).unwrap();
+        fs::remove_file(&published.artifact_path).unwrap();
+
+        let mut first_registry = load_registry(&tempdir);
+        let mut second_registry = load_registry(&tempdir);
+        let repaired_package = build_package("pkg", "1.0.0", []);
+        let repaired_bytes = repaired_package.to_bytes();
+        first_registry.cache_package(repaired_package.into()).unwrap();
+
+        let mut conflicting_package = build_package("pkg", "1.0.0", []);
+        conflicting_package.sections.push(Section::new(
+            SectionId::custom("cache-repair-race-test").unwrap(),
+            Vec::from([1, 2, 3]),
+        ));
+        assert_eq!(Some(conflicting_package.digest()), published.version.digest);
+        let error = second_registry
+            .cache_package(conflicting_package.into())
+            .expect_err("cache repair should revalidate the artifact under the index lock");
+        assert!(matches!(error, LocalRegistryError::DuplicateSemanticVersion { .. }));
+        assert_eq!(fs::read(&published.artifact_path).unwrap(), repaired_bytes);
+    }
+
+    #[test]
+    fn cache_repair_checks_legacy_artifact_before_writing_qualified_artifact() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let package_path = tempdir.path().join("pkg.masp");
+        build_package("pkg", "1.0.0", []).write_to_file(&package_path).unwrap();
+        let published = registry.publish(&package_path).unwrap();
+        let original_bytes = fs::read(&published.artifact_path).unwrap();
+        let legacy_path =
+            registry.legacy_artifact_path_for_digest(published.version.digest.unwrap());
+        fs::rename(&published.artifact_path, &legacy_path).unwrap();
+
+        let mut conflicting_package = build_package("pkg", "1.0.0", []);
+        conflicting_package.sections.push(Section::new(
+            SectionId::custom("legacy-cache-repair-test").unwrap(),
+            Vec::from([1, 2, 3]),
+        ));
+        assert_eq!(Some(conflicting_package.digest()), published.version.digest);
+
+        let error = registry
+            .cache_package(conflicting_package.into())
+            .expect_err("cache repair should reject conflicts with the legacy artifact");
+        assert!(matches!(error, LocalRegistryError::DuplicateSemanticVersion { .. }));
+        assert!(!published.artifact_path.exists());
+        assert_eq!(fs::read(&legacy_path).unwrap(), original_bytes);
+
+        let loaded = registry.load_package(&PackageId::from("pkg"), &published.version).unwrap();
+        assert!(loaded.sections.is_empty());
+    }
+
+    #[test]
+    fn cache_repair_checks_legacy_artifact_before_replacing_corrupt_qualified_artifact() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let package_path = tempdir.path().join("pkg.masp");
+        build_package("pkg", "1.0.0", []).write_to_file(&package_path).unwrap();
+        let published = registry.publish(&package_path).unwrap();
+        let original_bytes = fs::read(&published.artifact_path).unwrap();
+        let legacy_path =
+            registry.legacy_artifact_path_for_digest(published.version.digest.unwrap());
+        fs::write(&legacy_path, &original_bytes).unwrap();
+        fs::write(&published.artifact_path, b"not a package").unwrap();
+
+        let mut conflicting_package = build_package("pkg", "1.0.0", []);
+        conflicting_package.sections.push(Section::new(
+            SectionId::custom("legacy-cache-corrupt-qualified-test").unwrap(),
+            Vec::from([1, 2, 3]),
+        ));
+        assert_eq!(Some(conflicting_package.digest()), published.version.digest);
+
+        let error = registry
+            .cache_package(conflicting_package.into())
+            .expect_err("cache repair should reject conflicts with the legacy artifact");
+        assert!(matches!(error, LocalRegistryError::DuplicateSemanticVersion { .. }));
+        assert_eq!(fs::read(&legacy_path).unwrap(), original_bytes);
+        assert_eq!(fs::read(&published.artifact_path).unwrap(), b"not a package");
     }
 
     #[test]

--- a/crates/package-registry/src/lib.rs
+++ b/crates/package-registry/src/lib.rs
@@ -221,10 +221,16 @@ pub trait PackageIndex: PackageRegistry {
     fn register(&mut self, name: PackageId, record: PackageRecord) -> Result<(), Self::Error>;
 }
 
-/// A writable package store used to publish assembled package artifacts and index metadata.
-pub trait PackageStore: PackageRegistry + PackageProvider {
+/// A writable package cache used to store assembled package artifacts resolved during assembly.
+pub trait PackageCache: PackageRegistry + PackageProvider {
     type Error: fmt::Display;
 
+    /// Cache `package`, returning the fully-qualified stored version.
+    fn cache_package(&mut self, package: Arc<MastPackage>) -> Result<Version, Self::Error>;
+}
+
+/// A writable package store used to publish assembled package artifacts and index metadata.
+pub trait PackageStore: PackageCache {
     /// Publish `package` to the store, returning the fully-qualified stored version.
     fn publish_package(&mut self, package: Arc<MastPackage>) -> Result<Version, Self::Error>;
 }
@@ -234,7 +240,10 @@ pub trait PackageStore: PackageRegistry + PackageProvider {
 #[error("{0}")]
 pub struct NoPackageStoreError(String);
 
-/// A package store implementation which always refuses publication.
+/// A package store implementation which refuses publication and loading.
+///
+/// Cache writes are accepted as a no-op so callers which do not need a persistent package store can
+/// still assemble source dependencies.
 #[derive(Default)]
 pub struct NoPackageStore;
 
@@ -254,13 +263,90 @@ impl PackageProvider for NoPackageStore {
     }
 }
 
-impl PackageStore for NoPackageStore {
+impl PackageCache for NoPackageStore {
     type Error = NoPackageStoreError;
 
+    fn cache_package(&mut self, package: Arc<MastPackage>) -> Result<Version, Self::Error> {
+        Ok(Version::new(package.version.clone(), package.digest()))
+    }
+}
+
+impl PackageStore for NoPackageStore {
     fn publish_package(&mut self, package: Arc<MastPackage>) -> Result<Version, Self::Error> {
         Err(NoPackageStoreError(format!(
             "cannot publish package {}@{}",
             package.name, package.version
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{collections::BTreeMap, vec, vec::Vec};
+
+    use miden_assembly_syntax::{
+        Library,
+        ast::{Path as AstPath, PathBuf},
+        library::{LibraryExport, ProcedureExport as LibraryProcedureExport},
+    };
+    use miden_core::{
+        mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, MastNodeId},
+        operations::Operation,
+    };
+    use miden_mast_package::{Package, TargetType};
+
+    use super::*;
+
+    fn build_forest() -> (MastForest, MastNodeId) {
+        let mut forest = MastForest::new();
+        let node_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+            .add_to_forest(&mut forest)
+            .expect("failed to build basic block");
+        forest.make_root(node_id);
+        (forest, node_id)
+    }
+
+    fn absolute_path(name: &str) -> Arc<AstPath> {
+        let path = PathBuf::new(name).expect("invalid path");
+        let path = path.as_path().to_absolute().into_owned();
+        Arc::from(path.into_boxed_path())
+    }
+
+    fn build_library(export: &str) -> Arc<Library> {
+        let (forest, node_id) = build_forest();
+        let path = absolute_path(export);
+        let export = LibraryProcedureExport::new(node_id, Arc::clone(&path));
+
+        let mut exports = BTreeMap::new();
+        exports.insert(path, LibraryExport::Procedure(export));
+
+        Arc::new(Library::new(Arc::new(forest), exports).expect("failed to build library"))
+    }
+
+    #[test]
+    fn no_package_store_cache_package_is_noop() {
+        let package: Arc<MastPackage> = Package::from_library(
+            PackageId::from("pkg"),
+            "1.0.0".parse().unwrap(),
+            TargetType::Library,
+            build_library("test::pkg::entry"),
+            [],
+        )
+        .into();
+        let expected = Version::new(package.version.clone(), package.digest());
+
+        let mut store = NoPackageStore;
+        let cached = store
+            .cache_package(Arc::clone(&package))
+            .expect("no package store should accept cache writes as no-op");
+
+        assert_eq!(cached, expected);
+        assert!(store.available_versions(&package.name).is_none());
+        store
+            .load_package(&package.name, &cached)
+            .expect_err("no package store should not persist cache writes");
+        store
+            .publish_package(package)
+            .expect_err("no package store should still reject publication");
     }
 }

--- a/crates/package-registry/src/resolver/index.rs
+++ b/crates/package-registry/src/resolver/index.rs
@@ -4,8 +4,8 @@ use miden_assembly_syntax::Report;
 use miden_mast_package::Package as MastPackage;
 
 use crate::{
-    PackageId, PackageIndex, PackageProvider, PackageRecord, PackageRegistry, PackageStore,
-    PackageVersions, SemVer, Version, VersionRequirement,
+    PackageCache, PackageId, PackageIndex, PackageProvider, PackageRecord, PackageRegistry,
+    PackageStore, PackageVersions, SemVer, Version, VersionRequirement,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -127,9 +127,51 @@ impl PackageProvider for InMemoryPackageRegistry {
     }
 }
 
-impl PackageStore for InMemoryPackageRegistry {
+impl PackageCache for InMemoryPackageRegistry {
     type Error = InMemoryPackageStoreError;
 
+    fn cache_package(&mut self, package: Arc<MastPackage>) -> Result<Version, Self::Error> {
+        let version = Version::new(package.version.clone(), package.digest());
+        let dependencies = package.manifest.dependencies().map(|dependency| {
+            let dependency_version = Version::new(dependency.version.clone(), dependency.digest);
+            (dependency.name.clone(), VersionRequirement::Exact(dependency_version))
+        });
+
+        let record = match package.description.clone() {
+            Some(description) => {
+                PackageRecord::new(version.clone(), dependencies).with_description(description)
+            },
+            None => PackageRecord::new(version.clone(), dependencies),
+        };
+
+        if let Some(existing) = self.get_by_semver(&package.name, &package.version) {
+            if existing.version() != &version || existing != &record {
+                return Err(InMemoryPackageStoreError::DuplicateSemanticVersion {
+                    package: package.name.clone(),
+                    version: package.version.clone(),
+                });
+            }
+            let artifact_key = (package.name.clone(), version.clone());
+            if let Some(existing_package) = self.artifacts.get(&artifact_key) {
+                if existing_package.as_ref() != package.as_ref() {
+                    return Err(InMemoryPackageStoreError::DuplicateSemanticVersion {
+                        package: package.name.clone(),
+                        version: package.version.clone(),
+                    });
+                }
+            } else {
+                self.artifacts.insert(artifact_key, package);
+            }
+            return Ok(version);
+        }
+
+        self.insert_record(package.name.clone(), record)?;
+        self.artifacts.insert((package.name.clone(), version.clone()), package);
+        Ok(version)
+    }
+}
+
+impl PackageStore for InMemoryPackageRegistry {
     fn publish_package(&mut self, package: Arc<MastPackage>) -> Result<Version, Self::Error> {
         let version = Version::new(package.version.clone(), package.digest());
         if self.is_semver_available(&package.name, &package.version) {
@@ -189,5 +231,90 @@ where
             }
         }
         index
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{collections::BTreeMap, vec, vec::Vec};
+
+    use miden_assembly_syntax::{
+        Library,
+        ast::{Path as AstPath, PathBuf},
+        library::{LibraryExport, ProcedureExport as LibraryProcedureExport},
+    };
+    use miden_core::{
+        mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, MastNodeId},
+        operations::Operation,
+    };
+    use miden_mast_package::{Dependency, Package, Section, SectionId, TargetType};
+
+    use super::*;
+
+    fn build_forest() -> (MastForest, MastNodeId) {
+        let mut forest = MastForest::new();
+        let node_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+            .add_to_forest(&mut forest)
+            .expect("failed to build basic block");
+        forest.make_root(node_id);
+        (forest, node_id)
+    }
+
+    fn absolute_path(name: &str) -> Arc<AstPath> {
+        let path = PathBuf::new(name).expect("invalid path");
+        let path = path.as_path().to_absolute().into_owned();
+        Arc::from(path.into_boxed_path())
+    }
+
+    fn build_library(export: &str) -> Arc<Library> {
+        let (forest, node_id) = build_forest();
+        let path = absolute_path(export);
+        let export = LibraryProcedureExport::new(node_id, Arc::clone(&path));
+
+        let mut exports = BTreeMap::new();
+        exports.insert(path, LibraryExport::Procedure(export));
+
+        Arc::new(Library::new(Arc::new(forest), exports).expect("failed to build library"))
+    }
+
+    fn build_package<'a>(
+        name: &str,
+        version: &str,
+        dependencies: impl IntoIterator<Item = (&'a str, &'a str, TargetType, miden_core::Word)>,
+    ) -> Arc<MastPackage> {
+        Package::from_library(
+            name.into(),
+            version.parse().unwrap(),
+            TargetType::Library,
+            build_library("test::pkg::entry"),
+            dependencies.into_iter().map(|(name, version, kind, digest)| Dependency {
+                name: name.into(),
+                version: version.parse().unwrap(),
+                kind,
+                digest,
+            }),
+        )
+        .into()
+    }
+
+    #[test]
+    fn cache_rejects_different_artifact_for_existing_exact_version() {
+        let mut registry = InMemoryPackageRegistry::default();
+        let package = build_package("pkg", "1.0.0", []);
+        let version = registry.cache_package(package.clone()).unwrap();
+
+        let mut conflicting_package = build_package("pkg", "1.0.0", []);
+        Arc::make_mut(&mut conflicting_package)
+            .sections
+            .push(Section::new(SectionId::custom("cache-test").unwrap(), Vec::from([1, 2, 3])));
+        assert_eq!(Some(conflicting_package.digest()), version.digest);
+
+        let error = registry
+            .cache_package(conflicting_package)
+            .expect_err("cache should reject conflicting package artifacts");
+        assert!(matches!(error, InMemoryPackageStoreError::DuplicateSemanticVersion { .. }));
+
+        let loaded = registry.load_package(&PackageId::from("pkg"), &version).unwrap();
+        assert_eq!(loaded.as_ref(), package.as_ref());
     }
 }


### PR DESCRIPTION
Fix local registry artifact storage and cache repair.

Artifacts are now stored with package-qualified paths, while legacy digest-only artifacts still load when they match the requested package.

Preassembled dependency artifacts are cached instead of published. This avoids requiring registry entries for dependency artifacts.

Cache and publish writes now reject stale or conflicting artifacts before replacing files.

Closes #2946.