### PR TITLE
Introduce `SparseMastForest`

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,2 @@
-# Allow up to 10 arguments in functions
-too-many-arguments-threshold = 10
+# Allow up to 11 arguments in functions
+too-many-arguments-threshold = 11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - Added the `miden-vm-synthetic-bench` crate for VM-level proving regression detection driven by row-count snapshots from an external producer ([#3024](https://github.com/0xMiden/miden-vm/pull/3024)).
 - Implemented the `miden-registry` tool for managing a local filesystem-based package registry. This is intended to help us explore what package management in Miden projects might look like with a central registry for sharing packages, without needing to go all-in on implementing one. [#2881](https://github.com/0xMiden/miden-vm/pull/2881).
+- Introduce `SparseMastForest`, and use it to shrink the size of `TraceGenerationContext` [#3105](https://github.com/0xMiden/miden-vm/pull/3105).
 
 #### Enhancements
 

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -109,6 +109,9 @@ pub use node_fingerprint::{DecoratorFingerprint, MastNodeFingerprint};
 mod node_builder_utils;
 pub use node_builder_utils::build_node_with_remapped_ids;
 
+mod sparse;
+pub use sparse::{MastForestId, SparseMastForest, SparseMastForestBuilder, VisitKind};
+
 #[cfg(test)]
 mod tests;
 
@@ -997,6 +1000,206 @@ impl IndexMut<DecoratorId> for MastForest {
     #[inline(always)]
     fn index_mut(&mut self, decorator_id: DecoratorId) -> &mut Self::Output {
         self.debug_info.decorator_mut(decorator_id).expect("DecoratorId out of bounds")
+    }
+}
+
+// EXECUTABLE MAST FOREST
+// ================================================================================================
+
+/// A MAST forest that can be used as the source of nodes during program execution.
+///
+/// Implemented by both [`MastForest`] (a dense forest containing all nodes) and
+/// [`SparseMastForest`] (a sparse subset of a forest containing only the nodes visited during
+/// some prior execution). The latter preserves the original [`MastNodeId`]s of its source forest,
+/// which allows it to stand in for the dense forest during re-execution.
+pub trait ExecutableMastForest: Index<DecoratorId, Output = Decorator> {
+    /// Returns the [`MastNode`] associated with the provided [`MastNodeId`] if present, or else
+    /// `None`.
+    fn get_node_by_id(&self, node_id: MastNodeId) -> Option<&MastNode>;
+
+    /// Returns the digest of the node associated with the provided [`MastNodeId`] if present, or
+    /// else `None`.
+    ///
+    /// For dense forests this is equivalent to `get_node_by_id(id).map(|n| n.digest())`. For
+    /// [`SparseMastForest`], it additionally consults the digest-only entries — nodes that were
+    /// referenced (but not entered) during execution and which were therefore stored as digest
+    /// only. Use this method whenever only the digest of a referenced node is needed (e.g. when
+    /// populating the hasher state of a parent's trace row).
+    fn get_digest_by_id(&self, node_id: MastNodeId) -> Option<Word>;
+
+    /// Returns the [`MastNodeId`] of the procedure associated with a given digest, if any.
+    fn find_procedure_root(&self, digest: Word) -> Option<MastNodeId>;
+
+    /// Returns the [`Decorator`] associated with the provided [`DecoratorId`] if present, or else
+    /// `None`.
+    fn decorator_by_id(&self, decorator_id: DecoratorId) -> Option<&Decorator>;
+
+    /// Returns the advice map associated with this forest.
+    fn advice_map(&self) -> &AdviceMap;
+
+    /// Returns the decorators that should be executed before entering the node with the provided
+    /// id, looked up via the forest's debug info (used for nodes whose decorator store is in the
+    /// `Linked` form).
+    fn linked_before_enter_decorators(&self, node_id: MastNodeId) -> &[DecoratorId];
+
+    /// Returns the decorators that should be executed after exiting the node with the provided
+    /// id, looked up via the forest's debug info (used for nodes whose decorator store is in the
+    /// `Linked` form).
+    fn linked_after_exit_decorators(&self, node_id: MastNodeId) -> &[DecoratorId];
+
+    /// Returns decorator indices for a specific operation within a basic block node.
+    fn decorator_indices_for_op(&self, node_id: MastNodeId, local_op_idx: usize) -> &[DecoratorId];
+
+    /// Returns the [`AssemblyOp`] associated with a node (and optionally an operation index inside
+    /// a basic block), if any.
+    ///
+    /// This is used by the error-reporting machinery to produce source locations.
+    fn get_assembly_op(
+        &self,
+        node_id: MastNodeId,
+        target_op_idx: Option<usize>,
+    ) -> Option<&AssemblyOp>;
+
+    /// Resolves an error code to its corresponding error message, if any.
+    fn resolve_error_message(&self, code: Felt) -> Option<Arc<str>>;
+}
+
+impl ExecutableMastForest for MastForest {
+    #[inline(always)]
+    fn get_node_by_id(&self, node_id: MastNodeId) -> Option<&MastNode> {
+        MastForest::get_node_by_id(self, node_id)
+    }
+
+    #[inline(always)]
+    fn get_digest_by_id(&self, node_id: MastNodeId) -> Option<Word> {
+        MastForest::get_node_by_id(self, node_id).map(MastNodeExt::digest)
+    }
+
+    #[inline(always)]
+    fn find_procedure_root(&self, digest: Word) -> Option<MastNodeId> {
+        MastForest::find_procedure_root(self, digest)
+    }
+
+    #[inline(always)]
+    fn decorator_by_id(&self, decorator_id: DecoratorId) -> Option<&Decorator> {
+        MastForest::decorator_by_id(self, decorator_id)
+    }
+
+    #[inline(always)]
+    fn advice_map(&self) -> &AdviceMap {
+        MastForest::advice_map(self)
+    }
+
+    #[inline(always)]
+    fn linked_before_enter_decorators(&self, node_id: MastNodeId) -> &[DecoratorId] {
+        MastForest::before_enter_decorators(self, node_id)
+    }
+
+    #[inline(always)]
+    fn linked_after_exit_decorators(&self, node_id: MastNodeId) -> &[DecoratorId] {
+        MastForest::after_exit_decorators(self, node_id)
+    }
+
+    #[inline(always)]
+    fn decorator_indices_for_op(&self, node_id: MastNodeId, local_op_idx: usize) -> &[DecoratorId] {
+        MastForest::decorator_indices_for_op(self, node_id, local_op_idx)
+    }
+
+    #[inline(always)]
+    fn get_assembly_op(
+        &self,
+        node_id: MastNodeId,
+        target_op_idx: Option<usize>,
+    ) -> Option<&AssemblyOp> {
+        MastForest::get_assembly_op(self, node_id, target_op_idx)
+    }
+
+    #[inline(always)]
+    fn resolve_error_message(&self, code: Felt) -> Option<Arc<str>> {
+        MastForest::resolve_error_message(self, code)
+    }
+}
+
+// Blanket impl: an `Arc<T>` is an `ExecutableMastForest` whenever the underlying `T` is, which
+// allows the executor and tracer plumbing to be generic over a forest type while the live
+// (`Arc<MastForest>`) and replay (`Arc<SparseMastForest>`) paths each pick a concrete instance.
+impl<T> Index<MastNodeId> for Arc<T>
+where
+    T: Index<MastNodeId, Output = MastNode> + ?Sized,
+{
+    type Output = MastNode;
+
+    #[inline(always)]
+    fn index(&self, node_id: MastNodeId) -> &Self::Output {
+        &(**self)[node_id]
+    }
+}
+
+impl<T> Index<DecoratorId> for Arc<T>
+where
+    T: Index<DecoratorId, Output = Decorator> + ?Sized,
+{
+    type Output = Decorator;
+
+    #[inline(always)]
+    fn index(&self, decorator_id: DecoratorId) -> &Self::Output {
+        &(**self)[decorator_id]
+    }
+}
+
+impl<T: ExecutableMastForest + ?Sized> ExecutableMastForest for Arc<T> {
+    #[inline(always)]
+    fn get_node_by_id(&self, node_id: MastNodeId) -> Option<&MastNode> {
+        T::get_node_by_id(self, node_id)
+    }
+
+    #[inline(always)]
+    fn get_digest_by_id(&self, node_id: MastNodeId) -> Option<Word> {
+        T::get_digest_by_id(self, node_id)
+    }
+
+    #[inline(always)]
+    fn find_procedure_root(&self, digest: Word) -> Option<MastNodeId> {
+        T::find_procedure_root(self, digest)
+    }
+
+    #[inline(always)]
+    fn decorator_by_id(&self, decorator_id: DecoratorId) -> Option<&Decorator> {
+        T::decorator_by_id(self, decorator_id)
+    }
+
+    #[inline(always)]
+    fn advice_map(&self) -> &AdviceMap {
+        T::advice_map(self)
+    }
+
+    #[inline(always)]
+    fn linked_before_enter_decorators(&self, node_id: MastNodeId) -> &[DecoratorId] {
+        T::linked_before_enter_decorators(self, node_id)
+    }
+
+    #[inline(always)]
+    fn linked_after_exit_decorators(&self, node_id: MastNodeId) -> &[DecoratorId] {
+        T::linked_after_exit_decorators(self, node_id)
+    }
+
+    #[inline(always)]
+    fn decorator_indices_for_op(&self, node_id: MastNodeId, local_op_idx: usize) -> &[DecoratorId] {
+        T::decorator_indices_for_op(self, node_id, local_op_idx)
+    }
+
+    #[inline(always)]
+    fn get_assembly_op(
+        &self,
+        node_id: MastNodeId,
+        target_op_idx: Option<usize>,
+    ) -> Option<&AssemblyOp> {
+        T::get_assembly_op(self, node_id, target_op_idx)
+    }
+
+    #[inline(always)]
+    fn resolve_error_message(&self, code: Felt) -> Option<Arc<str>> {
+        T::resolve_error_message(self, code)
     }
 }
 

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -6,8 +6,8 @@ use crate::{
     chiplets::hasher,
     crypto::hash::Blake3_256,
     mast::{
-        DecoratedLinksIter, DecoratedOpLink, DecoratorId, DecoratorStore, MastForest,
-        MastForestError, MastNode, MastNodeFingerprint, MastNodeId,
+        DecoratedLinksIter, DecoratedOpLink, DecoratorId, DecoratorStore, ExecutableMastForest,
+        MastForest, MastForestError, MastNode, MastNodeFingerprint, MastNodeId,
     },
     operations::{DecoratorList, Operation},
     prettier::PrettyPrint,
@@ -730,26 +730,32 @@ impl MastNodeExt for BasicBlockNode {
         self.digest
     }
 
-    fn before_enter<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         match &self.decorators {
             DecoratorStore::Owned { before_enter, .. } => before_enter,
             DecoratorStore::Linked { id } => {
                 // For linked nodes, get the decorators from the forest's NodeToDecoratorIds
                 #[cfg(debug_assertions)]
                 self.verify_node_in_forest(forest);
-                forest.before_enter_decorators(*id)
+                forest.linked_before_enter_decorators(*id)
             },
         }
     }
 
-    fn after_exit<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         match &self.decorators {
             DecoratorStore::Owned { after_exit, .. } => after_exit,
             DecoratorStore::Linked { id } => {
                 // For linked nodes, get the decorators from the forest's NodeToDecoratorIds
                 #[cfg(debug_assertions)]
                 self.verify_node_in_forest(forest);
-                forest.after_exit_decorators(*id)
+                forest.linked_after_exit_decorators(*id)
             },
         }
     }
@@ -812,11 +818,15 @@ impl MastNodeExt for BasicBlockNode {
     }
 
     #[cfg(debug_assertions)]
-    fn verify_node_in_forest(&self, forest: &MastForest) {
+    fn verify_node_in_forest<F>(&self, forest: &F)
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         if let DecoratorStore::Linked { id } = &self.decorators {
             // Verify that this node is the one stored at the given ID in the forest
             let self_ptr = self as *const Self;
-            let forest_node = &forest.nodes[*id];
+            let forest_node =
+                forest.get_node_by_id(*id).expect("linked node id must be present in forest");
             let forest_node_ptr = match forest_node {
                 MastNode::Block(block_node) => block_node as *const BasicBlockNode as *const (),
                 _ => panic!("Node type mismatch at {id:?}"),

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -15,7 +15,8 @@ use crate::{
     Felt, Word,
     chiplets::hasher,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
+        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        MastNodeFingerprint, MastNodeId,
     },
     operations::opcodes,
     utils::{Idx, LookupByIdx},
@@ -199,14 +200,20 @@ impl MastNodeExt for CallNode {
     }
 
     /// Returns the decorators to be executed before this node is executed.
-    fn before_enter<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         #[cfg(debug_assertions)]
         self.verify_node_in_forest(forest);
         self.decorator_store.before_enter(forest)
     }
 
     /// Returns the decorators to be executed after this node is executed.
-    fn after_exit<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         #[cfg(debug_assertions)]
         self.verify_node_in_forest(forest);
         self.decorator_store.after_exit(forest)
@@ -269,11 +276,15 @@ impl MastNodeExt for CallNode {
     }
 
     #[cfg(debug_assertions)]
-    fn verify_node_in_forest(&self, forest: &MastForest) {
+    fn verify_node_in_forest<F>(&self, forest: &F)
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         if let Some(id) = self.decorator_store.linked_id() {
             // Verify that this node is the one stored at the given ID in the forest
             let self_ptr = self as *const Self;
-            let forest_node = &forest.nodes[id];
+            let forest_node =
+                forest.get_node_by_id(id).expect("linked node id must be present in forest");
             let forest_node_ptr = match forest_node {
                 MastNode::Call(call_node) => call_node as *const CallNode as *const (),
                 _ => panic!("Node type mismatch at {id:?}"),

--- a/core/src/mast/node/decorator_store.rs
+++ b/core/src/mast/node/decorator_store.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    mast::{DecoratorId, MastNodeId},
+    mast::{DecoratorId, ExecutableMastForest, MastNodeId},
     operations::DecoratorList,
 };
 
@@ -53,18 +53,24 @@ impl DecoratorStore {
     }
 
     /// Get the before_enter decorators, borrowing from the forest if linked
-    pub fn before_enter<'a>(&'a self, forest: &'a crate::mast::MastForest) -> &'a [DecoratorId] {
+    pub fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         match self {
             DecoratorStore::Owned { before_enter, .. } => before_enter,
-            DecoratorStore::Linked { id } => forest.before_enter_decorators(*id),
+            DecoratorStore::Linked { id } => forest.linked_before_enter_decorators(*id),
         }
     }
 
     /// Get the after_exit decorators, borrowing from the forest if linked
-    pub fn after_exit<'a>(&'a self, forest: &'a crate::mast::MastForest) -> &'a [DecoratorId] {
+    pub fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         match self {
             DecoratorStore::Owned { after_exit, .. } => after_exit,
-            DecoratorStore::Linked { id } => forest.after_exit_decorators(*id),
+            DecoratorStore::Linked { id } => forest.linked_after_exit_decorators(*id),
         }
     }
 

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -10,7 +10,8 @@ use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
+        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        MastNodeFingerprint, MastNodeId,
     },
     operations::opcodes,
     prettier::{Document, PrettyPrint, const_text, nl},
@@ -177,14 +178,20 @@ impl MastNodeExt for DynNode {
     }
 
     /// Returns the decorators to be executed before this node is executed.
-    fn before_enter<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         #[cfg(debug_assertions)]
         self.verify_node_in_forest(forest);
         self.decorator_store.before_enter(forest)
     }
 
     /// Returns the decorators to be executed after this node is executed.
-    fn after_exit<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         #[cfg(debug_assertions)]
         self.verify_node_in_forest(forest);
         self.decorator_store.after_exit(forest)
@@ -247,11 +254,15 @@ impl MastNodeExt for DynNode {
     }
 
     #[cfg(debug_assertions)]
-    fn verify_node_in_forest(&self, forest: &MastForest) {
+    fn verify_node_in_forest<F>(&self, forest: &F)
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         if let Some(id) = self.decorator_store.linked_id() {
             // Verify that this node is the one stored at the given ID in the forest
             let self_ptr = self as *const Self;
-            let forest_node = &forest.nodes[id];
+            let forest_node =
+                forest.get_node_by_id(id).expect("linked node id must be present in forest");
             let forest_node_ptr = match forest_node {
                 MastNode::Dyn(dyn_node) => dyn_node as *const DynNode as *const (),
                 _ => panic!("Node type mismatch at {id:?}"),

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -12,7 +12,8 @@ use super::{MastForestContributor, MastNodeExt};
 use crate::{
     Felt, Word,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
+        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        MastNodeFingerprint, MastNodeId,
     },
     utils::LookupByIdx,
 };
@@ -141,12 +142,18 @@ impl MastNodeExt for ExternalNode {
     }
 
     /// Returns the decorators to be executed before this node is executed.
-    fn before_enter<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         self.decorator_store.before_enter(forest)
     }
 
     /// Returns the decorators to be executed after this node is executed.
-    fn after_exit<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         self.decorator_store.after_exit(forest)
     }
 
@@ -199,11 +206,15 @@ impl MastNodeExt for ExternalNode {
     }
 
     #[cfg(debug_assertions)]
-    fn verify_node_in_forest(&self, forest: &MastForest) {
+    fn verify_node_in_forest<F>(&self, forest: &F)
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         if let Some(id) = self.decorator_store.linked_id() {
             // Verify that this node is the one stored at the given ID in the forest
             let self_ptr = self as *const Self;
-            let forest_node = &forest.nodes[id];
+            let forest_node =
+                forest.get_node_by_id(id).expect("linked node id must be present in forest");
             let forest_node_ptr = match forest_node {
                 crate::mast::MastNode::External(external) => {
                     external as *const ExternalNode as *const ()

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -11,7 +11,8 @@ use crate::{
     Felt, Word,
     chiplets::hasher,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
+        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        MastNodeFingerprint, MastNodeId,
     },
     operations::opcodes,
     prettier::PrettyPrint,
@@ -189,14 +190,20 @@ impl MastNodeExt for JoinNode {
     }
 
     /// Returns the decorators to be executed before this node is executed.
-    fn before_enter<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         #[cfg(debug_assertions)]
         self.verify_node_in_forest(forest);
         self.decorator_store.before_enter(forest)
     }
 
     /// Returns the decorators to be executed after this node is executed.
-    fn after_exit<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         #[cfg(debug_assertions)]
         self.verify_node_in_forest(forest);
         self.decorator_store.after_exit(forest)
@@ -253,11 +260,15 @@ impl MastNodeExt for JoinNode {
     }
 
     #[cfg(debug_assertions)]
-    fn verify_node_in_forest(&self, forest: &MastForest) {
+    fn verify_node_in_forest<F>(&self, forest: &F)
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         if let Some(id) = self.decorator_store.linked_id() {
             // Verify that this node is the one stored at the given ID in the forest
             let self_ptr = self as *const Self;
-            let forest_node = &forest.nodes[id];
+            let forest_node =
+                forest.get_node_by_id(id).expect("linked node id must be present in forest");
             let forest_node_ptr = match forest_node {
                 MastNode::Join(join_node) => join_node as *const JoinNode as *const (),
                 _ => panic!("Node type mismatch at {id:?}"),

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -11,7 +11,8 @@ use crate::{
     Felt, Word,
     chiplets::hasher,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
+        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        MastNodeFingerprint, MastNodeId,
     },
     operations::opcodes,
     prettier::PrettyPrint,
@@ -140,14 +141,20 @@ impl MastNodeExt for LoopNode {
     }
 
     /// Returns the decorators to be executed before this node is executed.
-    fn before_enter<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         #[cfg(debug_assertions)]
         self.verify_node_in_forest(forest);
         self.decorator_store.before_enter(forest)
     }
 
     /// Returns the decorators to be executed after this node is executed.
-    fn after_exit<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         #[cfg(debug_assertions)]
         self.verify_node_in_forest(forest);
         self.decorator_store.after_exit(forest)
@@ -202,11 +209,15 @@ impl MastNodeExt for LoopNode {
     }
 
     #[cfg(debug_assertions)]
-    fn verify_node_in_forest(&self, forest: &MastForest) {
+    fn verify_node_in_forest<F>(&self, forest: &F)
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         if let Some(id) = self.decorator_store.linked_id() {
             // Verify that this node is the one stored at the given ID in the forest
             let self_ptr = self as *const Self;
-            let forest_node = &forest.nodes[id];
+            let forest_node =
+                forest.get_node_by_id(id).expect("linked node id must be present in forest");
             let forest_node_ptr = match forest_node {
                 MastNode::Loop(loop_node) => loop_node as *const LoopNode as *const (),
                 _ => panic!("Node type mismatch at {id:?}"),

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -39,17 +39,21 @@ mod decorator_store;
 pub use decorator_store::DecoratorStore;
 
 use super::DecoratorId;
-use crate::mast::{MastForest, MastNodeId};
+use crate::mast::{ExecutableMastForest, MastForest, MastNodeId};
 
 pub trait MastNodeExt {
     /// Returns a commitment/hash of the node.
     fn digest(&self) -> Word;
 
     /// Returns the decorators to be executed before this node is executed.
-    fn before_enter<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId];
+    fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized;
 
     /// Returns the decorators to be executed after this node is executed.
-    fn after_exit<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId];
+    fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized;
 
     /// Returns a display formatter for this node.
     fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a>;
@@ -73,7 +77,9 @@ pub trait MastNodeExt {
 
     /// Verifies that this node is stored at the ID in its decorators field in the forest.
     #[cfg(debug_assertions)]
-    fn verify_node_in_forest(&self, forest: &MastForest);
+    fn verify_node_in_forest<F>(&self, forest: &F)
+    where
+        F: ExecutableMastForest + ?Sized;
 
     /// Converts this node into its corresponding builder, reusing allocated data where possible.
     type Builder: MastForestContributor;

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -11,7 +11,8 @@ use crate::{
     Felt, Word,
     chiplets::hasher,
     mast::{
-        DecoratorId, DecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId,
+        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        MastNodeFingerprint, MastNodeId,
     },
     operations::opcodes,
     prettier::PrettyPrint,
@@ -149,14 +150,20 @@ impl MastNodeExt for SplitNode {
     }
 
     /// Returns the decorators to be executed before this node is executed.
-    fn before_enter<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         #[cfg(debug_assertions)]
         self.verify_node_in_forest(forest);
         self.decorator_store.before_enter(forest)
     }
 
     /// Returns the decorators to be executed after this node is executed.
-    fn after_exit<'a>(&'a self, forest: &'a MastForest) -> &'a [DecoratorId] {
+    fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         #[cfg(debug_assertions)]
         self.verify_node_in_forest(forest);
         self.decorator_store.after_exit(forest)
@@ -213,11 +220,15 @@ impl MastNodeExt for SplitNode {
     }
 
     #[cfg(debug_assertions)]
-    fn verify_node_in_forest(&self, forest: &MastForest) {
+    fn verify_node_in_forest<F>(&self, forest: &F)
+    where
+        F: ExecutableMastForest + ?Sized,
+    {
         if let Some(id) = self.decorator_store.linked_id() {
             // Verify that this node is the one stored at the given ID in the forest
             let self_ptr = self as *const Self;
-            let forest_node = &forest.nodes[id];
+            let forest_node =
+                forest.get_node_by_id(id).expect("linked node id must be present in forest");
             let forest_node_ptr = match forest_node {
                 MastNode::Split(split_node) => split_node as *const SplitNode as *const (),
                 _ => panic!("Node type mismatch at {id:?}"),

--- a/core/src/mast/sparse.rs
+++ b/core/src/mast/sparse.rs
@@ -1,0 +1,312 @@
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    vec::Vec,
+};
+use core::ops::Index;
+
+use miden_utils_indexing::newtype_id;
+
+use crate::{
+    Felt, Word,
+    advice::AdviceMap,
+    mast::{
+        DebugInfo, Decorator, DecoratorId, ExecutableMastForest, MastForest, MastNode, MastNodeExt,
+        MastNodeId,
+    },
+    operations::AssemblyOp,
+};
+
+// MAST FOREST ID
+// ================================================================================================
+
+// `MastForestId` is an opaque handle to a [`MastForest`] in some forest store such as the
+// `TraceGenerationContext::mast_forest_store`. It is not a content-derived or stable identity for a
+// forest, and must not be compared or reused across stores or trace contexts. It is analogous to
+// `MastNodeId`, which is meaningful only within one forest's node store.
+newtype_id!(MastForestId);
+
+// SPARSE MAST FOREST
+// ================================================================================================
+
+/// A sparse replay view over a single source [`MastForest`]'s [`MastNodeId`] space, retaining only
+/// the nodes visited during execution.
+///
+/// Unlike [`MastForest`], which stores nodes contiguously in an `IndexVec`, a [`SparseMastForest`]
+/// uses a `BTreeMap` so that it can preserve the original [`MastNodeId`]s of the source forest
+/// while omitting nodes that were not visited. A [`SparseMastForest`] is not an independent forest
+/// shape: it shares its source forest's ID space, and is intended to back re-execution of the same
+/// program. Lookups by the original [`MastNodeId`] continue to resolve to the correct
+/// [`MastNode`]s.
+///
+/// In addition to the visited nodes, a [`SparseMastForest`] may also carry digest-only entries for
+/// nodes that were referenced during execution but never actually entered (e.g. the not-taken
+/// branch of a split, or the children of a join that only need to contribute their digests to the
+/// parent's trace row). These entries let trace generation read the digest without having to copy
+/// the full child node, and they make accidental entry into a pruned node a clean
+/// `get_node_by_id` miss rather than a partially-populated node.
+#[derive(Debug)]
+pub struct SparseMastForest {
+    /// Subset of the original forest's nodes, keyed by their original [`MastNodeId`].
+    nodes: BTreeMap<MastNodeId, MastNode>,
+
+    /// Digests of nodes that were referenced (but not entered) during execution, keyed by their
+    /// original [`MastNodeId`]. Nodes present in [`Self::nodes`] are excluded from this map: a
+    /// full-node entry implicitly carries its own digest via [`MastNodeExt::digest`].
+    digests: BTreeMap<MastNodeId, Word>,
+
+    /// Total number of nodes in the source [`MastForest`] from which this sparse forest was
+    /// built. Note that this is *not* `nodes.len()` — it is the upper bound on the original
+    /// [`MastNodeId`] space, preserved so that callers materializing dense-shaped state (e.g.
+    /// allocating an `IndexVec` keyed by [`MastNodeId`]) know its required size.
+    num_nodes: usize,
+
+    /// Roots of procedures defined within the original MAST forest.
+    roots: Vec<MastNodeId>,
+
+    /// Advice map to be loaded into the VM prior to executing procedures from this MAST forest.
+    advice_map: AdviceMap,
+
+    /// Debug information including decorators and error codes.
+    debug_info: DebugInfo,
+
+    /// Cached commitment to the original MAST forest (i.e. a commitment to all roots).
+    commitment_cache: Word,
+}
+
+impl SparseMastForest {
+    /// Returns the underlying nodes of this sparse forest, keyed by their original
+    /// [`MastNodeId`].
+    pub fn nodes(&self) -> &BTreeMap<MastNodeId, MastNode> {
+        &self.nodes
+    }
+
+    /// Returns the total number of nodes in the source [`MastForest`] from which this sparse
+    /// forest was built. This is *not* the number of visited (i.e. present) nodes — see
+    /// [`Self::nodes`] for that.
+    pub fn num_nodes(&self) -> usize {
+        self.num_nodes
+    }
+
+    /// Returns the roots of procedures defined within this sparse forest.
+    pub fn procedure_roots(&self) -> &[MastNodeId] {
+        &self.roots
+    }
+
+    /// Returns the advice map associated with this sparse forest.
+    pub fn advice_map(&self) -> &AdviceMap {
+        &self.advice_map
+    }
+
+    /// Returns the debug info associated with this sparse forest.
+    pub fn debug_info(&self) -> &DebugInfo {
+        &self.debug_info
+    }
+
+    /// Returns the commitment to this sparse forest, computed from the procedure roots.
+    ///
+    /// The commitment value is derived from the digests of the procedure roots in the original
+    /// forest; it is therefore equal to the commitment of the source [`MastForest`] from which
+    /// this sparse forest was built.
+    pub fn commitment(&self) -> Word {
+        self.commitment_cache
+    }
+}
+
+impl ExecutableMastForest for SparseMastForest {
+    #[inline(always)]
+    fn get_node_by_id(&self, node_id: MastNodeId) -> Option<&MastNode> {
+        self.nodes.get(&node_id)
+    }
+
+    #[inline(always)]
+    fn get_digest_by_id(&self, node_id: MastNodeId) -> Option<Word> {
+        if let Some(node) = self.nodes.get(&node_id) {
+            return Some(node.digest());
+        }
+        self.digests.get(&node_id).copied()
+    }
+
+    #[inline(always)]
+    fn find_procedure_root(&self, digest: Word) -> Option<MastNodeId> {
+        // The `roots` list is copied wholesale from the source forest and may include roots that
+        // were never visited (and thus aren't present in `nodes`). Skip those gracefully rather
+        // than panicking via the `Index` impl.
+        self.roots.iter().find_map(|&root_id| {
+            let node = self.nodes.get(&root_id)?;
+            (node.digest() == digest).then_some(root_id)
+        })
+    }
+
+    #[inline(always)]
+    fn decorator_by_id(&self, decorator_id: DecoratorId) -> Option<&Decorator> {
+        self.debug_info.decorator(decorator_id)
+    }
+
+    #[inline(always)]
+    fn advice_map(&self) -> &AdviceMap {
+        &self.advice_map
+    }
+
+    #[inline(always)]
+    fn linked_before_enter_decorators(&self, node_id: MastNodeId) -> &[DecoratorId] {
+        self.debug_info.before_enter_decorators(node_id)
+    }
+
+    #[inline(always)]
+    fn linked_after_exit_decorators(&self, node_id: MastNodeId) -> &[DecoratorId] {
+        self.debug_info.after_exit_decorators(node_id)
+    }
+
+    #[inline(always)]
+    fn decorator_indices_for_op(&self, node_id: MastNodeId, local_op_idx: usize) -> &[DecoratorId] {
+        self.debug_info.decorators_for_operation(node_id, local_op_idx)
+    }
+
+    #[inline(always)]
+    fn get_assembly_op(
+        &self,
+        node_id: MastNodeId,
+        target_op_idx: Option<usize>,
+    ) -> Option<&AssemblyOp> {
+        match target_op_idx {
+            Some(op_idx) => self.debug_info.asm_op_for_operation(node_id, op_idx),
+            None => self.debug_info.first_asm_op_for_node(node_id),
+        }
+    }
+
+    #[inline(always)]
+    fn resolve_error_message(&self, code: Felt) -> Option<Arc<str>> {
+        self.debug_info.error_message(code.as_canonical_u64())
+    }
+}
+
+impl Index<DecoratorId> for SparseMastForest {
+    type Output = Decorator;
+
+    #[inline(always)]
+    fn index(&self, decorator_id: DecoratorId) -> &Self::Output {
+        self.debug_info
+            .decorator(decorator_id)
+            .expect("DecoratorId out of bounds in sparse forest")
+    }
+}
+
+// SPARSE MAST FOREST BUILDER
+// ================================================================================================
+
+/// Describes how a node referenced during execution should be represented in the resulting
+/// [`SparseMastForest`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VisitKind {
+    /// The node was actually entered (or otherwise needs to be available in full at replay time).
+    /// The full [`MastNode`] is copied into [`SparseMastForest::nodes`].
+    FullVisit,
+    /// Only the node's digest is required at replay time (e.g. a child of a control-flow node
+    /// whose digest contributes to the parent's trace row, but which is itself never entered).
+    /// The digest is copied into the digest-only map; the full node is omitted.
+    DigestOnly,
+}
+
+/// Incrementally builds a [`SparseMastForest`] by collecting the [`MastNodeId`]s of nodes visited
+/// during execution of a single source [`MastForest`].
+///
+/// The builder retains a strong reference to the source forest so that it can copy out the visited
+/// nodes (and the source's roots, advice map, and debug info) at finalization time.
+///
+/// Each recorded id carries a [`VisitKind`] that controls whether the full node is copied or only
+/// its digest. If the same id is recorded as both a [`VisitKind::FullVisit`] and a
+/// [`VisitKind::DigestOnly`], the full-visit representation wins (the digest is recoverable from
+/// the full node).
+#[derive(Debug)]
+pub struct SparseMastForestBuilder {
+    /// The source forest whose nodes are being collected.
+    source: Arc<MastForest>,
+
+    /// Total number of nodes in the source forest, captured at construction time. Propagated to
+    /// the finalized [`SparseMastForest`] so consumers know the original [`MastNodeId`] space.
+    num_nodes: usize,
+
+    /// IDs of nodes that were entered during execution. Their full [`MastNode`] is copied into the
+    /// finalized forest's `nodes` map.
+    full_visits: BTreeSet<MastNodeId>,
+
+    /// IDs of nodes that were only referenced (not entered) during execution. At finalization,
+    /// any id that also appears in [`Self::full_visits`] is excluded; the remainder contributes a
+    /// digest-only entry to the finalized forest.
+    digest_only_visits: BTreeSet<MastNodeId>,
+}
+
+impl SparseMastForestBuilder {
+    /// Creates a new builder for the given source forest.
+    pub fn new(source: Arc<MastForest>) -> Self {
+        let num_nodes = source.nodes().len();
+        Self {
+            source,
+            num_nodes,
+            full_visits: BTreeSet::new(),
+            digest_only_visits: BTreeSet::new(),
+        }
+    }
+
+    /// Records a visit to the node with the provided id. Idempotent.
+    ///
+    /// If the same id is recorded both as [`VisitKind::FullVisit`] and as
+    /// [`VisitKind::DigestOnly`], the full-visit representation wins.
+    pub fn record_visit(&mut self, node_id: MastNodeId, kind: VisitKind) {
+        match kind {
+            VisitKind::FullVisit => {
+                self.full_visits.insert(node_id);
+            },
+            VisitKind::DigestOnly => {
+                self.digest_only_visits.insert(node_id);
+            },
+        }
+    }
+
+    /// Returns a strong reference to the source forest backing this builder.
+    pub fn source(&self) -> &Arc<MastForest> {
+        &self.source
+    }
+
+    /// Consumes the builder and produces a [`SparseMastForest`] containing only the visited nodes
+    /// from the source forest. The roots, advice map, and debug info are cloned from the source
+    /// in full (they are not yet trimmed to visited nodes only).
+    pub fn finalize(self) -> SparseMastForest {
+        let SparseMastForestBuilder {
+            source,
+            num_nodes,
+            full_visits,
+            digest_only_visits,
+        } = self;
+
+        let mut nodes = BTreeMap::new();
+        for node_id in &full_visits {
+            let node = source
+                .get_node_by_id(*node_id)
+                .expect("recorded full-visit id must exist in source forest");
+            nodes.insert(*node_id, node.clone());
+        }
+
+        let mut digests = BTreeMap::new();
+        for node_id in digest_only_visits {
+            if full_visits.contains(&node_id) {
+                continue;
+            }
+            let node = source
+                .get_node_by_id(node_id)
+                .expect("recorded digest-only id must exist in source forest");
+            digests.insert(node_id, node.digest());
+        }
+
+        SparseMastForest {
+            nodes,
+            digests,
+            num_nodes,
+            roots: source.procedure_roots().to_vec(),
+            advice_map: source.advice_map().clone(),
+            debug_info: source.debug_info().clone(),
+            commitment_cache: source.commitment(),
+        }
+    }
+}

--- a/crates/utils-core-derive/src/lib.rs
+++ b/crates/utils-core-derive/src/lib.rs
@@ -137,14 +137,20 @@ fn generate_method_impl_for_trait_method(
             }
         },
         "before_enter" => quote! {
-            fn before_enter<'a>(&'a self, forest: &'a crate::mast::MastForest) -> &'a [crate::mast::DecoratorId] {
+            fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [crate::mast::DecoratorId]
+            where
+                F: crate::mast::ExecutableMastForest + ?Sized,
+            {
                 match self {
                     #(#enum_name::#variant_names(field) => field.before_enter(forest)),*
                 }
             }
         },
         "after_exit" => quote! {
-            fn after_exit<'a>(&'a self, forest: &'a crate::mast::MastForest) -> &'a [crate::mast::DecoratorId] {
+            fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [crate::mast::DecoratorId]
+            where
+                F: crate::mast::ExecutableMastForest + ?Sized,
+            {
                 match self {
                     #(#enum_name::#variant_names(field) => field.after_exit(forest)),*
                 }
@@ -194,7 +200,10 @@ fn generate_method_impl_for_trait_method(
         },
         "verify_node_in_forest" => quote! {
             #[cfg(debug_assertions)]
-            fn verify_node_in_forest(&self, forest: &crate::mast::MastForest) {
+            fn verify_node_in_forest<F>(&self, forest: &F)
+            where
+                F: crate::mast::ExecutableMastForest + ?Sized,
+            {
                 match self {
                     #(#enum_name::#variant_names(field) => field.verify_node_in_forest(forest)),*
                 }

--- a/processor/src/continuation_stack.rs
+++ b/processor/src/continuation_stack.rs
@@ -1,9 +1,6 @@
-use alloc::{sync::Arc, vec::Vec};
+use alloc::vec::Vec;
 
-use miden_core::{
-    mast::{MastForest, MastNodeId},
-    program::Program,
-};
+use miden_core::{mast::MastNodeId, program::Program};
 
 /// A hint for the initial size of the continuation stack.
 const CONTINUATION_STACK_SIZE_HINT: usize = 64;
@@ -15,8 +12,13 @@ const CONTINUATION_STACK_SIZE_HINT: usize = 64;
 ///
 /// This enum defines the different types of continuations that can be performed on MAST nodes
 /// during program execution.
+///
+/// The type parameter `F` is the representation of a MAST forest carried by the
+/// [`Continuation::EnterForest`] variant. For live execution this is `Arc<MastForest>`; for the
+/// snapshotted continuation stack inside a trace fragment it is a `usize` index into the
+/// `mast_forest_store` of the trace generation context.
 #[derive(Debug, Clone)]
-pub enum Continuation {
+pub enum Continuation<F> {
     /// Start processing a node in the MAST forest.
     StartNode(MastNodeId),
     /// Process the finish phase of a Join node.
@@ -53,12 +55,12 @@ pub enum Continuation {
     ///
     /// When we encounter an `ExternalNode`, we enter the corresponding MAST forest directly, and
     /// push an `EnterForest` continuation to restore the previous forest when done.
-    EnterForest(Arc<MastForest>),
+    EnterForest(F),
     /// Process the `after_exit` decorators of the given node.
     AfterExitDecorators(MastNodeId),
 }
 
-impl Continuation {
+impl<F> Continuation<F> {
     /// Returns true if executing this continuation increments the processor clock, and false
     /// otherwise.
     pub fn increments_clk(&self) -> bool {
@@ -96,12 +98,18 @@ impl Continuation {
 /// This allows the processor to execute a program iteratively in a loop rather than recursively
 /// traversing the nodes. It also allows the processor to pass the state of execution to another
 /// processor for further processing, which is useful for parallel execution of MAST forests.
-#[derive(Debug, Default, Clone)]
-pub struct ContinuationStack {
-    stack: Vec<Continuation>,
+#[derive(Debug, Clone)]
+pub struct ContinuationStack<F> {
+    stack: Vec<Continuation<F>>,
 }
 
-impl ContinuationStack {
+impl<F> Default for ContinuationStack<F> {
+    fn default() -> Self {
+        Self { stack: Vec::new() }
+    }
+}
+
+impl<F> ContinuationStack<F> {
     /// Creates a new continuation stack for a program.
     ///
     /// # Arguments
@@ -117,7 +125,7 @@ impl ContinuationStack {
     // --------------------------------------------------------------------------------------------
 
     /// Pushes a continuation onto the continuation stack.
-    pub fn push_continuation(&mut self, continuation: Continuation) {
+    pub fn push_continuation(&mut self, continuation: Continuation<F>) {
         self.stack.push(continuation);
     }
 
@@ -125,7 +133,7 @@ impl ContinuationStack {
     ///
     /// # Arguments
     /// * `forest` - The MAST forest to enter
-    pub fn push_enter_forest(&mut self, forest: Arc<MastForest>) {
+    pub fn push_enter_forest(&mut self, forest: F) {
         self.stack.push(Continuation::EnterForest(forest));
     }
 
@@ -169,8 +177,14 @@ impl ContinuationStack {
 
     /// Pops the next continuation from the continuation stack, and returns it along with its
     /// associated MAST forest.
-    pub fn pop_continuation(&mut self) -> Option<Continuation> {
+    pub fn pop_continuation(&mut self) -> Option<Continuation<F>> {
         self.stack.pop()
+    }
+
+    /// Consumes this stack and returns its continuations in bottom-to-top order (i.e. the order in
+    /// which they were originally pushed).
+    pub fn into_inner(self) -> Vec<Continuation<F>> {
+        self.stack
     }
 
     // PUBLIC ACCESSORS
@@ -186,7 +200,7 @@ impl ContinuationStack {
     /// Note that more than one continuation may execute in the same clock cycle. To get all
     /// continuations that will execute in the next clock cycle, use
     /// [`Self::iter_continuations_for_next_clock`].
-    pub fn peek_continuation(&self) -> Option<&Continuation> {
+    pub fn peek_continuation(&self) -> Option<&Continuation<F>> {
         self.stack.last()
     }
 
@@ -201,7 +215,7 @@ impl ContinuationStack {
     /// stack. This is currently the case, and is a reasonable invariant to maintain, as
     /// continuations that don't increment the clock can be expected to be simple (e.g. run some
     /// decorators, or enter a new mast forest).
-    pub fn iter_continuations_for_next_clock(&self) -> impl Iterator<Item = &Continuation> {
+    pub fn iter_continuations_for_next_clock(&self) -> impl Iterator<Item = &Continuation<F>> {
         let mut found_incrementing_cont = false;
 
         self.stack.iter().rev().take_while(move |continuation| {
@@ -225,17 +239,21 @@ impl ContinuationStack {
 
 #[cfg(test)]
 mod tests {
+    use alloc::sync::Arc;
+
+    use miden_core::mast::MastForest;
+
     use super::*;
 
     #[test]
     fn get_next_clock_cycle_increment_empty_stack() {
-        let stack = ContinuationStack::default();
+        let stack: ContinuationStack<Arc<MastForest>> = ContinuationStack::default();
         assert!(stack.iter_continuations_for_next_clock().next().is_none());
     }
 
     #[test]
     fn get_next_clock_cycle_increment_ends_with_incrementing() {
-        let mut stack = ContinuationStack::default();
+        let mut stack: ContinuationStack<Arc<MastForest>> = ContinuationStack::default();
         // Push a continuation that increments the clock
         stack.push_continuation(Continuation::StartNode(MastNodeId::new_unchecked(0)));
 
@@ -246,7 +264,7 @@ mod tests {
 
     #[test]
     fn get_next_clock_cycle_increment_non_incrementing_after_incrementing() {
-        let mut stack = ContinuationStack::default();
+        let mut stack: ContinuationStack<Arc<MastForest>> = ContinuationStack::default();
         // Push an incrementing continuation first (bottom of stack)
         stack.push_continuation(Continuation::StartNode(MastNodeId::new_unchecked(0)));
         // Push a non-incrementing continuation on top
@@ -262,7 +280,7 @@ mod tests {
 
     #[test]
     fn get_next_clock_cycle_increment_two_non_incrementing_after_incrementing() {
-        let mut stack = ContinuationStack::default();
+        let mut stack: ContinuationStack<Arc<MastForest>> = ContinuationStack::default();
         // Push an incrementing continuation first (bottom of stack)
         stack.push_continuation(Continuation::StartNode(MastNodeId::new_unchecked(0)));
         // Push two non-incrementing continuations on top

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -12,7 +12,7 @@ use crate::{
     advice::AdviceError,
     event::{EventError, EventId, EventName},
     fast::SystemEventError,
-    mast::{MastForest, MastNodeId},
+    mast::{ExecutableMastForest, MastNodeId},
     utils::to_hex,
 };
 
@@ -371,12 +371,15 @@ impl OperationError {
     ///
     /// This is useful when working with `ControlFlow` or other non-`Result` return types
     /// where the `OperationResultExt::map_exec_err` extension trait cannot be used directly.
-    pub fn with_context(
+    pub fn with_context<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
-    ) -> ExecutionError {
+    ) -> ExecutionError
+    where
+        F: ExecutableMastForest,
+    {
         let (label, source_file) = get_label_and_source_file(None, mast_forest, node_id, host);
         ExecutionError::OperationError { label, source_file, err: self }
     }
@@ -402,12 +405,15 @@ pub struct MerklePathVerificationFailedInner {
 /// This function is called by the extension traits to compute source location
 /// only when an error occurs. Since errors are rare, the cost of decorator
 /// traversal is acceptable.
-fn get_label_and_source_file(
+fn get_label_and_source_file<F>(
     op_idx: Option<usize>,
-    mast_forest: &MastForest,
+    mast_forest: &F,
     node_id: MastNodeId,
     host: &impl BaseHost,
-) -> (SourceSpan, Option<Arc<SourceFile>>) {
+) -> (SourceSpan, Option<Arc<SourceFile>>)
+where
+    F: ExecutableMastForest,
+{
     mast_forest
         .get_assembly_op(node_id, op_idx)
         .and_then(|assembly_op| assembly_op.location())
@@ -421,13 +427,16 @@ fn get_label_and_source_file(
 ///
 /// This is useful when working with `ControlFlow` or other non-`Result` return types
 /// where the extension traits cannot be used directly.
-pub fn advice_error_with_context(
+pub fn advice_error_with_context<F>(
     err: AdviceError,
-    mast_forest: &MastForest,
+    mast_forest: &F,
     node_id: MastNodeId,
     host: &impl BaseHost,
     op_idx: Option<usize>,
-) -> ExecutionError {
+) -> ExecutionError
+where
+    F: ExecutableMastForest,
+{
     let (label, source_file) = get_label_and_source_file(op_idx, mast_forest, node_id, host);
     ExecutionError::AdviceError { label, source_file, err }
 }
@@ -436,15 +445,18 @@ pub fn advice_error_with_context(
 ///
 /// This is useful when working with `ControlFlow` or other non-`Result` return types
 /// where an extension trait on `Result` cannot be used directly.
-pub fn event_error_with_context(
+pub fn event_error_with_context<F>(
     error: EventError,
-    mast_forest: &MastForest,
+    mast_forest: &F,
     node_id: MastNodeId,
     host: &impl BaseHost,
     op_idx: Option<usize>,
     event_id: EventId,
     event_name: Option<EventName>,
-) -> ExecutionError {
+) -> ExecutionError
+where
+    F: ExecutableMastForest,
+{
     let (label, source_file) = get_label_and_source_file(op_idx, mast_forest, node_id, host);
     ExecutionError::EventError {
         label,
@@ -456,12 +468,15 @@ pub fn event_error_with_context(
 }
 
 /// Creates a `ProcedureNotFound` error with execution context.
-pub fn procedure_not_found_with_context(
+pub fn procedure_not_found_with_context<F>(
     root_digest: Word,
-    mast_forest: &MastForest,
+    mast_forest: &F,
     node_id: MastNodeId,
     host: &impl BaseHost,
-) -> ExecutionError {
+) -> ExecutionError
+where
+    F: ExecutableMastForest,
+{
     let (label, source_file) = get_label_and_source_file(None, mast_forest, node_id, host);
     ExecutionError::ProcedureNotFound { label, source_file, root_digest }
 }
@@ -479,12 +494,14 @@ pub fn procedure_not_found_with_context(
 /// Implement this for error types that can be converted to `ExecutionError` using
 /// just the MAST forest, node ID, and host for source location lookup.
 pub trait MapExecErr<T> {
-    fn map_exec_err(
+    fn map_exec_err<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
-    ) -> Result<T, ExecutionError>;
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest;
 }
 
 /// Extension trait for mapping errors to `ExecutionError` with op index context.
@@ -492,13 +509,15 @@ pub trait MapExecErr<T> {
 /// Implement this for error types that occur within basic blocks where the
 /// operation index is available for more precise source location.
 pub trait MapExecErrWithOpIdx<T> {
-    fn map_exec_err_with_op_idx(
+    fn map_exec_err_with_op_idx<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
         op_idx: usize,
-    ) -> Result<T, ExecutionError>;
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest;
 }
 
 /// Extension trait for mapping errors to `ExecutionError` without context.
@@ -512,12 +531,15 @@ pub trait MapExecErrNoCtx<T> {
 // OperationError implementations
 impl<T> MapExecErr<T> for Result<T, OperationError> {
     #[inline(always)]
-    fn map_exec_err(
+    fn map_exec_err<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
-    ) -> Result<T, ExecutionError> {
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest,
+    {
         match self {
             Ok(v) => Ok(v),
             Err(err) => {
@@ -531,13 +553,16 @@ impl<T> MapExecErr<T> for Result<T, OperationError> {
 
 impl<T> MapExecErrWithOpIdx<T> for Result<T, OperationError> {
     #[inline(always)]
-    fn map_exec_err_with_op_idx(
+    fn map_exec_err_with_op_idx<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
         op_idx: usize,
-    ) -> Result<T, ExecutionError> {
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest,
+    {
         match self {
             Ok(v) => Ok(v),
             Err(err) => {
@@ -566,12 +591,15 @@ impl<T> MapExecErrNoCtx<T> for Result<T, OperationError> {
 // AdviceError implementations
 impl<T> MapExecErr<T> for Result<T, AdviceError> {
     #[inline(always)]
-    fn map_exec_err(
+    fn map_exec_err<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
-    ) -> Result<T, ExecutionError> {
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest,
+    {
         match self {
             Ok(v) => Ok(v),
             Err(err) => Err(advice_error_with_context(err, mast_forest, node_id, host, None)),
@@ -596,12 +624,15 @@ impl<T> MapExecErrNoCtx<T> for Result<T, AdviceError> {
 // MemoryError implementations
 impl<T> MapExecErr<T> for Result<T, MemoryError> {
     #[inline(always)]
-    fn map_exec_err(
+    fn map_exec_err<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
-    ) -> Result<T, ExecutionError> {
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest,
+    {
         match self {
             Ok(v) => Ok(v),
             Err(err) => {
@@ -615,13 +646,16 @@ impl<T> MapExecErr<T> for Result<T, MemoryError> {
 
 impl<T> MapExecErrWithOpIdx<T> for Result<T, MemoryError> {
     #[inline(always)]
-    fn map_exec_err_with_op_idx(
+    fn map_exec_err_with_op_idx<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
         op_idx: usize,
-    ) -> Result<T, ExecutionError> {
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest,
+    {
         match self {
             Ok(v) => Ok(v),
             Err(err) => {
@@ -636,12 +670,15 @@ impl<T> MapExecErrWithOpIdx<T> for Result<T, MemoryError> {
 // SystemEventError implementations
 impl<T> MapExecErr<T> for Result<T, SystemEventError> {
     #[inline(always)]
-    fn map_exec_err(
+    fn map_exec_err<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
-    ) -> Result<T, ExecutionError> {
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest,
+    {
         match self {
             Ok(v) => Ok(v),
             Err(err) => {
@@ -665,13 +702,16 @@ impl<T> MapExecErr<T> for Result<T, SystemEventError> {
 
 impl<T> MapExecErrWithOpIdx<T> for Result<T, SystemEventError> {
     #[inline(always)]
-    fn map_exec_err_with_op_idx(
+    fn map_exec_err_with_op_idx<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
         op_idx: usize,
-    ) -> Result<T, ExecutionError> {
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest,
+    {
         match self {
             Ok(v) => Ok(v),
             Err(err) => {
@@ -696,13 +736,16 @@ impl<T> MapExecErrWithOpIdx<T> for Result<T, SystemEventError> {
 // IoError implementations
 impl<T> MapExecErrWithOpIdx<T> for Result<T, IoError> {
     #[inline(always)]
-    fn map_exec_err_with_op_idx(
+    fn map_exec_err_with_op_idx<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
         op_idx: usize,
-    ) -> Result<T, ExecutionError> {
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest,
+    {
         match self {
             Ok(v) => Ok(v),
             Err(err) => {
@@ -725,13 +768,16 @@ impl<T> MapExecErrWithOpIdx<T> for Result<T, IoError> {
 // CryptoError implementations
 impl<T> MapExecErrWithOpIdx<T> for Result<T, CryptoError> {
     #[inline(always)]
-    fn map_exec_err_with_op_idx(
+    fn map_exec_err_with_op_idx<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
         op_idx: usize,
-    ) -> Result<T, ExecutionError> {
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest,
+    {
         match self {
             Ok(v) => Ok(v),
             Err(err) => {
@@ -753,13 +799,16 @@ impl<T> MapExecErrWithOpIdx<T> for Result<T, CryptoError> {
 // AceEvalError implementations
 impl<T> MapExecErrWithOpIdx<T> for Result<T, AceEvalError> {
     #[inline(always)]
-    fn map_exec_err_with_op_idx(
+    fn map_exec_err_with_op_idx<F>(
         self,
-        mast_forest: &MastForest,
+        mast_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
         op_idx: usize,
-    ) -> Result<T, ExecutionError> {
+    ) -> Result<T, ExecutionError>
+    where
+        F: ExecutableMastForest,
+    {
         match self {
             Ok(v) => Ok(v),
             Err(err) => {

--- a/processor/src/execution/basic_block.rs
+++ b/processor/src/execution/basic_block.rs
@@ -1,4 +1,3 @@
-use alloc::sync::Arc;
 use core::ops::ControlFlow;
 
 use crate::{
@@ -8,7 +7,7 @@ use crate::{
         ExecutionState, InternalBreakReason, execute_op, finalize_clock_cycle_with_continuation,
         finalize_clock_cycle_with_continuation_and_op_helpers,
     },
-    mast::{BasicBlockNode, MastForest, MastNodeId},
+    mast::{BasicBlockNode, ExecutableMastForest, MastNodeId},
     operation::Operation,
     processor::Processor,
     tracer::Tracer,
@@ -19,17 +18,18 @@ use crate::{
 
 /// Execute the given basic block node.
 #[inline(always)]
-pub(super) fn execute_basic_block_node_from_start<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn execute_basic_block_node_from_start<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     basic_block_node: &BasicBlockNode,
     node_id: MastNodeId,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<InternalBreakReason>
+    current_forest: &F,
+) -> ControlFlow<InternalBreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     state.tracer.start_clock_cycle(
         state.processor,
@@ -75,19 +75,20 @@ where
 /// Executes the give basic block node starting from the specified operation index within the
 /// specified batch.
 #[inline(always)]
-pub(super) fn execute_basic_block_node_from_op_idx<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn execute_basic_block_node_from_op_idx<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     basic_block_node: &BasicBlockNode,
     node_id: MastNodeId,
     start_batch_index: usize,
     start_op_idx_in_batch: usize,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<InternalBreakReason>
+    current_forest: &F,
+) -> ControlFlow<InternalBreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     let batch_offset_in_block = basic_block_node
         .op_batches()
@@ -118,18 +119,19 @@ where
 
 /// Executes the give basic block node starting from the RESPAN preceding the specified batch.
 #[inline(always)]
-pub(super) fn execute_basic_block_node_from_batch<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn execute_basic_block_node_from_batch<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     basic_block_node: &BasicBlockNode,
     node_id: MastNodeId,
     start_batch_index: usize,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<InternalBreakReason>
+    current_forest: &F,
+) -> ControlFlow<InternalBreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     let mut batch_offset_in_block = basic_block_node
         .op_batches()
@@ -186,23 +188,22 @@ where
         batch_offset_in_block += op_batch.ops().len();
     }
 
-    finish_basic_block(state, basic_block_node, node_id, current_forest)
-        .map_break(InternalBreakReason::from)
+    finish_basic_block(state, node_id, current_forest).map_break(InternalBreakReason::from)
 }
 
 /// Execute the finish phase of a basic block node.
 #[inline(always)]
-pub(super) fn finish_basic_block<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
-    _basic_block_node: &BasicBlockNode,
+pub(super) fn finish_basic_block<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     node_id: MastNodeId,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     state.tracer.start_clock_cycle(
         state.processor,
@@ -232,19 +233,20 @@ where
 /// Executes a single operation batch within a basic block node, starting from the operation
 /// index `start_op_idx`.
 #[inline(always)]
-fn execute_op_batch<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+fn execute_op_batch<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     basic_block: &BasicBlockNode,
     batch_index: usize,
     start_op_idx: usize,
     batch_offset_in_block: usize,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<InternalBreakReason>
+    current_forest: &F,
+) -> ControlFlow<InternalBreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     let batch = &basic_block.op_batches()[batch_index];
 
@@ -337,12 +339,12 @@ where
 /// That is, `op_idx_in_batch` is the index of the operation that was just executed within the batch
 /// `batch_index` of the basic block `basic_block_node`.
 #[inline(always)]
-fn get_continuation_after_executing_operation(
+fn get_continuation_after_executing_operation<F>(
     basic_block_node: &BasicBlockNode,
     node_id: MastNodeId,
     batch_index: usize,
     op_idx_in_batch: usize,
-) -> Continuation {
+) -> Continuation<F> {
     let last_op_idx_in_batch = basic_block_node.op_batches()[batch_index].ops().len() - 1;
     let last_batch_idx_in_block = basic_block_node.num_op_batches() - 1;
 
@@ -370,18 +372,19 @@ fn get_continuation_after_executing_operation(
 
 /// Function to be called after [`InternalBreakReason::Emit`] is handled. See the documentation of
 /// that enum variant for more details.
-pub fn finish_emit_op_execution<P, S, T>(
-    post_emit_continuation: Continuation,
+pub fn finish_emit_op_execution<P, S, T, F>(
+    post_emit_continuation: Continuation<F>,
     processor: &mut P,
-    continuation_stack: &mut ContinuationStack,
-    current_forest: &Arc<MastForest>,
+    continuation_stack: &mut ContinuationStack<F>,
+    current_forest: &F,
     tracer: &mut T,
     stopper: &S,
-) -> ControlFlow<BreakReason>
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     // When we enter here, the `continuation_stack` top contains the continuation to execute *after*
     // the basic block that contained the `Emit` operation (i.e. after all operations are executed,

--- a/processor/src/execution/call.rs
+++ b/processor/src/execution/call.rs
@@ -1,4 +1,3 @@
-use alloc::sync::Arc;
 use core::ops::ControlFlow;
 
 use miden_core::{FMP_ADDR, FMP_INIT_VALUE};
@@ -10,8 +9,9 @@ use crate::{
         ExecutionState, finalize_clock_cycle, finalize_clock_cycle_with_continuation,
         get_next_ctx_id,
     },
-    mast::{CallNode, MastForest, MastNodeExt, MastNodeId},
+    mast::{CallNode, ExecutableMastForest, MastNodeId},
     operation::OperationError,
+    option_map_break_reason,
     processor::{MemoryInterface, Processor, SystemInterface},
     tracer::Tracer,
 };
@@ -21,17 +21,18 @@ use crate::{
 
 /// Executes a Call node from the start.
 #[inline(always)]
-pub(super) fn start_call_node<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn start_call_node<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     call_node: &CallNode,
     current_node_id: MastNodeId,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     state.tracer.start_clock_cycle(
         state.processor,
@@ -47,7 +48,10 @@ where
 
     state.processor.save_context_and_truncate_stack();
 
-    let callee_hash = current_forest[call_node.callee()].digest();
+    let callee_hash = option_map_break_reason(
+        current_forest.get_digest_by_id(call_node.callee()),
+        "callee node not found in current forest",
+    )?;
     if call_node.is_syscall() {
         // check if the callee is in the kernel
         if !state.kernel.contains_proc(callee_hash) {
@@ -103,16 +107,17 @@ where
 
 /// Executes the finish phase of a Call node.
 #[inline(always)]
-pub(super) fn finish_call_node<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn finish_call_node<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     node_id: MastNodeId,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     state.tracer.start_clock_cycle(
         state.processor,

--- a/processor/src/execution/dyn.rs
+++ b/processor/src/execution/dyn.rs
@@ -1,4 +1,3 @@
-use alloc::sync::Arc;
 use core::ops::ControlFlow;
 
 use miden_core::{FMP_ADDR, FMP_INIT_VALUE};
@@ -10,7 +9,8 @@ use crate::{
         ExecutionState, InternalBreakReason, finalize_clock_cycle,
         finalize_clock_cycle_with_continuation, get_next_ctx_id,
     },
-    mast::{MastForest, MastNodeId},
+    mast::{ExecutableMastForest, MastNodeId},
+    option_map_break_reason,
     processor::{MemoryInterface, Processor, StackInterface, SystemInterface},
     tracer::Tracer,
 };
@@ -20,16 +20,17 @@ use crate::{
 
 /// Executes a Dyn node from the start.
 #[inline(always)]
-pub(super) fn start_dyn_node<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn start_dyn_node<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     current_node_id: MastNodeId,
-    current_forest: &mut Arc<MastForest>,
-) -> ControlFlow<InternalBreakReason>
+    current_forest: &mut F,
+) -> ControlFlow<InternalBreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     state.tracer.start_clock_cycle(
         state.processor,
@@ -44,7 +45,12 @@ where
         .execute_before_enter_decorators(current_node_id, current_forest, state.host)
         .map_break(InternalBreakReason::from)?;
 
-    let dyn_node = current_forest[current_node_id].unwrap_dyn();
+    let dyn_node = option_map_break_reason(
+        current_forest.get_node_by_id(current_node_id),
+        "dyn node not found in current forest",
+    )
+    .map_break(InternalBreakReason::from)?
+    .unwrap_dyn();
 
     // Retrieve callee hash from memory, using stack top as the memory address.
     let read_ctx = state.processor.system().ctx();
@@ -137,25 +143,26 @@ where
 
 /// Function to be called after [`InternalBreakReason::LoadMastForestFromDyn`] is handled. See the
 /// documentation of that enum variant for more details.
-pub fn finish_load_mast_forest_from_dyn_start<P, S, T>(
+pub fn finish_load_mast_forest_from_dyn_start<P, S, T, F>(
     root_id: MastNodeId,
-    new_forest: Arc<MastForest>,
+    new_forest: F,
     processor: &mut P,
-    current_forest: &mut Arc<MastForest>,
-    continuation_stack: &mut ContinuationStack,
+    current_forest: &mut F,
+    continuation_stack: &mut ContinuationStack<F>,
     tracer: &mut T,
     stopper: &S,
-) -> ControlFlow<BreakReason>
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     // Save the old forest: the continuation from start_clock_cycle references nodes in it.
-    let old_forest = Arc::clone(current_forest);
+    let old_forest = current_forest.clone();
 
     // Push current forest to the continuation stack so that we can return to it
-    continuation_stack.push_enter_forest(Arc::clone(current_forest));
+    continuation_stack.push_enter_forest(current_forest.clone());
 
     // Push the root node of the external MAST forest onto the continuation stack.
     continuation_stack.push_start_node(root_id);
@@ -175,16 +182,17 @@ where
 
 /// Executes the finish phase of a Dyn node.
 #[inline(always)]
-pub(super) fn finish_dyn_node<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn finish_dyn_node<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     node_id: MastNodeId,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     state.tracer.start_clock_cycle(
         state.processor,
@@ -193,7 +201,11 @@ where
         current_forest,
     );
 
-    let dyn_node = current_forest[node_id].unwrap_dyn();
+    let dyn_node = option_map_break_reason(
+        current_forest.get_node_by_id(node_id),
+        "dyn node not found in current forest",
+    )?
+    .unwrap_dyn();
     // For dyncall, restore the context.
     if dyn_node.is_dyncall()
         && let Err(e) = state.processor.restore_context()

--- a/processor/src/execution/external.rs
+++ b/processor/src/execution/external.rs
@@ -1,12 +1,12 @@
-use alloc::sync::Arc;
 use core::ops::ControlFlow;
 
 use crate::{
     BaseHost, BreakReason,
     continuation_stack::ContinuationStack,
     execution::InternalBreakReason,
-    mast::{MastForest, MastNodeExt, MastNodeId},
+    mast::{ExecutableMastForest, MastNodeExt, MastNodeId},
     operation::OperationError,
+    option_map_break_reason,
     processor::Processor,
     tracer::Tracer,
 };
@@ -16,22 +16,38 @@ use crate::{
 
 /// Executes an External node.
 #[inline(always)]
-pub(super) fn execute_external_node(
-    processor: &mut impl Processor,
+pub(super) fn execute_external_node<P, T, F>(
+    processor: &mut P,
     external_node_id: MastNodeId,
-    current_forest: &mut Arc<MastForest>,
+    current_forest: &mut F,
     host: &mut impl BaseHost,
-) -> ControlFlow<InternalBreakReason> {
+    tracer: &mut T,
+) -> ControlFlow<InternalBreakReason<F>>
+where
+    P: Processor,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
+{
     // Execute decorators that should be executed before entering the node
     processor
         .execute_before_enter_decorators(external_node_id, current_forest, host)
         .map_break(InternalBreakReason::from)?;
 
+    // External nodes don't drive a clock cycle and so don't reach `Tracer::start_clock_cycle`.
+    // Inform the tracer that we are entering this node so accumulating tracers (e.g. the sparse
+    // forest builder) can mark it as visited.
+    tracer.record_external_node_entered(external_node_id, current_forest);
+
     // This is a sans-IO point: we cannot proceed with loading the MAST forest, since some
     // processors need this to be done asynchronously. Thus, we break here and make the implementing
     // processor handle the loading in the outer execution loop. When done, the processor *must*
     // call `finish_load_mast_forest_from_external()` below for execution to proceed properly.
-    let external_node = current_forest[external_node_id].unwrap_external();
+    let external_node = option_map_break_reason(
+        current_forest.get_node_by_id(external_node_id),
+        "external node not found in current forest",
+    )
+    .map_break(InternalBreakReason::from)?
+    .unwrap_external();
     ControlFlow::Break(InternalBreakReason::LoadMastForestFromExternal {
         external_node_id,
         procedure_hash: external_node.digest(),
@@ -40,39 +56,52 @@ pub(super) fn execute_external_node(
 
 /// Function to be called after [`InternalBreakReason::LoadMastForestFromExternal`] is handled. See
 /// the documentation of that enum variant for more details.
-pub fn finish_load_mast_forest_from_external(
-    resolved_node_id: MastNodeId,
-    new_mast_forest: Arc<MastForest>,
-    external_node_id: MastNodeId,
-    current_forest: &mut Arc<MastForest>,
-    continuation_stack: &mut ContinuationStack,
+pub fn finish_load_mast_forest_from_external<F, T>(
+    resolved_node_id_new_forest: MastNodeId,
+    new_mast_forest: F,
+    external_node_id_old_forest: MastNodeId,
+    current_forest: &mut F,
+    continuation_stack: &mut ContinuationStack<F>,
     host: &mut impl BaseHost,
-    tracer: &mut impl Tracer,
-) -> ControlFlow<BreakReason> {
-    let external_node = current_forest[external_node_id].unwrap_external();
+    tracer: &mut T,
+) -> ControlFlow<BreakReason<F>>
+where
+    F: ExecutableMastForest + Clone,
+    T: Tracer<Forest = F>,
+{
+    let old_forest = current_forest as &F;
+    let external_node_old_forest = option_map_break_reason(
+        old_forest.get_node_by_id(external_node_id_old_forest),
+        "external node not found in current forest",
+    )?
+    .unwrap_external();
+    let resolved_node_new_forest = option_map_break_reason(
+        new_mast_forest.get_node_by_id(resolved_node_id_new_forest),
+        "resolved node not found in new mast forest",
+    )?;
     // if the node that we got by looking up an external reference is also an External
     // node, we are about to enter into an infinite loop - so, return an error
-    if new_mast_forest[resolved_node_id].is_external() {
+    if resolved_node_new_forest.is_external() {
         return ControlFlow::Break(BreakReason::Err(
-            OperationError::CircularExternalNode(external_node.digest()).with_context(
-                current_forest,
-                external_node_id,
+            OperationError::CircularExternalNode(external_node_old_forest.digest()).with_context(
+                old_forest,
+                external_node_id_old_forest,
                 host,
             ),
         ));
     }
 
-    tracer.record_mast_forest_resolution(resolved_node_id, &new_mast_forest);
+    tracer.record_mast_forest_resolution(resolved_node_id_new_forest, &new_mast_forest);
 
     // Push a continuation to execute after_exit decorators when we return from the external
     // forest
-    continuation_stack.push_finish_external(external_node_id);
+    continuation_stack.push_finish_external(external_node_id_old_forest);
 
     // Push current forest to the continuation stack so that we can return to it
-    continuation_stack.push_enter_forest(current_forest.clone());
+    continuation_stack.push_enter_forest(old_forest.clone());
 
     // Push the root node of the external MAST forest onto the continuation stack.
-    continuation_stack.push_start_node(resolved_node_id);
+    continuation_stack.push_start_node(resolved_node_id_new_forest);
 
     // Update the current forest to the new MAST forest.
     *current_forest = new_mast_forest;

--- a/processor/src/execution/join.rs
+++ b/processor/src/execution/join.rs
@@ -1,11 +1,10 @@
-use alloc::sync::Arc;
 use core::ops::ControlFlow;
 
 use crate::{
     BaseHost, BreakReason, Stopper,
     continuation_stack::Continuation,
     execution::{ExecutionState, finalize_clock_cycle, finalize_clock_cycle_with_continuation},
-    mast::{JoinNode, MastForest, MastNodeId},
+    mast::{ExecutableMastForest, JoinNode, MastNodeId},
     processor::Processor,
     tracer::Tracer,
 };
@@ -15,17 +14,18 @@ use crate::{
 
 /// Executes a Join node from the start.
 #[inline(always)]
-pub(super) fn start_join_node<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn start_join_node<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     join_node: &JoinNode,
     node_id: MastNodeId,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     state.tracer.start_clock_cycle(
         state.processor,
@@ -55,16 +55,17 @@ where
 
 /// Executes the finish phase of a Join node.
 #[inline(always)]
-pub(super) fn finish_join_node<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn finish_join_node<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     node_id: MastNodeId,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     state.tracer.start_clock_cycle(
         state.processor,

--- a/processor/src/execution/loop.rs
+++ b/processor/src/execution/loop.rs
@@ -1,12 +1,12 @@
-use alloc::sync::Arc;
 use core::ops::ControlFlow;
 
 use crate::{
     BaseHost, BreakReason, MapExecErr, ONE, Stopper, ZERO,
     continuation_stack::Continuation,
     execution::{ExecutionState, finalize_clock_cycle, finalize_clock_cycle_with_continuation},
-    mast::{LoopNode, MastForest, MastNodeId},
+    mast::{ExecutableMastForest, LoopNode, MastNodeId},
     operation::OperationError,
+    option_map_break_reason,
     processor::{Processor, StackInterface},
     tracer::Tracer,
 };
@@ -16,17 +16,18 @@ use crate::{
 
 /// Executes a Loop node from the start.
 #[inline(always)]
-pub(super) fn start_loop_node<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn start_loop_node<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     loop_node: &LoopNode,
     current_node_id: MastNodeId,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     state.tracer.start_clock_cycle(
         state.processor,
@@ -106,17 +107,18 @@ where
 /// `loop_was_entered` is true), or when the loop condition was found to be ZERO at the start of
 /// the loop (in which case `loop_was_entered` is false).
 #[inline(always)]
-pub(super) fn finish_loop_node<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn finish_loop_node<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     loop_was_entered: bool,
     current_node_id: MastNodeId,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     // This happens after loop body execution or when the loop condition was ZERO at the start.
     // Check condition again to see if we should continue looping. If the loop was never entered, we
@@ -126,7 +128,11 @@ where
     } else {
         ZERO
     };
-    let loop_node = current_forest[current_node_id].unwrap_loop();
+    let loop_node = option_map_break_reason(
+        current_forest.get_node_by_id(current_node_id),
+        "loop node not found in current forest",
+    )?
+    .unwrap_loop();
 
     if condition == ONE {
         // Start the clock cycle corresponding to the REPEAT operation, before re-entering the loop

--- a/processor/src/execution/mod.rs
+++ b/processor/src/execution/mod.rs
@@ -1,10 +1,9 @@
-use alloc::sync::Arc;
 use core::ops::ControlFlow;
 
 use crate::{
     BaseHost, BreakReason, ContextId, Kernel, Stopper, Word,
     continuation_stack::{Continuation, ContinuationStack},
-    mast::{MastForest, MastNode, MastNodeId},
+    mast::{ExecutableMastForest, MastNode, MastNodeId},
     processor::{Processor, SystemInterface},
     tracer::{OperationHelperRegisters, Tracer},
 };
@@ -35,9 +34,9 @@ use operations::execute_op;
 /// Note: `current_forest` is intentionally excluded from this struct. Including it would prevent
 /// passing node references (obtained from the forest) alongside `&mut ExecutionState` to
 /// functions, since both would borrow the same struct.
-pub(crate) struct ExecutionState<'a, P, H, S, T> {
+pub(crate) struct ExecutionState<'a, P, H, S, T, F> {
     pub processor: &'a mut P,
-    pub continuation_stack: &'a mut ContinuationStack,
+    pub continuation_stack: &'a mut ContinuationStack<F>,
     pub kernel: &'a Kernel,
     pub host: &'a mut H,
     pub tracer: &'a mut T,
@@ -127,19 +126,20 @@ pub(crate) struct ExecutionState<'a, P, H, S, T> {
 ///     }
 /// }
 /// ```
-pub(crate) fn execute_impl<P, S, T>(
+pub(crate) fn execute_impl<P, S, T, F>(
     processor: &mut P,
-    continuation_stack: &mut ContinuationStack,
-    current_forest: &mut Arc<MastForest>,
+    continuation_stack: &mut ContinuationStack<F>,
+    current_forest: &mut F,
     kernel: &Kernel,
     host: &mut impl BaseHost,
     tracer: &mut T,
     stopper: &S,
-) -> ControlFlow<InternalBreakReason>
+) -> ControlFlow<InternalBreakReason<F>>
 where
     P: Processor,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     let mut state = ExecutionState {
         processor,
@@ -186,6 +186,7 @@ where
                         node_id,
                         current_forest,
                         state.host,
+                        state.tracer,
                     )?,
                 }
             },
@@ -243,16 +244,8 @@ where
                 )?
             },
             Continuation::FinishBasicBlock(node_id) => {
-                let basic_block_node =
-                    current_forest.get_node_by_id(node_id).unwrap().unwrap_basic_block();
-
-                basic_block::finish_basic_block(
-                    &mut state,
-                    basic_block_node,
-                    node_id,
-                    current_forest,
-                )
-                .map_break(InternalBreakReason::from)?
+                basic_block::finish_basic_block(&mut state, node_id, current_forest)
+                    .map_break(InternalBreakReason::from)?
             },
             Continuation::EnterForest(previous_forest) => {
                 // Restore the previous forest
@@ -316,12 +309,12 @@ where
 /// After the MAST forest has been loaded, the processor *must* call
 /// [`finish_load_mast_forest_from_external`] to complete the execution of the operation and resume
 /// execution with the first operation of the called procedure.
-pub enum InternalBreakReason {
-    User(BreakReason),
+pub enum InternalBreakReason<F> {
+    User(BreakReason<F>),
     Emit {
         basic_block_node_id: MastNodeId,
         op_idx: usize,
-        continuation: Continuation,
+        continuation: Continuation<F>,
     },
     LoadMastForestFromDyn {
         dyn_node_id: MastNodeId,
@@ -333,8 +326,8 @@ pub enum InternalBreakReason {
     },
 }
 
-impl From<BreakReason> for InternalBreakReason {
-    fn from(reason: BreakReason) -> Self {
+impl<F> From<BreakReason<F>> for InternalBreakReason<F> {
+    fn from(reason: BreakReason<F>) -> Self {
         Self::User(reason)
     }
 }
@@ -347,17 +340,18 @@ impl From<BreakReason> for InternalBreakReason {
 /// Delegates to [`finalize_clock_cycle_with_continuation`] with a continuation closure that returns
 /// no continuation.
 #[inline(always)]
-fn finalize_clock_cycle<P, S, T>(
+fn finalize_clock_cycle<P, S, T, F>(
     processor: &mut P,
     tracer: &mut T,
     stopper: &S,
-    continuation_stack: &ContinuationStack,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    continuation_stack: &ContinuationStack<F>,
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     finalize_clock_cycle_with_continuation(
         processor,
@@ -374,18 +368,19 @@ where
 /// Delegates to [`finalize_clock_cycle_with_continuation_and_op_helpers`] with the `Empty` variant
 /// of [`OperationHelperRegisters`].
 #[inline(always)]
-fn finalize_clock_cycle_with_continuation<P, S, T>(
+fn finalize_clock_cycle_with_continuation<P, S, T, F>(
     processor: &mut P,
     tracer: &mut T,
     stopper: &S,
-    continuation_stack: &ContinuationStack,
-    continuation_after_stop: impl FnOnce() -> Option<Continuation>,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    continuation_stack: &ContinuationStack<F>,
+    continuation_after_stop: impl FnOnce() -> Option<Continuation<F>>,
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     finalize_clock_cycle_with_continuation_and_op_helpers(
         processor,
@@ -418,19 +413,20 @@ where
 /// before being stopped). No continuation is provided in case of error, since it is expected that
 /// execution will not be resumed.
 #[inline(always)]
-fn finalize_clock_cycle_with_continuation_and_op_helpers<P, S, T>(
+fn finalize_clock_cycle_with_continuation_and_op_helpers<P, S, T, F>(
     processor: &mut P,
     tracer: &mut T,
     stopper: &S,
-    continuation_stack: &ContinuationStack,
-    continuation_after_stop: impl FnOnce() -> Option<Continuation>,
+    continuation_stack: &ContinuationStack<F>,
+    continuation_after_stop: impl FnOnce() -> Option<Continuation<F>>,
     op_helper_registers: OperationHelperRegisters,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     // Signal the end of clock cycle to tracer (before incrementing processor clock).
     tracer.finalize_clock_cycle(processor, op_helper_registers, current_forest);

--- a/processor/src/execution/operations/crypto_ops/mod.rs
+++ b/processor/src/execution/operations/crypto_ops/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     ContextId, Felt, MemoryError, ONE, RowIndex, Word, ZERO,
     errors::{CryptoError, MerklePathVerificationFailedInner, OperationError},
     field::{BasedVectorSpace, QuadFelt},
-    mast::MastForest,
+    mast::ExecutableMastForest,
     processor::{
         AdviceProviderInterface, HasherInterface, MemoryInterface, Processor, StackInterface,
         SystemInterface,
@@ -93,12 +93,15 @@ pub(super) fn op_hperm<P: Processor, T: Tracer>(
 ///   the specified root.
 /// - Path to the node at the specified depth and index is not known to the advice provider.
 #[inline(always)]
-pub(super) fn op_mpverify<P: Processor, T: Tracer>(
+pub(super) fn op_mpverify<P: Processor, T: Tracer, F>(
     processor: &mut P,
     err_code: Felt,
-    program: &MastForest,
+    program: &F,
     tracer: &mut T,
-) -> Result<OperationHelperRegisters, CryptoError> {
+) -> Result<OperationHelperRegisters, CryptoError>
+where
+    F: ExecutableMastForest + ?Sized,
+{
     // read node value, depth, index and root value from the stack
     let node = processor.stack().get_word(0);
     let depth = processor.stack().get(4);

--- a/processor/src/execution/operations/mod.rs
+++ b/processor/src/execution/operations/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     BaseHost, ExecutionError, Felt,
     errors::MapExecErrWithOpIdx,
-    mast::{MastForest, MastNodeId},
+    mast::{ExecutableMastForest, MastNodeId},
     operation::Operation,
     processor::{Processor, StackInterface},
     tracer::{OperationHelperRegisters, Tracer},
@@ -39,11 +39,11 @@ const DOUBLE_WORD_SIZE: Felt = Felt::new_unchecked(8);
 /// - If a control flow operation is provided.
 /// - If an `Emit` operation is provided.
 #[inline(always)]
-pub(crate) fn execute_op<P, T>(
+pub(crate) fn execute_op<P, T, F>(
     processor: &mut P,
     op: &Operation,
     op_idx: usize,
-    current_forest: &MastForest,
+    current_forest: &F,
     node_id: MastNodeId,
     host: &mut impl BaseHost,
     tracer: &mut T,
@@ -51,6 +51,7 @@ pub(crate) fn execute_op<P, T>(
 where
     P: Processor,
     T: Tracer<Processor = P>,
+    F: ExecutableMastForest,
 {
     let user_op_helpers = match op {
         // ----- system operations ------------------------------------------------------------

--- a/processor/src/execution/operations/sys_ops/mod.rs
+++ b/processor/src/execution/operations/sys_ops/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     ExecutionError, Felt, ONE,
     errors::OperationError,
-    mast::MastForest,
+    mast::ExecutableMastForest,
     processor::{Processor, StackInterface, SystemInterface},
     tracer::OperationHelperRegisters,
 };
@@ -17,13 +17,14 @@ mod tests;
 /// # Errors
 /// Returns an error if the popped value is not ONE.
 #[inline(always)]
-pub(super) fn op_assert<P>(
+pub(super) fn op_assert<P, F>(
     processor: &mut P,
     err_code: Felt,
-    program: &MastForest,
+    program: &F,
 ) -> Result<OperationHelperRegisters, OperationError>
 where
     P: Processor,
+    F: ExecutableMastForest,
 {
     if processor.stack().get(0) != ONE {
         let err_msg = program.resolve_error_message(err_code);

--- a/processor/src/execution/operations/u32_ops/mod.rs
+++ b/processor/src/execution/operations/u32_ops/mod.rs
@@ -4,7 +4,7 @@ use paste::paste;
 
 use crate::{
     ExecutionError, Felt, ZERO,
-    mast::MastForest,
+    mast::ExecutableMastForest,
     operation::OperationError,
     processor::{Processor, StackInterface},
     tracer::{OperationHelperRegisters, Tracer},
@@ -301,12 +301,15 @@ where
 /// the high values are equal to 0; if they are, puts the original elements back onto the
 /// stack; if they are not, returns an error.
 #[inline(always)]
-pub(super) fn op_u32assert2<P: Processor, T: Tracer>(
+pub(super) fn op_u32assert2<P: Processor, T: Tracer, F>(
     processor: &mut P,
     err_code: Felt,
     tracer: &mut T,
-    program: &MastForest,
-) -> Result<OperationHelperRegisters, OperationError> {
+    program: &F,
+) -> Result<OperationHelperRegisters, OperationError>
+where
+    F: ExecutableMastForest + ?Sized,
+{
     let first = processor.stack().get(0);
     let second = processor.stack().get(1);
 

--- a/processor/src/execution/split.rs
+++ b/processor/src/execution/split.rs
@@ -1,11 +1,10 @@
-use alloc::sync::Arc;
 use core::ops::ControlFlow;
 
 use crate::{
     BaseHost, BreakReason, MapExecErr, ONE, Stopper, ZERO,
     continuation_stack::Continuation,
     execution::{ExecutionState, finalize_clock_cycle, finalize_clock_cycle_with_continuation},
-    mast::{MastForest, MastNodeId, SplitNode},
+    mast::{ExecutableMastForest, MastNodeId, SplitNode},
     operation::OperationError,
     processor::{Processor, StackInterface},
     tracer::Tracer,
@@ -16,17 +15,18 @@ use crate::{
 
 /// Executes a Split node from the start.
 #[inline(always)]
-pub(super) fn start_split_node<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn start_split_node<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     split_node: &SplitNode,
     node_id: MastNodeId,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     state.tracer.start_clock_cycle(
         state.processor,
@@ -78,16 +78,17 @@ where
 
 /// Executes the finish phase of a Split node.
 #[inline(always)]
-pub(super) fn finish_split_node<P, H, S, T>(
-    state: &mut ExecutionState<'_, P, H, S, T>,
+pub(super) fn finish_split_node<P, H, S, T, F>(
+    state: &mut ExecutionState<'_, P, H, S, T, F>,
     node_id: MastNodeId,
-    current_forest: &Arc<MastForest>,
-) -> ControlFlow<BreakReason>
+    current_forest: &F,
+) -> ControlFlow<BreakReason<F>>
 where
     P: Processor,
     H: BaseHost,
-    S: Stopper<Processor = P>,
-    T: Tracer<Processor = P>,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
 {
     state.tracer.start_clock_cycle(
         state.processor,

--- a/processor/src/fast/basic_block/mod.rs
+++ b/processor/src/fast/basic_block/mod.rs
@@ -3,7 +3,7 @@ use core::ops::ControlFlow;
 
 use miden_core::{
     events::{EventId, SystemEvent},
-    mast::{MastForest, MastNodeId},
+    mast::{ExecutableMastForest, MastNodeId},
 };
 
 use crate::{
@@ -20,14 +20,17 @@ use sys_event_handlers::handle_system_event;
 
 impl FastProcessor {
     #[inline(always)]
-    fn handle_system_event(
+    fn handle_system_event<F>(
         &mut self,
         system_event: SystemEvent,
-        current_forest: &MastForest,
+        current_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
         op_idx: usize,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         match handle_system_event(self, system_event).map_exec_err_with_op_idx(
             current_forest,
             node_id,
@@ -40,15 +43,18 @@ impl FastProcessor {
     }
 
     #[inline(always)]
-    fn apply_host_event_mutations(
+    fn apply_host_event_mutations<F>(
         &mut self,
-        current_forest: &MastForest,
+        current_forest: &F,
         node_id: MastNodeId,
         host: &impl BaseHost,
         op_idx: usize,
         event_id: EventId,
         mutations: Result<Vec<AdviceMutation>, EventError>,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         let mutations = match mutations {
             Ok(mutations) => mutations,
             Err(err) => {
@@ -78,13 +84,16 @@ impl FastProcessor {
     }
 
     #[inline(always)]
-    pub(super) fn op_emit_sync(
+    pub(super) fn op_emit_sync<F>(
         &mut self,
         host: &mut impl SyncHost,
-        current_forest: &MastForest,
+        current_forest: &F,
         node_id: MastNodeId,
         op_idx: usize,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         let event_id = EventId::from_felt(self.stack_get(0));
 
         // If it's a system event, handle it directly. Otherwise, forward it to the host.
@@ -98,13 +107,16 @@ impl FastProcessor {
     }
 
     #[inline(always)]
-    pub(super) async fn op_emit(
+    pub(super) async fn op_emit<F>(
         &mut self,
         host: &mut impl Host,
-        current_forest: &MastForest,
+        current_forest: &F,
         node_id: MastNodeId,
         op_idx: usize,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         let event_id = EventId::from_felt(self.stack_get(0));
 
         if let Some(system_event) = SystemEvent::from_event_id(event_id) {

--- a/processor/src/fast/execution_api.rs
+++ b/processor/src/fast/execution_api.rs
@@ -104,7 +104,7 @@ impl FastProcessor {
         tracer: &mut T,
     ) -> Result<ExecutionOutput, ExecutionError>
     where
-        T: Tracer<Processor = Self>,
+        T: Tracer<Processor = Self, Forest = Arc<MastForest>>,
     {
         let mut continuation_stack = ContinuationStack::new(program);
         let mut current_forest = program.mast_forest().clone();
@@ -131,7 +131,7 @@ impl FastProcessor {
         tracer: &mut T,
     ) -> Result<ExecutionOutput, ExecutionError>
     where
-        T: Tracer<Processor = Self>,
+        T: Tracer<Processor = Self, Forest = Arc<MastForest>>,
     {
         let mut continuation_stack = ContinuationStack::new(program);
         let mut current_forest = program.mast_forest().clone();
@@ -214,8 +214,8 @@ impl FastProcessor {
     /// Converts a step-wise execution result into the next resume context, if execution stopped.
     #[inline(always)]
     fn resume_context_from_flow(
-        flow: ControlFlow<BreakReason, StackOutputs>,
-        mut continuation_stack: ContinuationStack,
+        flow: ControlFlow<BreakReason<Arc<MastForest>>, StackOutputs>,
+        mut continuation_stack: ContinuationStack<Arc<MastForest>>,
         current_forest: Arc<MastForest>,
         kernel: Kernel,
     ) -> Result<Option<ResumeContext>, ExecutionError> {
@@ -258,16 +258,16 @@ impl FastProcessor {
     /// processor for a second program is incorrect. This is mainly meant to be used in tests.
     fn execute_impl<S, T>(
         &mut self,
-        continuation_stack: &mut ContinuationStack,
+        continuation_stack: &mut ContinuationStack<Arc<MastForest>>,
         current_forest: &mut Arc<MastForest>,
         kernel: &Kernel,
         host: &mut impl SyncHost,
         tracer: &mut T,
         stopper: &S,
-    ) -> ControlFlow<BreakReason, StackOutputs>
+    ) -> ControlFlow<BreakReason<Arc<MastForest>>, StackOutputs>
     where
-        S: Stopper<Processor = Self>,
-        T: Tracer<Processor = Self>,
+        S: Stopper<Processor = Self, Forest = Arc<MastForest>>,
+        T: Tracer<Processor = Self, Forest = Arc<MastForest>>,
     {
         while let ControlFlow::Break(internal_break_reason) =
             execute_impl(self, continuation_stack, current_forest, kernel, host, tracer, stopper)
@@ -363,16 +363,16 @@ impl FastProcessor {
 
     async fn execute_impl_async<S, T>(
         &mut self,
-        continuation_stack: &mut ContinuationStack,
+        continuation_stack: &mut ContinuationStack<Arc<MastForest>>,
         current_forest: &mut Arc<MastForest>,
         kernel: &Kernel,
         host: &mut impl Host,
         tracer: &mut T,
         stopper: &S,
-    ) -> ControlFlow<BreakReason, StackOutputs>
+    ) -> ControlFlow<BreakReason<Arc<MastForest>>, StackOutputs>
     where
-        S: Stopper<Processor = Self>,
-        T: Tracer<Processor = Self>,
+        S: Stopper<Processor = Self, Forest = Arc<MastForest>>,
+        T: Tracer<Processor = Self, Forest = Arc<MastForest>>,
     {
         while let ControlFlow::Break(internal_break_reason) =
             execute_impl(self, continuation_stack, current_forest, kernel, host, tracer, stopper)

--- a/processor/src/fast/external.rs
+++ b/processor/src/fast/external.rs
@@ -1,4 +1,4 @@
-use miden_core::mast::MastForest;
+use miden_core::mast::ExecutableMastForest;
 
 use crate::{
     BaseHost, ExecutionError,
@@ -31,12 +31,15 @@ use crate::{
 ///
 /// The carets and line numbers point to the `call` instruction that triggered the error because of
 /// the remapping we do in this function.
-pub(super) fn maybe_use_caller_error_context(
+pub(super) fn maybe_use_caller_error_context<F>(
     original_err: ExecutionError,
-    current_forest: &MastForest,
-    continuation_stack: &ContinuationStack,
+    current_forest: &F,
+    continuation_stack: &ContinuationStack<F>,
     host: &mut impl BaseHost,
-) -> ExecutionError {
+) -> ExecutionError
+where
+    F: ExecutableMastForest,
+{
     // We only care about procedure-not-found errors or malformed MAST forest errors.
     let root_digest = match &original_err {
         ExecutionError::ProcedureNotFound { root_digest, .. } => *root_digest,

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -8,7 +8,7 @@ use core::{cmp::min, ops::ControlFlow};
 use miden_air::{Felt, trace::RowIndex};
 use miden_core::{
     EMPTY_WORD, WORD_SIZE, Word, ZERO,
-    mast::{MastForest, MastNodeExt, MastNodeId},
+    mast::{ExecutableMastForest, MastForest, MastNodeExt, MastNodeId},
     operations::Decorator,
     precompile::PrecompileTranscript,
     program::{MIN_STACK_DEPTH, Program, StackInputs, StackOutputs},
@@ -162,7 +162,7 @@ impl FastProcessor {
     /// Converts the terminal result of a full execution run into [`ExecutionOutput`].
     #[inline(always)]
     fn execution_result_from_flow(
-        flow: ControlFlow<BreakReason, StackOutputs>,
+        flow: ControlFlow<BreakReason<Arc<MastForest>>, StackOutputs>,
         processor: Self,
     ) -> Result<ExecutionOutput, ExecutionError> {
         match flow {
@@ -182,7 +182,7 @@ impl FastProcessor {
     #[cfg(any(test, feature = "testing"))]
     #[inline(always)]
     fn stack_result_from_flow(
-        flow: ControlFlow<BreakReason, StackOutputs>,
+        flow: ControlFlow<BreakReason<Arc<MastForest>>, StackOutputs>,
     ) -> Result<StackOutputs, ExecutionError> {
         match flow {
             ControlFlow::Continue(stack_outputs) => Ok(stack_outputs),
@@ -523,12 +523,15 @@ impl FastProcessor {
     // --------------------------------------------------------------------------------------------
 
     /// Executes the decorators that should be executed before entering a node.
-    fn execute_before_enter_decorators(
+    fn execute_before_enter_decorators<F>(
         &self,
         node_id: MastNodeId,
-        current_forest: &MastForest,
+        current_forest: &F,
         host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         if !self.should_execute_decorators() {
             return ControlFlow::Continue(());
         }
@@ -548,12 +551,15 @@ impl FastProcessor {
     }
 
     /// Executes the decorators that should be executed after exiting a node.
-    fn execute_after_exit_decorators(
+    fn execute_after_exit_decorators<F>(
         &self,
         node_id: MastNodeId,
-        current_forest: &MastForest,
+        current_forest: &F,
         host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         if !self.should_execute_decorators() {
             return ControlFlow::Continue(());
         }
@@ -573,11 +579,11 @@ impl FastProcessor {
     }
 
     /// Executes the specified decorator
-    fn execute_decorator(
+    fn execute_decorator<F>(
         &self,
         decorator: &Decorator,
         host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>> {
         match decorator {
             Decorator::Debug(options) => {
                 if self.in_debug_mode() {
@@ -766,13 +772,14 @@ pub struct NoopTracer;
 
 impl Tracer for NoopTracer {
     type Processor = FastProcessor;
+    type Forest = Arc<MastForest>;
 
     #[inline(always)]
     fn start_clock_cycle(
         &mut self,
         _processor: &FastProcessor,
-        _continuation: Continuation,
-        _continuation_stack: &ContinuationStack,
+        _continuation: Continuation<Arc<MastForest>>,
+        _continuation_stack: &ContinuationStack<Arc<MastForest>>,
         _current_forest: &Arc<MastForest>,
     ) {
         // do nothing

--- a/processor/src/fast/operation.rs
+++ b/processor/src/fast/operation.rs
@@ -7,7 +7,7 @@ use miden_air::{
 use miden_core::{
     WORD_SIZE, Word, ZERO,
     crypto::{hash::Poseidon2, merkle::MerklePath},
-    mast::{MastForest, MastNodeId},
+    mast::{ExecutableMastForest, MastNodeId},
     precompile::{PrecompileTranscript, PrecompileTranscriptState},
 };
 
@@ -87,38 +87,50 @@ impl Processor for FastProcessor {
     }
 
     #[inline(always)]
-    fn execute_before_enter_decorators(
+    fn execute_before_enter_decorators<F>(
         &self,
         node_id: MastNodeId,
-        current_forest: &MastForest,
+        current_forest: &F,
         host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         self.execute_before_enter_decorators(node_id, current_forest, host)
     }
 
     #[inline(always)]
-    fn execute_after_exit_decorators(
+    fn execute_after_exit_decorators<F>(
         &self,
         node_id: MastNodeId,
-        current_forest: &MastForest,
+        current_forest: &F,
         host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         self.execute_after_exit_decorators(node_id, current_forest, host)
     }
 
     #[inline(always)]
-    fn execute_decorators_for_op(
+    fn execute_decorators_for_op<F>(
         &self,
         node_id: MastNodeId,
         op_idx_in_block: usize,
-        current_forest: &MastForest,
+        current_forest: &F,
         host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         if self.should_execute_decorators() {
             #[cfg(test)]
             self.record_decorator_retrieval();
 
-            for decorator in current_forest.decorators_for_op(node_id, op_idx_in_block) {
+            for &decorator_id in current_forest.decorator_indices_for_op(node_id, op_idx_in_block) {
+                let decorator = current_forest
+                    .decorator_by_id(decorator_id)
+                    .expect("decorator id must be valid");
                 self.execute_decorator(decorator, host)?;
             }
         }

--- a/processor/src/fast/step.rs
+++ b/processor/src/fast/step.rs
@@ -18,13 +18,13 @@ use crate::{
 #[derive(Debug)]
 pub struct ResumeContext {
     pub(crate) current_forest: Arc<MastForest>,
-    pub(crate) continuation_stack: ContinuationStack,
+    pub(crate) continuation_stack: ContinuationStack<Arc<MastForest>>,
     pub(crate) kernel: Kernel,
 }
 
 impl ResumeContext {
     /// Returns a reference to the continuation stack.
-    pub fn continuation_stack(&self) -> &ContinuationStack {
+    pub fn continuation_stack(&self) -> &ContinuationStack<Arc<MastForest>> {
         &self.continuation_stack
     }
 
@@ -48,14 +48,15 @@ pub struct NeverStopper;
 
 impl Stopper for NeverStopper {
     type Processor = FastProcessor;
+    type Forest = Arc<MastForest>;
 
     #[inline(always)]
     fn should_stop(
         &self,
         processor: &FastProcessor,
-        continuation_stack: &ContinuationStack,
-        _continuation_after_stop: impl FnOnce() -> Option<Continuation>,
-    ) -> ControlFlow<BreakReason> {
+        continuation_stack: &ContinuationStack<Arc<MastForest>>,
+        _continuation_after_stop: impl FnOnce() -> Option<Continuation<Arc<MastForest>>>,
+    ) -> ControlFlow<BreakReason<Arc<MastForest>>> {
         check_if_max_cycles_exceeded(processor)?;
         check_if_continuation_stack_too_large(processor, continuation_stack)
     }
@@ -67,14 +68,15 @@ pub struct StepStopper;
 
 impl Stopper for StepStopper {
     type Processor = FastProcessor;
+    type Forest = Arc<MastForest>;
 
     #[inline(always)]
     fn should_stop(
         &self,
         processor: &FastProcessor,
-        continuation_stack: &ContinuationStack,
-        continuation_after_stop: impl FnOnce() -> Option<Continuation>,
-    ) -> ControlFlow<BreakReason> {
+        continuation_stack: &ContinuationStack<Arc<MastForest>>,
+        continuation_after_stop: impl FnOnce() -> Option<Continuation<Arc<MastForest>>>,
+    ) -> ControlFlow<BreakReason<Arc<MastForest>>> {
         check_if_max_cycles_exceeded(processor)?;
         check_if_continuation_stack_too_large(processor, continuation_stack)?;
 
@@ -84,7 +86,7 @@ impl Stopper for StepStopper {
 
 /// Checks if the maximum cycle count has been exceeded, returning a `BreakReason::Err` if so.
 #[inline(always)]
-fn check_if_max_cycles_exceeded(processor: &FastProcessor) -> ControlFlow<BreakReason> {
+fn check_if_max_cycles_exceeded<F>(processor: &FastProcessor) -> ControlFlow<BreakReason<F>> {
     if processor.clk > processor.options.max_cycles() as usize {
         ControlFlow::Break(BreakReason::Err(ExecutionError::CycleLimitExceeded(
             processor.options.max_cycles(),
@@ -97,10 +99,10 @@ fn check_if_max_cycles_exceeded(processor: &FastProcessor) -> ControlFlow<BreakR
 /// Checks if the continuation stack size exceeds the maximum allowed, returning a
 /// `BreakReason::Err` if so.
 #[inline(always)]
-fn check_if_continuation_stack_too_large(
+fn check_if_continuation_stack_too_large<F>(
     processor: &FastProcessor,
-    continuation_stack: &ContinuationStack,
-) -> ControlFlow<BreakReason> {
+    continuation_stack: &ContinuationStack<F>,
+) -> ControlFlow<BreakReason<F>> {
     if continuation_stack.len() > processor.options.max_num_continuations() {
         ControlFlow::Break(BreakReason::Err(ExecutionError::Internal(
             "continuation stack size exceeded the allowed maximum",
@@ -115,7 +117,7 @@ fn check_if_continuation_stack_too_large(
 
 /// The reason why execution was interrupted.
 #[derive(Debug)]
-pub enum BreakReason {
+pub enum BreakReason<F> {
     /// An execution error occurred
     Err(ExecutionError),
     /// Execution was stopped by a [`Stopper`]. Provides the continuation to add to the continuation
@@ -127,5 +129,5 @@ pub enum BreakReason {
     ///
     /// If yes, then `None` should be returned. If not, then the continuation that runs the next
     /// step in `FastProcessor::execute_impl()` should be returned.
-    Stopped(Option<Continuation>),
+    Stopped(Option<Continuation<F>>),
 }

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -24,6 +24,8 @@ mod host;
 mod processor;
 mod tracer;
 
+use miden_core::mast::ExecutableMastForest;
+
 use crate::{
     advice::{AdviceInputs, AdviceProvider},
     continuation_stack::ContinuationStack,
@@ -264,6 +266,11 @@ impl<'a> ProcessorState<'a> {
 pub trait Stopper {
     type Processor;
 
+    /// The forest representation used by the executor this stopper is paired with.
+    ///
+    /// For live execution this is `Arc<MastForest>`; for replay it is `Arc<SparseMastForest>`.
+    type Forest: ExecutableMastForest + Clone;
+
     /// Determines whether execution should be stopped at the end of each clock cycle.
     ///
     /// This method is guaranteed to be called at the end of each clock cycle, *after* the processor
@@ -281,9 +288,9 @@ pub trait Stopper {
     fn should_stop(
         &self,
         processor: &Self::Processor,
-        continuation_stack: &ContinuationStack,
-        continuation_after_stop: impl FnOnce() -> Option<Continuation>,
-    ) -> ControlFlow<BreakReason>;
+        continuation_stack: &ContinuationStack<Self::Forest>,
+        continuation_after_stop: impl FnOnce() -> Option<Continuation<Self::Forest>>,
+    ) -> ControlFlow<BreakReason<Self::Forest>>;
 }
 
 // EXECUTION CONTEXT
@@ -384,5 +391,27 @@ impl core::ops::Add<u32> for MemoryAddress {
 
     fn add(self, rhs: u32) -> Self::Output {
         MemoryAddress(self.0 + rhs)
+    }
+}
+
+// HELPERS
+// ===============================================================================================
+
+/// Lifts an [`Option<T>`] into a [`ControlFlow`] suitable for the execution loop, mapping `None`
+/// to a break carrying an [`ExecutionError::Internal`] with `err_msg`.
+///
+/// Intended for use with `?` at sites where a `None` represents a violated internal invariant —
+/// most commonly a missing node returned by
+/// [`ExecutableMastForest::get_node_by_id`](miden_core::mast::ExecutableMastForest::get_node_by_id).
+/// For functions returning `ControlFlow<InternalBreakReason<F>>`, chain
+/// `.map_break(InternalBreakReason::from)` before `?`.
+#[track_caller]
+fn option_map_break_reason<F, T>(
+    opt: Option<T>,
+    err_msg: &'static str,
+) -> ControlFlow<BreakReason<F>, T> {
+    match opt {
+        Some(value) => ControlFlow::Continue(value),
+        None => ControlFlow::Break(BreakReason::Err(ExecutionError::Internal(err_msg))),
     }
 }

--- a/processor/src/processor.rs
+++ b/processor/src/processor.rs
@@ -7,7 +7,7 @@ use crate::{
     advice::AdviceError,
     crypto::merkle::MerklePath,
     errors::OperationError,
-    mast::{MastForest, MastNodeId},
+    mast::{ExecutableMastForest, MastNodeId},
     precompile::PrecompileTranscriptState,
 };
 
@@ -67,30 +67,36 @@ pub(crate) trait Processor: Sized {
     fn set_precompile_transcript_state(&mut self, state: PrecompileTranscriptState);
 
     /// Executes the decorators that should be executed before entering a node.
-    fn execute_before_enter_decorators(
+    fn execute_before_enter_decorators<F>(
         &self,
         node_id: MastNodeId,
-        current_forest: &MastForest,
+        current_forest: &F,
         host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason>;
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest;
 
     /// Executes the decorators that should be executed after exiting a node.
-    fn execute_after_exit_decorators(
+    fn execute_after_exit_decorators<F>(
         &self,
         node_id: MastNodeId,
-        current_forest: &MastForest,
+        current_forest: &F,
         host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason>;
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest;
 
     /// Executes any decorator in a basic block that is to be executed before the operation at the
     /// given index in the block.
-    fn execute_decorators_for_op(
+    fn execute_decorators_for_op<F>(
         &self,
         node_id: MastNodeId,
         op_idx_in_block: usize,
-        current_forest: &MastForest,
+        current_forest: &F,
         host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason>;
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest;
 }
 
 // SYSTEM INTERFACE

--- a/processor/src/trace/execution_tracer.rs
+++ b/processor/src/trace/execution_tracer.rs
@@ -1,4 +1,4 @@
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 
 use miden_air::trace::chiplets::hasher::{
     CONTROLLER_ROWS_PER_PERM_FELT, CONTROLLER_ROWS_PER_PERMUTATION, STATE_WIDTH,
@@ -22,12 +22,13 @@ use crate::{
     continuation_stack::{Continuation, ContinuationStack},
     crypto::merkle::MerklePath,
     mast::{
-        BasicBlockNode, JoinNode, LoopNode, MastForest, MastNode, MastNodeExt, MastNodeId,
-        SplitNode,
+        BasicBlockNode, JoinNode, LoopNode, MastForest, MastForestId, MastNode, MastNodeExt,
+        MastNodeId, SparseMastForest, SparseMastForestBuilder, SplitNode, VisitKind,
     },
     processor::{Processor, StackInterface, SystemInterface},
     trace::chiplets::{CircuitEvaluation, PTR_OFFSET_ELEM, PTR_OFFSET_WORD},
     tracer::{OperationHelperRegisters, Tracer},
+    utils::Idx,
 };
 
 // STATE SNAPSHOT
@@ -37,8 +38,11 @@ use crate::{
 #[derive(Debug)]
 struct StateSnapshot {
     state: CoreTraceState,
-    continuation_stack: ContinuationStack,
-    initial_mast_forest: Arc<MastForest>,
+    /// Continuation stack with forest references already translated to [`MastForestId`]s into the
+    /// `mast_forest_store` of the [`TraceGenerationContext`] being built.
+    continuation_stack: ContinuationStack<MastForestId>,
+    /// The active forest at the start of this fragment, in `mast_forest_store`.
+    initial_mast_forest_id: MastForestId,
 }
 
 // TRACE GENERATION CONTEXT
@@ -48,6 +52,14 @@ struct StateSnapshot {
 pub struct TraceGenerationContext {
     /// The list of trace fragment contexts built during execution.
     pub core_trace_contexts: Vec<CoreTraceFragmentContext>,
+
+    /// Sparse MAST forests, one per source [`MastForest`] visited during execution.
+    ///
+    /// Each entry contains only the [`MastNode`]s that were actually visited, while preserving the
+    /// original [`MastNodeId`]s of the source forest. References from `CoreTraceFragmentContext`,
+    /// `MastForestResolutionReplay`, and `HasherOp::HashBasicBlock` are encoded as
+    /// [`MastForestId`]s into this vector.
+    pub mast_forest_store: Vec<Arc<SparseMastForest>>,
 
     // Replays that contain additional data needed to generate the range checker and chiplets
     // columns.
@@ -114,6 +126,22 @@ pub struct ExecutionTracer {
     // Output
     fragment_contexts: Vec<CoreTraceFragmentContext>,
 
+    /// Per-source-forest sparse builders, indexed by `mast_forest_indices`.
+    ///
+    /// Each builder accumulates the [`MastNodeId`]s of nodes visited inside its source forest
+    /// during execution, and is finalized into an [`Arc<SparseMastForest>`] in
+    /// [`Self::into_trace_generation_context`].
+    mast_forest_builders: Vec<SparseMastForestBuilder>,
+
+    /// Maps a source forest's `Arc::as_ptr` identity to its [`MastForestId`] in
+    /// `mast_forest_builders` (and, by construction, the eventual id in
+    /// `TraceGenerationContext::mast_forest_store`).
+    ///
+    /// Pointer identity is sound here because the trace-generation flow never crosses a process
+    /// boundary: the tracer builds the store and the replay processor consumes it in the same
+    /// run.
+    mast_forest_ids: BTreeMap<*const MastForest, MastForestId>,
+
     /// The number of rows per core trace fragment.
     fragment_size: usize,
 
@@ -154,11 +182,88 @@ impl ExecutionTracer {
             ace: AceReplay::default(),
             external: MastForestResolutionReplay::default(),
             fragment_contexts: Vec::new(),
+            mast_forest_builders: Vec::new(),
+            mast_forest_ids: BTreeMap::new(),
             fragment_size,
             max_stack_depth,
             pending_restore_context: false,
             is_eval_circuit_op: false,
         }
+    }
+
+    /// Returns the [`MastForestId`] of `forest` in [`Self::mast_forest_builders`], creating a new
+    /// builder for it on first encounter. Forests are identified by `Arc::as_ptr`.
+    #[inline]
+    fn forest_id(&mut self, forest: &Arc<MastForest>) -> MastForestId {
+        let key = Arc::as_ptr(forest);
+        if let Some(&id) = self.mast_forest_ids.get(&key) {
+            return id;
+        }
+
+        let id = MastForestId::from(self.mast_forest_builders.len() as u32);
+        self.mast_forest_builders.push(SparseMastForestBuilder::new(forest.clone()));
+        self.mast_forest_ids.insert(key, id);
+        id
+    }
+
+    /// Records that the node with id `node_id` was visited inside `forest`. Also records the
+    /// node's immediate children (if any) as digest-only references.
+    ///
+    /// The parent is recorded as a [`VisitKind::FullVisit`] so its full [`MastNode`] is available
+    /// at replay time. Children are recorded as [`VisitKind::DigestOnly`] because trace
+    /// generation only needs their digest when building the parent's trace row (e.g. a Split
+    /// node needs the digest of *both* branches even if only one is taken; a Join needs both
+    /// children's digests; a Call needs the callee's digest). If a child is later actually
+    /// entered, a subsequent `record_visit` call promotes it to a full visit.
+    ///
+    /// Keeping un-entered children as digest-only means accidental entry into a pruned node
+    /// surfaces as a clean `get_node_by_id` miss rather than a partially-populated node.
+    #[inline]
+    fn record_visit(&mut self, forest: &Arc<MastForest>, node_id: MastNodeId) {
+        let id = self.forest_id(forest);
+        self.mast_forest_builders[id.to_usize()].record_visit(node_id, VisitKind::FullVisit);
+
+        if let Some(node) = forest.get_node_by_id(node_id) {
+            node.for_each_child(|child_id| {
+                self.mast_forest_builders[id.to_usize()]
+                    .record_visit(child_id, VisitKind::DigestOnly);
+            });
+        }
+    }
+
+    /// Translates a live continuation stack carrying `Arc<MastForest>` references into one carrying
+    /// [`MastForestId`]s into `mast_forest_builders`.
+    fn translate_continuation_stack(
+        &mut self,
+        live: ContinuationStack<Arc<MastForest>>,
+    ) -> ContinuationStack<MastForestId> {
+        let mut translated: ContinuationStack<MastForestId> = ContinuationStack::default();
+        for cont in live.into_inner() {
+            let translated_cont = match cont {
+                Continuation::EnterForest(forest) => {
+                    Continuation::EnterForest(self.forest_id(&forest))
+                },
+                Continuation::StartNode(id) => Continuation::StartNode(id),
+                Continuation::FinishJoin(id) => Continuation::FinishJoin(id),
+                Continuation::FinishSplit(id) => Continuation::FinishSplit(id),
+                Continuation::FinishLoop { node_id, was_entered } => {
+                    Continuation::FinishLoop { node_id, was_entered }
+                },
+                Continuation::FinishCall(id) => Continuation::FinishCall(id),
+                Continuation::FinishDyn(id) => Continuation::FinishDyn(id),
+                Continuation::FinishExternal(id) => Continuation::FinishExternal(id),
+                Continuation::ResumeBasicBlock { node_id, batch_index, op_idx_in_batch } => {
+                    Continuation::ResumeBasicBlock { node_id, batch_index, op_idx_in_batch }
+                },
+                Continuation::Respan { node_id, batch_index } => {
+                    Continuation::Respan { node_id, batch_index }
+                },
+                Continuation::FinishBasicBlock(id) => Continuation::FinishBasicBlock(id),
+                Continuation::AfterExitDecorators(id) => Continuation::AfterExitDecorators(id),
+            };
+            translated.push_continuation(translated_cont);
+        }
+        translated
     }
 
     /// Convert the `ExecutionTracer` into a [TraceGenerationContext] using the data accumulated
@@ -168,8 +273,18 @@ impl ExecutionTracer {
         // If there is an ongoing trace state being built, finish it
         self.finish_current_fragment_context();
 
+        // Finalize each per-source-forest builder into a `SparseMastForest`. Indices stored on
+        // fragments and replays line up with the position in this vector by construction (the
+        // builders were appended in the same order the indices were assigned).
+        let mast_forest_store = self
+            .mast_forest_builders
+            .into_iter()
+            .map(|builder| Arc::new(builder.finalize()))
+            .collect();
+
         TraceGenerationContext {
             core_trace_contexts: self.fragment_contexts,
+            mast_forest_store,
             range_checker_replay: self.range_checker,
             memory_writes: self.memory_writes,
             bitwise_replay: self.bitwise,
@@ -196,47 +311,50 @@ impl ExecutionTracer {
         &mut self,
         system_state: SystemState,
         stack_top: [Felt; MIN_STACK_DEPTH],
-        mut continuation_stack: ContinuationStack,
-        continuation: Continuation,
+        mut continuation_stack: ContinuationStack<Arc<MastForest>>,
+        continuation: Continuation<Arc<MastForest>>,
         current_forest: Arc<MastForest>,
     ) {
         // If there is an ongoing snapshot, finish it
         self.finish_current_fragment_context();
 
         // Start a new snapshot
-        self.state_snapshot = {
-            let decoder_state = {
-                if self.block_stack.is_empty() {
-                    DecoderState { current_addr: ZERO, parent_addr: ZERO }
-                } else {
-                    let block_info = self.block_stack.peek();
+        let decoder_state = {
+            if self.block_stack.is_empty() {
+                DecoderState { current_addr: ZERO, parent_addr: ZERO }
+            } else {
+                let block_info = self.block_stack.peek();
 
-                    DecoderState {
-                        current_addr: block_info.addr,
-                        parent_addr: block_info.parent_addr,
-                    }
+                DecoderState {
+                    current_addr: block_info.addr,
+                    parent_addr: block_info.parent_addr,
                 }
-            };
-            let stack = {
-                let stack_depth =
-                    MIN_STACK_DEPTH + self.overflow_table.num_elements_in_current_ctx();
-                let last_overflow_addr = self.overflow_table.last_update_clk_in_current_ctx();
-                StackState::new(stack_top, stack_depth, last_overflow_addr)
-            };
-
-            // Push new continuation corresponding to the current execution state
-            continuation_stack.push_continuation(continuation);
-
-            Some(StateSnapshot {
-                state: CoreTraceState {
-                    system: system_state,
-                    decoder: decoder_state,
-                    stack,
-                },
-                continuation_stack,
-                initial_mast_forest: current_forest,
-            })
+            }
         };
+        let stack = {
+            let stack_depth = MIN_STACK_DEPTH + self.overflow_table.num_elements_in_current_ctx();
+            let last_overflow_addr = self.overflow_table.last_update_clk_in_current_ctx();
+            StackState::new(stack_top, stack_depth, last_overflow_addr)
+        };
+
+        // Push new continuation corresponding to the current execution state
+        continuation_stack.push_continuation(continuation);
+
+        // Translate the live `Arc<MastForest>`-bearing continuation stack into one indexed by
+        // `MastForestId` into `mast_forest_builders`, registering any newly-encountered forests
+        // along the way.
+        let initial_mast_forest_id = self.forest_id(&current_forest);
+        let translated_stack = self.translate_continuation_stack(continuation_stack);
+
+        self.state_snapshot = Some(StateSnapshot {
+            state: CoreTraceState {
+                system: system_state,
+                decoder: decoder_state,
+                stack,
+            },
+            continuation_stack: translated_stack,
+            initial_mast_forest_id,
+        });
     }
 
     #[inline(always)]
@@ -426,7 +544,7 @@ impl ExecutionTracer {
                     execution_context: execution_context_replay,
                 },
                 continuation: snapshot.continuation_stack,
-                initial_mast_forest: snapshot.initial_mast_forest,
+                initial_mast_forest_id: snapshot.initial_mast_forest_id,
             };
 
             self.fragment_contexts.push(trace_state);
@@ -454,6 +572,7 @@ impl ExecutionTracer {
 
 impl Tracer for ExecutionTracer {
     type Processor = FastProcessor;
+    type Forest = Arc<MastForest>;
 
     /// When sufficiently many clock cycles have elapsed, starts a new trace state. Also updates the
     /// internal block stack.
@@ -461,8 +580,8 @@ impl Tracer for ExecutionTracer {
     fn start_clock_cycle(
         &mut self,
         processor: &FastProcessor,
-        continuation: Continuation,
-        continuation_stack: &ContinuationStack,
+        continuation: Continuation<Arc<MastForest>>,
+        continuation_stack: &ContinuationStack<Arc<MastForest>>,
         current_forest: &Arc<MastForest>,
     ) {
         // check if we need to start a new trace state
@@ -477,6 +596,14 @@ impl Tracer for ExecutionTracer {
                 continuation.clone(),
                 current_forest.clone(),
             );
+        }
+
+        // Record that the node being executed at this cycle was visited inside `current_forest`.
+        // This builds up the per-source-forest sparse subset used at trace generation time. Note
+        // that an `ExecutionTracer`'s state is invalidated on error, so it is safe to record the
+        // visit here even if the operation later fails (per Tracer invariants).
+        if let Some(visited_node_id) = node_id_for_visit(&continuation) {
+            self.record_visit(current_forest, visited_node_id);
         }
 
         match continuation {
@@ -537,15 +664,15 @@ impl Tracer for ExecutionTracer {
                     }
                 },
                 MastNode::Block(basic_block_node) => {
+                    let forest_id = self.forest_id(current_forest);
                     self.hasher_for_chiplet.record_hash_basic_block(
-                        current_forest.clone(),
+                        forest_id,
                         mast_node_id,
                         basic_block_node.digest(),
                     );
                     let block_addr =
                         self.hasher_chiplet_shim.record_hash_basic_block(basic_block_node);
-                    let parent_addr =
-                        self.block_stack.push(block_addr, None);
+                    let parent_addr = self.block_stack.push(block_addr, None);
                     self.block_stack_replay.record_node_start_parent_addr(parent_addr);
                 },
                 MastNode::External(_) => unreachable!(
@@ -600,7 +727,21 @@ impl Tracer for ExecutionTracer {
 
     #[inline(always)]
     fn record_mast_forest_resolution(&mut self, node_id: MastNodeId, forest: &Arc<MastForest>) {
-        self.external.record_resolution(node_id, forest.clone());
+        let forest_id = self.forest_id(forest);
+        self.external.record_resolution(node_id, forest_id);
+    }
+
+    #[inline(always)]
+    fn record_external_node_entered(
+        &mut self,
+        external_node_id: MastNodeId,
+        forest: &Arc<MastForest>,
+    ) {
+        // External nodes don't go through `start_clock_cycle`, so we record their visit here so
+        // the per-source-forest sparse builder includes them. The replay path needs the external
+        // node present in the sparse forest because `execute_external_node` indexes the forest by
+        // id to fetch the procedure digest.
+        self.record_visit(forest, external_node_id);
     }
 
     #[inline(always)]
@@ -834,6 +975,29 @@ impl Tracer for ExecutionTracer {
 
             self.is_eval_circuit_op = false;
         }
+    }
+}
+
+/// Extracts the [`MastNodeId`] that is being executed at the start of a clock cycle from the given
+/// continuation, so that the node can be marked as visited in its source forest's sparse builder.
+///
+/// Continuations not passed to [`Tracer::start_clock_cycle`] (per the trait contract) are matched
+/// pessimistically here, returning `None`.
+#[inline]
+fn node_id_for_visit<F>(continuation: &Continuation<F>) -> Option<MastNodeId> {
+    match *continuation {
+        Continuation::StartNode(id)
+        | Continuation::FinishJoin(id)
+        | Continuation::FinishSplit(id)
+        | Continuation::FinishCall(id)
+        | Continuation::FinishDyn(id)
+        | Continuation::FinishBasicBlock(id) => Some(id),
+        Continuation::FinishLoop { node_id, .. }
+        | Continuation::ResumeBasicBlock { node_id, .. }
+        | Continuation::Respan { node_id, .. } => Some(node_id),
+        Continuation::FinishExternal(_)
+        | Continuation::EnterForest(_)
+        | Continuation::AfterExitDecorators(_) => None,
     }
 }
 

--- a/processor/src/trace/parallel/mod.rs
+++ b/processor/src/trace/parallel/mod.rs
@@ -16,16 +16,17 @@ use miden_air::{
 use miden_core::{
     ONE, Word, ZERO,
     field::batch_inversion_allow_zeros,
-    mast::{MastForest, MastNode},
+    mast::{ExecutableMastForest, MastForestId, MastNode, SparseMastForest},
     operations::opcodes,
     program::{Kernel, MIN_STACK_DEPTH},
+    utils::Idx,
 };
 use rayon::prelude::*;
 use tracing::instrument;
 
 use crate::{
     ContextId, ExecutionError,
-    continuation_stack::ContinuationStack,
+    continuation_stack::{Continuation, ContinuationStack},
     errors::MapExecErrNoCtx,
     trace::{
         ChipletsLengths, ExecutionTrace, TraceBuildInputs, TraceLenSummary,
@@ -108,6 +109,7 @@ pub fn build_trace_with_max_len(
 
     let TraceGenerationContext {
         core_trace_contexts,
+        mast_forest_store,
         range_checker_replay,
         memory_writes,
         bitwise_replay: bitwise,
@@ -147,6 +149,7 @@ pub fn build_trace_with_max_len(
         kernel_replay,
         hasher_for_chiplet,
         ace_replay,
+        &mast_forest_store,
         max_trace_len,
     )?;
 
@@ -156,6 +159,7 @@ pub fn build_trace_with_max_len(
         core_trace_contexts,
         program_info.kernel().clone(),
         fragment_size,
+        &mast_forest_store,
         max_stack_depth,
     )?;
 
@@ -234,6 +238,7 @@ fn generate_core_trace_row_major(
     core_trace_contexts: Vec<CoreTraceFragmentContext>,
     kernel: Kernel,
     fragment_size: usize,
+    mast_forest_store: &[Arc<SparseMastForest>],
     max_stack_depth: usize,
 ) -> Result<Vec<Felt>, ExecutionError> {
     let num_fragments = core_trace_contexts.len();
@@ -259,7 +264,13 @@ fn generate_core_trace_row_major(
         .zip(writers.into_par_iter())
         .map(|(trace_state, writer)| {
             let (mut processor, mut tracer, mut continuation_stack, mut current_forest) =
-                split_trace_fragment_context(trace_state, writer, fragment_size, max_stack_depth);
+                split_trace_fragment_context(
+                    trace_state,
+                    writer,
+                    fragment_size,
+                    mast_forest_store,
+                    max_stack_depth,
+                )?;
 
             processor.execute(
                 &mut continuation_stack,
@@ -454,6 +465,7 @@ fn initialize_chiplets(
     kernel_replay: KernelReplay,
     hasher_for_chiplet: HasherRequestReplay,
     ace_replay: AceReplay,
+    mast_forest_store: &[Arc<SparseMastForest>],
     max_trace_len: usize,
 ) -> Result<Chiplets, ExecutionError> {
     let check_chiplets_trace_len = |chiplets: &Chiplets| -> Result<(), ExecutionError> {
@@ -476,7 +488,11 @@ fn initialize_chiplets(
                 let _ = chiplets.hasher.hash_control_block(h1, h2, domain, expected_hash);
                 check_chiplets_trace_len(&chiplets)?;
             },
-            HasherOp::HashBasicBlock((forest, node_id, expected_hash)) => {
+            HasherOp::HashBasicBlock((forest_id, node_id, expected_hash)) => {
+                let forest =
+                    mast_forest_store.get(forest_id.to_usize()).ok_or(ExecutionError::Internal(
+                        "MAST forest id in hasher replay out of range of mast_forest_store",
+                    ))?;
                 let node = forest
                     .get_node_by_id(node_id)
                     .ok_or(ExecutionError::Internal("invalid node ID in hasher replay"))?;
@@ -675,19 +691,32 @@ fn pad_core_row_major(core_trace_data: &mut Vec<Felt>, main_trace_len: usize) {
         });
 }
 
+type SplitFragmentContext<'a> = (
+    ReplayProcessor,
+    CoreTraceGenerationTracer<'a>,
+    ContinuationStack<Arc<SparseMastForest>>,
+    Arc<SparseMastForest>,
+);
+
 /// Uses the provided `CoreTraceFragmentContext` to build and return a `ReplayProcessor` and
 /// `CoreTraceGenerationTracer` that can be used to execute the fragment.
+///
+/// `mast_forest_store` provides the [`SparseMastForest`]s that the indices stored in the fragment
+/// (the initial forest index and the `EnterForest` continuations) refer to.
+///
+/// # Errors
+///
+/// Returns [`ExecutionError::Internal`] if any [`MastForestId`] referenced by the fragment
+/// (either `initial_mast_forest_id` or an `EnterForest` continuation) is out of range of
+/// `mast_forest_store`. Because [`CoreTraceFragmentContext`] is attacker-controllable when fed in
+/// from outside, we validate these indices rather than indexing-and-panicking.
 fn split_trace_fragment_context<'a>(
     fragment_context: CoreTraceFragmentContext,
     writer: RowMajorTraceWriter<'a, Felt>,
     fragment_size: usize,
+    mast_forest_store: &[Arc<SparseMastForest>],
     max_stack_depth: usize,
-) -> (
-    ReplayProcessor,
-    CoreTraceGenerationTracer<'a>,
-    ContinuationStack,
-    Arc<MastForest>,
-) {
+) -> Result<SplitFragmentContext<'a>, ExecutionError> {
     let CoreTraceFragmentContext {
         state: CoreTraceState { system, decoder, stack },
         replay:
@@ -702,8 +731,14 @@ fn split_trace_fragment_context<'a>(
                 mast_forest_resolution: mast_forest_resolution_replay,
             },
         continuation,
-        initial_mast_forest,
+        initial_mast_forest_id,
     } = fragment_context;
+
+    let translated_continuation =
+        translate_snapshot_continuation_stack(continuation, mast_forest_store)?;
+
+    let initial_mast_forest =
+        lookup_mast_forest(mast_forest_store, initial_mast_forest_id)?.clone();
 
     let processor = ReplayProcessor::new(
         system,
@@ -714,11 +749,61 @@ fn split_trace_fragment_context<'a>(
         memory_reads_replay,
         hasher_response_replay,
         mast_forest_resolution_replay,
+        mast_forest_store.to_vec(),
         max_stack_depth,
         fragment_size.into(),
     );
     let tracer =
         CoreTraceGenerationTracer::new(writer, decoder, block_address_replay, block_stack_replay);
 
-    (processor, tracer, continuation, initial_mast_forest)
+    Ok((processor, tracer, translated_continuation, initial_mast_forest))
+}
+
+/// Translates a snapshotted `ContinuationStack<MastForestId>` into one carrying actual
+/// [`Arc<SparseMastForest>`] handles, ready to drive `execute_impl`.
+///
+/// Returns [`ExecutionError::Internal`] if any `EnterForest` continuation carries a
+/// [`MastForestId`] that is out of range of `mast_forest_store`.
+fn translate_snapshot_continuation_stack(
+    snapshot: ContinuationStack<MastForestId>,
+    mast_forest_store: &[Arc<SparseMastForest>],
+) -> Result<ContinuationStack<Arc<SparseMastForest>>, ExecutionError> {
+    let mut out: ContinuationStack<Arc<SparseMastForest>> = ContinuationStack::default();
+    for cont in snapshot.into_inner() {
+        let translated = match cont {
+            Continuation::EnterForest(id) => {
+                Continuation::EnterForest(lookup_mast_forest(mast_forest_store, id)?.clone())
+            },
+            Continuation::StartNode(id) => Continuation::StartNode(id),
+            Continuation::FinishJoin(id) => Continuation::FinishJoin(id),
+            Continuation::FinishSplit(id) => Continuation::FinishSplit(id),
+            Continuation::FinishLoop { node_id, was_entered } => {
+                Continuation::FinishLoop { node_id, was_entered }
+            },
+            Continuation::FinishCall(id) => Continuation::FinishCall(id),
+            Continuation::FinishDyn(id) => Continuation::FinishDyn(id),
+            Continuation::FinishExternal(id) => Continuation::FinishExternal(id),
+            Continuation::ResumeBasicBlock { node_id, batch_index, op_idx_in_batch } => {
+                Continuation::ResumeBasicBlock { node_id, batch_index, op_idx_in_batch }
+            },
+            Continuation::Respan { node_id, batch_index } => {
+                Continuation::Respan { node_id, batch_index }
+            },
+            Continuation::FinishBasicBlock(id) => Continuation::FinishBasicBlock(id),
+            Continuation::AfterExitDecorators(id) => Continuation::AfterExitDecorators(id),
+        };
+        out.push_continuation(translated);
+    }
+    Ok(out)
+}
+
+/// Looks up `id` in `mast_forest_store`, returning [`ExecutionError::Internal`] if it is out of
+/// range.
+pub(super) fn lookup_mast_forest(
+    mast_forest_store: &[Arc<SparseMastForest>],
+    id: MastForestId,
+) -> Result<&Arc<SparseMastForest>, ExecutionError> {
+    mast_forest_store
+        .get(id.to_usize())
+        .ok_or(ExecutionError::Internal("MastForestId out of range of mast_forest_store"))
 }

--- a/processor/src/trace/parallel/processor.rs
+++ b/processor/src/trace/parallel/processor.rs
@@ -1,11 +1,11 @@
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 use core::ops::ControlFlow;
 
 use miden_air::{Felt, trace::RowIndex};
 use miden_core::{
     WORD_SIZE, Word, ZERO,
     field::PrimeField64,
-    mast::{MastForest, MastNodeId},
+    mast::{ExecutableMastForest, MastNodeId, SparseMastForest},
     precompile::PrecompileTranscriptState,
     program::{Kernel, MIN_STACK_DEPTH},
     utils::range,
@@ -54,6 +54,11 @@ pub(crate) struct ReplayProcessor {
     pub hasher_response_replay: HasherResponseReplay,
     pub mast_forest_resolution_replay: MastForestResolutionReplay,
 
+    /// Per-fragment view of the [`crate::TraceGenerationContext`]'s `mast_forest_store`. Used to
+    /// resolve `usize` indices recorded in the replays back to [`Arc<SparseMastForest>`] handles
+    /// during execution.
+    pub mast_forest_store: Vec<Arc<SparseMastForest>>,
+
     /// The maximum number of field elements allowed on the operand stack in an active execution
     /// context.
     pub max_stack_depth: usize,
@@ -77,6 +82,7 @@ impl ReplayProcessor {
         memory_reads_replay: MemoryReadsReplay,
         hasher_response_replay: HasherResponseReplay,
         mast_forest_resolution_replay: MastForestResolutionReplay,
+        mast_forest_store: Vec<Arc<SparseMastForest>>,
         max_stack_depth: usize,
         num_clocks_to_execute: RowIndex,
     ) -> Self {
@@ -91,6 +97,7 @@ impl ReplayProcessor {
             memory_reads_replay,
             hasher_response_replay,
             mast_forest_resolution_replay,
+            mast_forest_store,
             max_stack_depth,
             maximum_clock,
         }
@@ -99,13 +106,13 @@ impl ReplayProcessor {
     /// Executes the processor until it reaches the end of the fragment, or until an error occurs.
     pub fn execute<T>(
         &mut self,
-        continuation_stack: &mut ContinuationStack,
-        current_forest: &mut Arc<MastForest>,
+        continuation_stack: &mut ContinuationStack<Arc<SparseMastForest>>,
+        current_forest: &mut Arc<SparseMastForest>,
         kernel: &Kernel,
         tracer: &mut T,
     ) -> Result<(), ExecutionError>
     where
-        T: Tracer<Processor = Self>,
+        T: Tracer<Processor = Self, Forest = Arc<SparseMastForest>>,
     {
         match self.execute_impl(continuation_stack, current_forest, kernel, tracer) {
             ControlFlow::Continue(_) => {
@@ -130,13 +137,13 @@ impl ReplayProcessor {
     /// execution loop. See its documentation for more details.
     fn execute_impl<T>(
         &mut self,
-        continuation_stack: &mut ContinuationStack,
-        current_forest: &mut Arc<MastForest>,
+        continuation_stack: &mut ContinuationStack<Arc<SparseMastForest>>,
+        current_forest: &mut Arc<SparseMastForest>,
         kernel: &Kernel,
         tracer: &mut T,
-    ) -> ControlFlow<BreakReason>
+    ) -> ControlFlow<BreakReason<Arc<SparseMastForest>>>
     where
-        T: Tracer<Processor = Self>,
+        T: Tracer<Processor = Self, Forest = Arc<SparseMastForest>>,
     {
         let host = &mut NoopHost;
         let stopper = &ReplayStopper;
@@ -165,12 +172,17 @@ impl ReplayProcessor {
                 },
                 InternalBreakReason::LoadMastForestFromDyn { .. } => {
                     // load mast forest from replay
-                    let (root_id, new_forest) =
+                    let (root_id, new_forest_id) =
                         match self.mast_forest_resolution_replay.replay_resolution() {
                             Ok(v) => v,
                             Err(err) => {
                                 return ControlFlow::Break(BreakReason::Err(err));
                             },
+                        };
+                    let new_forest =
+                        match super::lookup_mast_forest(&self.mast_forest_store, new_forest_id) {
+                            Ok(f) => f.clone(),
+                            Err(err) => return ControlFlow::Break(BreakReason::Err(err)),
                         };
 
                     // Finish loading the MAST forest from the Dyn node, as per the sans-IO
@@ -190,12 +202,17 @@ impl ReplayProcessor {
                     procedure_hash: _,
                 } => {
                     // load mast forest from replay
-                    let (root_id, new_forest) =
+                    let (root_id, new_forest_id) =
                         match self.mast_forest_resolution_replay.replay_resolution() {
                             Ok(v) => v,
                             Err(err) => {
                                 return ControlFlow::Break(BreakReason::Err(err));
                             },
+                        };
+                    let new_forest =
+                        match super::lookup_mast_forest(&self.mast_forest_store, new_forest_id) {
+                            Ok(f) => f.clone(),
+                            Err(err) => return ControlFlow::Break(BreakReason::Err(err)),
                         };
 
                     // Finish loading the MAST forest from the External node, as per the sans-IO
@@ -456,33 +473,42 @@ impl Processor for ReplayProcessor {
         self.system.pc_transcript_state = state;
     }
 
-    fn execute_before_enter_decorators(
+    fn execute_before_enter_decorators<F>(
         &self,
         _node_id: MastNodeId,
-        _current_forest: &MastForest,
+        _current_forest: &F,
         _host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         // do nothing - we don't execute decorators in this processor
         ControlFlow::Continue(())
     }
 
-    fn execute_after_exit_decorators(
+    fn execute_after_exit_decorators<F>(
         &self,
         _node_id: MastNodeId,
-        _current_forest: &MastForest,
+        _current_forest: &F,
         _host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         // do nothing - we don't execute decorators in this processor
         ControlFlow::Continue(())
     }
 
-    fn execute_decorators_for_op(
+    fn execute_decorators_for_op<F>(
         &self,
         _node_id: MastNodeId,
         _op_idx_in_block: usize,
-        _current_forest: &MastForest,
+        _current_forest: &F,
         _host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
+    ) -> ControlFlow<BreakReason<F>>
+    where
+        F: ExecutableMastForest,
+    {
         // do nothing - we don't execute decorators in this processor
         ControlFlow::Continue(())
     }
@@ -498,13 +524,14 @@ pub(crate) struct ReplayStopper;
 
 impl Stopper for ReplayStopper {
     type Processor = ReplayProcessor;
+    type Forest = Arc<SparseMastForest>;
 
     fn should_stop(
         &self,
         processor: &ReplayProcessor,
-        _continuation_stack: &ContinuationStack,
-        continuation_after_stop: impl FnOnce() -> Option<Continuation>,
-    ) -> ControlFlow<BreakReason> {
+        _continuation_stack: &ContinuationStack<Arc<SparseMastForest>>,
+        continuation_after_stop: impl FnOnce() -> Option<Continuation<Arc<SparseMastForest>>>,
+    ) -> ControlFlow<BreakReason<Arc<SparseMastForest>>> {
         if processor.system().clock() >= processor.maximum_clock {
             ControlFlow::Break(BreakReason::Stopped(continuation_after_stop()))
         } else {
@@ -539,6 +566,7 @@ mod tests {
             MemoryReadsReplay::default(),
             HasherResponseReplay::default(),
             MastForestResolutionReplay::default(),
+            Vec::new(),
             MIN_STACK_DEPTH,
             1_u32.into(),
         )

--- a/processor/src/trace/parallel/tests.rs
+++ b/processor/src/trace/parallel/tests.rs
@@ -15,8 +15,8 @@ use miden_core::{
     field::QuadFelt,
     mast::{
         BasicBlockNodeBuilder, CallNodeBuilder, DynNodeBuilder, ExternalNodeBuilder,
-        JoinNodeBuilder, LoopNodeBuilder, MastForest, MastForestContributor, MastNodeExt,
-        MastNodeId, SplitNodeBuilder,
+        JoinNodeBuilder, LoopNodeBuilder, MastForest, MastForestContributor, MastForestId,
+        MastNodeExt, MastNodeId, SplitNodeBuilder,
     },
     operations::{Operation, opcodes},
     precompile::PrecompileRequest,
@@ -1004,6 +1004,95 @@ fn test_build_trace_returns_err_on_bad_node_id_in_hasher_replay() {
     assert!(
         result.is_err(),
         "build_trace should return Err when hasher replay has bad node ID"
+    );
+}
+
+/// Where to tamper with a [`miden_core::mast::MastForestId`] in a [`TraceBuildInputs`].
+#[derive(Debug, Clone, Copy)]
+enum BadForestIdLocation {
+    /// Replace the first fragment's `initial_mast_forest_id`.
+    InitialForestId,
+    /// Replace the forest id of the first entry in the first fragment's `mast_forest_resolution`
+    /// replay (DYN/External resolution path).
+    ResolutionReplay,
+}
+
+/// Verifies that `build_trace` returns `Err` (instead of panicking) when a fragment carries a
+/// [`miden_core::mast::MastForestId`] that does not exist in `mast_forest_store`.
+///
+/// `CoreTraceFragmentContext` can come from outside this process (e.g. when serialized and
+/// rebuilt), and so its [`miden_core::mast::MastForestId`]s must be treated as
+/// untrusted/attacker-controlled. Both the up-front ids (`initial_mast_forest_id`, continuation
+/// stack) and the per-resolution ids in `mast_forest_resolution` (the DYN/External path that is
+/// most likely to be hit when libraries are involved) must be validated rather than indexed
+/// into, and the error must propagate up through `build_trace`.
+#[rstest]
+#[case::initial_forest_id(
+    basic_block_program_small(),
+    DEFAULT_STACK,
+    false,
+    BadForestIdLocation::InitialForestId
+)]
+#[case::dyn_resolution(
+    dyn_program(),
+    external_lib_proc_hash_for_stack(),
+    true,
+    BadForestIdLocation::ResolutionReplay
+)]
+#[case::external_resolution(
+    external_program(),
+    DEFAULT_STACK,
+    true,
+    BadForestIdLocation::ResolutionReplay
+)]
+fn test_build_trace_returns_err_on_invalid_mast_forest_id(
+    #[case] program: Program,
+    #[case] stack_inputs: &[Felt],
+    #[case] load_library: bool,
+    #[case] tamper_at: BadForestIdLocation,
+) {
+    const MAX_FRAGMENT_SIZE: usize = 1 << 20;
+
+    let processor = FastProcessor::new_with_options(
+        StackInputs::new(stack_inputs).unwrap(),
+        AdviceInputs::default(),
+        ExecutionOptions::default()
+            .with_core_trace_fragment_size(MAX_FRAGMENT_SIZE)
+            .unwrap(),
+    )
+    .expect("processor advice inputs should fit advice map limits");
+    let mut host = DefaultHost::default();
+    if load_library {
+        host.load_library(create_simple_library()).unwrap();
+    }
+    let mut trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
+
+    let store_len = trace_inputs.trace_generation_context().mast_forest_store.len();
+    let bogus_forest_id = MastForestId::from(store_len as u32);
+    let ctx = &mut trace_inputs.trace_generation_context_mut().core_trace_contexts[0];
+    match tamper_at {
+        BadForestIdLocation::InitialForestId => {
+            ctx.initial_mast_forest_id = bogus_forest_id;
+        },
+        BadForestIdLocation::ResolutionReplay => {
+            let resolution = &mut ctx.replay.mast_forest_resolution;
+            let mut entries = Vec::new();
+            while let Ok(entry) = resolution.replay_resolution() {
+                entries.push(entry);
+            }
+            assert!(!entries.is_empty(), "expected at least one resolution to tamper with");
+            entries[0].1 = bogus_forest_id;
+            for (node_id, forest_id) in entries {
+                resolution.record_resolution(node_id, forest_id);
+            }
+        },
+    }
+
+    let result = build_trace(trace_inputs);
+    assert!(
+        result.is_err(),
+        "build_trace should return Err when a fragment carries a MastForestId out of range of \
+         the mast_forest_store"
     );
 }
 

--- a/processor/src/trace/parallel/tests.rs
+++ b/processor/src/trace/parallel/tests.rs
@@ -16,7 +16,7 @@ use miden_core::{
     mast::{
         BasicBlockNodeBuilder, CallNodeBuilder, DynNodeBuilder, ExternalNodeBuilder,
         JoinNodeBuilder, LoopNodeBuilder, MastForest, MastForestContributor, MastNodeExt,
-        SplitNodeBuilder,
+        MastNodeId, SplitNodeBuilder,
     },
     operations::{Operation, opcodes},
     precompile::PrecompileRequest,
@@ -990,18 +990,15 @@ fn test_build_trace_returns_err_on_bad_node_id_in_hasher_replay() {
     let mut host = DefaultHost::default();
     let mut trace_inputs = processor.execute_trace_inputs_sync(&program, &mut host).unwrap();
 
-    // Inject a HashBasicBlock entry with a node ID that points to a non-existent node in an empty
-    // forest.
-    let empty_forest = Arc::new(MastForest::new());
-    // Build a small forest just to get a valid MastNodeId, then pair it with the empty forest.
-    let mut temp_forest = MastForest::new();
-    let valid_id = BasicBlockNodeBuilder::new(vec![Operation::Noop], Vec::new())
-        .add_to_forest(&mut temp_forest)
-        .unwrap();
+    // Inject a HashBasicBlock entry that references the executed program's forest (id 0 in the
+    // store, which the tracer always populates with the entrypoint's forest) with a node ID that
+    // is well past any node actually in the sparse forest.
+    let bogus_node_id = MastNodeId::new_unchecked(u32::MAX);
+    let forest_id = MastForestId::from(0u32);
     trace_inputs
         .trace_generation_context_mut()
         .hasher_for_chiplet
-        .record_hash_basic_block(empty_forest, valid_id, [ZERO; 4].into());
+        .record_hash_basic_block(forest_id, bogus_node_id, [ZERO; 4].into());
 
     let result = build_trace(trace_inputs);
     assert!(

--- a/processor/src/trace/parallel/tracer/mod.rs
+++ b/processor/src/trace/parallel/tracer/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     ExecutionError, Felt, ONE, Word, ZERO,
     continuation_stack::{Continuation, ContinuationStack},
     errors::MapExecErrNoCtx,
-    mast::{MastForest, MastNode, MastNodeExt, MastNodeId},
+    mast::{ExecutableMastForest, MastNode, MastNodeExt, MastNodeId, SparseMastForest},
     trace::trace_state::NodeFlags,
     tracer::{OperationHelperRegisters, Tracer},
 };
@@ -91,7 +91,7 @@ pub(crate) struct CoreTraceGenerationTracer<'a> {
     /// The continuation captured at the beginning of the clock cycle (in
     /// [`start_clock_cycle`](Tracer::start_clock_cycle)), describing what is being executed at
     /// this cycle.
-    continuation: Option<Continuation>,
+    continuation: Option<Continuation<Arc<SparseMastForest>>>,
 
     /// Whether the node ending in this clock cycle is a body of a LOOP node. This is determined
     /// by peeking at the continuation stack in [`start_clock_cycle`](Tracer::start_clock_cycle)
@@ -152,7 +152,7 @@ impl<'a> CoreTraceGenerationTracer<'a> {
         &mut self,
         node_id: MastNodeId,
         processor: &ReplayProcessor,
-        current_forest: &Arc<MastForest>,
+        current_forest: &Arc<SparseMastForest>,
     ) -> Result<(), ExecutionError> {
         let node = get_node_in_forest(current_forest, node_id)?;
 
@@ -233,8 +233,8 @@ impl<'a> CoreTraceGenerationTracer<'a> {
     /// element has been dropped, as per the semantics of DYNCALL.
     fn get_execution_context_for_dyncall(
         &self,
-        current_forest: &MastForest,
-        continuation: &Continuation,
+        current_forest: &Arc<SparseMastForest>,
+        continuation: &Continuation<Arc<SparseMastForest>>,
         processor: &ReplayProcessor,
     ) -> Result<Option<ExecutionContextInfo>, ExecutionError> {
         let Continuation::StartNode(node_id) = &continuation else {
@@ -287,7 +287,7 @@ impl<'a> CoreTraceGenerationTracer<'a> {
     /// should be re-executed), and `false` otherwise (meaning the loop is finished).
     fn get_finish_loop_condition(
         &self,
-        continuation: &Continuation,
+        continuation: &Continuation<Arc<SparseMastForest>>,
         processor: &ReplayProcessor,
     ) -> Option<bool> {
         if let Continuation::FinishLoop { .. } = &continuation {
@@ -302,8 +302,8 @@ impl<'a> CoreTraceGenerationTracer<'a> {
     /// captured in `start_clock_cycle`.
     fn compute_node_flags(
         &self,
-        continuation: &Continuation,
-        current_forest: &MastForest,
+        continuation: &Continuation<Arc<SparseMastForest>>,
+        current_forest: &Arc<SparseMastForest>,
     ) -> Result<NodeFlags, ExecutionError> {
         let is_loop_body = self.is_loop_body;
 
@@ -351,9 +351,9 @@ impl<'a> CoreTraceGenerationTracer<'a> {
     /// hash (as a word) from memory.
     fn get_dyn_callee_hash(
         &self,
-        continuation: &Continuation,
+        continuation: &Continuation<Arc<SparseMastForest>>,
         processor: &ReplayProcessor,
-        current_forest: &MastForest,
+        current_forest: &Arc<SparseMastForest>,
     ) -> Result<Option<Word>, ExecutionError> {
         if let Continuation::StartNode(node_id) = continuation {
             let Some(node) = current_forest.get_node_by_id(*node_id) else {
@@ -380,13 +380,14 @@ impl<'a> CoreTraceGenerationTracer<'a> {
 
 impl Tracer for CoreTraceGenerationTracer<'_> {
     type Processor = ReplayProcessor;
+    type Forest = Arc<SparseMastForest>;
 
     fn start_clock_cycle(
         &mut self,
         processor: &ReplayProcessor,
-        continuation: Continuation,
-        continuation_stack: &ContinuationStack,
-        current_forest: &Arc<MastForest>,
+        continuation: Continuation<Arc<SparseMastForest>>,
+        continuation_stack: &ContinuationStack<Arc<SparseMastForest>>,
+        current_forest: &Arc<SparseMastForest>,
     ) {
         if self.error_encountered.is_some() {
             return;
@@ -423,7 +424,7 @@ impl Tracer for CoreTraceGenerationTracer<'_> {
         &mut self,
         processor: &ReplayProcessor,
         op_helper_registers: OperationHelperRegisters,
-        current_forest: &Arc<MastForest>,
+        current_forest: &Arc<SparseMastForest>,
     ) {
         if self.error_encountered.is_some() {
             return;
@@ -619,12 +620,26 @@ impl Tracer for CoreTraceGenerationTracer<'_> {
 // ================================================================================================
 
 /// Returns a reference to the node with the given ID from the forest, or an error if not found.
-fn get_node_in_forest(
-    forest: &MastForest,
-    node_id: MastNodeId,
-) -> Result<&MastNode, ExecutionError> {
+fn get_node_in_forest<F>(forest: &F, node_id: MastNodeId) -> Result<&MastNode, ExecutionError>
+where
+    F: ExecutableMastForest + ?Sized,
+{
     forest
         .get_node_by_id(node_id)
+        .ok_or(ExecutionError::Internal("invalid node ID stored in continuation"))
+}
+
+/// Returns the digest of the node with the given ID from the forest, or an error if not found.
+///
+/// Prefer this over [`get_node_in_forest`] when only the digest is needed: on a
+/// [`miden_core::mast::SparseMastForest`], digest-only entries are reachable through this path
+/// but not through [`get_node_in_forest`].
+fn get_digest_in_forest<F>(forest: &F, node_id: MastNodeId) -> Result<Word, ExecutionError>
+where
+    F: ExecutableMastForest + ?Sized,
+{
+    forest
+        .get_digest_by_id(node_id)
         .ok_or(ExecutionError::Internal("invalid node ID stored in continuation"))
 }
 
@@ -673,8 +688,13 @@ mod tests {
     #[test]
     fn get_execution_context_for_dyncall_at_min_stack_depth_with_overflow_entries() {
         // Build a MastForest with a single DYNCALL node.
-        let mut forest = MastForest::new();
+        let mut forest = miden_core::mast::MastForest::new();
         let dyncall_node_id = DynNodeBuilder::new_dyncall().add_to_forest(&mut forest).unwrap();
+        // Build a sparse forest containing only the visited dyncall node (matching what the
+        // execution tracer would produce for this fragment).
+        let mut sparse_builder = miden_core::mast::SparseMastForestBuilder::new(Arc::new(forest));
+        sparse_builder.record_visit(dyncall_node_id, miden_core::mast::VisitKind::FullVisit);
+        let forest = Arc::new(sparse_builder.finalize());
 
         let continuation = Continuation::StartNode(dyncall_node_id);
 
@@ -704,6 +724,7 @@ mod tests {
             MemoryReadsReplay::default(),
             HasherResponseReplay::default(),
             MastForestResolutionReplay::default(),
+            vec![forest.clone()],
             crate::ExecutionOptions::DEFAULT_MAX_STACK_DEPTH,
             1u32.into(),
         );

--- a/processor/src/trace/parallel/tracer/trace_row.rs
+++ b/processor/src/trace/parallel/tracer/trace_row.rs
@@ -1,5 +1,7 @@
 //! Module which concerns itself with all the trace row building logic.
 
+use alloc::sync::Arc;
+
 use miden_air::trace::{
     CLK_COL_IDX, CTX_COL_IDX, DECODER_TRACE_OFFSET, FN_HASH_OFFSET, STACK_TRACE_OFFSET,
     STACK_TRACE_WIDTH, SYS_TRACE_WIDTH,
@@ -14,12 +16,13 @@ use miden_air::trace::{
 use miden_core::{
     Felt, ONE, Word, ZERO,
     mast::{
-        BasicBlockNode, CallNode, JoinNode, LoopNode, MastForest, MastNodeExt, OpBatch, SplitNode,
+        BasicBlockNode, CallNode, JoinNode, LoopNode, MastNodeExt, OpBatch, SparseMastForest,
+        SplitNode,
     },
     operations::{Operation, opcodes},
 };
 
-use super::{ExecutionContextInfo, StackState, SystemState, get_node_in_forest};
+use super::{ExecutionContextInfo, StackState, SystemState, get_digest_in_forest};
 use crate::{
     ExecutionError,
     trace::parallel::{
@@ -270,12 +273,12 @@ impl<'a> CoreTraceGenerationTracer<'a> {
         system: &SystemState,
         stack: &StackState,
         call_node: &CallNode,
-        current_forest: &MastForest,
+        current_forest: &Arc<SparseMastForest>,
     ) -> Result<(), ExecutionError> {
         // For CALL/SYSCALL operations, the hasher state in start operations contains the callee
         // hash in the first half, and zeros in the second half (since CALL only has one
         // child)
-        let callee_hash: Word = get_node_in_forest(current_forest, call_node.callee())?.digest();
+        let callee_hash: Word = get_digest_in_forest(current_forest, call_node.callee())?;
         let zero_hash = Word::default();
 
         let decoder_row = DecoderRow::new_control_flow(
@@ -349,11 +352,11 @@ impl<'a> CoreTraceGenerationTracer<'a> {
         system: &SystemState,
         stack: &StackState,
         join_node: &JoinNode,
-        current_forest: &MastForest,
+        current_forest: &Arc<SparseMastForest>,
     ) -> Result<(), ExecutionError> {
         // Get the child hashes for the hasher state
-        let child1_hash: Word = get_node_in_forest(current_forest, join_node.first())?.digest();
-        let child2_hash: Word = get_node_in_forest(current_forest, join_node.second())?.digest();
+        let child1_hash: Word = get_digest_in_forest(current_forest, join_node.first())?;
+        let child2_hash: Word = get_digest_in_forest(current_forest, join_node.second())?;
 
         let decoder_row = DecoderRow::new_control_flow(
             opcodes::JOIN,
@@ -374,11 +377,11 @@ impl<'a> CoreTraceGenerationTracer<'a> {
         system: &SystemState,
         stack: &StackState,
         loop_node: &LoopNode,
-        current_forest: &MastForest,
+        current_forest: &Arc<SparseMastForest>,
     ) -> Result<(), ExecutionError> {
         // For LOOP operations, the hasher state in start operations contains the loop body hash in
         // the first half.
-        let body_hash: Word = get_node_in_forest(current_forest, loop_node.body())?.digest();
+        let body_hash: Word = get_digest_in_forest(current_forest, loop_node.body())?;
         let zero_hash = Word::default();
 
         let decoder_row = DecoderRow::new_control_flow(
@@ -397,12 +400,12 @@ impl<'a> CoreTraceGenerationTracer<'a> {
         system: &SystemState,
         stack: &StackState,
         loop_node: &LoopNode,
-        current_forest: &MastForest,
+        current_forest: &Arc<SparseMastForest>,
         current_addr: Felt,
     ) -> Result<(), ExecutionError> {
         // For REPEAT operations, the hasher state in start operations contains the loop body hash
         // in the first half.
-        let body_hash: Word = get_node_in_forest(current_forest, loop_node.body())?.digest();
+        let body_hash: Word = get_digest_in_forest(current_forest, loop_node.body())?;
 
         let decoder_row = DecoderRow::new_control_flow(
             opcodes::REPEAT,
@@ -424,12 +427,11 @@ impl<'a> CoreTraceGenerationTracer<'a> {
         system: &SystemState,
         stack: &StackState,
         split_node: &SplitNode,
-        current_forest: &MastForest,
+        current_forest: &Arc<SparseMastForest>,
     ) -> Result<(), ExecutionError> {
         // Get the child hashes for the hasher state
-        let on_true_hash: Word = get_node_in_forest(current_forest, split_node.on_true())?.digest();
-        let on_false_hash: Word =
-            get_node_in_forest(current_forest, split_node.on_false())?.digest();
+        let on_true_hash: Word = get_digest_in_forest(current_forest, split_node.on_true())?;
+        let on_false_hash: Word = get_digest_in_forest(current_forest, split_node.on_false())?;
 
         let decoder_row = DecoderRow::new_control_flow(
             opcodes::SPLIT,

--- a/processor/src/trace/trace_state.rs
+++ b/processor/src/trace/trace_state.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::VecDeque, string::ToString, sync::Arc};
+use alloc::{collections::VecDeque, string::ToString};
 
 use miden_air::trace::{
     RowIndex,
@@ -11,7 +11,7 @@ use crate::{
     continuation_stack::ContinuationStack,
     crypto::merkle::MerklePath,
     errors::OperationError,
-    mast::{MastForest, MastNodeId},
+    mast::{MastForestId, MastNodeId},
     precompile::PrecompileTranscriptState,
     processor::{
         AdviceProviderInterface, HasherInterface, MemoryInterface, Processor, SystemInterface,
@@ -43,8 +43,11 @@ use crate::{
 pub struct CoreTraceFragmentContext {
     pub state: CoreTraceState,
     pub replay: ExecutionReplay,
-    pub continuation: ContinuationStack,
-    pub initial_mast_forest: Arc<MastForest>,
+    /// Continuation stack with forest references encoded as [`MastForestId`]s into the
+    /// `mast_forest_store` of the owning [`crate::TraceGenerationContext`].
+    pub continuation: ContinuationStack<MastForestId>,
+    /// MAST forest active at the start of this fragment.
+    pub initial_mast_forest_id: MastForestId,
 }
 
 // CORE TRACE STATE
@@ -453,20 +456,26 @@ pub struct ExecutionContextSystemInfo {
 /// These calls are made when encountering an [`miden_core::mast::ExternalNode`], or when
 /// encountering a [`miden_core::mast::DynNode`] where the procedure hash on the stack refers to
 /// a procedure not present in the current forest.
+///
+/// The forest reference is stored as a [`MastForestId`] into the `mast_forest_store` of the
+/// [`crate::TraceGenerationContext`] that owns this replay. This avoids holding a strong
+/// `Arc<MastForest>` reference per resolution, allowing the trace generation context to deduplicate
+/// forests across fragments.
 #[derive(Debug, Default)]
 pub struct MastForestResolutionReplay {
-    mast_forest_resolutions: VecDeque<(MastNodeId, Arc<MastForest>)>,
+    mast_forest_resolutions: VecDeque<(MastNodeId, MastForestId)>,
 }
 
 impl MastForestResolutionReplay {
-    /// Records a resolution of a MastNodeId with its associated MastForest when encountering an
-    /// External node, or `DYN`/`DYNCALL` node with an external procedure hash on the stack.
-    pub fn record_resolution(&mut self, node_id: MastNodeId, forest: Arc<MastForest>) {
-        self.mast_forest_resolutions.push_back((node_id, forest));
+    /// Records a resolution of a MastNodeId with the id of its associated MAST forest in the
+    /// trace generation context's `mast_forest_store`.
+    pub fn record_resolution(&mut self, node_id: MastNodeId, forest_id: MastForestId) {
+        self.mast_forest_resolutions.push_back((node_id, forest_id));
     }
 
-    /// Replays the next recorded MastForest resolution, returning both the node ID and forest
-    pub fn replay_resolution(&mut self) -> Result<(MastNodeId, Arc<MastForest>), ExecutionError> {
+    /// Replays the next recorded MastForest resolution, returning both the node ID and the forest
+    /// id.
+    pub fn replay_resolution(&mut self) -> Result<(MastNodeId, MastForestId), ExecutionError> {
         self.mast_forest_resolutions
             .pop_front()
             .ok_or(ExecutionError::Internal("no MastForest resolutions recorded"))
@@ -1000,7 +1009,9 @@ impl HasherInterface for HasherResponseReplay {
 pub enum HasherOp {
     Permute([Felt; STATE_WIDTH]),
     HashControlBlock((Word, Word, Felt, Word)),
-    HashBasicBlock((Arc<MastForest>, MastNodeId, Word)),
+    /// `(forest_id, node_id, expected_hash)` — `forest_id` is an id into the
+    /// `mast_forest_store` of the [`crate::TraceGenerationContext`] that owns this replay.
+    HashBasicBlock((MastForestId, MastNodeId, Word)),
     BuildMerkleRoot((Word, MerklePath, Felt)),
     UpdateMerkleRoot((Word, Word, MerklePath, Felt)),
 }
@@ -1036,12 +1047,12 @@ impl HasherRequestReplay {
     /// Records a `Hasher::hash_basic_block()` request.
     pub fn record_hash_basic_block(
         &mut self,
-        forest: Arc<MastForest>,
+        forest_id: MastForestId,
         node_id: MastNodeId,
         expected_hash: Word,
     ) {
         self.hasher_ops
-            .push_back(HasherOp::HashBasicBlock((forest, node_id, expected_hash)));
+            .push_back(HasherOp::HashBasicBlock((forest_id, node_id, expected_hash)));
     }
 
     /// Records a `Hasher::build_merkle_root()` request.

--- a/processor/src/tracer.rs
+++ b/processor/src/tracer.rs
@@ -1,11 +1,9 @@
-use alloc::sync::Arc;
-
 use miden_air::trace::{RowIndex, chiplets::hasher::STATE_WIDTH, decoder::NUM_USER_OP_HELPERS};
 use miden_core::{
     Felt, Word, ZERO,
     crypto::merkle::MerklePath,
     field::{BasedVectorSpace, Field, QuadFelt},
-    mast::{MastForest, MastNodeId},
+    mast::{ExecutableMastForest, MastNodeId},
 };
 
 use crate::{
@@ -60,6 +58,14 @@ use crate::{
 pub trait Tracer {
     type Processor;
 
+    /// The forest representation passed to this tracer's [`start_clock_cycle`] /
+    /// [`finalize_clock_cycle`] / [`record_mast_forest_resolution`] hooks.
+    ///
+    /// For live execution this is `Arc<MastForest>`; for the replay path it is
+    /// `Arc<SparseMastForest>`. Continuation stacks and continuations carrying forest references
+    /// (e.g. `Continuation::EnterForest`) use the same type.
+    type Forest: ExecutableMastForest + Clone;
+
     /// Signals the start of a new clock cycle, guaranteed to be called at the start of the clock
     /// cycle, before any mutations to the processor state is made. For example, it is safe to
     /// access the processor's stack and memory state as they are before executing the operation at
@@ -81,9 +87,9 @@ pub trait Tracer {
     fn start_clock_cycle(
         &mut self,
         processor: &Self::Processor,
-        continuation: Continuation,
-        continuation_stack: &ContinuationStack,
-        current_forest: &Arc<MastForest>,
+        continuation: Continuation<Self::Forest>,
+        continuation_stack: &ContinuationStack<Self::Forest>,
+        current_forest: &Self::Forest,
     );
 
     /// Signals the end of a clock cycle, guaranteed to be called before incrementing the system
@@ -98,7 +104,7 @@ pub trait Tracer {
         &mut self,
         processor: &Self::Processor,
         op_helper_registers: OperationHelperRegisters,
-        current_forest: &Arc<MastForest>,
+        current_forest: &Self::Forest,
     );
 
     // MAST FOREST RESOLUTION
@@ -115,7 +121,20 @@ pub trait Tracer {
     /// [Tracer::start_clock_cycle] is called on the resolved node (i.e. *not* the external node).
     /// This method is called on the external node before it is resolved, and hence is guaranteed to
     /// be called before [Tracer::start_clock_cycle] for clock cycles involving an external node.
-    fn record_mast_forest_resolution(&mut self, _node_id: MastNodeId, _forest: &Arc<MastForest>) {}
+    fn record_mast_forest_resolution(&mut self, _node_id: MastNodeId, _forest: &Self::Forest) {}
+
+    /// Records that the [miden_core::mast::ExternalNode] with the given id is being entered in
+    /// `forest`. Because external nodes are resolved before [Tracer::start_clock_cycle], they are
+    /// otherwise invisible to the tracer; this hook is provided so that implementations that
+    /// accumulate visited nodes (for building a sparse forest, for example) can include them.
+    ///
+    /// Default: no-op.
+    fn record_external_node_entered(
+        &mut self,
+        _external_node_id: MastNodeId,
+        _forest: &Self::Forest,
+    ) {
+    }
 
     // IN-CYCLE METHODS
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
Partially closes #2766 (`TraceGenerationContext` serialization not implemented yet)

## Motivation

`TraceGenerationContext` previously held `Arc<MastForest>`s to refer to `MastForest`s, making serialization impractical since most nodes in those forests are not visited, and hence serialized needlessly.

## What changed (high level)

The core line of changes is
- introduce a `SparseMastForest` type (pretty much as described in #2766), 
- In the `ExecutionTracer`, for each `MastForest` accessed during execution, build a `SparseMastForest` containing all the nodes actually accessed during execution,
- Update the execution pipeline to be generic over `MastForest` (where the methods needed during execution are encoded in a new `ExecutableMastForest` trait).

## Tradeoffs

The main tradeoff that we're making here is that we're increasing memory usage for the use case where the trace is built on the same machine that generated the `TraceGenerationContext`, since we're now building `SparseMastForest`s, where just reusing `Arc<MastForest>` would have sufficed (as it did previously). Supporting both modes (using `Arc<MastForest>` for a non-serializable `TraceGenerationContext`, and `SparseMastForest`s for a serializable `TraceGenerationContext`) would require more thought.

## Detailed changes

### New types in `miden-core`

- **`SparseMastForest`** — a subset of a source `MastForest` containing only the nodes visited during execution. Uses `BTreeMap<MastNodeId, MastNode>` so the original `MastNodeId`s are preserved, allowing the sparse forest to drop into the executor as if it were the dense source.
- **`SparseMastForestBuilder`** — accumulator that records visited `MastNodeId`s and finalizes into a `SparseMastForest`.
- **`ExecutableMastForest`** trait — the API the executor and decorator pipeline need from a forest (`get_node_by_id`, `find_procedure_root`, `decorator_by_id`, `linked_before_enter_decorators`, `linked_after_exit_decorators`, `decorator_indices_for_op`, `advice_map`, `get_assembly_op`, `resolve_error_message`, `Index<MastNodeId>` and `Index<DecoratorId>` as supertraits). Implemented for `MastForest`, `SparseMastForest`, and `Arc<T: ExecutableMastForest>`.
- **`MastForestId`** newtype — opaque handle into a forest store.

### Executor pipeline generic over `ExecutableMastForest`

The whole executor + tracer surface is now generic over `F: ExecutableMastForest`:

- `Continuation<F>`, `ContinuationStack<F>` (only `EnterForest(F)` carries the type)
- `BreakReason<F>`, `InternalBreakReason<F>`
- `Tracer { type Forest: ExecutableMastForest + Clone; ... }`, `Stopper { type Forest; ... }`
- `Processor`'s decorator methods made generic over `F`
- `execute_impl<P, S, T, F>` and every inner exec function
- `MapExecErr`/`MapExecErrWithOpIdx` traits + their impls + free helpers (`with_context`, `advice_error_with_context`, etc.) take a generic forest
- `MastNodeExt::{before_enter, after_exit, verify_node_in_forest}` made generic (derive macro updated)

### `TraceGenerationContext` changes

- `TraceGenerationContext` gains a `mast_forest_store: Vec<Arc<SparseMastForest>>`.
- Fragment-internal `Arc<MastForest>` references are replaced by `MastForestId` indices: `CoreTraceFragmentContext.{continuation: ContinuationStack<MastForestId>, initial_mast_forest_id}`, `MastForestResolutionReplay`, and `HasherOp::HashBasicBlock`.
- `ExecutionTracer` carries per-source-forest `SparseMastForestBuilder`s keyed by forest commitment, populated in `start_clock_cycle`, `record_mast_forest_resolution`, and a new `record_external_node_entered` hook (external nodes don't drive a clock cycle so they need a separate hook). When a node is recorded, its immediate children are also recorded — needed so the trace generator can read child digests on `Join`/`Split`/`Loop`/`Call` rows even when only one child is taken.
- Replay translates `MastForestId` → `Arc<SparseMastForest>` at fragment setup (`split_trace_fragment_context` returns `Result`, validating attacker-controlled ids rather than panic-indexing).

## Validation

Trace generation now uses attacker-controlled `MastForestId`s to access `SparseMastForest`s; added a test to ensure that this properly returns an error for invalid `MastForestId`s.

## Out of scope

- Serialization of `TraceGenerationContext` — this PR makes that tractable but doesn't implement it.
- Trimming `roots`, `advice_map`, and `debug_info` of `SparseMastForest` to only the visited subset.