### PR TITLE
ci: guard miden-standards component roots

### DIFF
--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -55,6 +55,14 @@ runs:
         chmod +x scripts/check-msrv.sh
         ./scripts/check-msrv.sh
 
+    - name: Check MASM procedure root stability
+      if: ${{ inputs.mode == 'dry-run' && github.ref == 'refs/heads/main' }}
+      shell: bash
+      run: |
+        rustup toolchain install nightly --profile minimal --no-self-update
+        chmod +x scripts/check-masm-root-stability.sh
+        ./scripts/check-masm-root-stability.sh
+
     # Clean packaging directory to avoid stale/corrupted tmp-registry state
     - name: Clean packaging directory
       shell: bash

--- a/scripts/check-masm-export-digests.rs
+++ b/scripts/check-masm-export-digests.rs
@@ -9,10 +9,11 @@ miden-assembly-syntax-current = { package = "miden-assembly-syntax", path = "../
 miden-mast-package-current = { package = "miden-mast-package", path = "../crates/mast-package" }
 miden-package-registry-current = { package = "miden-package-registry", path = "../crates/package-registry", features = ["resolver"] }
 
-miden-assembly-previous = { package = "miden-assembly", git = "https://github.com/0xMiden/miden-vm", tag = "v0.22.4" }
-miden-assembly-syntax-previous = { package = "miden-assembly-syntax", git = "https://github.com/0xMiden/miden-vm", tag = "v0.22.4" }
-miden-mast-package-previous = { package = "miden-mast-package", git = "https://github.com/0xMiden/miden-vm", tag = "v0.22.4" }
-miden-package-registry-previous = { package = "miden-package-registry", git = "https://github.com/0xMiden/miden-vm", tag = "v0.22.4", features = ["resolver"] }
+# The release wrapper rewrites these tags to the latest release tag on main.
+miden-assembly-previous = { package = "miden-assembly", git = "https://github.com/0xMiden/miden-vm", tag = "v0.23.0" }
+miden-assembly-syntax-previous = { package = "miden-assembly-syntax", git = "https://github.com/0xMiden/miden-vm", tag = "v0.23.0" }
+miden-mast-package-previous = { package = "miden-mast-package", git = "https://github.com/0xMiden/miden-vm", tag = "v0.23.0" }
+miden-package-registry-previous = { package = "miden-package-registry", git = "https://github.com/0xMiden/miden-vm", tag = "v0.23.0", features = ["resolver"] }
 ---
 
 use std::{

--- a/scripts/check-masm-export-digests.rs
+++ b/scripts/check-masm-export-digests.rs
@@ -1,0 +1,209 @@
+#!/usr/bin/env -S cargo +nightly -Zscript
+---cargo
+[package]
+edition = "2024"
+
+[dependencies]
+miden-assembly-current = { package = "miden-assembly", path = "../crates/assembly" }
+miden-assembly-syntax-current = { package = "miden-assembly-syntax", path = "../crates/assembly-syntax" }
+miden-mast-package-current = { package = "miden-mast-package", path = "../crates/mast-package" }
+miden-package-registry-current = { package = "miden-package-registry", path = "../crates/package-registry", features = ["resolver"] }
+
+miden-assembly-previous = { package = "miden-assembly", git = "https://github.com/0xMiden/miden-vm", tag = "v0.22.4" }
+miden-assembly-syntax-previous = { package = "miden-assembly-syntax", git = "https://github.com/0xMiden/miden-vm", tag = "v0.22.4" }
+miden-mast-package-previous = { package = "miden-mast-package", git = "https://github.com/0xMiden/miden-vm", tag = "v0.22.4" }
+miden-package-registry-previous = { package = "miden-package-registry", git = "https://github.com/0xMiden/miden-vm", tag = "v0.22.4", features = ["resolver"] }
+---
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env,
+    path::{Path, PathBuf},
+    process,
+};
+
+type Exports = BTreeMap<String, ExportInfo>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExportInfo {
+    digest: String,
+    signature: String,
+    attributes: String,
+}
+
+impl ExportInfo {
+    fn describe(&self) -> String {
+        let Self { digest, signature, attributes } = self;
+        format!("digest={digest}, signature={signature}, attributes={attributes}")
+    }
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("{err}");
+        process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let mut args = env::args().skip(1);
+    let previous_input = args.next().map(PathBuf::from).ok_or_else(usage)?;
+    let current_input = args.next().map(PathBuf::from).ok_or_else(usage)?;
+    if args.next().is_some() {
+        return Err(usage());
+    }
+
+    let previous = previous::collect_exports(&previous_input)?;
+    let current = current::collect_exports(&current_input)?;
+    compare_exports(previous, current)
+}
+
+fn usage() -> String {
+    "usage: check-masm-export-digests.rs <previous-miden-project.toml|previous-project-dir> <current-miden-project.toml|current-project-dir>".to_string()
+}
+
+fn compare_exports(previous: Exports, current: Exports) -> Result<(), String> {
+    let mut status = Ok(());
+    let export_names = previous.keys().chain(current.keys()).cloned().collect::<BTreeSet<_>>();
+
+    for name in export_names {
+        match (previous.get(&name), current.get(&name)) {
+            (Some(previous_export), Some(current_export)) if previous_export == current_export => {
+                println!("{name} {}", current_export.describe());
+            },
+            (Some(previous_export), Some(current_export)) => {
+                if previous_export.digest != current_export.digest {
+                    eprintln!(
+                        "::error::export digest changed for {name}: previous={}, current={}",
+                        previous_export.digest, current_export.digest,
+                    );
+                }
+                if previous_export.signature != current_export.signature {
+                    eprintln!(
+                        "::error::export signature changed for {name}: previous={}, current={}",
+                        previous_export.signature, current_export.signature,
+                    );
+                }
+                if previous_export.attributes != current_export.attributes {
+                    eprintln!(
+                        "::error::export attributes changed for {name}: previous={}, current={}",
+                        previous_export.attributes, current_export.attributes,
+                    );
+                }
+                status = Err("procedure exports changed".to_string());
+            },
+            (Some(previous_export), None) => {
+                eprintln!(
+                    "::error::export removed: {name} previous={}",
+                    previous_export.describe()
+                );
+                status = Err("procedure exports changed".to_string());
+            },
+            (None, Some(current_export)) => {
+                eprintln!("::error::export added: {name} current={}", current_export.describe());
+                status = Err("procedure exports changed".to_string());
+            },
+            (None, None) => unreachable!("name came from at least one side"),
+        }
+    }
+
+    status
+}
+
+mod current {
+    use super::*;
+    use miden_assembly_current::{Assembler, ProjectTargetSelector};
+    use miden_assembly_syntax_current::prettier::PrettyPrint;
+    use miden_mast_package_current::{Package, PackageExport};
+    use miden_package_registry_current::InMemoryPackageRegistry;
+
+    pub fn collect_exports(input: &Path) -> Result<Exports, String> {
+        let mut store = InMemoryPackageRegistry::default();
+        let mut project =
+            Assembler::default().for_project_at_path(input, &mut store).map_err(|err| {
+                format!("current: failed to load project '{}': {err}", input.display())
+            })?;
+        let package =
+            project.assemble(ProjectTargetSelector::Library, "release").map_err(|err| {
+                format!("current: failed to assemble project '{}': {err}", input.display())
+            })?;
+
+        collect_package_exports(package.as_ref())
+    }
+
+    fn collect_package_exports(package: &Package) -> Result<Exports, String> {
+        Ok(package
+            .manifest
+            .exports()
+            .filter_map(|export| match export {
+                PackageExport::Procedure(procedure) => Some((
+                    procedure.path.to_string(),
+                    ExportInfo {
+                        digest: procedure.digest.to_string(),
+                        signature: procedure
+                            .signature
+                            .as_ref()
+                            .map(PrettyPrint::to_pretty_string)
+                            .unwrap_or_else(|| "None".to_string()),
+                        attributes: procedure
+                            .attributes
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect::<Vec<_>>()
+                            .join(" "),
+                    },
+                )),
+                PackageExport::Constant(_) | PackageExport::Type(_) => None,
+            })
+            .collect())
+    }
+}
+
+mod previous {
+    use super::*;
+    use miden_assembly_previous::{Assembler, ProjectTargetSelector};
+    use miden_assembly_syntax_previous::prettier::PrettyPrint;
+    use miden_mast_package_previous::{Package, PackageExport};
+    use miden_package_registry_previous::InMemoryPackageRegistry;
+
+    pub fn collect_exports(input: &Path) -> Result<Exports, String> {
+        let mut store = InMemoryPackageRegistry::default();
+        let mut project =
+            Assembler::default().for_project_at_path(input, &mut store).map_err(|err| {
+                format!("previous: failed to load project '{}': {err}", input.display())
+            })?;
+        let package =
+            project.assemble(ProjectTargetSelector::Library, "release").map_err(|err| {
+                format!("previous: failed to assemble project '{}': {err}", input.display())
+            })?;
+
+        collect_package_exports(package.as_ref())
+    }
+
+    fn collect_package_exports(package: &Package) -> Result<Exports, String> {
+        Ok(package
+            .manifest
+            .exports()
+            .filter_map(|export| match export {
+                PackageExport::Procedure(procedure) => Some((
+                    procedure.path.to_string(),
+                    ExportInfo {
+                        digest: procedure.digest.to_string(),
+                        signature: procedure
+                            .signature
+                            .as_ref()
+                            .map(PrettyPrint::to_pretty_string)
+                            .unwrap_or_else(|| "None".to_string()),
+                        attributes: procedure
+                            .attributes
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect::<Vec<_>>()
+                            .join(" "),
+                    },
+                )),
+                PackageExport::Constant(_) | PackageExport::Type(_) => None,
+            })
+            .collect())
+    }
+}

--- a/scripts/check-masm-export-digests.rs
+++ b/scripts/check-masm-export-digests.rs
@@ -25,17 +25,59 @@ use std::{
 type Exports = BTreeMap<String, ExportInfo>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ExportInfo {
+enum ExportInfo {
+    Procedure(ProcedureInfo),
+    Type(TypeInfo),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProcedureInfo {
     digest: String,
-    signature: String,
-    attributes: String,
+    signature: Option<String>,
+    abi_attributes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TypeInfo {
+    ty: String,
 }
 
 impl ExportInfo {
     fn describe(&self) -> String {
-        let Self { digest, signature, attributes } = self;
-        format!("digest={digest}, signature={signature}, attributes={attributes}")
+        match self {
+            Self::Procedure(procedure) => procedure.describe(),
+            Self::Type(ty) => ty.describe(),
+        }
     }
+}
+
+impl ProcedureInfo {
+    fn describe(&self) -> String {
+        let Self { digest, signature, abi_attributes } = self;
+        format!(
+            "procedure digest={digest}, signature={}, abi_attributes={}",
+            signature.as_deref().unwrap_or("None"),
+            format_attributes(abi_attributes),
+        )
+    }
+}
+
+impl TypeInfo {
+    fn describe(&self) -> String {
+        format!("type={}", self.ty)
+    }
+}
+
+fn format_attributes(attributes: &BTreeMap<String, String>) -> String {
+    if attributes.is_empty() {
+        return "None".to_string();
+    }
+
+    attributes
+        .iter()
+        .map(|(name, value)| format!("{name}={value}"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn main() {
@@ -72,25 +114,9 @@ fn compare_exports(previous: Exports, current: Exports) -> Result<(), String> {
                 println!("{name} {}", current_export.describe());
             },
             (Some(previous_export), Some(current_export)) => {
-                if previous_export.digest != current_export.digest {
-                    eprintln!(
-                        "::error::export digest changed for {name}: previous={}, current={}",
-                        previous_export.digest, current_export.digest,
-                    );
+                if compare_export(&name, previous_export, current_export) {
+                    status = Err("exports changed".to_string());
                 }
-                if previous_export.signature != current_export.signature {
-                    eprintln!(
-                        "::error::export signature changed for {name}: previous={}, current={}",
-                        previous_export.signature, current_export.signature,
-                    );
-                }
-                if previous_export.attributes != current_export.attributes {
-                    eprintln!(
-                        "::error::export attributes changed for {name}: previous={}, current={}",
-                        previous_export.attributes, current_export.attributes,
-                    );
-                }
-                status = Err("procedure exports changed".to_string());
             },
             (Some(previous_export), None) => {
                 eprintln!(
@@ -99,15 +125,88 @@ fn compare_exports(previous: Exports, current: Exports) -> Result<(), String> {
                 );
                 status = Err("procedure exports changed".to_string());
             },
-            (None, Some(current_export)) => {
-                eprintln!("::error::export added: {name} current={}", current_export.describe());
-                status = Err("procedure exports changed".to_string());
+            (None, Some(current_export)) => match current_export {
+                ExportInfo::Procedure(_) => {
+                    eprintln!(
+                        "::error::export added: {name} current={}",
+                        current_export.describe()
+                    );
+                    status = Err("procedure exports changed".to_string());
+                },
+                ExportInfo::Type(_) => {
+                    println!("{name} {}", current_export.describe());
+                },
             },
             (None, None) => unreachable!("name came from at least one side"),
         }
     }
 
     status
+}
+
+fn compare_export(name: &str, previous: &ExportInfo, current: &ExportInfo) -> bool {
+    match (previous, current) {
+        (ExportInfo::Procedure(previous), ExportInfo::Procedure(current)) => {
+            compare_procedure(name, previous, current)
+        },
+        (ExportInfo::Type(previous), ExportInfo::Type(current)) => {
+            if previous.ty == current.ty {
+                false
+            } else {
+                eprintln!(
+                    "::error::exported type changed for {name}: previous={}, current={}",
+                    previous.ty, current.ty,
+                );
+                true
+            }
+        },
+        _ => {
+            eprintln!(
+                "::error::export kind changed for {name}: previous={}, current={}",
+                previous.describe(),
+                current.describe(),
+            );
+            true
+        },
+    }
+}
+
+fn compare_procedure(name: &str, previous: &ProcedureInfo, current: &ProcedureInfo) -> bool {
+    let mut changed = false;
+
+    if previous.digest != current.digest {
+        eprintln!(
+            "::error::export digest changed for {name}: previous={}, current={}",
+            previous.digest, current.digest,
+        );
+        changed = true;
+    }
+
+    if previous.signature.is_some() && previous.signature != current.signature {
+        eprintln!(
+            "::error::export signature changed for {name}: previous={}, current={}",
+            previous.signature.as_deref().unwrap_or("None"),
+            current.signature.as_deref().unwrap_or("None"),
+        );
+        changed = true;
+    }
+
+    // Adding ABI metadata is non-breaking; removing or changing previously published ABI metadata is not.
+    for (attr, previous_value) in &previous.abi_attributes {
+        let current_value = current.abi_attributes.get(attr).map(String::as_str).unwrap_or("None");
+        if previous_value != current_value {
+            eprintln!(
+                "::error::export ABI attribute changed for {name}: {attr} previous={previous_value}, current={current_value}",
+            );
+            changed = true;
+        }
+    }
+
+    changed
+}
+
+fn is_abi_attribute(name: &str) -> bool {
+    matches!(name, "auth_script" | "callconv")
 }
 
 mod current {
@@ -138,22 +237,22 @@ mod current {
             .filter_map(|export| match export {
                 PackageExport::Procedure(procedure) => Some((
                     procedure.path.to_string(),
-                    ExportInfo {
+                    ExportInfo::Procedure(ProcedureInfo {
                         digest: procedure.digest.to_string(),
-                        signature: procedure
-                            .signature
-                            .as_ref()
-                            .map(PrettyPrint::to_pretty_string)
-                            .unwrap_or_else(|| "None".to_string()),
-                        attributes: procedure
+                        signature: procedure.signature.as_ref().map(PrettyPrint::to_pretty_string),
+                        abi_attributes: procedure
                             .attributes
                             .iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(" "),
-                    },
+                            .filter(|attr| is_abi_attribute(attr.name()))
+                            .map(|attr| (attr.name().to_string(), attr.to_string()))
+                            .collect(),
+                    }),
                 )),
-                PackageExport::Constant(_) | PackageExport::Type(_) => None,
+                PackageExport::Type(ty) => Some((
+                    ty.path.to_string(),
+                    ExportInfo::Type(TypeInfo { ty: ty.ty.to_pretty_string() }),
+                )),
+                PackageExport::Constant(_) => None,
             })
             .collect())
     }
@@ -187,22 +286,22 @@ mod previous {
             .filter_map(|export| match export {
                 PackageExport::Procedure(procedure) => Some((
                     procedure.path.to_string(),
-                    ExportInfo {
+                    ExportInfo::Procedure(ProcedureInfo {
                         digest: procedure.digest.to_string(),
-                        signature: procedure
-                            .signature
-                            .as_ref()
-                            .map(PrettyPrint::to_pretty_string)
-                            .unwrap_or_else(|| "None".to_string()),
-                        attributes: procedure
+                        signature: procedure.signature.as_ref().map(PrettyPrint::to_pretty_string),
+                        abi_attributes: procedure
                             .attributes
                             .iter()
-                            .map(ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join(" "),
-                    },
+                            .filter(|attr| is_abi_attribute(attr.name()))
+                            .map(|attr| (attr.name().to_string(), attr.to_string()))
+                            .collect(),
+                    }),
                 )),
-                PackageExport::Constant(_) | PackageExport::Type(_) => None,
+                PackageExport::Type(ty) => Some((
+                    ty.path.to_string(),
+                    ExportInfo::Type(TypeInfo { ty: ty.ty.to_pretty_string() }),
+                )),
+                PackageExport::Constant(_) => None,
             })
             .collect())
     }

--- a/scripts/check-masm-root-stability.sh
+++ b/scripts/check-masm-root-stability.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+workspace_version="$(
+    awk '
+        /^\[workspace.package\]/ { in_workspace_package = 1; next }
+        /^\[/ { in_workspace_package = 0 }
+        in_workspace_package && /^version[[:space:]]*=/ {
+            gsub(/"/, "", $3)
+            print $3
+            exit
+        }
+    ' "$repo_root/Cargo.toml"
+)"
+
+parse_version() {
+    local version="$1"
+    local prefix="$2"
+    local major minor patch
+
+    IFS=. read -r major minor patch <<<"$version"
+    if [[ ! "$major" =~ ^[0-9]+$ || ! "$minor" =~ ^[0-9]+$ || ! "$patch" =~ ^[0-9]+$ ]]; then
+        echo "::error::could not parse semantic version '$version'"
+        exit 1
+    fi
+
+    eval "${prefix}_major=\$major"
+    eval "${prefix}_minor=\$minor"
+    eval "${prefix}_patch=\$patch"
+}
+
+latest_release_tag_on_head() {
+    git -C "$repo_root" tag --merged HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' \
+        | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+        | sort -V \
+        | tail -n1
+}
+
+parse_version "$workspace_version" current
+
+git -C "$repo_root" fetch --tags origin
+
+baseline_tag="$(latest_release_tag_on_head)"
+if [[ -z "$baseline_tag" ]]; then
+    echo "No release tag found on the current branch history; skipping MASM root stability check"
+    exit 0
+fi
+
+baseline_version="${baseline_tag#v}"
+parse_version "$baseline_version" baseline
+
+if (( baseline_major != current_major )); then
+    echo "workspace version changed major version from ${baseline_version} to ${workspace_version}; skipping MASM root stability check"
+    exit 0
+fi
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/masm-root-check.XXXXXX")"
+check_script="$repo_root/scripts/.check-masm-export-digests.${baseline_tag}.$$.rs"
+
+cleanup() {
+    rm -f "$check_script"
+    git -C "$repo_root" worktree remove --force "$workdir/baseline" >/dev/null 2>&1 || true
+    rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+git -C "$repo_root" worktree add --detach --quiet "$workdir/baseline" "$baseline_tag"
+sed -E "s/tag = \"v[0-9]+\\.[0-9]+\\.[0-9]+\"/tag = \"${baseline_tag}\"/g" \
+    "$repo_root/scripts/check-masm-export-digests.rs" >"$check_script"
+chmod +x "$check_script"
+
+if (($# > 0)); then
+    projects=("$@")
+elif [[ -n "${MIDEN_ROOT_CHECK_PROJECTS:-}" ]]; then
+    # shellcheck disable=SC2206
+    projects=(${MIDEN_ROOT_CHECK_PROJECTS})
+else
+    projects=("crates/lib/core/asm/miden-project.toml")
+fi
+
+for project in "${projects[@]}"; do
+    if [[ "$project" = /* ]]; then
+        current_project="$project"
+        relative_project="${project#"$repo_root"/}"
+    else
+        current_project="$repo_root/$project"
+        relative_project="$project"
+    fi
+
+    baseline_project="$workdir/baseline/$relative_project"
+
+    if [[ ! -e "$current_project" ]]; then
+        echo "::error::current MASM project does not exist: $current_project"
+        exit 1
+    fi
+
+    if [[ ! -e "$baseline_project" ]]; then
+        echo "MASM project '$relative_project' did not exist in $baseline_tag; skipping"
+        continue
+    fi
+
+    echo "Checking MASM root stability for $relative_project against $baseline_tag"
+    RUSTC_WRAPPER= rustup run nightly cargo -Zscript \
+        "$check_script" \
+        "$baseline_project" \
+        "$current_project"
+done
+
+echo "MASM procedure roots are stable against $baseline_tag"

--- a/scripts/check-masm-root-stability.sh
+++ b/scripts/check-masm-root-stability.sh
@@ -34,7 +34,8 @@ latest_release_tag_on_head() {
     git -C "$repo_root" tag --merged HEAD --list 'v[0-9]*.[0-9]*.[0-9]*' \
         | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
         | sort -V \
-        | tail -n1
+        | tail -n1 \
+        || true
 }
 
 parse_version "$workspace_version" current


### PR DESCRIPTION
Adds a non-blocking release gate for public `miden-standards` account component procedure roots.

For patch releases, the workspace release action now compares the component root set from the current checkout against the previous patch tag, for the same `miden-standards` crate version. This runs in the shared `workspace-release` action, so it covers both workspace dry-run and publish workflows.

This catches regressions like #3144, where unchanged public component MASM produced different procedure roots across a patch release.