### PR TITLE
ci: keep synthetic tx nonregression bounded

### DIFF
--- a/.github/workflows/synthetic-tx-nonregression.yml
+++ b/.github/workflows/synthetic-tx-nonregression.yml
@@ -20,10 +20,35 @@ on:
         required: false
         default: "5"
         type: string
+      regression_min_delta_ms:
+        description: Minimum absolute slowdown before the workflow fails.
+        required: false
+        default: "1"
+        type: string
       rayon_num_threads:
         description: RAYON_NUM_THREADS value used for the benchmark.
         required: false
         default: "8"
+        type: string
+      sample_size:
+        description: Criterion sample size.
+        required: false
+        default: "10"
+        type: string
+      measurement_time_secs:
+        description: Criterion measurement time per benchmark.
+        required: false
+        default: "10"
+        type: string
+      warm_up_time_secs:
+        description: Criterion warm-up time per benchmark.
+        required: false
+        default: "1"
+        type: string
+      bench_axes:
+        description: Comma-separated benchmark axes. Defaults to the fast CI axes.
+        required: false
+        default: "exec,trace_prep,verify"
         type: string
       scenario_filter:
         description: Optional SYNTH_SCENARIO filter for the synthetic benchmark.
@@ -39,7 +64,7 @@ jobs:
   benchmark:
     name: Benchmark baseline vs current
     runs-on: warp-ubuntu-latest-x64-8x
-    timeout-minutes: 240
+    timeout-minutes: 60
     permissions:
       contents: read
     outputs:
@@ -90,7 +115,12 @@ jobs:
           INPUT_BASELINE_REF: ${{ inputs.baseline_ref }}
           INPUT_CURRENT_REF: ${{ inputs.current_ref }}
           INPUT_THRESHOLD_PCT: ${{ inputs.regression_threshold_pct }}
+          INPUT_MIN_DELTA_MS: ${{ inputs.regression_min_delta_ms }}
           INPUT_RAYON_THREADS: ${{ inputs.rayon_num_threads }}
+          INPUT_SAMPLE_SIZE: ${{ inputs.sample_size }}
+          INPUT_MEASUREMENT_TIME_SECS: ${{ inputs.measurement_time_secs }}
+          INPUT_WARM_UP_TIME_SECS: ${{ inputs.warm_up_time_secs }}
+          INPUT_BENCH_AXES: ${{ inputs.bench_axes }}
           INPUT_SCENARIO_FILTER: ${{ inputs.scenario_filter }}
         shell: bash
         run: |
@@ -126,13 +156,23 @@ jobs:
             current_ref="${GITHUB_SHA}"
             baseline_ref="${BEFORE_SHA}"
             threshold_pct="5"
+            min_delta_ms="1"
             rayon_threads="8"
+            sample_size="10"
+            measurement_time_secs="10"
+            warm_up_time_secs="1"
+            bench_axes="exec,trace_prep,verify"
             scenario_filter=""
           else
             baseline_ref="${INPUT_BASELINE_REF}"
             current_ref="${INPUT_CURRENT_REF}"
             threshold_pct="${INPUT_THRESHOLD_PCT}"
+            min_delta_ms="${INPUT_MIN_DELTA_MS}"
             rayon_threads="${INPUT_RAYON_THREADS}"
+            sample_size="${INPUT_SAMPLE_SIZE}"
+            measurement_time_secs="${INPUT_MEASUREMENT_TIME_SECS}"
+            warm_up_time_secs="${INPUT_WARM_UP_TIME_SECS}"
+            bench_axes="${INPUT_BENCH_AXES}"
             scenario_filter="${INPUT_SCENARIO_FILTER}"
           fi
 
@@ -144,8 +184,28 @@ jobs:
             threshold_pct="5"
           fi
 
+          if [[ -z "${min_delta_ms}" ]]; then
+            min_delta_ms="1"
+          fi
+
           if [[ -z "${rayon_threads}" ]]; then
             rayon_threads="8"
