### PR TITLE
Canonicalize EventId in serde deserialization

### DIFF
--- a/core/src/events/mod.rs
+++ b/core/src/events/mod.rs
@@ -6,7 +6,7 @@ use miden_crypto::{
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{Felt, utils::hash_string_to_word};
 
@@ -29,13 +29,24 @@ pub use sys_events::SystemEvent;
 ///
 /// Event IDs are derived from event names using blake3 hashing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(
     all(feature = "arbitrary", test),
     miden_test_serde_macros::serde_test(binary_serde(true))
 )]
 pub struct EventId(u64);
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for EventId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let event_id = u64::deserialize(deserializer)?;
+        Ok(Self::from_u64(event_id))
+    }
+}
 
 impl EventId {
     /// Computes the canonical event identifier for the given `name`.

--- a/core/src/precompile.rs
+++ b/core/src/precompile.rs
@@ -230,6 +230,15 @@ mod tests {
         };
         assert!(message.contains("requested 2 elements"));
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn precompile_request_serde_canonicalizes_event_id() {
+        let json = format!("{{\"event_id\":{},\"calldata\":[]}}", Felt::ORDER);
+        let request: PrecompileRequest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(request.event_id(), EventId::from_u64(0));
+    }
 }
 
 impl PrecompileVerifierRegistry {


### PR DESCRIPTION
  ## Describe your changes
                                                                                                                                                                                                     
  This PR fixes an inconsistency in `EventId` deserialization semantics.                                                                                                                             
                                                                                                                                                                                                     
  `EventId` values were already canonicalized in binary deserialization, but serde deserialization used a derived path that could preserve non-canonical raw values. That could make equivalent IDs behave differently in `EventId`-keyed lookups (including precompile verifier routing).                                                                                                             
                                                                                                                                                                                                     
  Changes in this PR:                                                                                                                                                                                
  - Replaced derived `Deserialize` for `EventId` with a manual implementation that deserializes `u64` via `EventId::from_u64` (canonicalized path).                                                  
  - Kept serialization behavior unchanged.                                                                                                                                                           
  - Added a regression test in `core/src/precompile.rs` to verify serde input `event_id = Felt::ORDER` is canonicalized to `EventId::from_u64(0)`.                                                   
                                                                                                                                                                                                     
  Validation run:                                                                                                                                                                                    
  - `cargo check -p miden-core --features serde`                                                                                                                                                     
  - `cargo test -p miden-core --features serde precompile_request_serde_canonicalizes_event_id`                                                                                                      
                                                                                                                                                                                                     
  Both pass.                                                                                                                                                                                         
                                                                                                                                                                                                     
  ## Checklist before requesting a review                                                                                                                                                            
  - [ ] Repo forked and branch created from `next` according to naming convention.                                                                                                                   
  - [ ] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).                                                                                                                      
  - [ ] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).                                                                      
  - [ ] Relevant issues are linked in the PR description.                                                                                                                                            
  - [x] Tests added for new functionality.                                                                                                                                                           
  - [ ] Documentation/comments updated according to changes.                                                                                                                                         
  - [ ] Updated `CHANGELOG.md`. 