### PR TITLE
Replace bincode proof serialization with wincode + bound proofs to 64MiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixes
 
 - Preserved `AssemblyOp` source mappings when merging `MastForest`s, preventing source-location loss after node deduplication.
+- Replaced `bincode` proof serialization with `wincode` and bounded verifier-side STARK proof deserialization to 64 MiB ([#3148](https://github.com/0xMiden/miden-vm/pull/3148)).
 
 ## v0.23.0 (2026-05-07)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,15 +147,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,7 +1348,6 @@ dependencies = [
 name = "miden-core-lib"
 version = "0.24.0"
 dependencies = [
- "bincode",
  "criterion",
  "env_logger",
  "fs-err",
@@ -1377,7 +1367,9 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha",
  "rstest",
+ "serde-wincode",
  "thiserror",
+ "wincode",
 ]
 
 [[package]]
@@ -1659,7 +1651,6 @@ dependencies = [
 name = "miden-prover"
 version = "0.24.0"
 dependencies = [
- "bincode",
  "miden-air",
  "miden-assembly",
  "miden-core",
@@ -1667,8 +1658,10 @@ dependencies = [
  "miden-debug-types",
  "miden-processor",
  "serde",
+ "serde-wincode",
  "tokio",
  "tracing",
+ "wincode",
 ]
 
 [[package]]
@@ -1786,13 +1779,14 @@ dependencies = [
 name = "miden-verifier"
 version = "0.24.0"
 dependencies = [
- "bincode",
  "miden-air",
  "miden-core",
  "miden-crypto",
  "serde",
+ "serde-wincode",
  "thiserror",
  "tracing",
+ "wincode",
 ]
 
 [[package]]
@@ -1800,7 +1794,6 @@ name = "miden-vm"
 version = "0.24.0"
 dependencies = [
  "assert_cmd",
- "bincode",
  "clap",
  "criterion",
  "escargot",
@@ -1820,12 +1813,14 @@ dependencies = [
  "predicates",
  "proptest",
  "serde",
+ "serde-wincode",
  "serde_json",
  "tokio",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
  "walkdir",
+ "wincode",
 ]
 
 [[package]]
@@ -2237,6 +2232,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "petgraph"
@@ -2779,6 +2780,17 @@ dependencies = [
  "serde",
  "serde_core",
  "typeid",
+]
+
+[[package]]
+name = "serde-wincode"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a62dfa6ae65cb073dfe001fb076eaf827fd4267fcba7eb3be2fee4f1e69ccb5"
+dependencies = [
+ "serde",
+ "thiserror",
+ "wincode",
 ]
 
 [[package]]
@@ -3565,6 +3577,18 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wincode"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "657690780ce23e6f66576a782ffd88eb353512381817029cc1d7a99154bb6d1f"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,8 @@ miden-lifted-stark = { version = "0.25", default-features = false }
 midenc-hir-type  = { version = "0.6.1", default-features = false }
 
 # Serialization
-bincode = "1.3"
+serde-wincode = { version = "0.1", default-features = false, features = ["alloc"] }
+wincode       = { version = "0.4.2", default-features = false, features = ["alloc"] }
 
 # Third-party crates
 clap            = { version = "4.5", features = ["derive"] }

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -56,7 +56,8 @@ num = { version = "0.4" }
 rand = { version = "0.9", default-features = false }
 rand_chacha = { workspace = true }
 rstest = { workspace = true }
-bincode.workspace = true
+serde-wincode.workspace = true
+wincode.workspace = true
 
 [build-dependencies]
 env_logger.workspace = true

--- a/crates/lib/core/tests/stark/verifier_recursive/mod.rs
+++ b/crates/lib/core/tests/stark/verifier_recursive/mod.rs
@@ -27,7 +27,7 @@ use miden_crypto::{
         challenger::CanObserve,
         fri::PcsTranscript,
         lmcs::{Lmcs, proof::BatchProofView},
-        proof::StarkTranscript,
+        proof::{StarkProof, StarkTranscript},
         verifier::VerifierError as CryptoVerifierError,
     },
 };
@@ -40,6 +40,7 @@ use miden_utils_testing::crypto::{MerklePath, MerkleStore, PartialMerkleTree};
 type Challenge = QuadFelt;
 type P2Config = config::Poseidon2Config;
 type P2Lmcs = <P2Config as StarkConfig<Felt, Challenge>>::Lmcs;
+const MAX_STARK_PROOF_BYTES: usize = 64 * 1024 * 1024;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct VerifierData {
@@ -77,7 +78,12 @@ pub fn generate_advice_inputs(
     let config = config::poseidon2_config(params);
 
     // 1. Deserialize STARK proof bytes.
-    let transcript_data = bincode::deserialize(proof_bytes)
+    let proof_encoding_config = wincode::config::Configuration::default()
+        .with_preallocation_size_limit::<MAX_STARK_PROOF_BYTES>();
+    let transcript_data =
+        <serde_wincode::SerdeCompat<StarkProof<Felt, QuadFelt, P2Config>> as wincode::config::Deserialize<
+            _,
+        >>::deserialize(proof_bytes, proof_encoding_config)
         .map_err(|e| VerifierError::ProofDeserializationError(e.to_string()))?;
 
     // 2. Build domain-separated challenger, then observe public values.

--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,6 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
 ignore = [
     "RUSTSEC-2024-0436", # paste is unmaintained but no alternative available
-    "RUSTSEC-2025-0141", # bincode is unmaintained, replace with wincode (#2550)
 ]
 
 # License configuration

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -91,7 +91,6 @@ tracing-forest = { version = "0.2", optional = true, features = ["ansi", "smallv
 
 [dev-dependencies]
 assert_cmd = { version = "2.1" }
-bincode = { workspace = true }
 criterion = { workspace = true, features = ["async_tokio"] }
 escargot = { version = "0.5" }
 miden-crypto.workspace = true
@@ -101,5 +100,7 @@ miden-test-serde-macros.workspace = true
 miden-utils-testing.workspace = true
 predicates = { version = "3.1" }
 proptest.workspace = true
+serde-wincode.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 walkdir.workspace = true
+wincode.workspace = true

--- a/miden-vm/tests/integration/prove_verify.rs
+++ b/miden-vm/tests/integration/prove_verify.rs
@@ -174,7 +174,7 @@ mod recursive_verifier {
         challenger::CanObserve,
         fri::PcsTranscript,
         lmcs::{Lmcs, proof::BatchProofView},
-        proof::StarkTranscript,
+        proof::{StarkProof, StarkTranscript},
     };
     use miden_lifted_stark::AirInstance;
     use miden_prover::{ProcessorAir, PublicInputs, config};
@@ -183,6 +183,7 @@ mod recursive_verifier {
     type Challenge = QuadFelt;
     type P2Config = config::Poseidon2Config;
     type P2Lmcs = <P2Config as StarkConfig<Felt, Challenge>>::Lmcs;
+    const MAX_STARK_PROOF_BYTES: usize = 64 * 1024 * 1024;
 
     pub struct VerifierInputs {
         pub initial_stack: Vec<u64>,
@@ -194,8 +195,12 @@ mod recursive_verifier {
     pub fn generate_advice_inputs(proof_bytes: &[u8], pub_inputs: PublicInputs) -> VerifierInputs {
         let params = config::pcs_params();
         let config = config::poseidon2_config(params);
-        let transcript_data =
-            bincode::deserialize(proof_bytes).expect("failed to deserialize proof bytes");
+        let proof_encoding_config = wincode::config::Configuration::default()
+            .with_preallocation_size_limit::<MAX_STARK_PROOF_BYTES>();
+        let transcript_data = <serde_wincode::SerdeCompat<StarkProof<Felt, QuadFelt, P2Config>> as wincode::config::Deserialize<
+            _,
+        >>::deserialize(proof_bytes, proof_encoding_config)
+        .expect("failed to deserialize proof bytes");
 
         let (public_values, kernel_felts) = pub_inputs.to_air_inputs();
         let mut challenger = config.challenger();

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -26,9 +26,10 @@ miden-processor.workspace = true
 miden-crypto.workspace = true
 
 # External dependencies
-bincode.workspace = true
 serde.workspace = true
+serde-wincode.workspace = true
 tracing.workspace = true
+wincode.workspace = true
 
 [dev-dependencies]
 miden-assembly.workspace = true

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -10,12 +10,17 @@ use alloc::{string::ToString, vec::Vec};
 use ::serde::Serialize;
 use miden_core::{Felt, WORD_SIZE, field::QuadFelt, utils::RowMajorMatrix};
 use miden_crypto::stark::{
-    StarkConfig, air::VarLenPublicInputs, challenger::CanObserve, lmcs::Lmcs, proof::StarkOutput,
+    StarkConfig,
+    air::VarLenPublicInputs,
+    challenger::CanObserve,
+    lmcs::Lmcs,
+    proof::{StarkOutput, StarkProof},
 };
 use miden_processor::{
     FastProcessor, Program,
     trace::{ExecutionTrace, build_trace},
 };
+use serde_wincode::SerdeCompat;
 use tracing::instrument;
 
 mod proving_options;
@@ -196,8 +201,10 @@ where
         challenger,
     )
     .map_err(|e| ExecutionError::ProvingError(e.to_string()))?;
-    // Proof serialization via bincode; see https://github.com/0xMiden/miden-vm/issues/2550.
-    let proof_bytes = bincode::serialize(&output.proof)
-        .map_err(|e| ExecutionError::ProvingError(e.to_string()))?;
+    let proof_encoding_config = wincode::config::Configuration::default();
+    let proof_bytes = <SerdeCompat<StarkProof<Felt, QuadFelt, SC>> as wincode::config::Serialize<
+        _,
+    >>::serialize(&output.proof, proof_encoding_config)
+    .map_err(|e| ExecutionError::ProvingError(e.to_string()))?;
     Ok(proof_bytes)
 }

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -28,7 +28,8 @@ miden-core.workspace = true
 miden-crypto.workspace = true
 
 # External dependencies
-bincode.workspace = true
 serde.workspace = true
+serde-wincode.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+wincode.workspace = true

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -13,6 +13,9 @@ use miden_crypto::stark::{
     StarkConfig, air::VarLenPublicInputs, challenger::CanObserve, lmcs::Lmcs, proof::StarkProof,
 };
 use serde::de::DeserializeOwned;
+use serde_wincode::SerdeCompat;
+
+const MAX_STARK_PROOF_BYTES: usize = 64 * 1024 * 1024;
 
 // RE-EXPORTS
 // ================================================================================================
@@ -188,7 +191,9 @@ pub enum VerificationError {
 #[derive(Debug, thiserror::Error)]
 pub enum StarkVerificationError {
     #[error("failed to deserialize proof: {0}")]
-    Deserialization(#[from] bincode::Error),
+    Deserialization(#[from] wincode::error::ReadError),
+    #[error("STARK proof is too large: {size} bytes exceeds the {max} byte limit")]
+    ProofTooLarge { size: usize, max: usize },
     #[error("log_trace_height {0} exceeds the two-adic order of the field")]
     InvalidTraceHeight(u8),
     #[error(transparent)]
@@ -209,8 +214,20 @@ where
     SC: StarkConfig<Felt, QuadFelt>,
     <SC::Lmcs as Lmcs>::Commitment: DeserializeOwned,
 {
-    // Proof deserialization via bincode; see https://github.com/0xMiden/miden-vm/issues/2550.
-    let proof: StarkProof<Felt, QuadFelt, SC> = bincode::deserialize(proof_bytes)?;
+    if proof_bytes.len() > MAX_STARK_PROOF_BYTES {
+        return Err(StarkVerificationError::ProofTooLarge {
+            size: proof_bytes.len(),
+            max: MAX_STARK_PROOF_BYTES,
+        });
+    }
+
+    let proof_encoding_config = wincode::config::Configuration::default()
+        .with_preallocation_size_limit::<MAX_STARK_PROOF_BYTES>();
+    let proof: StarkProof<Felt, QuadFelt, SC> =
+        <SerdeCompat<StarkProof<Felt, QuadFelt, SC>> as wincode::config::Deserialize<_>>::deserialize(
+            proof_bytes,
+            proof_encoding_config,
+        )?;
 
     let mut challenger = config.challenger();
     config::observe_protocol_params(&mut challenger);
@@ -225,4 +242,60 @@ where
         challenger,
     )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::*;
+
+    #[test]
+    fn proof_encoding_config_rejects_oversized_native_vec_preallocation() {
+        let proof_encoding_config = wincode::config::Configuration::default()
+            .with_preallocation_size_limit::<MAX_STARK_PROOF_BYTES>();
+        let element_count = MAX_STARK_PROOF_BYTES + 1;
+        let mut length_prefix = Vec::new();
+
+        <usize as wincode::config::Serialize<_>>::serialize_into(
+            &mut length_prefix,
+            &element_count,
+            proof_encoding_config,
+        )
+        .unwrap();
+        let err = <Vec<u8> as wincode::config::Deserialize<_>>::deserialize(
+            &length_prefix,
+            proof_encoding_config,
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                wincode::error::ReadError::PreallocationSizeLimit { needed, limit }
+                    if needed == element_count && limit == MAX_STARK_PROOF_BYTES
+            ),
+            "expected proof encoding config to reject oversized allocation, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn verify_stark_proof_rejects_oversized_proof_bytes() {
+        let params = config::pcs_params();
+        let config = config::poseidon2_config(params);
+        let proof_bytes = Vec::from_iter(core::iter::repeat_n(0, MAX_STARK_PROOF_BYTES + 1));
+
+        let err = verify_stark_proof(&config, &[], &[], &proof_bytes).unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                StarkVerificationError::ProofTooLarge {
+                    size,
+                    max: MAX_STARK_PROOF_BYTES,
+                } if size == proof_bytes.len()
+            ),
+            "expected explicit proof byte limit to reject oversized proof, got {err:?}"
+        );
+    }
 }


### PR DESCRIPTION
Fixes 0xMiden/security-issues#10 by bounding verifier-side STARK proof deserialization and preallocation.

Fixes 0xMiden/miden-vm#2550 by replacing bincode usage with serde-wincode/wincode.