### PR TITLE
perf(processor): drop dead `clk` arg from u32 range-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 - [BREAKING] Updated the Miden crypto stack to `miden-crypto` v0.25, and switched SMT leaf hashing to use Poseidon2 domain separation so masm-side leaf digests match `SmtLeaf::hash()` ([#3095](https://github.com/0xMiden/miden-vm/pull/3095)).
 - [BREAKING] Reject post-last operation-indexed decorators in block assembly and serialized MAST forests; use `after_exit` for decorators that run after a block exits ([#3114](https://github.com/0xMiden/miden-vm/pull/3114)).
 - [BREAKING] Removed `Continuation::AfterExitDecoratorsBasicBlock`. New MAST merges operation-indexed decorators at the post-last-op sentinel index into `after_exit` at build time; execution uses `AfterExitDecorators` only, with legacy forests still supported ([#2633](https://github.com/0xMiden/miden-vm/issues/2633)).
+- Drop dead `clk` argument from u32 range-check ([#3135](https://github.com/0xMiden/miden-vm/issues/3135)).
 
 ## 0.22.3 (2026-05-01)
 

--- a/processor/src/execution/operations/u32_ops/mod.rs
+++ b/processor/src/execution/operations/u32_ops/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     ExecutionError, Felt, ZERO,
     mast::MastForest,
     operation::OperationError,
-    processor::{Processor, StackInterface, SystemInterface},
+    processor::{Processor, StackInterface},
     tracer::{OperationHelperRegisters, Tracer},
 };
 
@@ -63,7 +63,7 @@ where
         let top = processor.stack().get(0);
         split_element(top)
     };
-    tracer.record_u32_range_checks(processor.system().clock(), top_lo, top_hi);
+    tracer.record_u32_range_checks(top_lo, top_hi);
 
     processor.stack_mut().increment_size()?;
     processor.stack_mut().set(0, top_lo);
@@ -88,7 +88,7 @@ pub(super) fn op_u32add<P: Processor, T: Tracer>(
         let result = Felt::new_unchecked(a.as_canonical_u64() + b.as_canonical_u64());
         split_element(result)
     };
-    tracer.record_u32_range_checks(processor.system().clock(), sum, carry);
+    tracer.record_u32_range_checks(sum, carry);
 
     processor.stack_mut().set(0, sum);
     processor.stack_mut().set(1, carry);
@@ -119,7 +119,7 @@ where
             Felt::new_unchecked(a.as_canonical_u64() + b.as_canonical_u64() + c.as_canonical_u64());
         split_element(result)
     };
-    tracer.record_u32_range_checks(processor.system().clock(), sum, carry);
+    tracer.record_u32_range_checks(sum, carry);
 
     // write sum to the new top of the stack, and carry after
     processor.stack_mut().decrement_size()?;
@@ -146,7 +146,7 @@ pub(super) fn op_u32sub<P: Processor, T: Tracer>(
     let borrow = Felt::new_unchecked(result >> 63);
     let diff = Felt::new_unchecked(result & u32::MAX as u64);
 
-    tracer.record_u32_range_checks(processor.system().clock(), diff, ZERO);
+    tracer.record_u32_range_checks(diff, ZERO);
 
     processor.stack_mut().set(0, borrow);
     processor.stack_mut().set(1, diff);
@@ -168,7 +168,7 @@ pub(super) fn op_u32mul<P: Processor, T: Tracer>(
 
     let result = Felt::new_unchecked(a.as_canonical_u64() * b.as_canonical_u64());
     let (hi, lo) = split_element(result);
-    tracer.record_u32_range_checks(processor.system().clock(), lo, hi);
+    tracer.record_u32_range_checks(lo, hi);
 
     processor.stack_mut().set(0, lo);
     processor.stack_mut().set(1, hi);
@@ -196,7 +196,7 @@ where
     let result =
         Felt::new_unchecked(a.as_canonical_u64() * b.as_canonical_u64() + c.as_canonical_u64());
     let (hi, lo) = split_element(result);
-    tracer.record_u32_range_checks(processor.system().clock(), lo, hi);
+    tracer.record_u32_range_checks(lo, hi);
 
     // write lo to the new top of the stack, and hi after
     processor.stack_mut().decrement_size()?;
@@ -243,7 +243,7 @@ pub(super) fn op_u32div<P: Processor, T: Tracer>(
     // These range checks help enforce that remainder < denominator.
     let hi = Felt::new_unchecked(denominator - remainder - 1);
 
-    tracer.record_u32_range_checks(processor.system().clock(), lo, hi);
+    tracer.record_u32_range_checks(lo, hi);
     Ok(OperationHelperRegisters::U32Div { lo, hi })
 }
 
@@ -337,7 +337,7 @@ pub(super) fn op_u32assert2<P: Processor, T: Tracer>(
         return Err(OperationError::NotU32Values { values: invalid_values });
     }
 
-    tracer.record_u32_range_checks(processor.system().clock(), first, second);
+    tracer.record_u32_range_checks(first, second);
 
     // Stack remains unchanged for assert operations
 

--- a/processor/src/trace/execution_tracer.rs
+++ b/processor/src/trace/execution_tracer.rs
@@ -763,11 +763,11 @@ impl Tracer for ExecutionTracer {
     }
 
     #[inline(always)]
-    fn record_u32_range_checks(&mut self, clk: RowIndex, u32_lo: Felt, u32_hi: Felt) {
+    fn record_u32_range_checks(&mut self, u32_lo: Felt, u32_hi: Felt) {
         let (t1, t0) = split_u32_into_u16(u32_lo.as_canonical_u64());
         let (t3, t2) = split_u32_into_u16(u32_hi.as_canonical_u64());
 
-        self.range_checker.record_range_check_u32(clk, [t0, t1, t2, t3]);
+        self.range_checker.record_range_check_u32([t0, t1, t2, t3]);
     }
 
     #[inline(always)]

--- a/processor/src/trace/parallel/mod.rs
+++ b/processor/src/trace/parallel/mod.rs
@@ -422,7 +422,7 @@ fn initialize_range_checker(
     let mut range_checker = RangeChecker::new();
 
     // Add all u32 range checks recorded during execution
-    for (_clk, values) in range_checker_replay.into_iter() {
+    for values in range_checker_replay {
         range_checker.add_range_checks(&values);
     }
 

--- a/processor/src/trace/trace_state.rs
+++ b/processor/src/trace/trace_state.rs
@@ -833,7 +833,7 @@ impl IntoIterator for AceReplay {
 /// This currently only records
 #[derive(Debug, Default)]
 pub struct RangeCheckerReplay {
-    range_checks_u32_ops: VecDeque<(RowIndex, [u16; 4])>,
+    range_checks_u32_ops: VecDeque<[u16; 4]>,
 }
 
 impl RangeCheckerReplay {
@@ -841,14 +841,14 @@ impl RangeCheckerReplay {
     // --------------------------------------------------------------------------------
 
     /// Records the set of range checks which result from a u32 operation.
-    pub fn record_range_check_u32(&mut self, row_index: RowIndex, u16_limbs: [u16; 4]) {
-        self.range_checks_u32_ops.push_back((row_index, u16_limbs));
+    pub fn record_range_check_u32(&mut self, u16_limbs: [u16; 4]) {
+        self.range_checks_u32_ops.push_back(u16_limbs);
     }
 }
 
 impl IntoIterator for RangeCheckerReplay {
-    type Item = (RowIndex, [u16; 4]);
-    type IntoIter = <VecDeque<(RowIndex, [u16; 4])> as IntoIterator>::IntoIter;
+    type Item = [u16; 4];
+    type IntoIter = <VecDeque<[u16; 4]> as IntoIterator>::IntoIter;
 
     /// Returns an iterator over all recorded range checks resulting from u32 operations.
     fn into_iter(self) -> Self::IntoIter {

--- a/processor/src/tracer.rs
+++ b/processor/src/tracer.rs
@@ -297,7 +297,7 @@ pub trait Tracer {
     ///
     /// Called by: `U32SPLIT`, `U32ADD`, `U32ADD3`, `U32SUB`, `U32MUL`, `U32MADD`, `U32DIV`,
     /// `U32ASSERT2`.
-    fn record_u32_range_checks(&mut self, _clk: RowIndex, _u32_lo: Felt, _u32_hi: Felt) {}
+    fn record_u32_range_checks(&mut self, _u32_lo: Felt, _u32_hi: Felt) {}
 
     /// Records the procedure hash of a syscall.
     ///


### PR DESCRIPTION
## Describe your changes

Since #3119 dropped `cycle_lookups`, the `clk` parameter  in `Tracer::record_u32_range_checks` is basically dead so can be removed to prune 4 bytes per insert.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'