+          fi
+
+          if [[ -z "${sample_size}" ]]; then
+            sample_size="10"
+          fi
+
+          if [[ -z "${measurement_time_secs}" ]]; then
+            measurement_time_secs="10"
+          fi
+
+          if [[ -z "${warm_up_time_secs}" ]]; then
+            warm_up_time_secs="1"
+          fi
+
+          if [[ -z "${bench_axes}" ]]; then
+            bench_axes="exec,trace_prep,verify"
           fi
 
           if [[ ! "${threshold_pct}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
@@ -153,8 +213,28 @@ jobs:
             exit 1
           fi
 
+          if [[ ! "${min_delta_ms}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+            echo "regression_min_delta_ms must be numeric" >&2
+            exit 1
+          fi
+
           if [[ ! "${rayon_threads}" =~ ^[0-9]+$ ]]; then
             echo "rayon_num_threads must be an integer" >&2
+            exit 1
+          fi
+
+          if [[ ! "${sample_size}" =~ ^[0-9]+$ ]]; then
+            echo "sample_size must be an integer" >&2
+            exit 1
+          fi
+
+          if [[ ! "${measurement_time_secs}" =~ ^[0-9]+$ ]]; then
+            echo "measurement_time_secs must be an integer" >&2
+            exit 1
+          fi
+
+          if [[ ! "${warm_up_time_secs}" =~ ^[0-9]+$ ]]; then
+            echo "warm_up_time_secs must be an integer" >&2
             exit 1
           fi
 
@@ -199,7 +279,12 @@ jobs:
             echo "baseline_sha=${baseline_sha}"
             echo "current_sha=${current_sha}"
             echo "threshold_pct=${threshold_pct}"
+            echo "min_delta_ms=${min_delta_ms}"
             echo "rayon_threads=${rayon_threads}"
+            echo "sample_size=${sample_size}"
+            echo "measurement_time_secs=${measurement_time_secs}"
+            echo "warm_up_time_secs=${warm_up_time_secs}"
+            echo "bench_axes=${bench_axes}"
             echo "scenario_filter=${scenario_filter}"
           } >> "${GITHUB_OUTPUT}"
 
@@ -220,6 +305,10 @@ jobs:
           WORKTREE_DIR: ${{ steps.dirs.outputs.worktree_dir }}
           ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
           RAYON_THREADS: ${{ steps.refs.outputs.rayon_threads }}
+          SAMPLE_SIZE: ${{ steps.refs.outputs.sample_size }}
+          MEASUREMENT_TIME_SECS: ${{ steps.refs.outputs.measurement_time_secs }}
+          WARM_UP_TIME_SECS: ${{ steps.refs.outputs.warm_up_time_secs }}
+          BENCH_AXES: ${{ steps.refs.outputs.bench_axes }}
           SCENARIO_FILTER: ${{ steps.refs.outputs.scenario_filter }}
           BASELINE_SHA: ${{ steps.refs.outputs.baseline_sha }}
         shell: bash
@@ -229,6 +318,10 @@ jobs:
             --repo-root "${WORKTREE_DIR}/baseline" \
             --output-dir "${ARTIFACT_DIR}/baseline" \
             --rayon-num-threads "${RAYON_THREADS}" \
+            --sample-size "${SAMPLE_SIZE}" \
+            --measurement-time-secs "${MEASUREMENT_TIME_SECS}" \
+            --warm-up-time-secs "${WARM_UP_TIME_SECS}" \
+            --bench-axes "${BENCH_AXES}" \
             --scenario-filter "${SCENARIO_FILTER}" \
             --git-ref "${BASELINE_SHA}"
 
@@ -238,6 +331,10 @@ jobs:
           WORKTREE_DIR: ${{ steps.dirs.outputs.worktree_dir }}
           ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
           RAYON_THREADS: ${{ steps.refs.outputs.rayon_threads }}
+          SAMPLE_SIZE: ${{ steps.refs.outputs.sample_size }}
+          MEASUREMENT_TIME_SECS: ${{ steps.refs.outputs.measurement_time_secs }}
+          WARM_UP_TIME_SECS: ${{ steps.refs.outputs.warm_up_time_secs }}
+          BENCH_AXES: ${{ steps.refs.outputs.bench_axes }}
           SCENARIO_FILTER: ${{ steps.refs.outputs.scenario_filter }}
           CURRENT_SHA: ${{ steps.refs.outputs.current_sha }}
         shell: bash
@@ -247,6 +344,10 @@ jobs:
             --repo-root "${WORKTREE_DIR}/current" \
             --output-dir "${ARTIFACT_DIR}/current" \
             --rayon-num-threads "${RAYON_THREADS}" \
+            --sample-size "${SAMPLE_SIZE}" \
+            --measurement-time-secs "${MEASUREMENT_TIME_SECS}" \
+            --warm-up-time-secs "${WARM_UP_TIME_SECS}" \
+            --bench-axes "${BENCH_AXES}" \
             --scenario-filter "${SCENARIO_FILTER}" \
             --git-ref "${CURRENT_SHA}"
 
@@ -256,6 +357,7 @@ jobs:
           GITHUB_WORKSPACE_PATH: ${{ github.workspace }}
           ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
           THRESHOLD_PCT: ${{ steps.refs.outputs.threshold_pct }}
+          MIN_DELTA_MS: ${{ steps.refs.outputs.min_delta_ms }}
         shell: bash
         run: |
           set -euo pipefail
@@ -265,6 +367,7 @@ jobs:
             --summary-out "${ARTIFACT_DIR}/summary.md" \
             --json-out "${ARTIFACT_DIR}/comparison.json" \
             --threshold-pct "${THRESHOLD_PCT}" \
+            --min-regression-ms "${MIN_DELTA_MS}" \
             --github-output "${GITHUB_OUTPUT}"
 
       - name: Publish job summary
@@ -327,15 +430,17 @@ jobs:
           exit 1
 
   comment:
-    name: Comment on pushed commit
+    name: Comment on pushed commit or associated PR
     runs-on: ubuntu-latest
     needs:
       - benchmark
     if: always() && github.event_name == 'push' && needs.benchmark.outputs.current_sha != '' && needs.benchmark.outputs.summary != ''
     permissions:
       contents: write
+      issues: write
+      pull-requests: read
     steps:
-      - name: Create or update commit comment
+      - name: Create or update benchmark comment
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           CURRENT_SHA: ${{ needs.benchmark.outputs.current_sha }}
@@ -354,6 +459,51 @@ jobs:
             const repo = context.repo.repo;
             const commitSha = process.env.CURRENT_SHA;
             const marker = process.env.MARKER;
+
+            const pulls = await github.paginate(
+              github.rest.repos.listPullRequestsAssociatedWithCommit,
+              {
+                owner,
+                repo,
+                commit_sha: commitSha,
+                per_page: 100,
+              },
+            );
+            const openPull = pulls.find(pull => pull.state === 'open') ?? pulls[0];
+
+            if (openPull) {
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                {
+                  owner,
+                  repo,
+                  issue_number: openPull.number,
+                  per_page: 100,
+                },
+              );
+
+              const existing = comments.find(comment =>
+                comment.user?.type === 'Bot' && comment.body?.includes(marker)
+              );
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: openPull.number,
+                body,
+              });
+              return;
+            }
 
             const comments = await github.paginate(
               github.rest.repos.listCommentsForCommit,

--- a/benches/synthetic-bench/benches/synthetic_bench.rs
+++ b/benches/synthetic-bench/benches/synthetic_bench.rs
@@ -14,10 +14,15 @@
 //! - `SYNTH_SCENARIO`: if set, restrict to scenarios whose slugified key contains this slugified
 //!   substring (case- and separator-insensitive; `"P2ID"`, `"p2id"`, `"P2ID note"`, and
 //!   `"p2id-note"` all match `"consume single P2ID note"`).
+//! - `SYNTH_BENCH_AXES`: comma-separated axes to run. Supported values are `exec`, `trace_prep`,
+//!   `prove`, `verify`, and `all`. Defaults to all axes.
+//! - `SYNTH_SAMPLE_SIZE`: Criterion sample size. Defaults to 30.
+//! - `SYNTH_MEASUREMENT_TIME_SECS`: Criterion measurement time per benchmark. Defaults to 30.
+//! - `SYNTH_WARM_UP_TIME_SECS`: Criterion warm-up time per benchmark. Defaults to 1.
 //! - `SYNTH_MASM_WRITE`: if set, write the emitted MASM to
 //!   `target/synthetic_bench_<producer-stem>__<scenario-slug>.masm`.
 
-use std::{hint::black_box, path::PathBuf, time::Duration};
+use std::{collections::BTreeSet, hint::black_box, path::PathBuf, time::Duration};
 
 use criterion::{BatchSize, Criterion, SamplingMode, criterion_group, criterion_main};
 use miden_processor::{
@@ -34,6 +39,64 @@ use miden_vm_synthetic_bench::{
 
 /// Hash function used for STARK `prove` and `verify` axes.
 const BENCH_HASH: HashFunction = HashFunction::Poseidon2;
+const ALL_AXES: [&str; 4] = ["exec", "trace_prep", "prove", "verify"];
+
+fn resolve_bench_axes() -> BTreeSet<&'static str> {
+    let Some(raw) = std::env::var("SYNTH_BENCH_AXES").ok().filter(|s| !s.trim().is_empty()) else {
+        return ALL_AXES.into_iter().collect();
+    };
+
+    let mut axes = BTreeSet::new();
+    for axis in raw.split(',').map(str::trim).filter(|axis| !axis.is_empty()) {
+        match axis {
+            "all" => axes.extend(ALL_AXES),
+            "exec" => {
+                axes.insert("exec");
+            },
+            "trace_prep" => {
+                axes.insert("trace_prep");
+            },
+            "prove" => {
+                axes.insert("prove");
+            },
+            "verify" => {
+                axes.insert("verify");
+            },
+            _ => panic!(
+                "unsupported SYNTH_BENCH_AXES value `{axis}`; supported values: {}",
+                ALL_AXES.join(", ")
+            ),
+        }
+    }
+    assert!(!axes.is_empty(), "SYNTH_BENCH_AXES did not select any benchmark axes");
+    axes
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    match std::env::var(name) {
+        Ok(raw) => {
+            let value = raw
+                .parse::<usize>()
+                .unwrap_or_else(|e| panic!("{name} must be a positive integer: {e}"));
+            assert!(value > 0, "{name} must be greater than zero");
+            value
+        },
+        Err(_) => default,
+    }
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    match std::env::var(name) {
+        Ok(raw) => {
+            let value = raw
+                .parse::<u64>()
+                .unwrap_or_else(|e| panic!("{name} must be a positive integer: {e}"));
+            assert!(value > 0, "{name} must be greater than zero");
+            value
+        },
+        Err(_) => default,
+    }
+}
 
 /// Builds the per-iteration inputs shared by the `exec` and `trace_prep` axes.
 fn processor_inputs(program: &Program) -> (DefaultHost, Program, FastProcessor) {
@@ -82,6 +145,15 @@ fn slugify(s: &str) -> String {
 }
 
 fn synthetic_bench(c: &mut Criterion) {
+    let axes = resolve_bench_axes();
+    let sample_size = env_usize("SYNTH_SAMPLE_SIZE", 30);
+    let measurement_time_secs = env_u64("SYNTH_MEASUREMENT_TIME_SECS", 30);
+    let warm_up_time_secs = env_u64("SYNTH_WARM_UP_TIME_SECS", 1);
+    println!("\n=== benchmark axes: {}", axes.iter().copied().collect::<Vec<_>>().join(", "));
+    println!(
+        "=== criterion: sample_size={sample_size} measurement_time={measurement_time_secs}s warm_up={warm_up_time_secs}s"
+    );
+
     let calibration = calibrate().expect("failed to calibrate snippets");
     println!("\n=== calibration (rows/iter)");
     for snippet in SNIPPETS {
@@ -116,6 +188,10 @@ fn synthetic_bench(c: &mut Criterion) {
                 &scenario_key,
                 &scenario_slug,
                 &snapshot,
+                &axes,
+                sample_size,
+                measurement_time_secs,
+                warm_up_time_secs,
             );
             benched_anything = true;
         }
@@ -130,6 +206,10 @@ fn bench_one_scenario(
     scenario_key: &str,
     scenario_slug: &str,
     snapshot: &TraceSnapshot,
+    axes: &BTreeSet<&'static str>,
+    sample_size: usize,
+    measurement_time_secs: u64,
+    warm_up_time_secs: u64,
 ) {
     println!("\n=== scenario: {producer_stem} / {scenario_key}");
     println!(
@@ -192,88 +272,98 @@ fn bench_one_scenario(
     let mut group = c.benchmark_group(format!("{producer_stem}/{scenario_slug}"));
     group
         .sampling_mode(SamplingMode::Flat)
-        .sample_size(30)
-        .warm_up_time(Duration::from_millis(1000))
-        .measurement_time(Duration::from_secs(30));
+        .sample_size(sample_size)
+        .warm_up_time(Duration::from_secs(warm_up_time_secs))
+        .measurement_time(Duration::from_secs(measurement_time_secs));
 
     // Four axes per scenario:
     //   exec       -- FastProcessor::execute_sync (no trace data)
     //   trace_prep -- FastProcessor::execute_trace_inputs_sync (the input to prove_from_trace_sync)
     //   prove      -- prove_sync (= trace_prep + STARK prove)
     //   verify     -- miden_vm::verify against a proof generated once outside the timed loop
-    group.bench_function("exec", |b| {
-        b.iter_batched(
-            || processor_inputs(&program),
-            |(mut host, program, processor)| {
-                black_box(processor.execute_sync(&program, &mut host).expect("exec"));
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    if axes.contains("exec") {
+        group.bench_function("exec", |b| {
+            b.iter_batched(
+                || processor_inputs(&program),
+                |(mut host, program, processor)| {
+                    black_box(processor.execute_sync(&program, &mut host).expect("exec"));
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
 
-    group.bench_function("trace_prep", |b| {
-        b.iter_batched(
-            || processor_inputs(&program),
-            |(mut host, program, processor)| {
-                black_box(
-                    processor.execute_trace_inputs_sync(&program, &mut host).expect("trace_prep"),
-                );
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    if axes.contains("trace_prep") {
+        group.bench_function("trace_prep", |b| {
+            b.iter_batched(
+                || processor_inputs(&program),
+                |(mut host, program, processor)| {
+                    black_box(
+                        processor
+                            .execute_trace_inputs_sync(&program, &mut host)
+                            .expect("trace_prep"),
+                    );
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
 
-    group.bench_function("prove", |b| {
-        b.iter_batched(
-            || {
-                let host = DefaultHost::default();
-                let stack = StackInputs::default();
-                let advice = AdviceInputs::default();
-                (host, program.clone(), stack, advice)
-            },
-            |(mut host, program, stack, advice)| {
-                black_box(
-                    prove_sync(
-                        &program,
-                        stack,
-                        advice,
-                        &mut host,
-                        ExecutionOptions::default(),
-                        ProvingOptions::new(BENCH_HASH),
-                    )
-                    .expect("prove"),
-                );
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    if axes.contains("prove") {
+        group.bench_function("prove", |b| {
+            b.iter_batched(
+                || {
+                    let host = DefaultHost::default();
+                    let stack = StackInputs::default();
+                    let advice = AdviceInputs::default();
+                    (host, program.clone(), stack, advice)
+                },
+                |(mut host, program, stack, advice)| {
+                    black_box(
+                        prove_sync(
+                            &program,
+                            stack,
+                            advice,
+                            &mut host,
+                            ExecutionOptions::default(),
+                            ProvingOptions::new(BENCH_HASH),
+                        )
+                        .expect("prove"),
+                    );
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
 
-    // Generate one proof outside the timed loop so prove_sync time isn't counted toward verify.
-    let program_info = ProgramInfo::from(program.clone());
-    let (stack_outputs, proof) = {
-        let mut host = DefaultHost::default();
-        prove_sync(
-            &program,
-            StackInputs::default(),
-            AdviceInputs::default(),
-            &mut host,
-            ExecutionOptions::default(),
-            ProvingOptions::new(BENCH_HASH),
-        )
-        .expect("prove for verify setup")
-    };
-    group.bench_function("verify", |b| {
-        b.iter_batched(
-            || (program_info.clone(), StackInputs::default(), stack_outputs, proof.clone()),
-            |(program_info, stack_inputs, stack_outputs, proof)| {
-                black_box(
-                    miden_vm::verify(program_info, stack_inputs, stack_outputs, proof)
-                        .expect("verify"),
-                );
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    if axes.contains("verify") {
+        // Generate one proof outside the timed loop so prove_sync time isn't counted toward verify.
+        let program_info = ProgramInfo::from(program.clone());
+        let (stack_outputs, proof) = {
+            let mut host = DefaultHost::default();
+            prove_sync(
+                &program,
+                StackInputs::default(),
+                AdviceInputs::default(),
+                &mut host,
+                ExecutionOptions::default(),
+                ProvingOptions::new(BENCH_HASH),
+            )
+            .expect("prove for verify setup")
+        };
+        group.bench_function("verify", |b| {
+            b.iter_batched(
+                || (program_info.clone(), StackInputs::default(), stack_outputs, proof.clone()),
+                |(program_info, stack_inputs, stack_outputs, proof)| {
+                    black_box(
+                        miden_vm::verify(program_info, stack_inputs, stack_outputs, proof)
+                            .expect("verify"),
+                    );
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
 
     group.finish();
 }

--- a/scripts/synthetic_tx_nonregression.py
+++ b/scripts/synthetic_tx_nonregression.py
@@ -13,6 +13,8 @@ import unittest.mock as mock
 from pathlib import Path
 from typing import Any
 
+DEFAULT_MIN_REGRESSION_MS = 1.0
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -28,6 +30,7 @@ def parse_args() -> argparse.Namespace:
     run.add_argument("--sample-size", type=int)
     run.add_argument("--measurement-time-secs", type=int)
     run.add_argument("--warm-up-time-secs", type=int)
+    run.add_argument("--bench-axes", default="")
     run.add_argument("--git-ref", default="")
 
     collect = commands.add_parser("collect", help="Collect Criterion estimates into JSON.")
@@ -36,6 +39,7 @@ def parse_args() -> argparse.Namespace:
     collect.add_argument("--bench-wall-ms", type=float)
     collect.add_argument("--rayon-num-threads", type=int)
     collect.add_argument("--scenario-filter", default="")
+    collect.add_argument("--bench-axes", default="")
     collect.add_argument("--git-ref", default="")
 
     compare = commands.add_parser("compare", help="Compare two benchmark result JSON files.")
@@ -44,6 +48,7 @@ def parse_args() -> argparse.Namespace:
     compare.add_argument("--summary-out", required=True, type=Path)
     compare.add_argument("--json-out", required=True, type=Path)
     compare.add_argument("--threshold-pct", required=True, type=float)
+    compare.add_argument("--min-regression-ms", type=float, default=DEFAULT_MIN_REGRESSION_MS)
     compare.add_argument("--github-output", type=Path)
 
     self_test = commands.add_parser("self-test", help="Run parser and comparison tests.")
@@ -86,6 +91,10 @@ def current_sha(repo_root: Path) -> str:
 def write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def split_csv(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
 
 
 def parse_criterion_estimate_path(criterion_root: Path, estimates_path: Path) -> tuple[str, str, str]:
@@ -133,6 +142,10 @@ def collect_result(
     bench_wall_ms: float | None,
     rayon_num_threads: int | None,
     scenario_filter: str,
+    bench_axes: str,
+    sample_size: int | None,
+    measurement_time_secs: int | None,
+    warm_up_time_secs: int | None,
 ) -> dict[str, Any]:
     return {
         "repo_root": str(repo_root),
@@ -141,6 +154,10 @@ def collect_result(
         "bench_wall_ms": bench_wall_ms,
         "rayon_num_threads": rayon_num_threads,
         "scenario_filter": scenario_filter,
+        "bench_axes": split_csv(bench_axes),
+        "sample_size": sample_size,
+        "measurement_time_secs": measurement_time_secs,
+        "warm_up_time_secs": warm_up_time_secs,
         "metrics": collect_criterion_metrics(repo_root),
     }
 
@@ -154,6 +171,14 @@ def cmd_run(args: argparse.Namespace) -> int:
     env["RAYON_NUM_THREADS"] = str(args.rayon_num_threads)
     if args.scenario_filter:
         env["SYNTH_SCENARIO"] = args.scenario_filter
+    if args.bench_axes:
+        env["SYNTH_BENCH_AXES"] = args.bench_axes
+    if args.sample_size is not None:
+        env["SYNTH_SAMPLE_SIZE"] = str(args.sample_size)
+    if args.measurement_time_secs is not None:
+        env["SYNTH_MEASUREMENT_TIME_SECS"] = str(args.measurement_time_secs)
+    if args.warm_up_time_secs is not None:
+        env["SYNTH_WARM_UP_TIME_SECS"] = str(args.warm_up_time_secs)
 
     run_logged_command(["cargo", "clean"], cwd=repo_root, env=env, log_path=output_dir / "clean.log")
 
@@ -187,6 +212,10 @@ def cmd_run(args: argparse.Namespace) -> int:
             bench_wall_ms=bench_wall_ms,
             rayon_num_threads=args.rayon_num_threads,
             scenario_filter=args.scenario_filter,
+            bench_axes=args.bench_axes,
+            sample_size=args.sample_size,
+            measurement_time_secs=args.measurement_time_secs,
+            warm_up_time_secs=args.warm_up_time_secs,
         ),
     )
     return 0
@@ -201,6 +230,10 @@ def cmd_collect(args: argparse.Namespace) -> int:
             bench_wall_ms=args.bench_wall_ms,
             rayon_num_threads=args.rayon_num_threads,
             scenario_filter=args.scenario_filter,
+            bench_axes=args.bench_axes,
+            sample_size=None,
+            measurement_time_secs=None,
+            warm_up_time_secs=None,
         ),
     )
     return 0
@@ -229,7 +262,10 @@ def fmt_pct(value: float | None) -> str:
 
 
 def compare_results(
-    baseline: dict[str, Any], current: dict[str, Any], threshold_pct: float
+    baseline: dict[str, Any],
+    current: dict[str, Any],
+    threshold_pct: float,
+    min_regression_ms: float = DEFAULT_MIN_REGRESSION_MS,
 ) -> dict[str, Any]:
     baseline_metrics = baseline.get("metrics", {})
     current_metrics = current.get("metrics", {})
@@ -252,21 +288,32 @@ def compare_results(
         )
     rows.sort(key=lambda r: r["delta_pct"] if r["delta_pct"] is not None else float("-inf"), reverse=True)
     worst = rows[0]
-    regression = bool(worst["delta_pct"] is not None and worst["delta_pct"] > threshold_pct)
+    regression_rows = [
+        row
+        for row in rows
+        if row["delta_pct"] is not None
+        and row["delta_pct"] > threshold_pct
+        and row["delta_ms"] > min_regression_ms
+    ]
+    regression = bool(regression_rows)
     return {
         "status": "regression" if regression else "ok",
         "regression": regression,
         "threshold_pct": threshold_pct,
+        "min_regression_ms": min_regression_ms,
         "baseline_sha": baseline.get("git_sha", ""),
         "current_sha": current.get("git_sha", ""),
         "baseline_ref": baseline.get("git_ref", ""),
         "current_ref": current.get("git_ref", ""),
         "baseline_bench_wall_ms": baseline.get("bench_wall_ms"),
         "current_bench_wall_ms": current.get("bench_wall_ms"),
+        "baseline_bench_axes": baseline.get("bench_axes", []),
+        "current_bench_axes": current.get("bench_axes", []),
         "max_delta_metric": worst["name"],
         "max_delta_ms": worst["delta_ms"],
         "max_delta_pct": worst["delta_pct"],
         "metric_rows": rows,
+        "regression_rows": regression_rows,
         "missing_in_current": sorted(set(baseline_metrics) - set(current_metrics)),
         "missing_in_baseline": sorted(set(current_metrics) - set(baseline_metrics)),
     }
@@ -282,11 +329,7 @@ def summary_markdown(result: dict[str, Any]) -> str:
         else result["current_bench_wall_ms"] - result["baseline_bench_wall_ms"]
     )
     wall_delta_pct = percent_delta(result["current_bench_wall_ms"], result["baseline_bench_wall_ms"])
-    over_threshold = [
-        row
-        for row in result["metric_rows"]
-        if row["delta_pct"] is not None and row["delta_pct"] > result["threshold_pct"]
-    ]
+    over_threshold = result["regression_rows"]
     metric_rows = result["metric_rows"]
     lines = [
         "# BENCHMARK REPORT: synthetic-tx-kernel-nonregression",
@@ -298,6 +341,9 @@ def summary_markdown(result: dict[str, Any]) -> str:
         f"- Baseline: `{baseline}`",
         f"- Current: `{current}`",
         f"- Threshold: `{result['threshold_pct']:.2f}%`",
+        f"- Minimum absolute slowdown: `{fmt_ms(result['min_regression_ms'])}`",
+        "- Axes: "
+        f"`{', '.join(result['current_bench_axes'] or result['baseline_bench_axes'] or ['all'])}`",
         "- Bench wall: "
         f"{fmt_ms(result['baseline_bench_wall_ms'])} -> "
         f"{fmt_ms(result['current_bench_wall_ms'])} "
@@ -306,11 +352,11 @@ def summary_markdown(result: dict[str, Any]) -> str:
         "### Result",
         "",
         f"- Status: **{status}**",
-        "- Worst regression: "
+        "- Worst slowdown: "
         f"`{result['max_delta_metric']}` moved by "
         f"`{fmt_delta(result['max_delta_ms'])}` ({fmt_pct(result['max_delta_pct'])})",
         "",
-        "### Metrics over threshold",
+        "### Regressions over threshold",
         "",
     ]
     if over_threshold:
@@ -372,6 +418,7 @@ def cmd_compare(args: argparse.Namespace) -> int:
         json.loads(args.baseline.read_text(encoding="utf-8")),
         json.loads(args.current.read_text(encoding="utf-8")),
         args.threshold_pct,
+        args.min_regression_ms,
     )
     write_json(args.json_out, result)
     args.summary_out.parent.mkdir(parents=True, exist_ok=True)
@@ -446,6 +493,14 @@ class Tests(unittest.TestCase):
         self.assertTrue(result["regression"])
         self.assertEqual(result["max_delta_metric"], "bench-tx/a/verify")
 
+    def test_compare_ignores_sub_millisecond_noise(self) -> None:
+        baseline = {"metrics": {"bench-tx/a/trace_prep": {"estimate_ms": 6.46}}}
+        current = {"metrics": {"bench-tx/a/trace_prep": {"estimate_ms": 6.94}}}
+        result = compare_results(baseline, current, 5.0)
+        self.assertFalse(result["regression"])
+        self.assertEqual(result["max_delta_metric"], "bench-tx/a/trace_prep")
+        self.assertEqual(result["regression_rows"], [])
+
     def test_summary_markdown_uses_requested_report_shape(self) -> None:
         result = compare_results(
             {
@@ -474,14 +529,15 @@ class Tests(unittest.TestCase):
         self.assertIn("- Baseline: `1764d66ca1c6`", summary)
         self.assertIn("- Current: `1234567890ab`", summary)
         self.assertIn("- Threshold: `5.00%`", summary)
+        self.assertIn("- Minimum absolute slowdown: `1.00 ms`", summary)
         self.assertIn("- Bench wall: 145,000.00 ms -> 152,000.00 ms (+7,000.00 ms, +4.83%)", summary)
         self.assertIn("### Result", summary)
         self.assertIn("- Status: **REGRESSION**", summary)
         self.assertIn(
-            "- Worst regression: `bench-tx/consume-single-p2id-note/prove` moved by `+145.07 ms` (+7.30%)",
+            "- Worst slowdown: `bench-tx/consume-single-p2id-note/prove` moved by `+145.07 ms` (+7.30%)",
             summary,
         )
-        self.assertIn("### Metrics over threshold", summary)
+        self.assertIn("### Regressions over threshold", summary)
         self.assertIn("- `bench-tx/consume-single-p2id-note/prove`: +145.07 ms (+7.30%)", summary)
         self.assertIn("### Per-benchmark results (2 of 2)", summary)
         self.assertIn(


### PR DESCRIPTION
The synthetic tx workflow was taking about two hours because it ran the full synthetic benchmark matrix twice, including the prove axis. The largest generated transaction spends roughly 48 seconds per prove iteration, and Criterion was collecting 30 samples, so one axis alone could consume about 24 minutes per side.

Make the CI path explicit and bounded: default it to exec, trace_prep, and verify; expose bench axes and Criterion timing knobs; lower the workflow timeout; and keep the full prove benchmark available through `workflow_dispatch` by setting `bench_axes=all` or `prove`.

Also add a minimum absolute slowdown gate so sub-millisecond timing noise does not fail next, and publish the benchmark report on an associated PR when one exists before falling back to a commit comment.
