### PR TITLE
Deprecate post-last op decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - Collapsed the kernel ROM chiplet to one row per digest with a LogUp multiplicity, eliminating duplicate-callsite rows ([#2962](https://github.com/0xMiden/miden-vm/pull/2962)).
 - Made all internal `core::math` procedures natively little-endian ([#3084](https://github.com/0xMiden/miden-vm/pull/3084)).
 - [BREAKING] Updated the Miden crypto stack to `miden-crypto` 0.25, and switched SMT leaf hashing to use Poseidon2 domain separation so masm-side leaf digests match `SmtLeaf::hash()` ([#3095](https://github.com/0xMiden/miden-vm/pull/3095)).
+- Deprecated post-last operation-indexed decorators in favor of `after_exit`, normalizing legacy assembler input with a warning and rejecting malformed linked or serialized decorator indices ([#3114](https://github.com/0xMiden/miden-vm/pull/3114))
 
 ## 0.22.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Redesigned the hasher chiplet to use a controller/permutation split architecture with permutation calls deduplication ([#2927](https://github.com/0xMiden/miden-vm/pull/2927)).
 - Cached repeated test compilations to speed up assembler tests without changing coverage, and fixed the core library build watch path ([#3047](https://github.com/0xMiden/miden-vm/pull/3047)).
 - Documented that enum variants are module-level constants and must be unique within a module ([#2932]((https://github.com/0xMiden/miden-vm/pull/2932)).
+- [BREAKING] Removed `Continuation::AfterExitDecoratorsBasicBlock`. New MAST merges operation-indexed decorators at the post-last-op sentinel index into `after_exit` at build time; execution uses `AfterExitDecorators` only, with legacy forests still supported ([#2633](https://github.com/0xMiden/miden-vm/issues/2633)).
 - Refactor trace generation to row-major format ([#2937](https://github.com/0xMiden/miden-vm/pull/2937)).
 - Documented non-overlap requirement for `memcopy_words`, `memcopy_elements`, and AEAD encrypt/decrypt procedures ([#2941](https://github.com/0xMiden/miden-vm/pull/2941)).
 - Clarified that `mmr::get` fails for positions outside the current MMR rather than returning a sentinel value ([#3001](https://github.com/0xMiden/miden-vm/issues/3001)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@
 - Collapsed the kernel ROM chiplet to one row per digest with a LogUp multiplicity, eliminating duplicate-callsite rows ([#2962](https://github.com/0xMiden/miden-vm/pull/2962)).
 - Made all internal `core::math` procedures natively little-endian ([#3084](https://github.com/0xMiden/miden-vm/pull/3084)).
 - [BREAKING] Updated the Miden crypto stack to `miden-crypto` 0.25, and switched SMT leaf hashing to use Poseidon2 domain separation so masm-side leaf digests match `SmtLeaf::hash()` ([#3095](https://github.com/0xMiden/miden-vm/pull/3095)).
-- Deprecated post-last operation-indexed decorators in favor of `after_exit`, normalizing legacy assembler input with a warning and rejecting malformed linked or serialized decorator indices ([#3114](https://github.com/0xMiden/miden-vm/pull/3114))
+- [BREAKING] Reject post-last operation-indexed decorators in block assembly and serialized MAST forests; use `after_exit` for decorators that run after a block exits ([#3114](https://github.com/0xMiden/miden-vm/pull/3114)).
 
 ## 0.22.1
 

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -687,6 +687,21 @@ impl MastForest {
                 basic_block.validate_batch_invariants().map_err(|error_msg| {
                     MastForestError::InvalidBatchPadding(node_id, error_msg)
                 })?;
+
+                let num_operations = basic_block.num_operations() as usize;
+                let decorator_links = match self.decorator_links_for_node(node_id) {
+                    Ok(decorator_links) => decorator_links,
+                    Err(DecoratorIndexError::NodeIndex(_)) => continue,
+                    Err(error) => return Err(MastForestError::DecoratorError(error)),
+                };
+                for (operation_idx, _) in decorator_links {
+                    if operation_idx >= num_operations {
+                        return Err(MastForestError::DecoratorOpIndexOutOfBounds {
+                            operation_idx,
+                            num_operations,
+                        });
+                    }
+                }
             }
         }
 

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -1308,6 +1308,13 @@ pub enum MastForestError {
     #[error("basic block cannot be created from an empty list of operations")]
     EmptyBasicBlock,
     #[error(
+        "decorator operation index {operation_idx} is greater than or equal to operation count {num_operations}"
+    )]
+    DecoratorOpIndexOutOfBounds {
+        operation_idx: usize,
+        num_operations: usize,
+    },
+    #[error(
         "decorator root of child with node id {0} is missing but is required for fingerprint computation"
     )]
     ChildFingerprintMissing(MastNodeId),

--- a/core/src/mast/node/basic_block_node/arbitrary.rs
+++ b/core/src/mast/node/basic_block_node/arbitrary.rs
@@ -148,9 +148,9 @@ pub fn decorator_pairs_strategy(
     max_id: u32,
     max_pairs: usize,
 ) -> impl Strategy<Value = Vec<(usize, DecoratorId)>> {
-    // indices in [0, ops_len] inclusive; size 0..=max_pairs
+    // indices in [0, ops_len); size 0..=max_pairs
     // Generate, then sort by index to match validation expectations
-    prop::collection::vec((0..=ops_len, decorator_id_strategy(max_id)), 0..=max_pairs).prop_map(
+    prop::collection::vec((0..ops_len, decorator_id_strategy(max_id)), 0..=max_pairs).prop_map(
         |mut v| {
             v.sort_by_key(|(i, _)| *i);
             v

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -139,6 +139,7 @@ impl BasicBlockNode {
         if operations.is_empty() {
             return Err(MastForestError::EmptyBasicBlock);
         }
+        validate_decorator_indices_within_ops(operations.len(), &decorators)?;
 
         // Validate decorators list (only in debug mode).
         #[cfg(debug_assertions)]
@@ -1239,6 +1240,20 @@ pub(crate) fn validate_decorators(operations_len: usize, decorators: &DecoratorL
     }
 }
 
+fn validate_decorator_indices_within_ops(
+    operations_len: usize,
+    decorators: &DecoratorList,
+) -> Result<(), MastForestError> {
+    if let Some(&(operation_idx, _)) = decorators.iter().find(|(idx, _)| *idx >= operations_len) {
+        return Err(MastForestError::DecoratorOpIndexOutOfBounds {
+            operation_idx,
+            num_operations: operations_len,
+        });
+    }
+
+    Ok(())
+}
+
 /// Raw-indexed prefix: how many paddings strictly before raw index r
 ///
 /// This struct provides O(1) lookup for converting raw operation indices to padded indices.
@@ -1492,6 +1507,7 @@ impl BasicBlockNodeBuilder {
                 if operations.is_empty() {
                     return Err(MastForestError::EmptyBasicBlock);
                 }
+                validate_decorator_indices_within_ops(operations.len(), &decorators)?;
 
                 // Validate decorators list (only in debug mode).
                 #[cfg(debug_assertions)]
@@ -1610,6 +1626,7 @@ impl MastForestContributor for BasicBlockNodeBuilder {
                 if operations.is_empty() {
                     return Err(MastForestError::EmptyBasicBlock);
                 }
+                validate_decorator_indices_within_ops(operations.len(), &decorators)?;
 
                 // Validate decorators list (only in debug mode).
                 #[cfg(debug_assertions)]
@@ -1678,6 +1695,7 @@ impl MastForestContributor for BasicBlockNodeBuilder {
         let (op_batches, digest, raw_decorators) = match &self.operation_data {
             OperationData::Raw { operations, decorators } => {
                 // Compute digest - use forced digest if available, otherwise compute normally
+                validate_decorator_indices_within_ops(operations.len(), decorators)?;
                 let (op_batches, computed_digest) = batch_and_hash_ops(operations);
                 let digest = self.digest.unwrap_or(computed_digest);
 

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -125,6 +125,10 @@ impl BasicBlockNode {
 impl BasicBlockNode {
     /// Returns a new [`BasicBlockNode`] instantiated with the specified operations and decorators.
     ///
+    /// Raw decorator indices are adjusted for padding, then op-indexed decorators at the
+    /// post-last-op sentinel are merged into `after_exit`, matching
+    /// [`BasicBlockNodeBuilder::build`].
+    ///
     /// Returns an error if:
     /// - `operations` vector is empty.
     #[cfg(any(test, feature = "arbitrary"))]
@@ -143,15 +147,20 @@ impl BasicBlockNode {
         let (op_batches, digest) = batch_and_hash_ops(&operations);
         // the prior line may have inserted some padding Noops in the op_batches
         // the decorator mapping should still point to the correct operation when that happens
-        let reflowed_decorators = BasicBlockNode::adjust_decorators(decorators, &op_batches);
+        let padded_decorators = BasicBlockNode::adjust_decorators(decorators, &op_batches);
+        let (padded_decorators, after_exit) = merge_sentinel_op_decorators_into_after_exit(
+            &op_batches,
+            padded_decorators,
+            Vec::new(),
+        );
 
         Ok(Self {
             op_batches,
             digest,
             decorators: DecoratorStore::Owned {
-                decorators: reflowed_decorators,
+                decorators: padded_decorators,
                 before_enter: Vec::new(),
-                after_exit: Vec::new(),
+                after_exit,
             },
         })
     }

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -33,6 +33,31 @@ mod tests;
 /// Maximum number of operations per group.
 pub const GROUP_SIZE: usize = 9;
 
+/// Op-indexed decorators at padded index `num_padded_ops` run after the last operation; merge them
+/// into `after_exit` (before any existing `after_exit` ids), preserving relative order.
+pub(crate) fn merge_sentinel_op_decorators_into_after_exit(
+    op_batches: &[OpBatch],
+    padded_decorators: DecoratorList,
+    after_exit: Vec<DecoratorId>,
+) -> (DecoratorList, Vec<DecoratorId>) {
+    let num_padded_ops: usize = op_batches.iter().map(|b| b.ops().len()).sum();
+    let mut rest = DecoratorList::with_capacity(padded_decorators.len());
+    let mut sentinel = Vec::new();
+    for (idx, id) in padded_decorators {
+        if idx == num_padded_ops {
+            sentinel.push(id);
+        } else {
+            debug_assert!(
+                idx < num_padded_ops,
+                "decorator op index {idx} exceeds padded op count {num_padded_ops}"
+            );
+            rest.push((idx, id));
+        }
+    }
+    let after_merged: Vec<DecoratorId> = sentinel.into_iter().chain(after_exit).collect();
+    (rest, after_merged)
+}
+
 /// Maximum number of groups per batch.
 pub const BATCH_SIZE: usize = 8;
 const _: [(); 1] = [(); ((BATCH_SIZE & (BATCH_SIZE - 1)) == 0) as usize];
@@ -1485,13 +1510,19 @@ impl BasicBlockNodeBuilder {
             },
         };
 
+        let (padded_decorators, after_exit) = merge_sentinel_op_decorators_into_after_exit(
+            &op_batches,
+            padded_decorators,
+            self.after_exit.clone(),
+        );
+
         Ok(BasicBlockNode {
             op_batches,
             digest,
             decorators: DecoratorStore::Owned {
                 decorators: padded_decorators,
                 before_enter: self.before_enter.clone(),
-                after_exit: self.after_exit.clone(),
+                after_exit,
             },
         })
     }
@@ -1598,6 +1629,12 @@ impl MastForestContributor for BasicBlockNodeBuilder {
             },
         };
 
+        let (padded_decorators, after_exit) = merge_sentinel_op_decorators_into_after_exit(
+            &op_batches,
+            padded_decorators,
+            self.after_exit.clone(),
+        );
+
         // Add decorator info to the forest storage
         forest
             .debug_info
@@ -1605,7 +1642,7 @@ impl MastForestContributor for BasicBlockNodeBuilder {
             .map_err(MastForestError::DecoratorError)?;
 
         // Add node-level decorators to the centralized NodeToDecoratorIds for efficient access
-        forest.register_node_decorators(future_node_id, &self.before_enter, &self.after_exit);
+        forest.register_node_decorators(future_node_id, &self.before_enter, &after_exit);
 
         // Create the node in the forest with Linked variant from the start
         let node_id = forest

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -33,31 +33,6 @@ mod tests;
 /// Maximum number of operations per group.
 pub const GROUP_SIZE: usize = 9;
 
-/// Op-indexed decorators at padded index `num_padded_ops` run after the last operation; merge them
-/// into `after_exit` (before any existing `after_exit` ids), preserving relative order.
-pub(crate) fn merge_sentinel_op_decorators_into_after_exit(
-    op_batches: &[OpBatch],
-    padded_decorators: DecoratorList,
-    after_exit: Vec<DecoratorId>,
-) -> (DecoratorList, Vec<DecoratorId>) {
-    let num_padded_ops: usize = op_batches.iter().map(|b| b.ops().len()).sum();
-    let mut rest = DecoratorList::with_capacity(padded_decorators.len());
-    let mut sentinel = Vec::new();
-    for (idx, id) in padded_decorators {
-        if idx == num_padded_ops {
-            sentinel.push(id);
-        } else {
-            debug_assert!(
-                idx < num_padded_ops,
-                "decorator op index {idx} exceeds padded op count {num_padded_ops}"
-            );
-            rest.push((idx, id));
-        }
-    }
-    let after_merged: Vec<DecoratorId> = sentinel.into_iter().chain(after_exit).collect();
-    (rest, after_merged)
-}
-
 /// Maximum number of groups per batch.
 pub const BATCH_SIZE: usize = 8;
 const _: [(); 1] = [(); ((BATCH_SIZE & (BATCH_SIZE - 1)) == 0) as usize];
@@ -125,8 +100,7 @@ impl BasicBlockNode {
 impl BasicBlockNode {
     /// Returns a new [`BasicBlockNode`] instantiated with the specified operations and decorators.
     ///
-    /// Raw decorator indices are adjusted for padding, then op-indexed decorators at the
-    /// post-last-op sentinel are merged into `after_exit`, matching
+    /// Raw decorator indices are adjusted for padding, matching
     /// [`BasicBlockNodeBuilder::build`].
     ///
     /// Returns an error if:
@@ -149,11 +123,6 @@ impl BasicBlockNode {
         // the prior line may have inserted some padding Noops in the op_batches
         // the decorator mapping should still point to the correct operation when that happens
         let padded_decorators = BasicBlockNode::adjust_decorators(decorators, &op_batches);
-        let (padded_decorators, after_exit) = merge_sentinel_op_decorators_into_after_exit(
-            &op_batches,
-            padded_decorators,
-            Vec::new(),
-        );
 
         Ok(Self {
             op_batches,
@@ -161,7 +130,7 @@ impl BasicBlockNode {
             decorators: DecoratorStore::Owned {
                 decorators: padded_decorators,
                 before_enter: Vec::new(),
-                after_exit,
+                after_exit: Vec::new(),
             },
         })
     }
@@ -1224,7 +1193,7 @@ impl<'a> Iterator for OperationOrDecoratorIterator<'a> {
 
 /// Checks if a given decorators list is valid (only checked in debug mode)
 /// - Assert the decorator list is in ascending order.
-/// - Assert the last op index in decorator list is less than or equal to the number of operations.
+/// - Assert the last op index in decorator list is less than the number of operations.
 #[cfg(debug_assertions)]
 pub(crate) fn validate_decorators(operations_len: usize, decorators: &DecoratorList) {
     if !decorators.is_empty() {
@@ -1232,10 +1201,10 @@ pub(crate) fn validate_decorators(operations_len: usize, decorators: &DecoratorL
         for i in 0..(decorators.len() - 1) {
             debug_assert!(decorators[i + 1].0 >= decorators[i].0, "unsorted decorators list");
         }
-        // assert the last index in decorator list is less than or equal to operations vector length
+        // assert the last index in decorator list is less than operations vector length
         debug_assert!(
-            operations_len >= decorators.last().expect("empty decorators list").0,
-            "last op index in decorator list should be less than or equal to the number of ops"
+            operations_len > decorators.last().expect("empty decorators list").0,
+            "last op index in decorator list should be less than the number of ops"
         );
     }
 }
@@ -1252,6 +1221,17 @@ fn validate_decorator_indices_within_ops(
     }
 
     Ok(())
+}
+
+fn num_padded_operations(op_batches: &[OpBatch]) -> usize {
+    op_batches.iter().map(|batch| batch.ops().len()).sum()
+}
+
+fn validate_padded_decorator_indices_within_batches(
+    op_batches: &[OpBatch],
+    decorators: &DecoratorList,
+) -> Result<(), MastForestError> {
+    validate_decorator_indices_within_ops(num_padded_operations(op_batches), decorators)
 }
 
 /// Raw-indexed prefix: how many paddings strictly before raw index r
@@ -1291,7 +1271,7 @@ impl RawToPaddedPrefix {
             }
         }
 
-        // Sentinel for r == raw_ops
+        // Extra prefix slot for r == raw_ops
         v.push(pads_so_far);
         RawToPaddedPrefix(v)
     }
@@ -1307,10 +1287,10 @@ impl RawToPaddedPrefix {
 ///
 /// ## Sentinel Access
 ///
-/// Some decorators have an operation index equal to the length of the
-/// operations array, to ensure they are executed at the end of the block
-/// (since the semantics of the decorator index is that it must be executed
-/// before the operation index it points to).
+/// The extra prefix slot supports internal raw end-of-block mappings, such as
+/// `after_exit` decorators returned by [`BasicBlockNode::raw_decorator_iter`].
+/// Op-indexed decorator input is still required to use indexes strictly below
+/// the number of raw operations.
 impl core::ops::Index<usize> for RawToPaddedPrefix {
     type Output = usize;
     #[inline]
@@ -1325,7 +1305,7 @@ impl core::ops::Index<usize> for RawToPaddedPrefix {
 /// For any padded index p, `padded_to_raw[p] = count of padding ops strictly before padded index
 /// p`.
 ///
-/// Length: `padded_ops + 1` (includes sentinel entry at `p == padded_ops`)
+/// Length: `padded_ops + 1` (includes extra entry at `p == padded_ops`)
 /// Usage: `raw_idx = p - padded_to_raw[p]` (subtraction)
 #[derive(Debug, Clone)]
 pub struct PaddedToRawPrefix(Vec<usize>);
@@ -1334,7 +1314,7 @@ impl PaddedToRawPrefix {
     /// Build a padded-indexed prefix array from op batches.
     ///
     /// Simulates emission of the padded sequence, recording padding count before each position.
-    /// Includes a sentinel entry at `p == padded_ops`.
+    /// Includes an extra entry at `p == padded_ops` for internal end-of-block mappings.
     pub fn new(op_batches: &[OpBatch]) -> Self {
         // Exact capacity to avoid reallocations: sum of per-group lengths across all batches.
         let padded_ops = op_batches
@@ -1374,7 +1354,7 @@ impl PaddedToRawPrefix {
             }
         }
 
-        // Sentinel at p == padded_ops
+        // Extra prefix slot at p == padded_ops
         v.push(pads_so_far);
 
         PaddedToRawPrefix(v)
@@ -1385,10 +1365,9 @@ impl PaddedToRawPrefix {
 ///
 /// ## Sentinel Access
 ///
-/// Some decorators have an operation index equal to the length of the
-/// operations array, to ensure they are executed at the end of the block
-/// (since the semantics of the decorator index is that it must be executed
-/// before the operation index it points to).
+/// The extra prefix slot supports internal padded end-of-block mappings.
+/// Op-indexed decorator input is still required to use indexes strictly below
+/// the number of padded operations.
 impl core::ops::Index<usize> for PaddedToRawPrefix {
     type Output = usize;
     #[inline]
@@ -1527,6 +1506,7 @@ impl BasicBlockNodeBuilder {
                 if op_batches.is_empty() {
                     return Err(MastForestError::EmptyBasicBlock);
                 }
+                validate_padded_decorator_indices_within_batches(&op_batches, &decorators)?;
 
                 // Decorators are already padded - no adjustment needed!
                 let digest = self.digest.expect("digest must be set for batched operations");
@@ -1535,19 +1515,13 @@ impl BasicBlockNodeBuilder {
             },
         };
 
-        let (padded_decorators, after_exit) = merge_sentinel_op_decorators_into_after_exit(
-            &op_batches,
-            padded_decorators,
-            self.after_exit.clone(),
-        );
-
         Ok(BasicBlockNode {
             op_batches,
             digest,
             decorators: DecoratorStore::Owned {
                 decorators: padded_decorators,
                 before_enter: self.before_enter.clone(),
-                after_exit,
+                after_exit: self.after_exit.clone(),
             },
         })
     }
@@ -1647,6 +1621,7 @@ impl MastForestContributor for BasicBlockNodeBuilder {
                 if op_batches.is_empty() {
                     return Err(MastForestError::EmptyBasicBlock);
                 }
+                validate_padded_decorator_indices_within_batches(&op_batches, &decorators)?;
 
                 // Decorators are already padded - no adjustment needed!
                 let digest = self.digest.expect("digest must be set for batched operations");
@@ -1655,12 +1630,6 @@ impl MastForestContributor for BasicBlockNodeBuilder {
             },
         };
 
-        let (padded_decorators, after_exit) = merge_sentinel_op_decorators_into_after_exit(
-            &op_batches,
-            padded_decorators,
-            self.after_exit.clone(),
-        );
-
         // Add decorator info to the forest storage
         forest
             .debug_info
@@ -1668,7 +1637,7 @@ impl MastForestContributor for BasicBlockNodeBuilder {
             .map_err(MastForestError::DecoratorError)?;
 
         // Add node-level decorators to the centralized NodeToDecoratorIds for efficient access
-        forest.register_node_decorators(future_node_id, &self.before_enter, &after_exit);
+        forest.register_node_decorators(future_node_id, &self.before_enter, &self.after_exit);
 
         // Create the node in the forest with Linked variant from the start
         let node_id = forest
@@ -1708,6 +1677,7 @@ impl MastForestContributor for BasicBlockNodeBuilder {
                 (op_batches, digest, decorators.clone())
             },
             OperationData::Batched { op_batches, decorators } => {
+                validate_padded_decorator_indices_within_batches(op_batches, decorators)?;
                 let digest = self.digest.expect("digest must be set for batched operations");
 
                 // Convert from padded to raw indices for fingerprinting

--- a/core/src/mast/node/basic_block_node/tests.rs
+++ b/core/src/mast/node/basic_block_node/tests.rs
@@ -279,13 +279,14 @@ fn operation_or_decorator_iterator() {
     let mut mast_forest = MastForest::new();
     let operations = vec![Operation::Add, Operation::Mul, Operation::MovDn2, Operation::MovDn3];
 
-    // Note: there are 2 decorators after the last instruction
     let decorators = vec![
         (0, Decorator::Trace(0)), // ID: 0
         (0, Decorator::Trace(1)), // ID: 1
         (3, Decorator::Trace(2)), // ID: 2
-        (4, Decorator::Trace(3)), // ID: 3
-        (4, Decorator::Trace(4)), // ID: 4
+    ];
+    let after_exit_decorators = vec![
+        Decorator::Trace(3), // ID: 3
+        Decorator::Trace(4), // ID: 4
     ];
 
     // Convert raw decorators to decorator list by adding them to the forest first
@@ -297,8 +298,14 @@ fn operation_or_decorator_iterator() {
         })
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
+    let after_exit: Vec<DecoratorId> = after_exit_decorators
+        .into_iter()
+        .map(|decorator| mast_forest.add_decorator(decorator))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
 
     let node_id = BasicBlockNodeBuilder::new(operations, decorator_list)
+        .with_after_exit(after_exit)
         .add_to_forest(&mut mast_forest)
         .unwrap();
     let node = mast_forest.get_node_by_id(node_id).unwrap().unwrap_basic_block();
@@ -605,9 +612,13 @@ fn validate_padding_semantics_rejects_num_groups_overflow_without_panicking() {
 fn decorator_strategy(
     nops: usize,
     max_decorators: usize,
-) -> impl Strategy<Value = Vec<(usize, DecoratorId)>> {
+) -> BoxedStrategy<Vec<(usize, DecoratorId)>> {
+    if nops == 0 {
+        return Just(Vec::new()).boxed();
+    }
+
     prop::collection::vec(
-        (0..=nops, any::<u32>().prop_map(DecoratorId::new_unchecked)),
+        (0..nops, any::<u32>().prop_map(DecoratorId::new_unchecked)),
         0..=max_decorators,
     )
     .prop_map(move |mut decorators| {
@@ -615,6 +626,7 @@ fn decorator_strategy(
         decorators.sort_by_key(|(idx, _)| *idx);
         decorators
     })
+    .boxed()
 }
 
 // Strategy for generating a list of decorators with valid indices for a given operation sequence
@@ -654,6 +666,18 @@ proptest! {
         // The collected decorators should match the original decorators
         prop_assert_eq!(collected_decorators, decs);
     }
+}
+
+#[test]
+fn basic_block_builder_rejects_post_last_op_decorator_index() {
+    let mut forest = MastForest::new();
+    let decorator_id = forest.add_decorator(Decorator::Trace(7)).unwrap();
+    let operations = vec![Operation::Add, Operation::Mul];
+
+    let result =
+        BasicBlockNodeBuilder::new(operations, vec![(2, decorator_id)]).add_to_forest(&mut forest);
+
+    assert!(result.is_err());
 }
 
 // Tests for the basic block decorator functionality added to support before_enter and after_exit

--- a/core/src/mast/node/basic_block_node/tests.rs
+++ b/core/src/mast/node/basic_block_node/tests.rs
@@ -680,6 +680,29 @@ fn basic_block_builder_rejects_post_last_op_decorator_index() {
     assert!(result.is_err());
 }
 
+#[test]
+fn basic_block_builder_rejects_post_last_padded_decorator_index() {
+    let mut forest = MastForest::new();
+    let decorator_id = forest.add_decorator(Decorator::Trace(7)).unwrap();
+    let (op_batches, digest) = batch_and_hash_ops(&[Operation::Add, Operation::Mul]);
+    let num_padded_ops = num_padded_operations(&op_batches);
+
+    let result = BasicBlockNodeBuilder::from_op_batches(
+        op_batches,
+        vec![(num_padded_ops, decorator_id)],
+        digest,
+    )
+    .add_to_forest(&mut forest);
+
+    assert!(matches!(
+        result,
+        Err(MastForestError::DecoratorOpIndexOutOfBounds {
+            operation_idx,
+            num_operations,
+        }) if operation_idx == num_padded_ops && num_operations == num_padded_ops
+    ));
+}
+
 // Tests for the basic block decorator functionality added to support before_enter and after_exit
 // decorators.
 // --------------------------------------------------------------------------------------------

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -2408,6 +2408,31 @@ fn test_untrusted_forest_accepts_full_prefix_batch() {
 }
 
 #[test]
+fn test_untrusted_forest_rejects_post_last_op_decorator_storage() {
+    let mut forest = MastForest::new();
+    let decorator_id = forest.add_decorator(Decorator::Trace(42)).unwrap();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add], Vec::new())
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.debug_info_mut().clear_mappings();
+    forest
+        .debug_info_mut()
+        .register_op_indexed_decorators(block_id, vec![(1, decorator_id)])
+        .unwrap();
+    forest.make_root(block_id);
+
+    let bytes = forest.to_bytes();
+
+    let parsed = MastForest::read_from_bytes(&bytes).unwrap();
+    let result = parsed.validate();
+
+    assert_matches!(
+        result,
+        Err(MastForestError::DecoratorOpIndexOutOfBounds { operation_idx: 1, num_operations: 1 })
+    );
+}
+
+#[test]
 fn test_untrusted_forest_rejects_basic_block_indptr_that_breaks_push_immediate_commitment() {
     // Two distinct immediates. Using large values reduces the chance of accidental equality with a
     // packed opcode group value.

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -341,8 +341,6 @@ fn serialize_deserialize_all_nodes() {
     let basic_block_id = {
         let operations = sample_basic_block_operations_all_variants();
 
-        let num_operations = operations.len();
-
         // Note: AssemblyOps are now stored separately in DebugInfo's asm_op storage,
         // not as decorators. See the asm_op module tests for AssemblyOp serialization.
         let decorators = vec![
@@ -352,8 +350,8 @@ fn serialize_deserialize_all_nodes() {
             (15, Decorator::Debug(DebugOptions::MemInterval(0, 16))),
             (17, Decorator::Debug(DebugOptions::LocalInterval(1, 2, 3))),
             (19, Decorator::Debug(DebugOptions::AdvStackTop(255))),
-            (num_operations, Decorator::Trace(55)),
         ];
+        let after_exit_decorator = Decorator::Trace(55);
 
         // Convert raw decorators to decorator list by adding them to the forest first
         let decorator_list: Vec<(usize, crate::mast::DecoratorId)> = decorators
@@ -363,8 +361,10 @@ fn serialize_deserialize_all_nodes() {
             })
             .collect::<Result<Vec<_>, MastForestError>>()
             .unwrap();
+        let after_exit = vec![mast_forest.add_decorator(after_exit_decorator).unwrap()];
 
         BasicBlockNodeBuilder::new(operations, decorator_list)
+            .with_after_exit(after_exit)
             .add_to_forest(&mut mast_forest)
             .unwrap()
     };
@@ -686,7 +686,8 @@ fn mast_forest_serialize_deserialize_with_child_ids_exceeding_parent_id() {
     let first = BasicBlockNodeBuilder::new(vec![Operation::U32add], vec![(0, deco0)])
         .add_to_forest(&mut forest)
         .unwrap();
-    let second = BasicBlockNodeBuilder::new(vec![Operation::U32and], vec![(1, deco1)])
+    let second = BasicBlockNodeBuilder::new(vec![Operation::U32and], Vec::new())
+        .with_after_exit(vec![deco1])
         .add_to_forest(&mut forest)
         .unwrap();
     JoinNodeBuilder::new([first, second]).add_to_forest(&mut forest).unwrap();
@@ -719,7 +720,8 @@ fn mast_forest_serialize_deserialize_with_overflowing_ids_fails() {
     let mut forest = MastForest::new();
     let deco0 = forest.add_decorator(Decorator::Trace(0)).unwrap();
     let deco1 = forest.add_decorator(Decorator::Trace(1)).unwrap();
-    BasicBlockNodeBuilder::new(vec![Operation::U32add], vec![(0, deco0), (1, deco1)])
+    BasicBlockNodeBuilder::new(vec![Operation::U32add], vec![(0, deco0)])
+        .with_after_exit(vec![deco1])
         .add_to_forest(&mut forest)
         .unwrap();
     // hack to force addition of a node which builder would return an error at runtime
@@ -800,7 +802,8 @@ fn mast_forest_serialize_deserialize_advice_map() {
     let first = BasicBlockNodeBuilder::new(vec![Operation::U32add], vec![(0, deco0)])
         .add_to_forest(&mut forest)
         .unwrap();
-    let second = BasicBlockNodeBuilder::new(vec![Operation::U32and], vec![(1, deco1)])
+    let second = BasicBlockNodeBuilder::new(vec![Operation::U32and], Vec::new())
+        .with_after_exit(vec![deco1])
         .add_to_forest(&mut forest)
         .unwrap();
     JoinNodeBuilder::new([first, second]).add_to_forest(&mut forest).unwrap();

--- a/crates/assembly/src/basic_block_builder.rs
+++ b/crates/assembly/src/basic_block_builder.rs
@@ -226,8 +226,17 @@ impl BasicBlockBuilder<'_> {
     /// epilogue of the builder.
     pub fn make_basic_block(&mut self) -> Result<Option<MastNodeId>, Report> {
         if !self.ops.is_empty() {
+            let op_count = self.ops.len();
             let ops = self.ops.drain(..).collect();
-            let decorators = self.decorators.drain(..).collect();
+            let mut decorators = DecoratorList::new();
+            let mut after_exit = Vec::new();
+            for (op_idx, decorator_id) in self.decorators.drain(..) {
+                if op_idx == op_count {
+                    after_exit.push(decorator_id);
+                } else {
+                    decorators.push((op_idx, decorator_id));
+                }
+            }
             let asm_ops = core::mem::take(&mut self.asm_ops);
             let debug_vars: Vec<(usize, DebugVarId)> = self.debug_vars.drain(..).collect();
 
@@ -237,7 +246,7 @@ impl BasicBlockBuilder<'_> {
                 asm_ops,
                 debug_vars,
                 vec![],
-                vec![],
+                after_exit,
             )?;
 
             Ok(Some(basic_block_node_id))

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -29,6 +29,8 @@ use crate::{
 
 /// Constant that decides how many operation batches disqualify a procedure from inlining.
 const PROCEDURE_INLINING_THRESHOLD: usize = 32;
+const POST_LAST_OP_DECORATOR_DEPRECATION_MESSAGE: &str = "post-last op decorators are deprecated; \
+this practice will be rejected in a future release. Use after-exit decorators instead.";
 
 // MAST FOREST BUILDER
 // ================================================================================================
@@ -258,24 +260,45 @@ fn serialize_asm_ops(asm_ops: &[(usize, AssemblyOp)]) -> Vec<u8> {
     data
 }
 
+struct SplitPostLastDecorators {
+    op_indexed_decorators: DecoratorList,
+    after_exit_decorators: Vec<DecoratorId>,
+    post_last_decorator_count: usize,
+}
+
 fn split_post_last_decorators(
     operations_len: usize,
     decorators: DecoratorList,
     after_exit: Vec<DecoratorId>,
-) -> (DecoratorList, Vec<DecoratorId>) {
+) -> SplitPostLastDecorators {
     let mut op_indexed_decorators = DecoratorList::with_capacity(decorators.len());
     let mut after_exit_decorators = Vec::new();
+    let mut post_last_decorator_count = 0;
 
     for (op_idx, decorator_id) in decorators {
         if op_idx == operations_len {
             after_exit_decorators.push(decorator_id);
+            post_last_decorator_count += 1;
         } else {
             op_indexed_decorators.push((op_idx, decorator_id));
         }
     }
     after_exit_decorators.extend(after_exit);
 
-    (op_indexed_decorators, after_exit_decorators)
+    SplitPostLastDecorators {
+        op_indexed_decorators,
+        after_exit_decorators,
+        post_last_decorator_count,
+    }
+}
+
+fn log_deprecated_post_last_op_decorators(post_last_decorator_count: usize) {
+    if post_last_decorator_count != 0 {
+        log::error!(
+            "{POST_LAST_OP_DECORATOR_DEPRECATION_MESSAGE} \
+rewrote {post_last_decorator_count} post-last op decorator(s) as after-exit decorator(s)."
+        );
+    }
 }
 
 /// Serializes AssemblyOp content referenced by `AsmOpId`s into bytes for fingerprint augmentation.
@@ -735,11 +758,11 @@ impl MastForestBuilder {
         before_enter: Vec<DecoratorId>,
         after_exit: Vec<DecoratorId>,
     ) -> Result<MastNodeId, Report> {
-        let (decorators, after_exit) =
-            split_post_last_decorators(operations.len(), decorators, after_exit);
-        let block = BasicBlockNodeBuilder::new(operations, decorators)
+        let split = split_post_last_decorators(operations.len(), decorators, after_exit);
+        log_deprecated_post_last_op_decorators(split.post_last_decorator_count);
+        let block = BasicBlockNodeBuilder::new(operations, split.op_indexed_decorators)
             .with_before_enter(before_enter)
-            .with_after_exit(after_exit);
+            .with_after_exit(split.after_exit_decorators);
 
         let base_fingerprint = block
             .fingerprint_for_node(&self.mast_forest, &self.hash_by_node_id)
@@ -1052,11 +1075,11 @@ impl MastForestBuilder {
         before_enter: Vec<DecoratorId>,
         after_exit: Vec<DecoratorId>,
     ) -> Result<MastNodeId, Report> {
-        let (decorators, after_exit) =
-            split_post_last_decorators(operations.len(), decorators, after_exit);
-        let block = BasicBlockNodeBuilder::new(operations, decorators)
+        let split = split_post_last_decorators(operations.len(), decorators, after_exit);
+        log_deprecated_post_last_op_decorators(split.post_last_decorator_count);
+        let block = BasicBlockNodeBuilder::new(operations, split.op_indexed_decorators)
             .with_before_enter(before_enter)
-            .with_after_exit(after_exit);
+            .with_after_exit(split.after_exit_decorators);
 
         // Compute the base fingerprint from the builder, then augment with external metadata
         // so the dedup key stays sensitive to source mappings without storing them on the
@@ -1585,6 +1608,24 @@ mod tests {
         );
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn split_post_last_decorators_reports_deprecated_compatibility_path() {
+        let op_indexed = DecoratorId::from(9);
+        let post_last = DecoratorId::from(10);
+        let after_exit = DecoratorId::from(11);
+
+        let split =
+            split_post_last_decorators(1, vec![(0, op_indexed), (1, post_last)], vec![after_exit]);
+
+        assert_eq!(split.op_indexed_decorators, vec![(0, op_indexed)]);
+        assert_eq!(split.after_exit_decorators, vec![post_last, after_exit]);
+        assert_eq!(split.post_last_decorator_count, 1);
+        assert!(
+            POST_LAST_OP_DECORATOR_DEPRECATION_MESSAGE
+                .contains("will be rejected in a future release")
+        );
     }
 
     /// Cloning a block with debug vars via `to_builder().with_before_enter()` must

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -29,8 +29,6 @@ use crate::{
 
 /// Constant that decides how many operation batches disqualify a procedure from inlining.
 const PROCEDURE_INLINING_THRESHOLD: usize = 32;
-const POST_LAST_OP_DECORATOR_DEPRECATION_MESSAGE: &str = "post-last op decorators are deprecated; \
-this practice will be rejected in a future release. Use after-exit decorators instead.";
 
 // MAST FOREST BUILDER
 // ================================================================================================
@@ -260,45 +258,22 @@ fn serialize_asm_ops(asm_ops: &[(usize, AssemblyOp)]) -> Vec<u8> {
     data
 }
 
-struct SplitPostLastDecorators {
-    op_indexed_decorators: DecoratorList,
-    after_exit_decorators: Vec<DecoratorId>,
-    post_last_decorator_count: usize,
-}
-
-fn split_post_last_decorators(
+fn split_merge_trailing_decorators(
     operations_len: usize,
     decorators: DecoratorList,
-    after_exit: Vec<DecoratorId>,
-) -> SplitPostLastDecorators {
+) -> (DecoratorList, Vec<DecoratorId>) {
     let mut op_indexed_decorators = DecoratorList::with_capacity(decorators.len());
     let mut after_exit_decorators = Vec::new();
-    let mut post_last_decorator_count = 0;
 
     for (op_idx, decorator_id) in decorators {
         if op_idx == operations_len {
             after_exit_decorators.push(decorator_id);
-            post_last_decorator_count += 1;
         } else {
             op_indexed_decorators.push((op_idx, decorator_id));
         }
     }
-    after_exit_decorators.extend(after_exit);
 
-    SplitPostLastDecorators {
-        op_indexed_decorators,
-        after_exit_decorators,
-        post_last_decorator_count,
-    }
-}
-
-fn log_deprecated_post_last_op_decorators(post_last_decorator_count: usize) {
-    if post_last_decorator_count != 0 {
-        log::error!(
-            "{POST_LAST_OP_DECORATOR_DEPRECATION_MESSAGE} \
-rewrote {post_last_decorator_count} post-last op decorator(s) as after-exit decorator(s)."
-        );
-    }
+    (op_indexed_decorators, after_exit_decorators)
 }
 
 /// Serializes AssemblyOp content referenced by `AsmOpId`s into bytes for fingerprint augmentation.
@@ -673,6 +648,8 @@ impl MastForestBuilder {
                 if !operations.is_empty() {
                     let block_ops = core::mem::take(&mut operations);
                     let block_decorators = core::mem::take(&mut decorators);
+                    let (block_decorators, block_after_exit) =
+                        split_merge_trailing_decorators(block_ops.len(), block_decorators);
                     let block_asm_ops = core::mem::take(&mut merged_asm_ops);
                     let block_debug_vars = core::mem::take(&mut merged_debug_vars);
                     let merged_basic_block_id = self.ensure_block_with_asm_op_and_debug_var_ids(
@@ -681,7 +658,7 @@ impl MastForestBuilder {
                         block_asm_ops,
                         block_debug_vars,
                         vec![],
-                        vec![],
+                        block_after_exit,
                     )?;
 
                     merged_basic_blocks.push(merged_basic_block_id);
@@ -694,13 +671,15 @@ impl MastForestBuilder {
         self.merged_basic_block_ids.extend(contiguous_basic_block_ids.iter());
 
         if !operations.is_empty() || !decorators.is_empty() {
+            let (decorators, after_exit) =
+                split_merge_trailing_decorators(operations.len(), decorators);
             let merged_basic_block = self.ensure_block_with_asm_op_and_debug_var_ids(
                 operations,
                 decorators,
                 merged_asm_ops,
                 merged_debug_vars,
                 vec![],
-                vec![],
+                after_exit,
             )?;
             merged_basic_blocks.push(merged_basic_block);
         }
@@ -758,10 +737,9 @@ impl MastForestBuilder {
         before_enter: Vec<DecoratorId>,
         after_exit: Vec<DecoratorId>,
     ) -> Result<MastNodeId, Report> {
-        let split = split_post_last_decorators(operations.len(), decorators, after_exit);
-        let block = BasicBlockNodeBuilder::new(operations, split.op_indexed_decorators)
+        let block = BasicBlockNodeBuilder::new(operations, decorators)
             .with_before_enter(before_enter)
-            .with_after_exit(split.after_exit_decorators);
+            .with_after_exit(after_exit);
 
         let base_fingerprint = block
             .fingerprint_for_node(&self.mast_forest, &self.hash_by_node_id)
@@ -1074,11 +1052,9 @@ impl MastForestBuilder {
         before_enter: Vec<DecoratorId>,
         after_exit: Vec<DecoratorId>,
     ) -> Result<MastNodeId, Report> {
-        let split = split_post_last_decorators(operations.len(), decorators, after_exit);
-        log_deprecated_post_last_op_decorators(split.post_last_decorator_count);
-        let block = BasicBlockNodeBuilder::new(operations, split.op_indexed_decorators)
+        let block = BasicBlockNodeBuilder::new(operations, decorators)
             .with_before_enter(before_enter)
-            .with_after_exit(split.after_exit_decorators);
+            .with_after_exit(after_exit);
 
         // Compute the base fingerprint from the builder, then augment with external metadata
         // so the dedup key stays sensitive to source mappings without storing them on the
@@ -1610,21 +1586,20 @@ mod tests {
     }
 
     #[test]
-    fn split_post_last_decorators_reports_deprecated_compatibility_path() {
-        let op_indexed = DecoratorId::from(9);
-        let post_last = DecoratorId::from(10);
-        let after_exit = DecoratorId::from(11);
+    fn ensure_block_rejects_post_last_decorator_index_without_panicking() {
+        let mut builder = MastForestBuilder::new(&[]).unwrap();
+        let decorator_id = builder.ensure_decorator(Decorator::Trace(42)).unwrap();
 
-        let split =
-            split_post_last_decorators(1, vec![(0, op_indexed), (1, post_last)], vec![after_exit]);
-
-        assert_eq!(split.op_indexed_decorators, vec![(0, op_indexed)]);
-        assert_eq!(split.after_exit_decorators, vec![post_last, after_exit]);
-        assert_eq!(split.post_last_decorator_count, 1);
-        assert!(
-            POST_LAST_OP_DECORATOR_DEPRECATION_MESSAGE
-                .contains("will be rejected in a future release")
+        let result = builder.ensure_block(
+            vec![Operation::Add],
+            vec![(1, decorator_id)],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
         );
+
+        assert!(result.is_err());
     }
 
     /// Cloning a block with debug vars via `to_builder().with_before_enter()` must

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -258,24 +258,6 @@ fn serialize_asm_ops(asm_ops: &[(usize, AssemblyOp)]) -> Vec<u8> {
     data
 }
 
-fn split_merge_trailing_decorators(
-    operations_len: usize,
-    decorators: DecoratorList,
-) -> (DecoratorList, Vec<DecoratorId>) {
-    let mut op_indexed_decorators = DecoratorList::with_capacity(decorators.len());
-    let mut after_exit_decorators = Vec::new();
-
-    for (op_idx, decorator_id) in decorators {
-        if op_idx == operations_len {
-            after_exit_decorators.push(decorator_id);
-        } else {
-            op_indexed_decorators.push((op_idx, decorator_id));
-        }
-    }
-
-    (op_indexed_decorators, after_exit_decorators)
-}
-
 /// Serializes AssemblyOp content referenced by `AsmOpId`s into bytes for fingerprint augmentation.
 fn serialize_asm_op_ids(forest: &MastForest, asm_op_ids: &[(usize, AsmOpId)]) -> Vec<u8> {
     let mut data = Vec::new();
@@ -598,6 +580,7 @@ impl MastForestBuilder {
 
         let mut operations: Vec<Operation> = Vec::new();
         let mut decorators = DecoratorList::new();
+        let mut pending_after_exit = Vec::new();
         // Track asm_ops and debug_vars being accumulated for merged blocks, with adjusted indices
         let mut merged_asm_ops: Vec<(usize, AsmOpId)> = Vec::new();
         let mut merged_debug_vars: Vec<(usize, miden_core::mast::DebugVarId)> = Vec::new();
@@ -615,19 +598,23 @@ impl MastForestBuilder {
             ) {
                 // Collect decorators and operations from the block (while still borrowing)
                 // We need owned copies so we can drop the borrow before mutating self
-                let (block_decorators, block_ops) = {
+                let (raw_decorators_including_node_level, block_ops) = {
                     let basic_block_node =
                         self.mast_forest[basic_block_id].get_basic_block().unwrap();
-                    let block_decorators: Vec<_> =
+                    let raw_decorators_including_node_level: Vec<_> =
                         basic_block_node.raw_decorator_iter(&self.mast_forest).collect();
                     let block_ops: Vec<Operation> = basic_block_node
                         .op_batches()
                         .iter()
                         .flat_map(|b| b.raw_ops().copied())
                         .collect();
-                    (block_decorators, block_ops)
+                    (raw_decorators_including_node_level, block_ops)
                 };
                 let ops_offset = operations.len();
+
+                for decorator in core::mem::take(&mut pending_after_exit) {
+                    decorators.push((ops_offset, decorator));
+                }
 
                 // Transfer any pending asm_ops and debug_vars for this block to the merged result
                 self.transfer_asm_ops_for_merge(basic_block_id, ops_offset, &mut merged_asm_ops);
@@ -637,9 +624,16 @@ impl MastForestBuilder {
                     &mut merged_debug_vars,
                 );
 
-                // Add decorators with adjusted indices
-                for (op_idx, decorator) in block_decorators {
-                    decorators.push((op_idx + ops_offset, decorator));
+                // Add decorators with adjusted indices. The raw iterator includes node-level
+                // decorators: `before_enter` appears at index 0, and `after_exit` appears at the
+                // block-length sentinel. Keep the latter pending until we know whether another
+                // block follows in this merged block.
+                for (op_idx, decorator) in raw_decorators_including_node_level {
+                    if op_idx == block_ops.len() {
+                        pending_after_exit.push(decorator);
+                    } else {
+                        decorators.push((op_idx + ops_offset, decorator));
+                    }
                 }
                 operations.extend(block_ops);
             } else {
@@ -648,8 +642,7 @@ impl MastForestBuilder {
                 if !operations.is_empty() {
                     let block_ops = core::mem::take(&mut operations);
                     let block_decorators = core::mem::take(&mut decorators);
-                    let (block_decorators, block_after_exit) =
-                        split_merge_trailing_decorators(block_ops.len(), block_decorators);
+                    let block_after_exit = core::mem::take(&mut pending_after_exit);
                     let block_asm_ops = core::mem::take(&mut merged_asm_ops);
                     let block_debug_vars = core::mem::take(&mut merged_debug_vars);
                     let merged_basic_block_id = self.ensure_block_with_asm_op_and_debug_var_ids(
@@ -670,16 +663,14 @@ impl MastForestBuilder {
         // Mark the removed basic blocks as merged
         self.merged_basic_block_ids.extend(contiguous_basic_block_ids.iter());
 
-        if !operations.is_empty() || !decorators.is_empty() {
-            let (decorators, after_exit) =
-                split_merge_trailing_decorators(operations.len(), decorators);
+        if !operations.is_empty() || !decorators.is_empty() || !pending_after_exit.is_empty() {
             let merged_basic_block = self.ensure_block_with_asm_op_and_debug_var_ids(
                 operations,
                 decorators,
                 merged_asm_ops,
                 merged_debug_vars,
                 vec![],
-                after_exit,
+                pending_after_exit,
             )?;
             merged_basic_blocks.push(merged_basic_block);
         }
@@ -1598,6 +1589,46 @@ mod tests {
             builder.mast_forest.after_exit_decorators(merged_block_id),
             &[after_exit_decorator],
         );
+    }
+
+    #[test]
+    fn test_merge_basic_blocks_places_boundary_after_exit_before_next_before_enter() {
+        let mut builder = MastForestBuilder::new(&[]).unwrap();
+
+        let first_after_exit = builder.ensure_decorator(Decorator::Trace(1)).unwrap();
+        let first_block_id = builder
+            .ensure_block(
+                vec![Operation::Add],
+                Vec::new(),
+                vec![],
+                vec![],
+                vec![],
+                vec![first_after_exit],
+            )
+            .unwrap();
+
+        let second_before_enter = builder.ensure_decorator(Decorator::Trace(2)).unwrap();
+        let second_block_id = builder
+            .ensure_block(
+                vec![Operation::Mul],
+                Vec::new(),
+                vec![],
+                vec![],
+                vec![second_before_enter],
+                vec![],
+            )
+            .unwrap();
+
+        let merged_blocks = builder.merge_basic_blocks(&[first_block_id, second_block_id]).unwrap();
+
+        assert_eq!(merged_blocks.len(), 1);
+        let merged_block_id = merged_blocks[0];
+        let merged_block = builder.mast_forest[merged_block_id].unwrap_basic_block();
+        let decorators: Vec<_> =
+            merged_block.indexed_decorator_iter(&builder.mast_forest).collect();
+
+        assert_eq!(decorators, vec![(1, first_after_exit), (1, second_before_enter)]);
+        assert!(builder.mast_forest.after_exit_decorators(merged_block_id).is_empty());
     }
 
     #[test]

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -598,21 +598,27 @@ impl MastForestBuilder {
             ) {
                 // Collect decorators and operations from the block (while still borrowing)
                 // We need owned copies so we can drop the borrow before mutating self
-                let (raw_decorators_including_node_level, block_ops) = {
+                let (block_decorators, block_before_enter, block_after_exit, block_ops) = {
                     let basic_block_node =
                         self.mast_forest[basic_block_id].get_basic_block().unwrap();
-                    let raw_decorators_including_node_level: Vec<_> =
-                        basic_block_node.raw_decorator_iter(&self.mast_forest).collect();
+                    let block_decorators =
+                        basic_block_node.raw_op_indexed_decorators(&self.mast_forest);
+                    let block_before_enter =
+                        basic_block_node.before_enter(&self.mast_forest).to_vec();
+                    let block_after_exit = basic_block_node.after_exit(&self.mast_forest).to_vec();
                     let block_ops: Vec<Operation> = basic_block_node
                         .op_batches()
                         .iter()
                         .flat_map(|b| b.raw_ops().copied())
                         .collect();
-                    (raw_decorators_including_node_level, block_ops)
+                    (block_decorators, block_before_enter, block_after_exit, block_ops)
                 };
                 let ops_offset = operations.len();
 
                 for decorator in core::mem::take(&mut pending_after_exit) {
+                    decorators.push((ops_offset, decorator));
+                }
+                for decorator in block_before_enter {
                     decorators.push((ops_offset, decorator));
                 }
 
@@ -624,17 +630,11 @@ impl MastForestBuilder {
                     &mut merged_debug_vars,
                 );
 
-                // Add decorators with adjusted indices. The raw iterator includes node-level
-                // decorators: `before_enter` appears at index 0, and `after_exit` appears at the
-                // block-length sentinel. Keep the latter pending until we know whether another
-                // block follows in this merged block.
-                for (op_idx, decorator) in raw_decorators_including_node_level {
-                    if op_idx == block_ops.len() {
-                        pending_after_exit.push(decorator);
-                    } else {
-                        decorators.push((op_idx + ops_offset, decorator));
-                    }
+                // Add operation-indexed decorators with adjusted indices.
+                for (op_idx, decorator) in block_decorators {
+                    decorators.push((op_idx + ops_offset, decorator));
                 }
+                pending_after_exit.extend(block_after_exit);
                 operations.extend(block_ops);
             } else {
                 // If we don't want to merge this block, flush the buffer of operations into a

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -759,7 +759,6 @@ impl MastForestBuilder {
         after_exit: Vec<DecoratorId>,
     ) -> Result<MastNodeId, Report> {
         let split = split_post_last_decorators(operations.len(), decorators, after_exit);
-        log_deprecated_post_last_op_decorators(split.post_last_decorator_count);
         let block = BasicBlockNodeBuilder::new(operations, split.op_indexed_decorators)
             .with_before_enter(before_enter)
             .with_after_exit(split.after_exit_decorators);

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -258,6 +258,26 @@ fn serialize_asm_ops(asm_ops: &[(usize, AssemblyOp)]) -> Vec<u8> {
     data
 }
 
+fn split_post_last_decorators(
+    operations_len: usize,
+    decorators: DecoratorList,
+    after_exit: Vec<DecoratorId>,
+) -> (DecoratorList, Vec<DecoratorId>) {
+    let mut op_indexed_decorators = DecoratorList::with_capacity(decorators.len());
+    let mut after_exit_decorators = Vec::new();
+
+    for (op_idx, decorator_id) in decorators {
+        if op_idx == operations_len {
+            after_exit_decorators.push(decorator_id);
+        } else {
+            op_indexed_decorators.push((op_idx, decorator_id));
+        }
+    }
+    after_exit_decorators.extend(after_exit);
+
+    (op_indexed_decorators, after_exit_decorators)
+}
+
 /// Serializes AssemblyOp content referenced by `AsmOpId`s into bytes for fingerprint augmentation.
 fn serialize_asm_op_ids(forest: &MastForest, asm_op_ids: &[(usize, AsmOpId)]) -> Vec<u8> {
     let mut data = Vec::new();
@@ -715,6 +735,8 @@ impl MastForestBuilder {
         before_enter: Vec<DecoratorId>,
         after_exit: Vec<DecoratorId>,
     ) -> Result<MastNodeId, Report> {
+        let (decorators, after_exit) =
+            split_post_last_decorators(operations.len(), decorators, after_exit);
         let block = BasicBlockNodeBuilder::new(operations, decorators)
             .with_before_enter(before_enter)
             .with_after_exit(after_exit);
@@ -1029,6 +1051,8 @@ impl MastForestBuilder {
         before_enter: Vec<DecoratorId>,
         after_exit: Vec<DecoratorId>,
     ) -> Result<MastNodeId, Report> {
+        let (decorators, after_exit) =
+            split_post_last_decorators(operations.len(), decorators, after_exit);
         let block = BasicBlockNodeBuilder::new(operations, decorators)
             .with_before_enter(before_enter)
             .with_after_exit(after_exit);

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -1569,6 +1569,38 @@ mod tests {
     }
 
     #[test]
+    fn test_merge_basic_blocks_preserves_trailing_after_exit_decorator() {
+        let mut builder = MastForestBuilder::new(&[]).unwrap();
+
+        let first_block_id = builder
+            .ensure_block(vec![Operation::Add], Vec::new(), vec![], vec![], vec![], vec![])
+            .unwrap();
+        let after_exit_decorator = builder.ensure_decorator(Decorator::Trace(7)).unwrap();
+        let second_block_id = builder
+            .ensure_block(
+                vec![Operation::Mul],
+                Vec::new(),
+                vec![],
+                vec![],
+                vec![],
+                vec![after_exit_decorator],
+            )
+            .unwrap();
+
+        let merged_blocks = builder.merge_basic_blocks(&[first_block_id, second_block_id]).unwrap();
+
+        assert_eq!(merged_blocks.len(), 1);
+        let merged_block_id = merged_blocks[0];
+        let merged_block = builder.mast_forest[merged_block_id].unwrap_basic_block();
+
+        assert!(merged_block.indexed_decorator_iter(&builder.mast_forest).next().is_none());
+        assert_eq!(
+            builder.mast_forest.after_exit_decorators(merged_block_id),
+            &[after_exit_decorator],
+        );
+    }
+
+    #[test]
     fn ensure_block_rejects_decorator_index_beyond_operation_count_without_panicking() {
         let mut builder = MastForestBuilder::new(&[]).unwrap();
         let decorator_id = builder.ensure_decorator(Decorator::Trace(42)).unwrap();

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -743,7 +743,8 @@ impl MastForestBuilder {
 
         let base_fingerprint = block
             .fingerprint_for_node(&self.mast_forest, &self.hash_by_node_id)
-            .expect("hash_by_node_id should contain the fingerprints of all children of `node`");
+            .into_diagnostic()
+            .wrap_err("assembler failed to fingerprint basic block")?;
         let dedup_fingerprint = self.maybe_augment(
             self.maybe_augment(
                 base_fingerprint,
@@ -1062,7 +1063,8 @@ impl MastForestBuilder {
         // builder itself.
         let base_fingerprint = block
             .fingerprint_for_node(&self.mast_forest, &self.hash_by_node_id)
-            .expect("hash_by_node_id should contain the fingerprints of all children of `node`");
+            .into_diagnostic()
+            .wrap_err("assembler failed to fingerprint basic block")?;
         let dedup_fingerprint = self.maybe_augment(
             self.maybe_augment(base_fingerprint, &serialize_asm_ops(&asm_ops)),
             &serialize_debug_vars(&self.mast_forest, &debug_vars),
@@ -1566,6 +1568,23 @@ mod tests {
         assert_eq!(merged_blocks.len(), 2);
         assert_eq!(merged_blocks[0], large_block_id);
         assert_eq!(merged_blocks[1], small_block_id);
+    }
+
+    #[test]
+    fn ensure_block_rejects_decorator_index_beyond_operation_count_without_panicking() {
+        let mut builder = MastForestBuilder::new(&[]).unwrap();
+        let decorator_id = builder.ensure_decorator(Decorator::Trace(42)).unwrap();
+
+        let result = builder.ensure_block(
+            vec![Operation::Add],
+            vec![(2, decorator_id)],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        );
+
+        assert!(result.is_err());
     }
 
     /// Cloning a block with debug vars via `to_builder().with_before_enter()` must

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -23,7 +23,7 @@ use miden_core::{
         CallNodeBuilder, JoinNodeBuilder, LoopNodeBuilder, MastForestContributor, MastNodeExt,
         MastNodeId, SplitNodeBuilder,
     },
-    operations::Operation,
+    operations::{Decorator, Operation},
     program::Program,
     serde::{Deserializable, DeserializationError, Serializable},
 };
@@ -2107,6 +2107,78 @@ fn decorators_basic_block() -> TestResult {
     );
     let program = context.assemble(source)?;
     insta::assert_snapshot!(program);
+    Ok(())
+}
+
+#[test]
+fn trailing_decorator_is_after_exit_not_last_op_decorator() -> TestResult {
+    let context = TestContext::default();
+    let source = source_file!(
+        &context,
+        "\
+    begin
+        push.1
+        push.2
+        trace.1
+        add
+        trace.2
+    end"
+    );
+
+    let program = context.assemble(source)?;
+    let forest = program.mast_forest();
+    let (block_id, block) = forest
+        .nodes()
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, node)| {
+            node.get_basic_block().map(|block| (MastNodeId::from(idx as u32), block))
+        })
+        .find(|(_, block)| matches!(block.raw_operations().last(), Some(Operation::Add)))
+        .expect("expected a basic block ending in add");
+
+    let raw_ops = block.raw_operations().collect::<Vec<_>>();
+    let last_real_op_idx = raw_ops.len() - 1;
+    assert!(
+        matches!(raw_ops.last(), Some(Operation::Add)),
+        "expected add to be the last real operation in the block",
+    );
+
+    let indexed_decorators = block.indexed_decorator_iter(forest).collect::<Vec<_>>();
+    let last_op_trace_decorators = indexed_decorators
+        .iter()
+        .filter_map(|(op_idx, decorator_id)| {
+            (*op_idx == last_real_op_idx).then(|| match &forest[*decorator_id] {
+                Decorator::Trace(value) => Some(*value),
+                _ => None,
+            })?
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        last_op_trace_decorators,
+        vec![1],
+        "only the pre-add decorator should be attached to the last real op",
+    );
+
+    let after_exit_trace_decorators = block
+        .after_exit(forest)
+        .iter()
+        .map(|decorator_id| match &forest[*decorator_id] {
+            Decorator::Trace(value) => *value,
+            decorator => panic!("expected trace decorator in after_exit, got {decorator:?}"),
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        after_exit_trace_decorators,
+        vec![2],
+        "trailing decorator should be placed in the containing block's after_exit set",
+    );
+
+    assert!(
+        forest.after_exit_decorators(block_id) == block.after_exit(forest),
+        "block-level and forest-level after_exit accessors should agree",
+    );
+
     Ok(())
 }
 

--- a/processor/src/continuation_stack.rs
+++ b/processor/src/continuation_stack.rs
@@ -47,7 +47,7 @@ pub enum Continuation {
     /// Process the finish phase of a basic block node.
     ///
     /// This corresponds to incrementing the clock to account for the inserted END operation, and
-    /// then executing `AfterExitDecoratorsBasicBlock`.
+    /// then executing `AfterExitDecorators`.
     FinishBasicBlock(MastNodeId),
     /// Enter a new MAST forest, where all subsequent `MastNodeId`s will be relative to this forest.
     ///
@@ -56,12 +56,6 @@ pub enum Continuation {
     EnterForest(Arc<MastForest>),
     /// Process the `after_exit` decorators of the given node.
     AfterExitDecorators(MastNodeId),
-    /// Process the `after_exit` decorators of the basic block node.
-    ///
-    /// Similar to `AfterExitDecorators`, but also executes all operation-level decorators that
-    /// refer to after the last operation in the basic block. See
-    /// [`miden_core::mast::BasicBlockNode`] for more details.
-    AfterExitDecoratorsBasicBlock(MastNodeId),
 }
 
 impl Continuation {
@@ -88,10 +82,7 @@ impl Continuation {
             | Respan { node_id: _, batch_index: _ }
             | FinishBasicBlock(_) => true,
 
-            FinishExternal(_)
-            | EnterForest(_)
-            | AfterExitDecorators(_)
-            | AfterExitDecoratorsBasicBlock(_) => false,
+            FinishExternal(_) | EnterForest(_) | AfterExitDecorators(_) => false,
         }
     }
 }

--- a/processor/src/execution/basic_block.rs
+++ b/processor/src/execution/basic_block.rs
@@ -194,7 +194,7 @@ where
 #[inline(always)]
 pub(super) fn finish_basic_block<P, H, S, T>(
     state: &mut ExecutionState<'_, P, H, S, T>,
-    basic_block_node: &BasicBlockNode,
+    _basic_block_node: &BasicBlockNode,
     node_id: MastNodeId,
     current_forest: &Arc<MastForest>,
 ) -> ControlFlow<BreakReason>
@@ -217,16 +217,10 @@ where
         state.tracer,
         state.stopper,
         state.continuation_stack,
-        || Some(Continuation::AfterExitDecoratorsBasicBlock(node_id)),
+        || Some(Continuation::AfterExitDecorators(node_id)),
         current_forest,
     )?;
 
-    state.processor.execute_end_of_block_decorators(
-        basic_block_node,
-        node_id,
-        current_forest,
-        state.host,
-    )?;
     state
         .processor
         .execute_after_exit_decorators(node_id, current_forest, state.host)

--- a/processor/src/execution/mod.rs
+++ b/processor/src/execution/mod.rs
@@ -262,24 +262,6 @@ where
                 .processor
                 .execute_after_exit_decorators(node_id, current_forest, state.host)
                 .map_break(InternalBreakReason::from)?,
-            Continuation::AfterExitDecoratorsBasicBlock(node_id) => {
-                let basic_block_node =
-                    current_forest.get_node_by_id(node_id).unwrap().unwrap_basic_block();
-
-                state
-                    .processor
-                    .execute_end_of_block_decorators(
-                        basic_block_node,
-                        node_id,
-                        current_forest,
-                        state.host,
-                    )
-                    .map_break(InternalBreakReason::from)?;
-                state
-                    .processor
-                    .execute_after_exit_decorators(node_id, current_forest, state.host)
-                    .map_break(InternalBreakReason::from)?;
-            },
         }
     }
 

--- a/processor/src/fast/basic_block/mod.rs
+++ b/processor/src/fast/basic_block/mod.rs
@@ -1,9 +1,9 @@
-use alloc::{sync::Arc, vec::Vec};
+use alloc::vec::Vec;
 use core::ops::ControlFlow;
 
 use miden_core::{
     events::{EventId, SystemEvent},
-    mast::{BasicBlockNode, MastForest, MastNodeId},
+    mast::{MastForest, MastNodeId},
 };
 
 use crate::{
@@ -75,30 +75,6 @@ impl FastProcessor {
                 Some(op_idx),
             ))),
         }
-    }
-
-    /// Executes any decorator in a basic block that is to be executed after all operations in the
-    /// block. This only differs from [`Self::execute_after_exit_decorators`] in that these
-    /// decorators are stored in the basic block node itself.
-    #[inline(always)]
-    pub(super) fn execute_end_of_block_decorators(
-        &self,
-        basic_block_node: &BasicBlockNode,
-        node_id: MastNodeId,
-        current_forest: &Arc<MastForest>,
-        host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
-        if self.should_execute_decorators() {
-            #[cfg(test)]
-            self.record_decorator_retrieval();
-
-            let num_ops = basic_block_node.num_operations() as usize;
-            for decorator in current_forest.decorators_for_op(node_id, num_ops) {
-                self.execute_decorator(decorator, host)?;
-            }
-        }
-
-        ControlFlow::Continue(())
     }
 
     #[inline(always)]

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -556,9 +556,10 @@ impl FastProcessor {
             .get_node_by_id(node_id)
             .expect("internal error: node id {node_id} not found in current forest");
 
-        // Basic blocks may still carry legacy op-indexed decorators at the sentinel index (padded op
-        // count). New MAST merges those into `after_exit` at build time; execute them here first so
-        // order matches historical `execute_end_of_block_decorators` + `after_exit`.
+        // Basic blocks may still carry legacy op-indexed decorators at the sentinel index (padded
+        // op count). New MAST merges those into `after_exit` at build time; execute them
+        // here first so order matches historical `execute_end_of_block_decorators` +
+        // `after_exit`.
         if let MastNode::Block(bb) = node {
             let num_ops = bb.num_operations() as usize;
             for decorator in current_forest.decorators_for_op(node_id, num_ops) {

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -8,7 +8,7 @@ use core::{cmp::min, ops::ControlFlow};
 use miden_air::{Felt, trace::RowIndex};
 use miden_core::{
     EMPTY_WORD, WORD_SIZE, Word, ZERO,
-    mast::{MastForest, MastNodeExt, MastNodeId},
+    mast::{MastForest, MastNode, MastNodeExt, MastNodeId},
     operations::Decorator,
     precompile::PrecompileTranscript,
     program::{MIN_STACK_DEPTH, Program, StackInputs, StackOutputs},
@@ -555,6 +555,16 @@ impl FastProcessor {
         let node = current_forest
             .get_node_by_id(node_id)
             .expect("internal error: node id {node_id} not found in current forest");
+
+        // Basic blocks may still carry legacy op-indexed decorators at the sentinel index (padded op
+        // count). New MAST merges those into `after_exit` at build time; execute them here first so
+        // order matches historical `execute_end_of_block_decorators` + `after_exit`.
+        if let MastNode::Block(bb) = node {
+            let num_ops = bb.num_operations() as usize;
+            for decorator in current_forest.decorators_for_op(node_id, num_ops) {
+                self.execute_decorator(decorator, host)?;
+            }
+        }
 
         for &decorator_id in node.after_exit(current_forest) {
             self.execute_decorator(&current_forest[decorator_id], host)?;

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -8,7 +8,7 @@ use core::{cmp::min, ops::ControlFlow};
 use miden_air::{Felt, trace::RowIndex};
 use miden_core::{
     EMPTY_WORD, WORD_SIZE, Word, ZERO,
-    mast::{MastForest, MastNode, MastNodeExt, MastNodeId},
+    mast::{MastForest, MastNodeExt, MastNodeId},
     operations::Decorator,
     precompile::PrecompileTranscript,
     program::{MIN_STACK_DEPTH, Program, StackInputs, StackOutputs},
@@ -555,17 +555,6 @@ impl FastProcessor {
         let node = current_forest
             .get_node_by_id(node_id)
             .expect("internal error: node id {node_id} not found in current forest");
-
-        // Basic blocks may still carry legacy op-indexed decorators at the sentinel index (padded
-        // op count). New MAST merges those into `after_exit` at build time; execute them
-        // here first so order matches historical `execute_end_of_block_decorators` +
-        // `after_exit`.
-        if let MastNode::Block(bb) = node {
-            let num_ops = bb.num_operations() as usize;
-            for decorator in current_forest.decorators_for_op(node_id, num_ops) {
-                self.execute_decorator(decorator, host)?;
-            }
-        }
 
         for &decorator_id in node.after_exit(current_forest) {
             self.execute_decorator(&current_forest[decorator_id], host)?;

--- a/processor/src/fast/operation.rs
+++ b/processor/src/fast/operation.rs
@@ -1,4 +1,3 @@
-use alloc::sync::Arc;
 use core::ops::ControlFlow;
 
 use miden_air::{
@@ -8,7 +7,7 @@ use miden_air::{
 use miden_core::{
     WORD_SIZE, Word, ZERO,
     crypto::{hash::Poseidon2, merkle::MerklePath},
-    mast::{BasicBlockNode, MastForest, MastNodeId},
+    mast::{MastForest, MastNodeId},
     precompile::{PrecompileTranscript, PrecompileTranscriptState},
 };
 
@@ -127,16 +126,6 @@ impl Processor for FastProcessor {
         ControlFlow::Continue(())
     }
 
-    #[inline(always)]
-    fn execute_end_of_block_decorators(
-        &self,
-        basic_block_node: &BasicBlockNode,
-        node_id: MastNodeId,
-        current_forest: &Arc<MastForest>,
-        host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
-        self.execute_end_of_block_decorators(basic_block_node, node_id, current_forest, host)
-    }
 }
 
 impl HasherInterface for FastProcessor {

--- a/processor/src/fast/operation.rs
+++ b/processor/src/fast/operation.rs
@@ -125,7 +125,6 @@ impl Processor for FastProcessor {
 
         ControlFlow::Continue(())
     }
-
 }
 
 impl HasherInterface for FastProcessor {

--- a/processor/src/processor.rs
+++ b/processor/src/processor.rs
@@ -1,4 +1,3 @@
-use alloc::sync::Arc;
 use core::ops::ControlFlow;
 
 use miden_air::trace::{RowIndex, chiplets::hasher::HasherState};
@@ -8,7 +7,7 @@ use crate::{
     advice::AdviceError,
     crypto::merkle::MerklePath,
     errors::OperationError,
-    mast::{BasicBlockNode, MastForest, MastNodeId},
+    mast::{MastForest, MastNodeId},
     precompile::PrecompileTranscriptState,
 };
 
@@ -89,17 +88,6 @@ pub(crate) trait Processor: Sized {
         node_id: MastNodeId,
         op_idx_in_block: usize,
         current_forest: &MastForest,
-        host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason>;
-
-    /// Executes any decorator in a basic block that is to be executed after all operations in the
-    /// block. This only differs from `execute_after_exit_decorators` in that these decorators are
-    /// stored in the basic block node itself.
-    fn execute_end_of_block_decorators(
-        &self,
-        basic_block_node: &BasicBlockNode,
-        node_id: MastNodeId,
-        current_forest: &Arc<MastForest>,
         host: &mut impl BaseHost,
     ) -> ControlFlow<BreakReason>;
 }

--- a/processor/src/trace/execution_tracer.rs
+++ b/processor/src/trace/execution_tracer.rs
@@ -580,10 +580,9 @@ impl Tracer for ExecutionTracer {
             },
             Continuation::FinishExternal(_)
             | Continuation::EnterForest(_)
-            | Continuation::AfterExitDecorators(_)
-            | Continuation::AfterExitDecoratorsBasicBlock(_) => {
+            | Continuation::AfterExitDecorators(_) => {
                 panic!(
-                    "FinishExternal, EnterForest, AfterExitDecorators and AfterExitDecoratorsBasicBlock continuations are guaranteed not to be passed here"
+                    "FinishExternal, EnterForest, and AfterExitDecorators continuations are guaranteed not to be passed here"
                 )
             },
         }

--- a/processor/src/trace/parallel/processor.rs
+++ b/processor/src/trace/parallel/processor.rs
@@ -5,7 +5,7 @@ use miden_air::{Felt, trace::RowIndex};
 use miden_core::{
     WORD_SIZE, Word, ZERO,
     field::PrimeField64,
-    mast::{BasicBlockNode, MastForest, MastNodeId},
+    mast::{MastForest, MastNodeId},
     precompile::PrecompileTranscriptState,
     program::{Kernel, MIN_STACK_DEPTH},
     utils::range,
@@ -464,17 +464,6 @@ impl Processor for ReplayProcessor {
         _node_id: MastNodeId,
         _op_idx_in_block: usize,
         _current_forest: &MastForest,
-        _host: &mut impl BaseHost,
-    ) -> ControlFlow<BreakReason> {
-        // do nothing - we don't execute decorators in this processor
-        ControlFlow::Continue(())
-    }
-
-    fn execute_end_of_block_decorators(
-        &self,
-        _basic_block_node: &BasicBlockNode,
-        _node_id: MastNodeId,
-        _current_forest: &Arc<MastForest>,
         _host: &mut impl BaseHost,
     ) -> ControlFlow<BreakReason> {
         // do nothing - we don't execute decorators in this processor

--- a/processor/src/trace/parallel/tracer/mod.rs
+++ b/processor/src/trace/parallel/tracer/mod.rs
@@ -599,10 +599,7 @@ impl Tracer for CoreTraceGenerationTracer<'_> {
                         flags.to_hasher_state_second_word(),
                     )?;
                 },
-                FinishExternal(_)
-                | EnterForest(_)
-                | AfterExitDecorators(_)
-                | AfterExitDecoratorsBasicBlock(_) => {
+                FinishExternal(_) | EnterForest(_) | AfterExitDecorators(_) => {
                     unreachable!(
                         "Tracer contract guarantees that these continuations do not occur here"
                     )

--- a/processor/src/tracer.rs
+++ b/processor/src/tracer.rs
@@ -73,8 +73,8 @@ pub trait Tracer {
     /// - Continuation::FinishExternal: because external nodes are resolved before starting a clock
     ///   cycle,
     /// - Continuation::EnterForest: because entering a new forest does not consume a clock cycle,
-    /// - Continuation::AfterExitDecorators: because after-exit decorators are executed at the end of
-    ///   an `END` operation; never at the start of a clock cycle
+    /// - Continuation::AfterExitDecorators: because after-exit decorators are executed at the end
+    ///   of an `END` operation; never at the start of a clock cycle
     ///
     /// Additionally, [miden_core::mast::ExternalNode] nodes are guaranteed to be resolved before
     /// this method is called.

--- a/processor/src/tracer.rs
+++ b/processor/src/tracer.rs
@@ -73,9 +73,8 @@ pub trait Tracer {
     /// - Continuation::FinishExternal: because external nodes are resolved before starting a clock
     ///   cycle,
     /// - Continuation::EnterForest: because entering a new forest does not consume a clock cycle,
-    /// - Continuation::AfterExitDecorators and Continuation::AfterExitDecoratorsBasicBlock: because
-    ///   after-exit decorators are executed at the end of an `END` operation; never at the start of
-    ///   a clock cycle
+    /// - Continuation::AfterExitDecorators: because after-exit decorators are executed at the end of
+    ///   an `END` operation; never at the start of a clock cycle
     ///
     /// Additionally, [miden_core::mast::ExternalNode] nodes are guaranteed to be resolved before
     /// this method is called.


### PR DESCRIPTION
This closes #2964, and partially closes #2633. The post-last op decorators are not rejected outright yet, so as to not break e.g. the compiler, but they are logged as deprecated, and converted to after-exit decorators.

- cherry-picks the relevant PR #2964 commits with original authorship preserved
- ~normalizes legacy post-last op decorators into `after_exit`~ rejects post-last op decorators
- ~logs a deprecation warning that post-last op decorators will be rejected in a future release~
- rejects out-of-bounds decorator indices beyond the post-last sentinel
- validates linked/serialized decorator storage so malformed forests cannot retain post-last op decorators
- avoids false deprecation warnings from internal basic-block merging