### PR TITLE
test(air): cover chiplet request opcode flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,12 @@
 - [BREAKING] Reduced the prove-from-trace API to post-execution trace inputs: `TraceBuildInputs` no longer carries full execution output, `prove_from_trace_sync()` takes `TraceProvingInputs`, and `ProvingOptions` no longer include `ExecutionOptions` ([#2948](https://github.com/0xMiden/miden-vm/pull/2948)).
 - Follow-up refactoring + couple perf improvements on trace generation ([#2953](https://github.com/0xMiden/miden-vm/pull/2953)).
 - Added chainable `Test` builders for common test setup in `miden-utils-testing` ([#2957](https://github.com/0xMiden/miden-vm/pull/2957)).
+- Added fuzz coverage for package semantic deserialization and project parsing, loading, and assembly ([#3015](https://github.com/0xMiden/miden-vm/pull/3015)).
+- Added regression coverage for chiplet-request opcode flag parity between the prover boolean fast path and polynomial AIR construction ([#3117](https://github.com/0xMiden/miden-vm/pull/3117)).
+- Made serde opt-in for package crates, and added macro-based binary and serde roundtrip tests for Arbitrary serialization types ([#3058](https://github.com/0xMiden/miden-vm/pull/3058)).
+- Speed-up AUX range check trace generation by changing divisors to a flat Vec layout ([#2966](https://github.com/0xMiden/miden-vm/pull/2966)).
+- Optimized call graph topological sort from O(V\*E) to O(V + E) by pre-computing in-degrees ([#2830](https://github.com/0xMiden/miden-vm/pull/2830)).
+- Removed AIR constraint tagging instrumentation, applied a uniform constraint description style across components, and optimized constraint evaluation ([#2856](https://github.com/0xMiden/miden-vm/pull/2856)).
 - [BREAKING] Unified all auxiliary-trace buses under a single declarative LogUp `LookupAir` shared by the verifier, prover aux-trace generator, and recursive ACE circuit; reduced committed boundary values to one per trace ([#2962](https://github.com/0xMiden/miden-vm/pull/2962)).
 - Collapsed the kernel ROM chiplet to one row per digest with a LogUp multiplicity, eliminating duplicate-callsite rows ([#2962](https://github.com/0xMiden/miden-vm/pull/2962)).
 - Speed-up AUX range check trace generation by changing divisors to a flat Vec layout ([#2966](https://github.com/0xMiden/miden-vm/pull/2966)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 #### Changes
 
 - Improved performances of auxiliary trace generation ([#3119](https://github.com/0xMiden/miden-vm/pull/3119)).
+- Aligned replay stack word access bounds with `StackInterface`, allowing the maximum valid start index for word reads and writes ([#3014](https://github.com/0xMiden/miden-vm/pull/3014)).
+
 
 ## v0.23.0 (2026-05-07)
 
@@ -37,7 +39,6 @@
 - Fixed `u256::wrapping_mul` so it preserves caller stack values below its operands ([#3071](https://github.com/0xMiden/miden-vm/pull/3071)).
 - Fixed host event and advice-mutation diagnostics to point to the triggering `emit.event(...)` instruction ([#3042](https://github.com/0xMiden/miden-vm/pull/3042)).
 - Fixed debug-only underflow in memory range-check trace generation when the first memory access is at `clk = 0` ([#2976](https://github.com/0xMiden/miden-vm/pull/2976)).
-- Aligned replay stack word access bounds with `StackInterface`, allowing the maximum valid start index for word reads and writes ([#3014](https://github.com/0xMiden/miden-vm/pull/3014)).
 - Replaced unsound `ptr::read` with safe unbox in panic recovery, removing UB from potential double-drop ([#2934](https://github.com/0xMiden/miden-vm/pull/2934)).
 - Library deserialization now rejects exports whose `MastNodeId` is not a procedure root, closing a silent-failure path ([#2933](https://github.com/0xMiden/miden-vm/pull/2933)).
 - Reverted `InvokeKind::ProcRef` back to `InvokeKind::Exec` in `visit_mut_procref` and added an explanatory comment (#2893).

--- a/air/src/constraints/lookup/buses/lookup_op_flags.rs
+++ b/air/src/constraints/lookup/buses/lookup_op_flags.rs
@@ -550,7 +550,10 @@ accessors!(
 
 #[cfg(test)]
 mod tests {
-    use miden_core::{ONE, ZERO, operations::Operation};
+    use miden_core::{
+        Felt, ONE, ZERO,
+        operations::{Operation, opcodes},
+    };
 
     use super::LookupOpFlags;
     use crate::constraints::op_flags::generate_test_row;
@@ -592,5 +595,109 @@ mod tests {
         let row = generate_test_row(opcode);
         let row_next = generate_test_row(0);
         LookupOpFlags::from_main_cols(&row.decoder, &row.stack, &row_next.decoder)
+    }
+
+    #[test]
+    fn boolean_row_matches_polynomial_for_chiplet_request_ops() {
+        let cases: [(&str, u8, fn(&LookupOpFlags<Felt>) -> Felt); 26] = [
+            ("join", opcodes::JOIN, LookupOpFlags::<Felt>::join),
+            ("split", opcodes::SPLIT, LookupOpFlags::<Felt>::split),
+            ("loop", opcodes::LOOP, LookupOpFlags::<Felt>::loop_op),
+            ("span", opcodes::SPAN, LookupOpFlags::<Felt>::span),
+            ("call", opcodes::CALL, LookupOpFlags::<Felt>::call),
+            ("syscall", opcodes::SYSCALL, LookupOpFlags::<Felt>::syscall),
+            ("respan", opcodes::RESPAN, LookupOpFlags::<Felt>::respan),
+            ("end", opcodes::END, LookupOpFlags::<Felt>::end),
+            ("dyn", opcodes::DYN, LookupOpFlags::<Felt>::dyn_op),
+            ("dyncall", opcodes::DYNCALL, LookupOpFlags::<Felt>::dyncall),
+            ("hperm", opcodes::HPERM, LookupOpFlags::<Felt>::hperm),
+            ("mpverify", opcodes::MPVERIFY, LookupOpFlags::<Felt>::mpverify),
+            ("mrupdate", opcodes::MRUPDATE, LookupOpFlags::<Felt>::mrupdate),
+            ("mload", opcodes::MLOAD, LookupOpFlags::<Felt>::mload),
+            ("mstore", opcodes::MSTORE, LookupOpFlags::<Felt>::mstore),
+            ("mloadw", opcodes::MLOADW, LookupOpFlags::<Felt>::mloadw),
+            ("mstorew", opcodes::MSTOREW, LookupOpFlags::<Felt>::mstorew),
+            ("mstream", opcodes::MSTREAM, LookupOpFlags::<Felt>::mstream),
+            ("pipe", opcodes::PIPE, LookupOpFlags::<Felt>::pipe),
+            ("cryptostream", opcodes::CRYPTOSTREAM, LookupOpFlags::<Felt>::cryptostream),
+            ("hornerbase", opcodes::HORNERBASE, LookupOpFlags::<Felt>::hornerbase),
+            ("hornerext", opcodes::HORNEREXT, LookupOpFlags::<Felt>::hornerext),
+            ("u32and", opcodes::U32AND, LookupOpFlags::<Felt>::u32and),
+            ("u32xor", opcodes::U32XOR, LookupOpFlags::<Felt>::u32xor),
+            ("evalcircuit", opcodes::EVALCIRCUIT, LookupOpFlags::<Felt>::evalcircuit),
+            ("log_precompile", opcodes::LOGPRECOMPILE, LookupOpFlags::<Felt>::log_precompile),
+        ];
+
+        for (name, opcode, get_flag) in cases {
+            let row = generate_test_row(opcode.into());
+            let row_next = generate_test_row(0);
+            let polynomial =
+                LookupOpFlags::from_main_cols(&row.decoder, &row.stack, &row_next.decoder);
+            let boolean =
+                LookupOpFlags::from_boolean_row(&row.decoder, &row.stack, &row_next.decoder);
+
+            assert_eq!(get_flag(&polynomial), ONE, "{name} polynomial flag should be active");
+            assert_eq!(get_flag(&boolean), ONE, "{name} boolean flag should be active");
+            assert_flags_match(name, &boolean, &polynomial);
+        }
+    }
+
+    fn assert_flags_match(
+        name: &str,
+        actual: &LookupOpFlags<Felt>,
+        expected: &LookupOpFlags<Felt>,
+    ) {
+        macro_rules! check {
+            ($($field:ident),* $(,)?) => {
+                $(
+                    assert_eq!(
+                        actual.$field,
+                        expected.$field,
+                        "{}: {} flag mismatch",
+                        name,
+                        stringify!($field),
+                    );
+                )*
+            };
+        }
+
+        check!(
+            end,
+            repeat,
+            respan,
+            call,
+            syscall,
+            mrupdate,
+            cryptostream,
+            join,
+            split,
+            span,
+            loop_op,
+            dyn_op,
+            dyncall,
+            push,
+            hperm,
+            mpverify,
+            mstream,
+            pipe,
+            evalcircuit,
+            log_precompile,
+            hornerbase,
+            hornerext,
+            mload,
+            mstore,
+            mloadw,
+            mstorew,
+            u32and,
+            u32xor,
+            end_next,
+            repeat_next,
+            respan_next,
+            halt_next,
+            left_shift,
+            right_shift,
+            overflow,
+            u32_rc_op,
+        );
     }
 }


### PR DESCRIPTION
## Describe your changes

Add a regression test for the chiplet-request opcode flags consumed by the LogUp bus emitter. The test enumerates the chiplet request opcodes and checks that the prover boolean fast path matches the polynomial AIR flag construction for every flag field.

This guards against a repeat of the missing `crypto_stream` bus request coverage fixed in #2786.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md`: N/A, test-only regression coverage.