### PR TITLE
Harden program serde entrypoint invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [BREAKING] Bounded the live advice map by total field elements during execution; advice-provider setup now returns an error when initial advice exceeds this limit ([#3085](https://github.com/0xMiden/miden-vm/pull/3085)).
 - Rejected empty kernel packages before linking so malformed dependency metadata returns a structured package error instead of reaching the linker's non-empty-kernel assertion ([#3082](https://github.com/0xMiden/miden-vm/pull/3082)).
 - [BREAKING] Fixed project artifact reuse to ignore unrelated manifest fields, rejected private cross-module imports, and kept signature-only type imports live ([#3091](https://github.com/0xMiden/miden-vm/pull/3091)).
+- Hardened `Program` serde deserialization to enforce entrypoint existence and procedure-root invariants, and expanded serde fuzz coverage for post-deserialization `Program` use paths ([#3102](https://github.com/0xMiden/miden-vm/pull/3102)).
 
 #### Changes
 

--- a/core/src/program/mod.rs
+++ b/core/src/program/mod.rs
@@ -27,7 +27,7 @@ pub use stack::{InputError, MIN_STACK_DEPTH, OutputError, StackInputs, StackOutp
 /// execution begins, and a definition of the kernel against which the program must be executed
 /// (the kernel can be an empty kernel).
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(
     all(feature = "arbitrary", test),
     miden_test_serde_macros::serde_test(binary_serde(true))
@@ -184,6 +184,36 @@ impl Deserializable for Program {
         }
 
         Ok(Self::with_kernel(mast_forest, entrypoint, kernel))
+    }
+}
+
+#[cfg(feature = "serde")]
+#[derive(Deserialize)]
+struct ProgramSerde {
+    mast_forest: Arc<MastForest>,
+    entrypoint: MastNodeId,
+    kernel: Kernel,
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Program {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let ProgramSerde { mast_forest, entrypoint, kernel } =
+            ProgramSerde::deserialize(deserializer)?;
+
+        if mast_forest.get_node_by_id(entrypoint).is_none() {
+            return Err(serde::de::Error::custom(format!("invalid entrypoint {entrypoint}")));
+        }
+        if !mast_forest.is_procedure_root(entrypoint) {
+            return Err(serde::de::Error::custom(format!(
+                "entrypoint {entrypoint} is not a procedure"
+            )));
+        }
+
+        Ok(Self { mast_forest, entrypoint, kernel })
     }
 }
 

--- a/miden-core-fuzz/fuzz_targets/program_serde_deserialize.rs
+++ b/miden-core-fuzz/fuzz_targets/program_serde_deserialize.rs
@@ -8,7 +8,22 @@ use libfuzzer_sys::fuzz_target;
 use miden_core::program::Program;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = serde_json::from_slice::<Program>(data);
-    let _ = serde_json::from_slice::<Vec<Program>>(data);
-    let _ = serde_json::from_slice::<Option<Program>>(data);
+    if let Ok(program) = serde_json::from_slice::<Program>(data) {
+        let _ = program.hash();
+        let _ = program.to_info();
+    }
+
+    if let Ok(programs) = serde_json::from_slice::<Vec<Program>>(data) {
+        for program in programs.iter().take(4) {
+            let _ = program.hash();
+            let _ = program.to_info();
+        }
+    }
+
+    if let Ok(maybe_program) = serde_json::from_slice::<Option<Program>>(data) {
+        if let Some(program) = maybe_program {
+            let _ = program.hash();
+            let _ = program.to_info();
+        }
+    }
 });


### PR DESCRIPTION
## Describe your changes
                                                                                                                                                                                                     
  This PR hardens Program serde deserialization so it enforces the same entrypoint invariants as the binary deserialization path, and expands fuzz coverage to exercise post-deserialization Program usage paths.                                                                                                                                                                                       
                                                                                                                                                                                                     
  ### What changed                                                                                                                                                                                   
                                                                                                                                                                                                     
  - Replaced derived Deserialize for Program with a manual implementation in core/src/program/mod.rs.                                                                                                
  - Added invariant checks during serde deserialization:                                                                                                                                             
      - entrypoint must exist in mast_forest.                                                                                                                                                        
      - entrypoint must be a procedure root.                                                                                                                                                         
  - Return structured serde errors instead of allowing invalid Program instances to be created.                                                                                                      
  - Expanded miden-core-fuzz/fuzz_targets/program_serde_deserialize.rs:                                                                                                                              
      - After successful deserialize, call hash() and to_info() on:                                                                                                                                  
          - Program                                                                                                                                                                                  
          - Vec<Program> (bounded iteration)                                                                                                                                                         
          - Option<Program>                                                                                                                                                                          
                                                                                                                                                                                                     
  ### Why                                                                                                                                                                                            
                                                                                                                                                                                                     
  Derived serde deserialization could bypass Program construction invariants and allow malformed objects, which could later panic on normal access paths. This change keeps invariants consistent across deserialization surfaces and improves robustness.                                                                                                                                           
                                                                                                                                                                                                     
  ### Related                                                                                                                                                                                        
                                                                                                                                                                                                     
  - Context/reference: #2849 (https://github.com/0xMiden/miden-vm/pull/2849)                                                                                                                         
                                                                                                                                                                                                     
  ———                                                                                                                                                                                                

  ## Checklist before requesting a review                                                                                                                                                            
                                                                                                                                                                                                     
  - [ ] Repo forked and branch created from next according to naming convention.                                                                                                                     
  - [ ] Commit messages and codestyle follow ../CONTRIBUTING.md.                                                                                                                                     
  - [ ] Commits are signed (https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).                                                                       
  - [ ] Relevant issues are linked in the PR description.                                                                                                                                            
  - [ ] Tests added for new functionality.                                                                                                                                                           
  - [ ] Documentation/comments updated according to changes.                                                                                                                                         
  - [x] Updated CHANGELOG.md.