### PR TITLE
Guard type alias resolution cycles depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [BREAKING] Bounded the live advice map by total field elements during execution; advice-provider setup now returns an error when initial advice exceeds this limit ([#3085](https://github.com/0xMiden/miden-vm/pull/3085)).
 - Rejected empty kernel packages before linking so malformed dependency metadata returns a structured package error instead of reaching the linker's non-empty-kernel assertion ([#3082](https://github.com/0xMiden/miden-vm/pull/3082)).
 - [BREAKING] Fixed project artifact reuse to ignore unrelated manifest fields, rejected private cross-module imports, and kept signature-only type imports live ([#3091](https://github.com/0xMiden/miden-vm/pull/3091)).
+- Guarded assembly type-alias resolution against cycles and excessive alias-chain depth, returning structured diagnostics instead of recursive failure paths, and added regression tests ([#3112](https://github.com/0xMiden/miden-vm/pull/3112)).
 
 #### Changes
 

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -744,7 +744,10 @@ impl crate::prettier::PrettyPrint for Module {
 struct ModuleTypeResolver<'a> {
     module: &'a Module,
     resolver: LocalSymbolResolver,
+    evaluating_types: Vec<ItemIndex>,
 }
+
+const MAX_LOCAL_TYPE_ALIAS_RESOLUTION_DEPTH: usize = 128;
 
 impl<'a> ModuleTypeResolver<'a> {
     pub fn new(
@@ -752,7 +755,11 @@ impl<'a> ModuleTypeResolver<'a> {
         source_manager: Arc<dyn SourceManager>,
     ) -> Result<Self, SymbolResolutionError> {
         let resolver = module.resolver(source_manager)?;
-        Ok(Self { module, resolver })
+        Ok(Self {
+            module,
+            resolver,
+            evaluating_types: Vec::new(),
+        })
     }
 }
 
@@ -772,7 +779,24 @@ impl TypeResolver<SymbolResolutionError> for ModuleTypeResolver<'_> {
         context: SourceSpan,
         id: ItemIndex,
     ) -> Result<Option<types::Type>, SymbolResolutionError> {
-        match &self.module[id] {
+        if self.evaluating_types.contains(&id) {
+            return Err(SymbolResolutionError::alias_expansion_cycle(
+                context,
+                &self.resolver.source_manager(),
+            ));
+        }
+
+        if self.evaluating_types.len() >= MAX_LOCAL_TYPE_ALIAS_RESOLUTION_DEPTH {
+            return Err(SymbolResolutionError::type_expression_depth_exceeded(
+                context,
+                MAX_LOCAL_TYPE_ALIAS_RESOLUTION_DEPTH,
+                &self.resolver.source_manager(),
+            ));
+        }
+
+        self.evaluating_types.push(id);
+
+        let result = match &self.module[id] {
             Export::Type(ty) => match ty {
                 TypeDecl::Alias(ty) => self.resolve(&ty.ty),
                 TypeDecl::Enum(ty) => Ok(Some(ty.ty().clone())),
@@ -783,7 +807,11 @@ impl TypeResolver<SymbolResolutionError> for ModuleTypeResolver<'_> {
                 item.span(),
                 &self.resolver.source_manager(),
             ))),
-        }
+        };
+
+        self.evaluating_types.pop();
+
+        result
     }
     #[inline(always)]
     fn resolve_local_failed(&self, err: SymbolResolutionError) -> SymbolResolutionError {

--- a/crates/assembly/src/linker/resolver/mod.rs
+++ b/crates/assembly/src/linker/resolver/mod.rs
@@ -34,11 +34,14 @@ pub struct Resolver<'a, 'b: 'a> {
 /// values that contain no references to other symbols. Since these resolutions can be expensive
 /// to compute, and often represent items which are referenced multiple times, we cache them to
 /// avoid recomputing the same information over and over again.
+const MAX_TYPE_ALIAS_RESOLUTION_DEPTH: usize = 128;
+
 #[derive(Default)]
 pub struct ResolverCache {
     pub types: BTreeMap<GlobalItemIndex, types::Type>,
     pub constants: BTreeMap<GlobalItemIndex, ast::ConstantValue>,
     pub evaluating_constants: BTreeMap<GlobalItemIndex, SourceSpan>,
+    pub evaluating_types: BTreeMap<GlobalItemIndex, SourceSpan>,
 }
 
 impl<'a, 'b: 'a> Resolver<'a, 'b> {
@@ -199,7 +202,28 @@ impl<'a, 'b: 'a> ast::TypeResolver<LinkerError> for Resolver<'a, 'b> {
         context: SourceSpan,
         gid: GlobalItemIndex,
     ) -> Result<types::Type, LinkerError> {
-        match self.resolver.linker()[gid].item() {
+        if let Some(ty) = self.cache.types.get(&gid) {
+            return Ok(ty.clone());
+        }
+
+        if self.cache.evaluating_types.contains_key(&gid) {
+            return Err(LinkerError::from(SymbolResolutionError::alias_expansion_cycle(
+                context,
+                self.resolver.source_manager(),
+            )));
+        }
+
+        if self.cache.evaluating_types.len() >= MAX_TYPE_ALIAS_RESOLUTION_DEPTH {
+            return Err(LinkerError::from(SymbolResolutionError::type_expression_depth_exceeded(
+                context,
+                MAX_TYPE_ALIAS_RESOLUTION_DEPTH,
+                self.resolver.source_manager(),
+            )));
+        }
+
+        self.cache.evaluating_types.insert(gid, context);
+
+        let result = match self.resolver.linker()[gid].item() {
             SymbolItem::Compiled(ItemInfo::Type(info)) => Ok(info.ty.clone()),
             SymbolItem::Type(ast::TypeDecl::Enum(ty)) => {
                 // When resolving an EnumType, we must do three things:
@@ -250,8 +274,12 @@ impl<'a, 'b: 'a> ast::TypeResolver<LinkerError> for Resolver<'a, 'b> {
                         .into_boxed_slice(),
                     })
             },
-            SymbolItem::Type(ast::TypeDecl::Alias(ty)) => {
-                Ok(ty.ty.resolve_type(self)?.expect("unreachable"))
+            SymbolItem::Type(ast::TypeDecl::Alias(ty)) => match ty.ty.resolve_type(self)? {
+                Some(ty) => Ok(ty),
+                None => Err(LinkerError::UndefinedType {
+                    span: context,
+                    source_file: self.get_source_file_for(context),
+                }),
             },
             SymbolItem::Compiled(_) | SymbolItem::Constant(_) | SymbolItem::Procedure(_) => {
                 Err(LinkerError::InvalidTypeRef {
@@ -260,7 +288,15 @@ impl<'a, 'b: 'a> ast::TypeResolver<LinkerError> for Resolver<'a, 'b> {
                 })
             },
             SymbolItem::Alias { .. } => unreachable!("resolver should have expanded all aliases"),
+        };
+
+        self.cache.evaluating_types.remove(&gid);
+
+        if let Ok(ty) = &result {
+            self.cache.types.insert(gid, ty.clone());
         }
+
+        result
     }
 
     fn get_local_type(

--- a/crates/assembly/src/linker/rewrites/mod.rs
+++ b/crates/assembly/src/linker/rewrites/mod.rs
@@ -85,10 +85,19 @@ pub fn rewrite_symbol(
                 cache,
                 current_module: gid.module,
             };
-            let ty = item
-                .ty()
-                .resolve_type(&mut resolver)?
-                .expect("type or error to have been raised");
+            let ty = match item.ty().resolve_type(&mut resolver)? {
+                Some(ty) => ty,
+                None => {
+                    return Err(LinkerError::UndefinedType {
+                        span: item.span(),
+                        source_file: resolver
+                            .resolver
+                            .source_manager()
+                            .get(item.span().source_id())
+                            .ok(),
+                    });
+                },
+            };
             resolver.cache.types.insert(gid, ty);
         },
     }

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -6303,6 +6303,48 @@ fn invoking_imported_type_alias_returns_error_instead_of_panicking() {
 }
 
 #[test]
+fn cyclic_type_aliases_are_rejected_without_panicking() {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    let program = r#"
+        type a = b
+        type b = a
+
+        begin
+            push.1
+        end
+    "#;
+
+    let assembled =
+        catch_unwind(AssertUnwindSafe(|| Assembler::default().assemble_program(program)));
+
+    assert!(assembled.is_ok(), "assembly panicked, expected a structured error");
+    let err = assembled.unwrap().expect_err("expected cyclic type aliases to be rejected");
+    assert_diagnostic!(&err, "alias expansion cycle detected");
+}
+
+#[test]
+fn deep_type_alias_chain_hits_resolution_depth_limit() {
+    use std::{
+        fmt::Write,
+        panic::{AssertUnwindSafe, catch_unwind},
+    };
+
+    let mut source = String::new();
+    for i in 0..=260 {
+        writeln!(&mut source, "type t{i} = t{}", i + 1).unwrap();
+    }
+    source.push_str("type t261 = u32\n\nbegin\n    push.1\nend\n");
+
+    let assembled =
+        catch_unwind(AssertUnwindSafe(|| Assembler::default().assemble_program(&source)));
+
+    assert!(assembled.is_ok(), "assembly panicked, expected a structured error");
+    let err = assembled.unwrap().expect_err("expected deep type alias chain to be rejected");
+    assert_diagnostic!(&err, "type expression nesting depth exceeded");
+}
+
+#[test]
 fn test_cross_module_quoted_identifier_resolution() -> TestResult {
     let context = TestContext::default();
 


### PR DESCRIPTION
  ## Describe your changes
                                                                                                                                                                                                     
  This PR hardens type resolution for assembly aliases to prevent recursive expansion failures from turning into stack overflows or panics.                                                          
                                                                                                                                                                                                     
  ### What changed                                                                                                                                                                                   
  - Added recursion guards for type alias resolution in:                                                                                                                                             
    - `crates/assembly/src/linker/resolver/mod.rs`                                                                                                                                                   
    - `crates/assembly-syntax/src/ast/module.rs`                                                                                                                                                     
  - Introduced explicit alias-resolution depth limits to stop unbounded alias chains with structured diagnostics.                                                                                    
  - Replaced panic-prone assumptions in rewrite/type resolution paths with proper compiler errors in:                                                                                                
    - `crates/assembly/src/linker/rewrites/mod.rs`                                                                                                                                                   
  - Added regression tests in `crates/assembly/src/tests.rs` to verify:                                                                                                                              
    - cyclic aliases are rejected with diagnostics (no panic)                                                                                                                                        
    - deep alias chains hit a bounded depth error (no stack overflow)                                                                                                                                
                                                                                                                                                                                                     
  ### Why                                                                                                                                                                                            
  Type alias recursion previously lacked full “in-progress” cycle tracking and bounded depth handling across the resolution chain. This change makes behavior deterministic, safer, and easier to maintain.                                                                                                                                                                                          
                                                                                                                                                                                                     
  ### Validation                                                                                                                                                                                     
  - Added/updated tests covering cycle and depth-limit scenarios.                                                                                                                                    
  - Verified affected assembly crate checks/tests for this change set.                                                                                                                               
                                                                                                                                                                                                     
  ### Related
  - Builds on prior recursion-hardening work: #2792                                                                                                                                                  
                                                                                                                                                                                                     
  ## Checklist before requesting a review                                                                                                                                                            
  - [ ] Repo forked and branch created from `next` according to naming convention.                                                                                                                   
  - [x] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).                                                                                                                      
  - [ ] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).                                                                      
  - [x] Relevant issues are linked in the PR description.                                                                                                                                            
  - [x] Tests added for new functionality.                                                                                                                                                           
  - [ ] Documentation/comments updated according to changes.                                                                                                                                         
  - [ ] Updated `CHANGELOG.md`.