### PR TITLE
fix(clippy): enable and fix clippy::unnecessary_wraps across workspace

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -92,7 +92,7 @@ xclippy = [
     # -Wclippy::cast_lossless              (603 warnings)
     # -Wclippy::manual_assert              (17 warnings)
     # -Wclippy::needless_pass_by_value     (43 warnings)
-    # -Wclippy::unnecessary_wraps          (40 warnings)
+    "-Wclippy::unnecessary_wraps",
     # -Wrust_2018_idioms                   (190 warnings)
     # -Wunreachable_pub                    (545 warnings)
 ]
@@ -156,6 +156,7 @@ xclippy-fix = [
     "-Wunexpected_cfgs",
     "-Wunused_lifetimes",
     "-Wunused_qualifications",
+    "-Wclippy::unnecessary_wraps",
 ]
 
 [target.wasm32-unknown-unknown]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Improved performances of auxiliary trace generation ([#3119](https://github.com/0xMiden/miden-vm/pull/3119)).
 - Aligned replay stack word access bounds with `StackInterface`, allowing the maximum valid start index for word reads and writes ([#3014](https://github.com/0xMiden/miden-vm/pull/3014)).
+- [BREAKING] Enabled `clippy::unnecessary_wraps` lint and removed all unnecessary `Option`/`Result` wrappings across the workspace ([#3143](https://github.com/0xMiden/miden-vm/pull/3143)).
 
 #### Fixes
 

--- a/air/src/constraints/lookup/buses/lookup_op_flags.rs
+++ b/air/src/constraints/lookup/buses/lookup_op_flags.rs
@@ -591,7 +591,7 @@ mod tests {
         }
     }
 
-    fn flags_for_opcode(opcode: usize) -> LookupOpFlags<miden_core::Felt> {
+    fn flags_for_opcode(opcode: usize) -> LookupOpFlags<Felt> {
         let row = generate_test_row(opcode);
         let row_next = generate_test_row(0);
         LookupOpFlags::from_main_cols(&row.decoder, &row.stack, &row_next.decoder)

--- a/crates/assembly-syntax/src/ast/alias.rs
+++ b/crates/assembly-syntax/src/ast/alias.rs
@@ -130,7 +130,7 @@ impl crate::prettier::PrettyPrint for Alias {
             target => {
                 let prefix = if self.is_absolute() { "::" } else { "" };
                 if self.is_renamed() {
-                    display(format_args!("{}{}->{}", prefix, target, &self.name))
+                    display(format_args!("{}{}->{}", prefix, target, self.name))
                 } else {
                     display(format_args!("{prefix}{target}"))
                 }

--- a/crates/assembly-syntax/src/ast/attribute/mod.rs
+++ b/crates/assembly-syntax/src/ast/attribute/mod.rs
@@ -171,7 +171,7 @@ impl fmt::Display for Attribute {
 impl prettier::PrettyPrint for Attribute {
     fn render(&self) -> prettier::Document {
         use prettier::*;
-        let doc = text(format!("@{}", &self.name()));
+        let doc = text(format!("@{}", self.name()));
         match self {
             Self::Marker(_) => doc,
             Self::List(meta) => {

--- a/crates/assembly-syntax/src/ast/item/index.rs
+++ b/crates/assembly-syntax/src/ast/item/index.rs
@@ -35,7 +35,7 @@ impl ItemIndex {
 
 impl core::fmt::Display for ItemIndex {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", &self.as_usize())
+        write!(f, "{}", self.as_usize())
     }
 }
 
@@ -76,7 +76,7 @@ pub struct GlobalItemIndex {
 
 impl core::fmt::Display for GlobalItemIndex {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}:{}", &self.module, &self.index)
+        write!(f, "{}:{}", self.module, self.index)
     }
 }
 
@@ -109,7 +109,7 @@ impl core::ops::Add<ItemIndex> for ModuleIndex {
 
 impl core::fmt::Display for ModuleIndex {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", &self.as_usize())
+        write!(f, "{}", self.as_usize())
     }
 }
 

--- a/crates/assembly-syntax/src/ast/procedure/procedure.rs
+++ b/crates/assembly-syntax/src/ast/procedure/procedure.rs
@@ -277,11 +277,11 @@ impl crate::prettier::PrettyPrint for Procedure {
             doc += const_text("begin");
         } else {
             if self.num_locals > 0 {
-                doc += text(format!("@locals(\"{}\")", &self.num_locals)) + nl();
+                doc += text(format!("@locals(\"{}\")", self.num_locals)) + nl();
             }
             match self.signature() {
                 Some(sig) if sig.cc != crate::ast::types::CallConv::Fast => {
-                    doc += text(format!("@callconv(\"{}\")", &sig.cc)) + nl();
+                    doc += text(format!("@callconv(\"{}\")", sig.cc)) + nl();
                 },
                 _ => (),
             }

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -385,7 +385,7 @@ impl Assembler {
                 if !self.kernel().is_empty() {
                     return Err(Report::msg(format!(
                         "duplicate kernels present in the dependency graph: '{}@{}' conflicts with another kernel we've already linked",
-                        &package.name, &package.version
+                        package.name, package.version
                     )));
                 }
 
@@ -616,7 +616,7 @@ impl Assembler {
         };
 
         let (mast_forest, id_remappings) = mast_forest_builder.build();
-        for (_proc_name, export) in exports.iter_mut() {
+        for export in exports.values_mut() {
             match export {
                 LibraryExport::Procedure(export) => {
                     if let Some(&new_node_id) = id_remappings.get(&export.node) {
@@ -687,7 +687,7 @@ impl Assembler {
                 );
 
                 let procedure = pctx.into_procedure(digest, node);
-                self.linker.register_procedure_root(gid, digest)?;
+                self.linker.register_procedure_root(gid, digest);
                 mast_forest_builder.insert_procedure(gid, procedure)?;
                 LibraryExport::Procedure(ProcedureExport {
                     node,
@@ -765,7 +765,7 @@ impl Assembler {
                     self.source_manager.clone(),
                 );
                 let procedure = pctx.into_procedure(digest, node);
-                self.linker.register_procedure_root(gid, digest)?;
+                self.linker.register_procedure_root(gid, digest);
                 mast_forest_builder.insert_procedure(gid, procedure)?;
 
                 return Ok(LibraryExport::Procedure(ProcedureExport {
@@ -797,7 +797,7 @@ impl Assembler {
         let program = source.parse_with_options(self.source_manager.clone(), options)?;
         assert!(program.is_executable());
 
-        self.assemble_executable_modules(program, [])?.into_program()
+        Ok(self.assemble_executable_modules(program, [])?.into_program())
     }
 
     pub(crate) fn assemble_library_modules(
@@ -997,7 +997,7 @@ impl Assembler {
         while let Some(procedure_gid) = worklist.pop() {
             // If we have already compiled this procedure, do not recompile
             if let Some(proc) = mast_forest_builder.get_procedure(procedure_gid) {
-                self.linker.register_procedure_root(procedure_gid, proc.mast_root())?;
+                self.linker.register_procedure_root(procedure_gid, proc.mast_root());
                 continue;
             }
             // Fetch procedure metadata from the graph
@@ -1040,7 +1040,7 @@ impl Assembler {
 
                     // Cache the compiled procedure
                     drop(proc);
-                    self.linker.register_procedure_root(procedure_gid, procedure.mast_root())?;
+                    self.linker.register_procedure_root(procedure_gid, procedure.mast_root());
                     mast_forest_builder.insert_procedure(procedure_gid, procedure)?;
                 },
                 SymbolItem::Alias { alias, resolved } => {
@@ -1100,7 +1100,7 @@ impl Assembler {
                     let procedure = pctx.into_procedure(proc_mast_root, proc_node_id);
 
                     // Make the MAST root available to all dependents
-                    self.linker.register_procedure_root(procedure_gid, proc_mast_root)?;
+                    self.linker.register_procedure_root(procedure_gid, proc_mast_root);
                     mast_forest_builder.insert_procedure(procedure_gid, procedure)?;
                 },
                 SymbolItem::Compiled(_) | SymbolItem::Constant(_) | SymbolItem::Type(_) => {

--- a/crates/assembly/src/assembler/product.rs
+++ b/crates/assembly/src/assembler/product.rs
@@ -49,15 +49,15 @@ impl AssemblyProduct {
     }
 
     // TODO(pauls): This can be removed when we remove Library/KernelLibrary/Program
-    pub fn into_program(self) -> Result<Program, Report> {
+    pub fn into_program(self) -> Program {
         assert_eq!(self.kind, TargetType::Executable);
         let entry = Path::exec_path().join(ast::ProcedureName::MAIN_PROC_NAME);
         let entrypoint = self.artifact.get_export_node_id(&entry);
-        Ok(if let Some(kernel) = self.kernel {
+        if let Some(kernel) = self.kernel {
             Program::with_kernel(self.artifact.mast_forest().clone(), entrypoint, kernel)
         } else {
             Program::new(self.artifact.mast_forest().clone(), entrypoint)
-        })
+        }
     }
 
     // TODO(pauls): This can be removed when we remove Library/KernelLibrary/Program

--- a/crates/assembly/src/basic_block_builder.rs
+++ b/crates/assembly/src/basic_block_builder.rs
@@ -170,7 +170,6 @@ impl BasicBlockBuilder<'_> {
             context_name: proc_ctx.path().to_string(),
             op: instruction.to_string(),
         });
-
     }
 
     /// Finalizes the pending AssemblyOp with the computed cycle count.

--- a/crates/assembly/src/basic_block_builder.rs
+++ b/crates/assembly/src/basic_block_builder.rs
@@ -162,7 +162,7 @@ impl BasicBlockBuilder<'_> {
         &mut self,
         instruction: &Span<Instruction>,
         proc_ctx: &ProcedureContext,
-    ) -> Result<(), Report> {
+    ) {
         let span = instruction.span();
         self.pending_asm_op = Some(PendingAsmOp {
             op_start: self.ops.len(),
@@ -171,7 +171,6 @@ impl BasicBlockBuilder<'_> {
             op: instruction.to_string(),
         });
 
-        Ok(())
     }
 
     /// Finalizes the pending AssemblyOp with the computed cycle count.

--- a/crates/assembly/src/instruction/crypto_ops.rs
+++ b/crates/assembly/src/instruction/crypto_ops.rs
@@ -275,5 +275,4 @@ fn update_mtree(block_builder: &mut BasicBlockBuilder) {
 
     // stack: [V_old, R_new, ...] (25 cycles)
     block_builder.push_ops(ops);
-
 }

--- a/crates/assembly/src/instruction/crypto_ops.rs
+++ b/crates/assembly/src/instruction/crypto_ops.rs
@@ -135,7 +135,7 @@ pub(super) fn mtree_set(block_builder: &mut BasicBlockBuilder) -> Result<(), Rep
     // stack: [d, i, R_old, V_new, ...]
 
     // stack: [V_old, R_new, ...] (30 cycles)
-    update_mtree(block_builder)
+    Ok(update_mtree(block_builder))
 }
 
 /// Creates a new Merkle tree in the advice provider by combining trees with the specified roots.
@@ -203,7 +203,7 @@ fn read_mtree_node(block_builder: &mut BasicBlockBuilder) {
 /// and perform the mutation on the copied tree.
 ///
 /// This operation takes 30 VM cycles.
-fn update_mtree(block_builder: &mut BasicBlockBuilder) -> Result<(), Report> {
+fn update_mtree(block_builder: &mut BasicBlockBuilder) {
     // stack: [d, i, R_old, V_new, ...]
     // output: [R_new, R_old, V_new, V_old, ...]
 
@@ -276,5 +276,4 @@ fn update_mtree(block_builder: &mut BasicBlockBuilder) -> Result<(), Report> {
     // stack: [V_old, R_new, ...] (25 cycles)
     block_builder.push_ops(ops);
 
-    Ok(())
 }

--- a/crates/assembly/src/instruction/crypto_ops.rs
+++ b/crates/assembly/src/instruction/crypto_ops.rs
@@ -135,7 +135,8 @@ pub(super) fn mtree_set(block_builder: &mut BasicBlockBuilder) -> Result<(), Rep
     // stack: [d, i, R_old, V_new, ...]
 
     // stack: [V_old, R_new, ...] (30 cycles)
-    Ok(update_mtree(block_builder))
+    update_mtree(block_builder);
+    Ok(())
 }
 
 /// Creates a new Merkle tree in the advice provider by combining trees with the specified roots.

--- a/crates/assembly/src/instruction/debug.rs
+++ b/crates/assembly/src/instruction/debug.rs
@@ -1,6 +1,6 @@
 use miden_core::WORD_SIZE;
 
-use crate::{ProcedureContext, ast::DebugOptions, diagnostics::Report};
+use crate::{ProcedureContext, ast::DebugOptions};
 
 /// Compiles the AST representation of a `debug` instruction into its VM representation.
 ///

--- a/crates/assembly/src/instruction/debug.rs
+++ b/crates/assembly/src/instruction/debug.rs
@@ -10,7 +10,7 @@ use crate::{ProcedureContext, ast::DebugOptions, diagnostics::Report};
 pub fn compile_options(
     options: &DebugOptions,
     proc_ctx: &ProcedureContext,
-) -> Result<miden_core::operations::DebugOptions, Report> {
+) -> miden_core::operations::DebugOptions {
     type Ast = DebugOptions;
     type Vm = miden_core::operations::DebugOptions;
 
@@ -39,5 +39,5 @@ pub fn compile_options(
         Ast::AdvStackTop(n) => Vm::AdvStackTop(n.expect_value()),
     };
 
-    Ok(compiled)
+    compiled
 }

--- a/crates/assembly/src/instruction/ext2_ops.rs
+++ b/crates/assembly/src/instruction/ext2_ops.rs
@@ -115,7 +115,7 @@ pub fn ext2_neg(block_builder: &mut BasicBlockBuilder) {
 /// assert b  = (1, 0) | (1, 0) is the multiplicative identity of extension field.
 ///
 /// This operation takes 8 VM cycles.
-pub fn ext2_inv(block_builder: &mut BasicBlockBuilder) -> Result<(), Report> {
+pub fn ext2_inv(block_builder: &mut BasicBlockBuilder) {
     block_builder.push_system_event(Ext2Inv);
     #[rustfmt::skip]
     let ops = [
@@ -130,5 +130,4 @@ pub fn ext2_inv(block_builder: &mut BasicBlockBuilder) -> Result<(), Report> {
     ];
     block_builder.push_ops(ops);
 
-    Ok(())
 }

--- a/crates/assembly/src/instruction/ext2_ops.rs
+++ b/crates/assembly/src/instruction/ext2_ops.rs
@@ -129,5 +129,4 @@ pub fn ext2_inv(block_builder: &mut BasicBlockBuilder) {
         Assert(ZERO),   // [a0', a1', ...] (verify c0 is truthy, i.e. == 1)
     ];
     block_builder.push_ops(ops);
-
 }

--- a/crates/assembly/src/instruction/ext2_ops.rs
+++ b/crates/assembly/src/instruction/ext2_ops.rs
@@ -1,7 +1,7 @@
 use miden_core::{events::SystemEvent::Ext2Inv, operations::Operation::*};
 
 use super::BasicBlockBuilder;
-use crate::{Report, ZERO};
+use crate::ZERO;
 
 /// Given a stack in the following initial configuration [b0, b1, a0, a1, ...] where a = (a0, a1)
 /// and b = (b0, b1) represent elements in the extension field of degree 2, this series

--- a/crates/assembly/src/instruction/mod.rs
+++ b/crates/assembly/src/instruction/mod.rs
@@ -48,7 +48,7 @@ impl Assembler {
         // Start tracking the instruction about to be executed; this will allow us to map the
         // instruction to the sequence of operations which were executed as a part of this
         // instruction.
-        block_builder.track_instruction(instruction, proc_ctx)?;
+        block_builder.track_instruction(instruction, proc_ctx);
 
         // For node-creating instructions, finalize the AssemblyOp now (it will have 0 cycles
         // since no operations have been added yet for this instruction).
@@ -161,7 +161,7 @@ impl Assembler {
             Instruction::Ext2Mul => ext2_ops::ext2_mul(block_builder),
             Instruction::Ext2Div => ext2_ops::ext2_div(block_builder),
             Instruction::Ext2Neg => ext2_ops::ext2_neg(block_builder),
-            Instruction::Ext2Inv => ext2_ops::ext2_inv(block_builder)?,
+            Instruction::Ext2Inv => ext2_ops::ext2_inv(block_builder),
 
             // ----- u32 manipulation -------------------------------------------------------------
             Instruction::U32Test => block_builder.push_ops([Dup0, U32split, Drop, Eqz]),
@@ -597,7 +597,7 @@ impl Assembler {
             // ----- debug decorators -------------------------------------------------------------
             Instruction::Debug(options) => {
                 block_builder
-                    .push_decorator(Decorator::Debug(debug::compile_options(options, proc_ctx)?))?;
+                    .push_decorator(Decorator::Debug(debug::compile_options(options, proc_ctx)))?;
             },
 
             Instruction::DebugVar(debug_var_info) => {

--- a/crates/assembly/src/instruction/procedures.rs
+++ b/crates/assembly/src/instruction/procedures.rs
@@ -113,7 +113,8 @@ impl Assembler {
                 .digest()
         };
 
-        Ok(self.procref_mast_root(mast_root, block_builder))
+        self.procref_mast_root(mast_root, block_builder);
+        Ok(())
     }
 
     fn procref_mast_root(&self, mast_root: Word, block_builder: &mut BasicBlockBuilder) {

--- a/crates/assembly/src/instruction/procedures.rs
+++ b/crates/assembly/src/instruction/procedures.rs
@@ -113,14 +113,14 @@ impl Assembler {
                 .digest()
         };
 
-        self.procref_mast_root(mast_root, block_builder)
+        Ok(self.procref_mast_root(mast_root, block_builder))
     }
 
     fn procref_mast_root(
         &self,
         mast_root: Word,
         block_builder: &mut BasicBlockBuilder,
-    ) -> Result<(), Report> {
+    ) {
         // Create an array with `Push` operations containing root elements.
         // Push in reverse order so that mast_root[0] ends up on top.
         let ops = mast_root
@@ -129,6 +129,5 @@ impl Assembler {
             .map(|elem| Operation::Push(*elem))
             .collect::<SmallVec<[_; 4]>>();
         block_builder.push_ops(ops);
-        Ok(())
     }
 }

--- a/crates/assembly/src/instruction/procedures.rs
+++ b/crates/assembly/src/instruction/procedures.rs
@@ -116,11 +116,7 @@ impl Assembler {
         Ok(self.procref_mast_root(mast_root, block_builder))
     }
 
-    fn procref_mast_root(
-        &self,
-        mast_root: Word,
-        block_builder: &mut BasicBlockBuilder,
-    ) {
+    fn procref_mast_root(&self, mast_root: Word, block_builder: &mut BasicBlockBuilder) {
         // Create an array with `Push` operations containing root elements.
         // Push in reverse order so that mast_root[0] ends up on top.
         let ops = mast_root

--- a/crates/assembly/src/linker/debug.rs
+++ b/crates/assembly/src/linker/debug.rs
@@ -65,7 +65,7 @@ struct DisplayModuleGraphNode<'a> {
 impl fmt::Debug for DisplayModuleGraphNode<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Node")
-            .field("id", &format_args!("{}", &self.id))
+            .field("id", &format_args!("{}", self.id))
             .field("module", &self.path)
             .field("name", &self.name)
             .field("source", &self.source)

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -221,7 +221,7 @@ impl Linker {
             self.callgraph.get_or_insert_node(gid);
             match &item {
                 ItemInfo::Procedure(item) => {
-                    self.register_procedure_root(gid, item.digest)?;
+                    self.register_procedure_root(gid, item.digest);
                 },
                 ItemInfo::Constant(_) | ItemInfo::Type(_) => (),
             }
@@ -594,7 +594,7 @@ impl Linker {
                             // calls/symbol refs
                             let proc = proc.borrow();
                             for invoke in proc.invoked() {
-                                log::debug!(target: "linker", "  | recording {} dependency on {}", invoke.kind, &invoke.target);
+                                log::debug!(target: "linker", "  | recording {} dependency on {}", invoke.kind, invoke.target);
 
                                 let context = SymbolResolutionContext {
                                     span: invoke.span(),
@@ -862,7 +862,7 @@ impl Linker {
         &mut self,
         id: GlobalItemIndex,
         procedure_mast_root: Word,
-    ) -> Result<(), LinkerError> {
+    ) {
         use alloc::collections::btree_map::Entry;
         match self.procedures_by_mast_root.entry(procedure_mast_root) {
             Entry::Occupied(ref mut entry) => {
@@ -877,7 +877,6 @@ impl Linker {
             },
         }
 
-        Ok(())
     }
 
     /// Resolve a [Path] to a [ModuleIndex] in this graph

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -876,7 +876,6 @@ impl Linker {
                 entry.insert(smallvec![id]);
             },
         }
-
     }
 
     /// Resolve a [Path] to a [ModuleIndex] in this graph

--- a/crates/assembly/src/linker/resolver/symbol_resolver.rs
+++ b/crates/assembly/src/linker/resolver/symbol_resolver.rs
@@ -601,7 +601,7 @@ impl<'a> SymbolResolver<'a> {
     ) -> Result<SymbolResolution, Box<SymbolResolutionError>> {
         let module = &self.graph[module];
         log::debug!(target: "name-resolver::local", "resolving '{symbol}' in module {}", module.path());
-        log::debug!(target: "name-resolver::local", "module status: {:?}", &module.status());
+        log::debug!(target: "name-resolver::local", "module status: {:?}", module.status());
         module.resolve(symbol, self)
     }
 

--- a/crates/assembly/src/project.rs
+++ b/crates/assembly/src/project.rs
@@ -557,7 +557,7 @@ where
         &self,
         package_id: &PackageId,
         selected: &PackageVersion,
-    ) -> bool  {
+    ) -> bool {
         let Some(record) = self.store.get_by_semver(package_id, &selected.version) else {
             return true;
         };

--- a/crates/assembly/src/project.rs
+++ b/crates/assembly/src/project.rs
@@ -430,7 +430,7 @@ where
                     *kind,
                     requirements,
                 )?;
-                let should_cache = self.should_cache_preassembled_package(package_id, selected)?;
+                let should_cache = self.should_cache_preassembled_package(package_id, selected);
                 (
                     ResolvedPackage {
                         linked_kernel_package: self
@@ -557,42 +557,42 @@ where
         &self,
         package_id: &PackageId,
         selected: &PackageVersion,
-    ) -> Result<bool, Report> {
+    ) -> bool  {
         let Some(record) = self.store.get_by_semver(package_id, &selected.version) else {
-            return Ok(true);
+            return true;
         };
         if record.version() != selected {
-            return Ok(false);
+            return false;
         }
 
         match self.store.load_package(package_id, selected) {
-            Ok(_) => Ok(false),
-            Err(_) => Ok(true),
+            Ok(_) => false,
+            Err(_) => true,
         }
     }
 
     fn cache_resolved_package(&mut self, package: &ResolvedPackage) -> Result<(), Report> {
         self.cache_package(package.package.clone())?;
         if let Some(kernel_package) = package.linked_kernel_package.clone()
-            && self.should_cache_linked_kernel_package(kernel_package.as_ref())?
+            && self.should_cache_linked_kernel_package(kernel_package.as_ref())
         {
             self.cache_package(kernel_package)?;
         }
         Ok(())
     }
 
-    fn should_cache_linked_kernel_package(&self, package: &MastPackage) -> Result<bool, Report> {
+    fn should_cache_linked_kernel_package(&self, package: &MastPackage) -> bool {
         let version = PackageVersion::new(package.version.clone(), package.digest());
         let Some(record) = self.store.get_by_semver(&package.name, &package.version) else {
-            return Ok(true);
+            return true;
         };
         if record.version() != &version {
-            return Ok(false);
+            return false;
         }
 
         match self.store.load_package(&package.name, &version) {
-            Ok(_) => Ok(false),
-            Err(_) => Ok(true),
+            Ok(_) => false,
+            Err(_) => true,
         }
     }
 

--- a/crates/assembly/src/project/tests.rs
+++ b/crates/assembly/src/project/tests.rs
@@ -1183,7 +1183,7 @@ end
         package
             .manifest
             .dependencies()
-            .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+            .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
             .collect::<Vec<_>>(),
         vec![format!("runtime@1.0.0#{runtime_digest}")]
     );
@@ -1274,7 +1274,7 @@ dep.workspace = true
         package
             .manifest
             .dependencies()
-            .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+            .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
             .collect::<Vec<_>>(),
         vec![format!("dep@0.2.0#{}", dep010.digest())]
     );
@@ -1339,7 +1339,7 @@ end
     let expected_dependency = first
         .manifest
         .dependencies()
-        .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+        .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
         .collect::<Vec<_>>();
     context.registry().clear_loaded_packages();
 
@@ -1359,7 +1359,7 @@ end
         second
             .manifest
             .dependencies()
-            .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+            .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
             .collect::<Vec<_>>(),
         expected_dependency
     );
@@ -1781,7 +1781,7 @@ end
     let expected_dependency = first
         .manifest
         .dependencies()
-        .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+        .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
         .collect::<Vec<_>>();
     context.registry().clear_loaded_packages();
 
@@ -1814,7 +1814,7 @@ dep = { path = "dep" }
         second
             .manifest
             .dependencies()
-            .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+            .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
             .collect::<Vec<_>>(),
         expected_dependency
     );
@@ -2056,7 +2056,7 @@ end
         package
             .manifest
             .dependencies()
-            .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+            .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
             .collect::<Vec<_>>(),
         vec![format!("dep@1.0.0#{dep_digest}")]
     );

--- a/crates/debug-types/src/location.rs
+++ b/crates/debug-types/src/location.rs
@@ -91,7 +91,7 @@ impl FileLineCol {
 
 impl fmt::Display for FileLineCol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{}@{}:{}]", &self.uri, self.line, self.column)
+        write!(f, "[{}@{}:{}]", self.uri, self.line, self.column)
     }
 }
 

--- a/crates/mast-package/src/package/section.rs
+++ b/crates/mast-package/src/package/section.rs
@@ -110,7 +110,7 @@ impl fmt::Debug for Section {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = f.alternate();
         let mut builder = f.debug_struct("Section");
-        builder.field("id", &format_args!("{}", &self.id));
+        builder.field("id", &format_args!("{}", self.id));
         if verbose {
             builder.field("data", &format_args!("{}", DisplayHex(&self.data))).finish()
         } else {

--- a/crates/package-registry/src/resolver/version_set.rs
+++ b/crates/package-registry/src/resolver/version_set.rs
@@ -176,8 +176,8 @@ impl From<SemverPubgrub> for VersionSet {
 impl fmt::Display for VersionSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.digests.as_slice() {
-            [] => write!(f, "{}", &self.range),
-            [digest] => write!(f, "{digest} in {}", &self.range),
+            [] => write!(f, "{}", self.range),
+            [digest] => write!(f, "{digest} in {}", self.range),
             digests => {
                 f.write_str("any of ")?;
                 for (i, digest) in digests.iter().enumerate() {
@@ -186,7 +186,7 @@ impl fmt::Display for VersionSet {
                     }
                     write!(f, "{digest}")?;
                 }
-                write!(f, " in {}", &self.range)
+                write!(f, " in {}", self.range)
             },
         }
     }

--- a/crates/package-registry/src/version.rs
+++ b/crates/package-registry/src/version.rs
@@ -174,7 +174,7 @@ impl Borrow<SemVer> for Version {
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(digest) = self.digest.as_ref() {
-            write!(f, "{}#{digest}", &self.version)
+            write!(f, "{}#{digest}", self.version)
         } else {
             fmt::Display::fmt(&self.version, f)
         }

--- a/crates/package-registry/src/version_requirement.rs
+++ b/crates/package-registry/src/version_requirement.rs
@@ -100,7 +100,7 @@ impl From<Word> for VersionRequirement {
 impl From<Version> for VersionRequirement {
     fn from(value: Version) -> Self {
         if value.digest.is_none() {
-            Self::Semantic(Span::unknown(format!("={}", &value.version).parse().unwrap()))
+            Self::Semantic(Span::unknown(format!("={}", value.version).parse().unwrap()))
         } else {
             Self::Exact(value)
         }

--- a/crates/project/src/ast/package.rs
+++ b/crates/project/src/ast/package.rs
@@ -260,7 +260,7 @@ impl ProjectFile {
                                 source_file: source,
                                 label: Label::new(
                                     dependency.span(),
-                                    format!("'{}' is not a workspace dependency", &dependency.name),
+                                    format!("'{}' is not a workspace dependency", dependency.name),
                                 ),
                             }
                             .into());

--- a/crates/project/src/package.rs
+++ b/crates/project/src/package.rs
@@ -105,7 +105,7 @@ impl Package {
                 self.lib = Some(Span::unknown(target));
             } else {
                 if self.bins.iter().any(|t| t.name == target.name) {
-                    panic!("duplicate definitions of the same target '{}'", &target.name);
+                    panic!("duplicate definitions of the same target '{}'", target.name);
                 }
                 self.bins.push(Span::unknown(target));
             }

--- a/miden-vm/src/cli/bundle.rs
+++ b/miden-vm/src/cli/bundle.rs
@@ -69,7 +69,7 @@ impl BundleCmd {
                 println!(
                     "Built kernel module {} with library {}",
                     kernel.display(),
-                    &self.dir.display()
+                    self.dir.display()
                 );
             },
             None => {


### PR DESCRIPTION
Enables the clippy::unnecessary_wraps lint in .cargo/config.toml for both xclippy and xclippy-fix commands, and fixes all instances across the workspace using cargo +nightly xclippy-fix plus manual fixes for cases where callers needed to be updated.

Closes the concern raised in #3137