### PR TITLE
fix(dsa): remove dead Option return type from falcon512_poseidon2::sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
 - [BREAKING] Reject post-last operation-indexed decorators in block assembly and serialized MAST forests; use `after_exit` for decorators that run after a block exits ([#3114](https://github.com/0xMiden/miden-vm/pull/3114)).
 - [BREAKING] Removed `Continuation::AfterExitDecoratorsBasicBlock`. New MAST merges operation-indexed decorators at the post-last-op sentinel index into `after_exit` at build time; execution uses `AfterExitDecorators` only, with legacy forests still supported ([#2633](https://github.com/0xMiden/miden-vm/issues/2633)).
 - Drop dead `clk` argument from u32 range-check ([#3135](https://github.com/0xMiden/miden-vm/issues/3135)).
+- Remove dead `Option` return type from `falcon512_poseidon2::sign` ([#3137](https://github.com/0xMiden/miden-vm/pull/3137)).
 
 ## 0.22.3 (2026-05-01)
 

--- a/crates/lib/core/src/dsa.rs
+++ b/crates/lib/core/src/dsa.rs
@@ -117,15 +117,14 @@ pub mod falcon512_poseidon2 {
     };
 
     /// Signs the provided message with the provided secret key and returns the resulting signature
-    /// encoded in the format required by the `falcon512_poseidon2::verify` procedure, or `None` if
-    /// the secret key is malformed due to either incorrect length or failed decoding.
+    /// encoded in the format required by the `falcon512_poseidon2::verify` procedure
     ///
     /// This is equivalent to calling [`encode_signature`] on the result of signing the message.
     ///
     /// See [`encode_signature`] for the encoding format.
-    pub fn sign(sk: &SecretKey, msg: Word) -> Option<Vec<Felt>> {
+    pub fn sign(sk: &SecretKey, msg: Word) -> Vec<Felt> {
         let sig = sk.sign(msg);
-        Some(encode_signature(sig.public_key(), &sig))
+        encode_signature(sig.public_key(), &sig)
     }
 
     /// Encodes the provided Falcon public key and signature into a vector of field elements in the

--- a/crates/lib/core/tests/crypto/falcon.rs
+++ b/crates/lib/core/tests/crypto/falcon.rs
@@ -271,8 +271,7 @@ fn test_move_sig_to_adv_stack() {
 
     let advice_map: Vec<(Word, Vec<Felt>)> = {
         let sig_key = Poseidon2::merge(&[public_key, message]);
-        let signature =
-        falcon512_poseidon2::sign(&secret_key, message);
+        let signature = falcon512_poseidon2::sign(&secret_key, message);
 
         vec![(sig_key, signature)]
     };

--- a/crates/lib/core/tests/crypto/falcon.rs
+++ b/crates/lib/core/tests/crypto/falcon.rs
@@ -85,8 +85,7 @@ pub fn push_falcon_signature(process: &ProcessorState) -> Result<Vec<AdviceMutat
     let sk = SecretKey::read_from_bytes(&sk_bytes)
         .map_err(|_| FalconError::MalformedSignatureKey { key_type: "Poseidon2 Falcon512" })?;
 
-    let signature_result = falcon512_poseidon2::sign(&sk, msg)
-        .ok_or(FalconError::MalformedSignatureKey { key_type: "Poseidon2 Falcon512" })?;
+    let signature_result = falcon512_poseidon2::sign(&sk, msg);
 
     Ok(vec![AdviceMutation::extend_stack(signature_result)])
 }
@@ -273,7 +272,7 @@ fn test_move_sig_to_adv_stack() {
     let advice_map: Vec<(Word, Vec<Felt>)> = {
         let sig_key = Poseidon2::merge(&[public_key, message]);
         let signature =
-            falcon512_poseidon2::sign(&secret_key, message).expect("failed to sign message");
+        falcon512_poseidon2::sign(&secret_key, message);
 
         vec![(sig_key, signature)]
     };


### PR DESCRIPTION
The falcon512_poseidon2::sign function claimed it could return None if the secret key was malformed, but this was never possible  the underlying SecretKey::sign() is infallible. Removed the misleading Option wrapper and updated all callers accordingly.

## Rationale
SecretKey::sign() in miden-crypto is infallible — it returns Signature directly, not Result or Option. The Option<Vec<Felt>> return type was 
dead code and the documentation was incorrect.

## Test plan
- cargo test -p miden-core-lib - all 351 tests pass