### PR TITLE
assembly-syntax: tighten enum repr parsing to <=64-bit/felt

### DIFF
--- a/crates/assembly-syntax/src/ast/type.rs
+++ b/crates/assembly-syntax/src/ast/type.rs
@@ -1061,8 +1061,8 @@ impl Variant {
     }
 
     /// Used to validate that this variant's discriminant value is an instance of `ty`,
-    /// which must be a type valid for use as the underlying representation for an enum, i.e. an
-    /// integer type up to 64 bits in size.
+    /// which must be a type valid for use as the underlying representation for an enum, i.e. felt
+    /// or an integer type up to 64 bits in size.
     ///
     /// It is expected that the discriminant expression has been folded to an integer value by the
     /// time this is called. If the discriminant has not been fully folded, then an error will be
@@ -1122,6 +1122,7 @@ impl Variant {
                     repr: ty.clone(),
                 })
             },
+            Type::I64 | Type::U64 => Ok(()),
             _ => Err(SemanticAnalysisError::InvalidEnumRepr { span: self.span }),
         }
     }

--- a/crates/assembly-syntax/src/parser/grammar.lalrpop
+++ b/crates/assembly-syntax/src/parser/grammar.lalrpop
@@ -333,7 +333,7 @@ TypeDecl: Form = {
         Form::Type(TypeAlias::new(vis, name, ty).with_span(span))
     },
 
-    <l:@L> <vis:Visibility> "enum" <name:BareIdent> ":" <repr:IntType> "{" <variants:CommaDelimitedAllowTrailing<EnumVariant>> "}" <r:@R> => {
+    <l:@L> <vis:Visibility> "enum" <name:BareIdent> ":" <repr:EnumReprType> "{" <variants:CommaDelimitedAllowTrailing<EnumVariant>> "}" <r:@R> => {
         let span = span!(source_id, l, r);
         let mut vs = Vec::with_capacity(variants.len());
         let mut next = ConstantExpr::Int(Span::new(span, IntValue::U8(0)));
@@ -584,6 +584,20 @@ IntType: Type = {
     "u32" => Type::U32,
     "u64" => Type::U64,
     "u128" => Type::U128,
+    "felt" => Type::Felt,
+}
+
+#[inline]
+EnumReprType: Type = {
+    "i1" => Type::I1,
+    "i8" => Type::I8,
+    "i16" => Type::I16,
+    "i32" => Type::I32,
+    "i64" => Type::I64,
+    "u8" => Type::U8,
+    "u16" => Type::U16,
+    "u32" => Type::U32,
+    "u64" => Type::U64,
     "felt" => Type::Felt,
 }
 

--- a/crates/assembly-syntax/src/sema/errors.rs
+++ b/crates/assembly-syntax/src/sema/errors.rs
@@ -79,7 +79,7 @@ pub enum SemanticAnalysisError {
         #[label]
         span: SourceSpan,
     },
-    #[error("invalid enum type representation: underlying type must be an integral or felt type")]
+    #[error("invalid enum type representation: underlying type must be felt or an integer up to 64 bits")]
     #[diagnostic()]
     InvalidEnumRepr {
         #[label]


### PR DESCRIPTION
  ## Describe your changes
                                                                                                                                                                                                 
  This PR aligns enum representation rules between parser and semantic validation in `miden-assembly-syntax` to avoid “accepted first, rejected later” behavior.                                 

  - Restrict enum repr parsing in `crates/assembly-syntax/src/parser/grammar.lalrpop` by introducing `EnumReprType` for enum declarations (`felt` + integer types up to 64 bits only).           
  - Fix a semantic validation gap in `crates/assembly-syntax/src/ast/type.rs` by adding the missing success branch for `Type::I64 | Type::U64` in `Variant::assert_instance_of`.                 
  - Update `InvalidEnumRepr` wording in `crates/assembly-syntax/src/sema/errors.rs` to match the actual supported range.                                                                         
                                                                                                                                                                                                 
  Result: enum repr constraints are now consistent across parse/semantic stages, with clearer and earlier feedback for unsupported repr types.                                                   
                                                                                                                                                                                                 
  ## Checklist before requesting a review                                                                                                                                                        
  - [ ] Repo forked and branch created from `next` according to naming convention.                                                                                                               
  - [ ] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).                                                                                                                  
  - [ ] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).                                                                  
  - [ ] Relevant issues are linked in the PR description.                                                                                                                                        
  - [ ] Tests added for new functionality.
  - [x] Documentation/comments updated according to changes.                                                                                                                                     
  - [ ] Updated `CHANGELOG.md`.  