### PR TITLE
fix(io_ops): remove shadow constants in `op_pipe` that duplicate module-level imports

### DIFF
--- a/processor/src/execution/operations/io_ops/mod.rs
+++ b/processor/src/execution/operations/io_ops/mod.rs
@@ -277,11 +277,6 @@ pub(super) fn op_pipe<P: Processor, T: Tracer>(
     processor: &mut P,
     tracer: &mut T,
 ) -> Result<OperationHelperRegisters, IoError> {
-    /// WORD_SIZE, but as a `Felt`.
-    const WORD_SIZE_FELT: Felt = Felt::new(4);
-    /// The size of a double-word.
-    const DOUBLE_WORD_SIZE: Felt = Felt::new(8);
-
     // The stack index where the memory address to load the words from is stored.
     const MEM_ADDR_STACK_IDX: usize = 12;
 


### PR DESCRIPTION
Fixes #3133

## Summary

`io_ops/mod.rs` imports `WORD_SIZE_FELT` and `DOUBLE_WORD_SIZE` from the parent module:

```rust
use super::{DOUBLE_WORD_SIZE, WORD_SIZE_FELT};
```

Inside `op_pipe`, the same two constants are redefined locally, silently **shadowing**
the imported names for the entire function body:

```rust
const WORD_SIZE_FELT: Felt = Felt::new_unchecked(4);
const DOUBLE_WORD_SIZE: Felt = Felt::new_unchecked(8);
```

The companion `op_mstream` uses the imported constants directly with no local redefinition,
confirming this duplication is unintentional.

## Changes

Remove the two local `const` declarations from `op_pipe` so it uses the canonical
module-level constants, consistent with `op_mstream`.

## Rationale

The shadowing is a maintenance hazard: if the parent-module constants ever change,
`op_pipe` silently keeps the stale values while `op_mstream` picks up the update.
The fix eliminates the divergence by having a single source of truth for both constants.

## Test Plan

The existing IO tests in `io_ops/tests.rs` cover `op_pipe` end-to-end, verifying that
the correct word-size arithmetic is applied. These tests continue to pass because the
removed local constants had the same values as the module-level imports they shadowed.