### PR TITLE
Clarify constant division semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@
 - [BREAKING] Refined MAST forest read policies with trusted wire-backed views, options-based untrusted reads, and separate wire and validation budgets ([#3077](https://github.com/0xMiden/miden-vm/pull/3077)).
 - Documented sortedness precondition more prominently for sorted array operations ([#2832](https://github.com/0xMiden/miden-vm/pull/2832)).
 - Removed AIR constraint tagging instrumentation, applied a uniform constraint description style across components, and optimized constraint evaluation ([#2856](https://github.com/0xMiden/miden-vm/pull/2856)).
-- Clarified `/` and `//` division semantics in constant expressions ([#3053](https://github.com/0xMiden/miden-vm/issues/3053)).
+- Clarified `/` and `//` division semantics in constant expressions ([#3113](https://github.com/0xMiden/miden-vm/pull/3113)).
 - [BREAKING] Updated the Miden crypto stack to `miden-crypto` and `miden-lifted-stark` v0.24, and switched digest-ordering code to `Word`'s native lexicographic ordering ([#3039](https://github.com/0xMiden/miden-vm/pull/3039)).
 - Borrowed operation slices in basic-block batching helpers to avoid cloning in the fingerprinting path ([#2994](https://github.com/0xMiden/miden-vm/pull/2994)).
 - [BREAKING] Sync execution and proving APIs now require `SyncHost`; async `Host`, `execute`, and `prove` remain available ([#2865](https://github.com/0xMiden/miden-vm/pull/2865)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@
 - [BREAKING] Refined MAST forest read policies with trusted wire-backed views, options-based untrusted reads, and separate wire and validation budgets ([#3077](https://github.com/0xMiden/miden-vm/pull/3077)).
 - Documented sortedness precondition more prominently for sorted array operations ([#2832](https://github.com/0xMiden/miden-vm/pull/2832)).
 - Removed AIR constraint tagging instrumentation, applied a uniform constraint description style across components, and optimized constraint evaluation ([#2856](https://github.com/0xMiden/miden-vm/pull/2856)).
+- Clarified `/` and `//` division semantics in constant expressions ([#3053](https://github.com/0xMiden/miden-vm/issues/3053)).
+- [BREAKING] Updated the Miden crypto stack to `miden-crypto` and `miden-lifted-stark` v0.24, and switched digest-ordering code to `Word`'s native lexicographic ordering ([#3039](https://github.com/0xMiden/miden-vm/pull/3039)).
+- Borrowed operation slices in basic-block batching helpers to avoid cloning in the fingerprinting path ([#2994](https://github.com/0xMiden/miden-vm/pull/2994)).
 - [BREAKING] Sync execution and proving APIs now require `SyncHost`; async `Host`, `execute`, and `prove` remain available ([#2865](https://github.com/0xMiden/miden-vm/pull/2865)).
 - [BREAKING] `miden_processor::execute()` and `execute_sync()` now return `ExecutionOutput`; trace building remains explicit via `execute_trace_inputs*()` and `trace::build_trace()` ([#2865](https://github.com/0xMiden/miden-vm/pull/2865)).
 - [BREAKING] Removed the deprecated `FastProcessor::execute_sync_mut()` alias; `execute_mut_sync()` is now the only sync mutable-execution entrypoint ([#2865](https://github.com/0xMiden/miden-vm/pull/2865)).

--- a/docs/src/user_docs/assembly/code_organization.md
+++ b/docs/src/user_docs/assembly/code_organization.md
@@ -235,7 +235,16 @@ Miden assembly supports constant declarations. Similar to procedures, constants 
 
 A constant's name must start with an upper-case letter and can contain any combination of numbers, upper-case ASCII letters, and underscores (`_`). The number of characters in a constant name cannot exceed 100.
 
-A constant's value must be in a decimal or hexadecimal form and be in the range between $0$ and $2^{64} - 2^{32}$ (both inclusive). Value can be defined by an arithmetic expression using `+`, `-`, `*`, `/`, `//`, `(`, `)` operators and references to the previously defined constants if it uses only decimal numbers. Here `/` is a field division and `//` is an integer division. Note that the arithmetic expression cannot contain spaces.
+A constant's value must be in a decimal or hexadecimal form and be in the range between $0$ and $2^{64} - 2^{32}$ (both inclusive). Value can be defined by an arithmetic expression using `+`, `-`, `*`, `/`, `//`, `(`, `)` operators and references to the previously defined constants if it uses only decimal numbers. Note that the arithmetic expression cannot contain spaces.
+
+The division operators in constant expressions have different semantics:
+
+| Operator | Semantics | Example |
+| -------- | --------- | ------- |
+| `/`      | Field division over the VM's base field. This evaluates as $a \cdot b^{-1} \mod p$, matching the [`div`](./field_operations.md#arithmetic-and-boolean-operations) instruction. | `3/2 = 9223372034707292162` |
+| `//`     | Integer floor division. This evaluates as the usual quotient with the remainder discarded. | `3//2 = 1` |
+
+Use `//` when the intended result is an integer quotient.
 
 **NOTE:** Constants used as immediate operands, e.g. `push.CONSTANT` do not currently support qualified paths. For example, `push.foo::BAR` is not allowed. Instead, you must import the constant first, i.e. `use foo::BAR`, and then reference it as a local definition, i.e. `push.BAR`. We may lift this limitation in the future.
 

--- a/docs/src/user_docs/assembly/code_organization.md
+++ b/docs/src/user_docs/assembly/code_organization.md
@@ -241,7 +241,7 @@ The division operators in constant expressions have different semantics:
 
 | Operator | Semantics | Example |
 | -------- | --------- | ------- |
-| `/`      | Field division over the VM's base field. This evaluates as $a \cdot b^{-1} \mod p$, matching the [`div`](./field_operations.md#arithmetic-and-boolean-operations) instruction. | `3/2 = 9223372034707292162` |
+| `/`      | Field division over the VM's base field. This evaluates as $a \cdot b^{-1}$ modulo the VM base-field modulus, matching the [`div`](./field_operations.md#arithmetic-and-boolean-operations) instruction. | `3/2 = 9223372034707292162` |
 | `//`     | Integer floor division. This evaluates as the usual quotient with the remainder discarded. | `3//2 = 1` |
 
 Use `//` when the intended result is an integer quotient.


### PR DESCRIPTION
Clarifies the difference between `/` and `//` in constant expressions:

- `/` is field division over the VM base field, matching the `div` instruction
- `//` is integer floor division
- adds a small `3/2` vs `3//2` example to make the behavior obvious

Closes #3053

Checked:
- `git diff --check`