### PR TITLE
fix(CI): convert clippy warnings into errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,6 +58,8 @@ jobs:
   clippy:
     name: clippy nightly on ubuntu-latest
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/air/src/constraints/columns.rs
+++ b/air/src/constraints/columns.rs
@@ -312,6 +312,6 @@ mod tests {
     /// `NUM_CHIPLETS_COLS` matches the chiplets segment width.
     #[test]
     fn chiplet_cols_width() {
-        assert_eq!(NUM_CHIPLETS_COLS, crate::trace::CHIPLETS_WIDTH);
+        assert_eq!(NUM_CHIPLETS_COLS, CHIPLETS_WIDTH);
     }
 }

--- a/air/src/constraints/lookup/buses/lookup_op_flags.rs
+++ b/air/src/constraints/lookup/buses/lookup_op_flags.rs
@@ -597,12 +597,10 @@ mod tests {
         LookupOpFlags::from_main_cols(&row.decoder, &row.stack, &row_next.decoder)
     }
 
-    type FlagGetter = fn(&LookupOpFlags<Felt>) -> Felt;
-    type FlagCase = (&'static str, u8, FlagGetter);
-
     #[test]
     fn boolean_row_matches_polynomial_for_chiplet_request_ops() {
-        let cases: [FlagCase; 26] = [
+        type FlagAccessor = fn(&LookupOpFlags<Felt>) -> Felt;
+        let cases: [(&str, u8, FlagAccessor); 26] = [
             ("join", opcodes::JOIN, LookupOpFlags::<Felt>::join),
             ("split", opcodes::SPLIT, LookupOpFlags::<Felt>::split),
             ("loop", opcodes::LOOP, LookupOpFlags::<Felt>::loop_op),

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -259,26 +259,26 @@ const PV_TRANSCRIPT_STATE: usize = NUM_PUBLIC_VALUES - WORD_SIZE;
 pub struct CoreAir;
 
 impl CoreAir {
-    fn width(&self) -> usize {
+    fn width(self) -> usize {
         constraints::columns::NUM_CORE_COLS
     }
 
-    fn periodic_columns(&self) -> Vec<Vec<Felt>> {
+    fn periodic_columns(self) -> Vec<Vec<Felt>> {
         // Core has no periodic columns; all periodic columns serve the chiplets.
         Vec::new()
     }
 
-    fn aux_width(&self) -> usize {
+    fn aux_width(self) -> usize {
         constraints::lookup::main_air::MAIN_COLUMN_SHAPE.len()
     }
 
-    fn num_var_len_public_inputs(&self) -> usize {
+    fn num_var_len_public_inputs(self) -> usize {
         // Kernel digests (the only VLPI today) belong to ChipletsAir's reduced_aux_values.
         0
     }
 
     fn reduced_aux_values<EF: ExtensionField<Felt>>(
-        &self,
+        self,
         aux_values: &[EF],
         challenges: &[EF],
         public_values: &[Felt],
@@ -324,7 +324,7 @@ impl CoreAir {
         })
     }
 
-    fn eval<AB: MidenAirBuilder>(&self, builder: &mut AB) {
+    fn eval<AB: MidenAirBuilder>(self, builder: &mut AB) {
         let main = builder.main();
         let local: &CoreCols<AB::Var> = (*main.current_slice()).borrow();
         let next: &CoreCols<AB::Var> = (*main.next_slice()).borrow();
@@ -339,33 +339,33 @@ impl CoreAir {
         self.lookup_eval(&mut lb);
     }
 
-    fn log_quotient_degree(&self) -> usize {
+    fn log_quotient_degree(self) -> usize {
         // Core dominates the combined quotient degree; override to avoid recomputing
         // through SymbolicAir.
         3
     }
 
-    fn lookup_num_columns(&self) -> usize {
+    fn lookup_num_columns(self) -> usize {
         constraints::lookup::main_air::MAIN_COLUMN_SHAPE.len()
     }
 
-    fn lookup_column_shape(&self) -> &'static [usize] {
+    fn lookup_column_shape(self) -> &'static [usize] {
         &constraints::lookup::main_air::MAIN_COLUMN_SHAPE
     }
 
-    fn lookup_max_message_width(&self) -> usize {
+    fn lookup_max_message_width(self) -> usize {
         MIDEN_MAX_MESSAGE_WIDTH
     }
 
-    fn lookup_num_bus_ids(&self) -> usize {
+    fn lookup_num_bus_ids(self) -> usize {
         BusId::COUNT
     }
 
-    fn lookup_eval<LB: MainLookupBuilder>(&self, builder: &mut LB) {
+    fn lookup_eval<LB: MainLookupBuilder>(self, builder: &mut LB) {
         MainLookupAir.eval(builder);
     }
 
-    fn lookup_eval_boundary<B: BoundaryBuilder>(&self, boundary: &mut B) {
+    fn lookup_eval_boundary<B: BoundaryBuilder>(self, boundary: &mut B) {
         constraints::lookup::miden_air::emit_core_boundary(boundary);
     }
 }
@@ -382,28 +382,28 @@ pub struct ChipletsAir;
 /// Per-trace AIR logic. Like [`CoreAir`], `ChipletsAir` is not an AIR trait impl itself —
 /// [`MidenAir`] dispatches to these inherent (struct) methods for per-trace concerns.
 impl ChipletsAir {
-    fn width(&self) -> usize {
+    fn width(self) -> usize {
         constraints::columns::NUM_CHIPLETS_COLS
     }
 
-    fn periodic_columns(&self) -> Vec<Vec<Felt>> {
+    fn periodic_columns(self) -> Vec<Vec<Felt>> {
         // All periodic columns (hasher round constants, bitwise operation table) belong to
         // the chiplets trace.
         constraints::chiplets::columns::PeriodicCols::periodic_columns()
     }
 
-    fn aux_width(&self) -> usize {
+    fn aux_width(self) -> usize {
         constraints::lookup::chiplet_air::CHIPLET_COLUMN_SHAPE.len()
     }
 
-    fn num_var_len_public_inputs(&self) -> usize {
+    fn num_var_len_public_inputs(self) -> usize {
         // Kernel digests boundary-cancel against the kernel-rom bus, which lives on
         // `CHIPLET_COLUMN_SHAPE[0]` — owned by ChipletsAir.
         1
     }
 
     fn reduced_aux_values<EF: ExtensionField<Felt>>(
-        &self,
+        self,
         aux_values: &[EF],
         challenges: &[EF],
         public_values: &[Felt],
@@ -457,7 +457,7 @@ impl ChipletsAir {
         })
     }
 
-    fn eval<AB: MidenAirBuilder>(&self, builder: &mut AB) {
+    fn eval<AB: MidenAirBuilder>(self, builder: &mut AB) {
         let main = builder.main();
         let local: &ChipletCols<AB::Var> = (*main.current_slice()).borrow();
         let next: &ChipletCols<AB::Var> = (*main.next_slice()).borrow();
@@ -471,29 +471,29 @@ impl ChipletsAir {
         self.lookup_eval(&mut lb);
     }
 
-    fn log_quotient_degree(&self) -> usize {
+    fn log_quotient_degree(self) -> usize {
         // The chiplet hasher dominates this AIR's quotient degree at deg 9 / log_blowup 3;
         // override to avoid recomputing through SymbolicAir.
         3
     }
 
-    fn lookup_num_columns(&self) -> usize {
+    fn lookup_num_columns(self) -> usize {
         constraints::lookup::chiplet_air::CHIPLET_COLUMN_SHAPE.len()
     }
 
-    fn lookup_column_shape(&self) -> &'static [usize] {
+    fn lookup_column_shape(self) -> &'static [usize] {
         &constraints::lookup::chiplet_air::CHIPLET_COLUMN_SHAPE
     }
 
-    fn lookup_max_message_width(&self) -> usize {
+    fn lookup_max_message_width(self) -> usize {
         MIDEN_MAX_MESSAGE_WIDTH
     }
 
-    fn lookup_num_bus_ids(&self) -> usize {
+    fn lookup_num_bus_ids(self) -> usize {
         BusId::COUNT
     }
 
-    fn lookup_eval<LB: ChipletLookupBuilder>(&self, builder: &mut LB) {
+    fn lookup_eval<LB: ChipletLookupBuilder>(self, builder: &mut LB) {
         let main = builder.main();
         let local: &ChipletCols<_> = main.current_slice().borrow();
         let next: &ChipletCols<_> = main.next_slice().borrow();
@@ -501,7 +501,7 @@ impl ChipletsAir {
         constraints::lookup::chiplet_air::emit_chiplet_lookup_columns(builder, local, next);
     }
 
-    fn lookup_eval_boundary<B: BoundaryBuilder>(&self, boundary: &mut B) {
+    fn lookup_eval_boundary<B: BoundaryBuilder>(self, boundary: &mut B) {
         constraints::lookup::miden_air::emit_chiplets_boundary(boundary);
     }
 }

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -144,7 +144,7 @@ impl MastForestMerger {
             self.merge_decorators(other_forest)?;
         }
         for other_forest in forests.iter() {
-            self.merge_error_codes(other_forest)?;
+            self.merge_error_codes(other_forest);
         }
 
         let iterator = MultiMastForestNodeIter::new(forests.clone());
@@ -189,7 +189,7 @@ impl MastForestMerger {
         self.register_asm_op_mappings()?;
 
         for (forest_idx, forest) in forests.iter().enumerate() {
-            self.merge_roots(forest_idx, forest)?;
+            self.merge_roots(forest_idx, forest);
         }
 
         self.merge_debug_metadata(&forests)?;
@@ -231,11 +231,10 @@ impl MastForestMerger {
             .map_err(|((key, _prev), _new)| MastForestError::AdviceMapKeyCollisionOnMerge(key))
     }
 
-    fn merge_error_codes(&mut self, other_forest: &MastForest) -> Result<(), MastForestError> {
+    fn merge_error_codes(&mut self, other_forest: &MastForest) {
         self.mast_forest.debug_info.extend_error_codes(
             other_forest.debug_info.error_codes().map(|(k, v)| (*k, v.clone())),
         );
-        Ok(())
     }
 
     fn merge_node(
@@ -314,11 +313,7 @@ impl MastForestMerger {
         Ok(())
     }
 
-    fn merge_roots(
-        &mut self,
-        forest_idx: usize,
-        other_forest: &MastForest,
-    ) -> Result<(), MastForestError> {
+    fn merge_roots(&mut self, forest_idx: usize, other_forest: &MastForest) {
         for root_id in other_forest.roots.iter() {
             // Map the previous root to its possibly new id.
             let new_root = self.node_id_mappings[forest_idx]
@@ -329,8 +324,6 @@ impl MastForestMerger {
             // this should be okay.
             self.mast_forest.make_root(new_root);
         }
-
-        Ok(())
     }
 
     /// Transfers procedure names and debug vars from the source forests into the merged forest,

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -112,10 +112,8 @@ fn assert_root_mapping(
 
 /// Asserts that all children of nodes in the given forest have an id that is less than the parent's
 /// ID.
-///
-/// Returns a Result which can be unwrapped in the calling test function to assert. This way, if
-/// this assertion fails it'll be clear which exact call failed.
-fn assert_child_id_lt_parent_id(forest: &MastForest) -> Result<(), &str> {
+#[track_caller]
+fn assert_child_id_lt_parent_id(forest: &MastForest) {
     for (mast_node_id, node) in forest.nodes().iter().enumerate() {
         node.for_each_child(|child_id| {
             if child_id.to_usize() >= mast_node_id {
@@ -123,8 +121,6 @@ fn assert_child_id_lt_parent_id(forest: &MastForest) -> Result<(), &str> {
             }
         });
     }
-
-    Ok(())
 }
 
 #[test]
@@ -233,7 +229,7 @@ fn mast_forest_merge_remap() {
     assert_eq!(u32::from(root_maps.map_root(0, &id_call_a).unwrap()), 1u32);
     assert_eq!(u32::from(root_maps.map_root(1, &id_call_b).unwrap()), 3u32);
 
-    assert_child_id_lt_parent_id(&merged).unwrap();
+    assert_child_id_lt_parent_id(&merged);
 }
 
 /// Tests that Forest_A + Forest_A = Forest_A (i.e. duplicates are removed).
@@ -273,7 +269,7 @@ fn mast_forest_merge_duplicate() {
         assert!(forest_a.decorators().contains(merged_decorator));
     }
 
-    assert_child_id_lt_parent_id(&merged).unwrap();
+    assert_child_id_lt_parent_id(&merged);
 }
 
 /// Tests that External(foo) is replaced by Block(foo) whether it is in forest A or B, and the
@@ -322,7 +318,7 @@ fn mast_forest_merge_replace_external() {
         assert_eq!(merged.roots.len(), 1);
         assert_eq!(root_map.map_root(0, &id_call_a).unwrap().to_usize(), 1);
         assert_eq!(root_map.map_root(1, &id_call_b).unwrap().to_usize(), 1);
-        assert_child_id_lt_parent_id(&merged).unwrap();
+        assert_child_id_lt_parent_id(&merged);
     }
 }
 
@@ -368,7 +364,7 @@ fn mast_forest_merge_roots() {
 
     assert_root_mapping(&root_maps, vec![&forest_a.roots, &forest_b.roots], &merged.roots).unwrap();
 
-    assert_child_id_lt_parent_id(&merged).unwrap();
+    assert_child_id_lt_parent_id(&merged);
 }
 
 /// Test that multiple trees can be merged when the same merger is reused.
@@ -431,7 +427,7 @@ fn mast_forest_merge_multiple() {
     )
     .unwrap();
 
-    assert_child_id_lt_parent_id(&merged).unwrap();
+    assert_child_id_lt_parent_id(&merged);
 }
 
 /// Tests that decorators are merged and that nodes who are identical except for their
@@ -565,7 +561,7 @@ fn mast_forest_merge_decorators() {
 
     assert_root_mapping(&root_maps, vec![&forest_a.roots, &forest_b.roots], &merged.roots).unwrap();
 
-    assert_child_id_lt_parent_id(&merged).unwrap();
+    assert_child_id_lt_parent_id(&merged);
 }
 
 /// Tests that an external node without decorators is replaced by its referenced node which has
@@ -626,7 +622,7 @@ fn mast_forest_merge_external_node_reference_with_decorator() {
                 .unwrap();
         }
 
-        assert_child_id_lt_parent_id(&merged).unwrap();
+        assert_child_id_lt_parent_id(&merged);
     }
 }
 
@@ -691,7 +687,7 @@ fn mast_forest_merge_external_node_with_decorator() {
                 .unwrap();
         }
 
-        assert_child_id_lt_parent_id(&merged).unwrap();
+        assert_child_id_lt_parent_id(&merged);
     }
 }
 
@@ -758,7 +754,7 @@ fn mast_forest_merge_external_node_and_referenced_node_have_decorators() {
                 .unwrap();
         }
 
-        assert_child_id_lt_parent_id(&merged).unwrap();
+        assert_child_id_lt_parent_id(&merged);
     }
 }
 
@@ -832,7 +828,7 @@ fn mast_forest_merge_multiple_external_nodes_with_decorator() {
                 .unwrap();
         }
 
-        assert_child_id_lt_parent_id(&merged).unwrap();
+        assert_child_id_lt_parent_id(&merged);
     }
 }
 
@@ -920,7 +916,7 @@ fn mast_forest_merge_external_dependencies() {
         assert!(digests.contains(&forest_b[id_qux_b].digest()));
         assert_eq!(merged.nodes().iter().filter(|node| node.is_external()).count(), 0);
 
-        assert_child_id_lt_parent_id(&merged).unwrap();
+        assert_child_id_lt_parent_id(&merged);
     }
 }
 

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -96,8 +96,8 @@ impl ForestLayout {
     }
 
     #[cfg(test)]
-    pub(super) fn advice_map_offset(&self) -> Result<usize, DeserializationError> {
-        Ok(self.advice_map_offset)
+    pub(super) fn advice_map_offset(&self) -> usize {
+        self.advice_map_offset
     }
 }
 

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -631,7 +631,7 @@ impl MastForestView for MastForest {
 
 #[cfg(test)]
 impl SerializedMastForest<'_> {
-    fn advice_map_offset(&self) -> Result<usize, DeserializationError> {
+    fn advice_map_offset(&self) -> usize {
         self.layout.advice_map_offset()
     }
 

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -588,7 +588,7 @@ fn test_serialized_mast_forest_large_counts() {
 
 fn debug_info_offset_after_advice_map(bytes: &[u8]) -> usize {
     let view = SerializedMastForest::new(bytes).unwrap();
-    let mut offset = view.advice_map_offset().unwrap();
+    let mut offset = view.advice_map_offset();
     let entry_count = read_usize_at(bytes, &mut offset).unwrap();
     for _ in 0..entry_count {
         for _ in 0..4 {

--- a/crates/assembly-syntax/src/parser/cst/folders.rs
+++ b/crates/assembly-syntax/src/parser/cst/folders.rs
@@ -1,3 +1,8 @@
+// Folders below share a uniform `fn(_, _) -> Result<Vec<ast::Op>, ParsingError>` signature so they
+// can be stored in the `CompactSuffixKind` enum as function pointers. Some folders genuinely need
+// to fail (e.g. division by zero), so the others wrap their value in `Ok` to match.
+#![allow(clippy::unnecessary_wraps)]
+
 use alloc::vec::Vec;
 
 use super::instructions::{inst_op, push_u32_op, push_zero_op};

--- a/crates/assembly-syntax/src/parser/cst/instructions.rs
+++ b/crates/assembly-syntax/src/parser/cst/instructions.rs
@@ -1199,7 +1199,7 @@ fn lower_stack_index_instruction(
     spec: &StackIndexSpec,
 ) -> Result<Option<Vec<ast::Op>>, ParsingError> {
     let immediate_span = context.parse().span_for_token(token);
-    let Some(index) = lower_decimal_u8_literal(token)? else {
+    let Some(index) = lower_decimal_u8_literal(token) else {
         return Ok(None);
     };
     let Some(instruction) = spec.instruction(index) else {
@@ -2043,7 +2043,7 @@ fn lower_push_mapvaln(
     token: &SyntaxToken,
 ) -> Result<Option<Vec<ast::Op>>, ParsingError> {
     let immediate_span = context.parse().span_for_token(token);
-    let Some(padding) = lower_decimal_u8_literal(token)? else {
+    let Some(padding) = lower_decimal_u8_literal(token) else {
         return Ok(None);
     };
     let event = match padding {
@@ -2109,7 +2109,7 @@ fn lower_u16_immediate(
             Ok(Some(Immediate::Constant(context.lower_constant_ident_token(token)?)))
         },
         SyntaxKind::Number => {
-            let Some(value) = lower_decimal_u64_literal(token)? else {
+            let Some(value) = lower_decimal_u64_literal(token) else {
                 return Ok(None);
             };
             let Ok(value) = u16::try_from(value) else {
@@ -2134,7 +2134,7 @@ fn lower_shift32_immediate(
             Ok(Some(Immediate::Constant(context.lower_constant_ident_token(token)?)))
         },
         SyntaxKind::Number => {
-            let Some(value) = lower_decimal_u64_literal(token)? else {
+            let Some(value) = lower_decimal_u64_literal(token) else {
                 return Ok(None);
             };
             let Ok(value) = u8::try_from(value) else {
@@ -2150,11 +2150,9 @@ fn lower_shift32_immediate(
 }
 
 /// Parses a decimal `u8` literal token without accepting non-decimal spellings.
-fn lower_decimal_u8_literal(token: &SyntaxToken) -> Result<Option<u8>, ParsingError> {
-    let Some(value) = lower_decimal_u64_literal(token)? else {
-        return Ok(None);
-    };
-    Ok(u8::try_from(value).ok())
+fn lower_decimal_u8_literal(token: &SyntaxToken) -> Option<u8> {
+    let value = lower_decimal_u64_literal(token)?;
+    u8::try_from(value).ok()
 }
 
 /// Returns the suffix subspan of a token span, used for diagnostics like `exp.u65 -> 65`.
@@ -2163,11 +2161,11 @@ fn token_suffix_span(span: SourceSpan, prefix_len: u32) -> SourceSpan {
 }
 
 /// Parses a decimal `u64` from a number token if the token is decimal-shaped.
-fn lower_decimal_u64_literal(token: &SyntaxToken) -> Result<Option<u64>, ParsingError> {
+fn lower_decimal_u64_literal(token: &SyntaxToken) -> Option<u64> {
     if token.kind() != SyntaxKind::Number {
-        return Ok(None);
+        return None;
     }
-    Ok(parse_decimal_u64(token.text()))
+    parse_decimal_u64(token.text())
 }
 
 /// Wraps an instruction in an AST op at `span`.

--- a/crates/assembly-syntax/src/parser/lexer.rs
+++ b/crates/assembly-syntax/src/parser/lexer.rs
@@ -481,6 +481,8 @@ impl<'input> Lexer<'input> {
         }
     }
 
+    // Uniform return type with other `lex_*` helpers so they can be dispatched the same way.
+    #[allow(clippy::unnecessary_wraps)]
     fn lex_identifier(&mut self) -> Result<Token<'input>, ParsingError> {
         let c = self.pop();
         debug_assert!(c.is_ascii_alphabetic() || c == '_');

--- a/crates/assembly-syntax/src/parser/mod.rs
+++ b/crates/assembly-syntax/src/parser/mod.rs
@@ -12,6 +12,7 @@ lalrpop_util::lalrpop_mod!(
     #[expect(clippy::all)]
     #[expect(clippy::redundant_closure_for_method_calls)]
     #[expect(clippy::trivially_copy_pass_by_ref)]
+    #[expect(clippy::unnecessary_wraps)]
     #[expect(unused_lifetimes)]
     #[expect(unused_qualifications)]
     grammar,

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -132,7 +132,7 @@ pub fn analyze(
                 analyzer.error(SemanticAnalysisError::UnexpectedEntrypoint { span: body.span() });
             },
             Form::AdviceMapEntry(entry) => {
-                add_advice_map_entry(&mut module, entry.with_docs(docs.take()), &mut analyzer)?;
+                add_advice_map_entry(&mut module, entry.with_docs(docs.take()), &mut analyzer);
             },
         }
     }
@@ -175,7 +175,7 @@ pub fn analyze(
     analyzer.has_failed()?;
 
     // Run item checks
-    visit_items(&mut module, &mut analyzer)?;
+    visit_items(&mut module, &mut analyzer);
 
     // Check unused imports
     for import in module.aliases() {
@@ -192,7 +192,7 @@ pub fn analyze(
 ///
 /// When this function returns, all local analysis is complete, and all that remains is construction
 /// of a module graph and global program analysis to perform any remaining transformations.
-fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<(), SyntaxError> {
+fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) {
     let is_kernel = module.is_kernel();
     let locals = BTreeMap::from_iter(
         module
@@ -306,8 +306,6 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) -> Result<()
             alias.uses = 1;
         }
     }
-
-    Ok(())
 }
 
 fn define_alias(
@@ -362,13 +360,7 @@ fn define_procedure(
 
 /// Inserts a new entry in the Advice Map and defines a constant corresposnding to the entry's
 /// key.
-///
-/// Returns `Err` if the symbol is already defined
-fn add_advice_map_entry(
-    module: &mut Module,
-    entry: AdviceMapEntry,
-    context: &mut AnalysisContext,
-) -> Result<(), SyntaxError> {
+fn add_advice_map_entry(module: &mut Module, entry: AdviceMapEntry, context: &mut AnalysisContext) {
     let key = match entry.key {
         Some(key) => Word::from(key.inner().0),
         None => Poseidon2::hash_elements(&entry.value),
@@ -388,5 +380,4 @@ fn add_advice_map_entry(
             module.advice_map.insert(key, entry.value);
         },
     }
-    Ok(())
 }

--- a/crates/assembly/src/instruction/crypto_ops.rs
+++ b/crates/assembly/src/instruction/crypto_ops.rs
@@ -1,7 +1,6 @@
 use miden_core::{Felt, ZERO, events::SystemEvent, operations::Operation::*};
 
 use super::BasicBlockBuilder;
-use crate::Report;
 
 // HASHING
 // ================================================================================================
@@ -131,12 +130,11 @@ pub(super) fn mtree_get(block_builder: &mut BasicBlockBuilder) {
 /// - new root of the tree after the update, 4 elements
 ///
 /// This operation takes 30 VM cycles.
-pub(super) fn mtree_set(block_builder: &mut BasicBlockBuilder) -> Result<(), Report> {
+pub(super) fn mtree_set(block_builder: &mut BasicBlockBuilder) {
     // stack: [d, i, R_old, V_new, ...]
 
     // stack: [V_old, R_new, ...] (30 cycles)
     update_mtree(block_builder);
-    Ok(())
 }
 
 /// Creates a new Merkle tree in the advice provider by combining trees with the specified roots.

--- a/crates/assembly/src/instruction/mod.rs
+++ b/crates/assembly/src/instruction/mod.rs
@@ -529,7 +529,7 @@ impl Assembler {
             Instruction::HPerm => block_builder.push_op(HPerm),
             Instruction::HMerge => crypto_ops::hmerge(block_builder),
             Instruction::MTreeGet => crypto_ops::mtree_get(block_builder),
-            Instruction::MTreeSet => crypto_ops::mtree_set(block_builder)?,
+            Instruction::MTreeSet => crypto_ops::mtree_set(block_builder),
             Instruction::MTreeMerge => crypto_ops::mtree_merge(block_builder),
             Instruction::MTreeVerify => block_builder.push_op(MpVerify(ZERO)),
             Instruction::MTreeVerifyWithError(err_msg) => {

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -112,7 +112,7 @@ fn empty_program() -> TestResult {
 }
 
 #[test]
-fn empty_if() -> TestResult {
+fn empty_if() {
     let context = TestContext::default();
     let source = source_file!(&context, "begin if.true end end");
     assert_assembler_diagnostic!(
@@ -125,7 +125,6 @@ fn empty_if() -> TestResult {
         "  :               `-- expected a non-empty `if` block",
         "  `----"
     );
-    Ok(())
 }
 
 #[test]
@@ -712,7 +711,7 @@ end
 }
 
 #[test]
-fn get_module_by_path() -> Result<(), Report> {
+fn get_module_by_path() {
     let context = TestContext::new();
     // declare foo module
     let foo_source = r#"
@@ -733,8 +732,6 @@ fn get_module_by_path() -> Result<(), Report> {
 
     let (_, foo_proc) = foo_module_info.procedures().next().unwrap();
     assert_eq!(foo_proc.name, ProcedureName::new("foo").unwrap());
-
-    Ok(())
 }
 
 #[test]
@@ -1104,7 +1101,7 @@ end
 }
 
 #[test]
-fn enum_felt_discriminant_negative_is_rejected() -> TestResult {
+fn enum_felt_discriminant_negative_is_rejected() {
     let context = TestContext::default();
     let source = source_file!(
         &context,
@@ -1122,11 +1119,10 @@ end
         .assemble(source)
         .expect_err("expected negative discriminant to be rejected");
     assert_diagnostic!(err, "invalid constant expression: value is larger than expected range");
-    Ok(())
 }
 
 #[test]
-fn enum_felt_discriminant_too_large_is_rejected() -> TestResult {
+fn enum_felt_discriminant_too_large_is_rejected() {
     let context = TestContext::default();
     let modulus = Felt::ORDER_U64;
     let source = source_file!(
@@ -1147,11 +1143,10 @@ end
         .assemble(source)
         .expect_err("expected out-of-range felt discriminant to be rejected");
     assert_diagnostic!(err, "invalid literal: value overflowed the field modulus");
-    Ok(())
 }
 
 #[test]
-fn constant_expression_overflow_is_rejected() -> TestResult {
+fn constant_expression_overflow_is_rejected() {
     let context = TestContext::default();
     let modulus_minus_one = Felt::ORDER_U64 - 1;
     let source = source_file!(
@@ -1164,7 +1159,6 @@ fn constant_expression_overflow_is_rejected() -> TestResult {
         .assemble(source)
         .expect_err("expected constant expression overflow to be rejected");
     assert_diagnostic!(err, "invalid constant expression: value is larger than expected range");
-    Ok(())
 }
 
 #[test]
@@ -1250,7 +1244,7 @@ fn constant_field_division() -> TestResult {
 }
 
 #[test]
-fn constant_err_const_not_initialized() -> TestResult {
+fn constant_err_const_not_initialized() {
     let context = TestContext::default();
     let source = source_file!(
         &context,
@@ -1272,11 +1266,10 @@ fn constant_err_const_not_initialized() -> TestResult {
         "  `----",
         " help: are you missing an import?"
     );
-    Ok(())
 }
 
 #[test]
-fn constant_err_div_by_zero() -> TestResult {
+fn constant_err_div_by_zero() {
     let context = TestContext::default();
     let source = source_file!(
         &context,
@@ -1311,11 +1304,10 @@ fn constant_err_div_by_zero() -> TestResult {
         "  :                       ^^^^",
         "  `----"
     );
-    Ok(())
 }
 
 #[test]
-fn constant_err_div_by_zero_indirect() -> TestResult {
+fn constant_err_div_by_zero_indirect() {
     let context = TestContext::default();
 
     let source = source_file!(
@@ -1342,8 +1334,6 @@ fn constant_err_div_by_zero_indirect() -> TestResult {
         "4 |",
         "  `----"
     );
-
-    Ok(())
 }
 
 #[test]
@@ -1386,7 +1376,7 @@ fn constant_err_div_by_zero_link_time() -> TestResult {
 }
 
 #[test]
-fn constants_must_be_uppercase() -> TestResult {
+fn constants_must_be_uppercase() {
     let context = TestContext::default();
     let source = source_file!(
         &context,
@@ -1407,12 +1397,10 @@ fn constants_must_be_uppercase() -> TestResult {
         "  `----",
         "help: bare identifiers must be lowercase alphanumeric with '_', quoted identifiers can include any graphical character"
     );
-
-    Ok(())
 }
 
 #[test]
-fn duplicate_constant_name() -> TestResult {
+fn duplicate_constant_name() {
     let context = TestContext::default();
     let source = source_file!(
         &context,
@@ -1436,11 +1424,10 @@ fn duplicate_constant_name() -> TestResult {
         "  :           `-- previously defined here",
         "  `----"
     );
-    Ok(())
 }
 
 #[test]
-fn constant_must_be_valid_felt() -> TestResult {
+fn constant_must_be_valid_felt() {
     let context = TestContext::default();
     let source = source_file!(
         &context,
@@ -1460,11 +1447,10 @@ fn constant_must_be_valid_felt() -> TestResult {
         "  :                         `-- unexpected trailing tokens in expression",
         "  `----"
     );
-    Ok(())
 }
 
 #[test]
-fn constant_must_be_within_valid_felt_range() -> TestResult {
+fn constant_must_be_within_valid_felt_range() {
     let context = TestContext::default();
 
     // test the u64::MAX value
@@ -1523,12 +1509,10 @@ fn constant_must_be_within_valid_felt_range() -> TestResult {
         "  :                  ^^^^^^^^^^^^^^^^^^",
         "  `----"
     );
-
-    Ok(())
 }
 
 #[test]
-fn constants_defined_in_global_scope() -> TestResult {
+fn constants_defined_in_global_scope() {
     let context = TestContext::default();
     let source = source_file!(
         &context,
@@ -1551,11 +1535,10 @@ fn constants_defined_in_global_scope() -> TestResult {
         "3 |     push.CONSTANT end",
         "  `----"
     );
-    Ok(())
 }
 
 #[test]
-fn constant_not_found() -> TestResult {
+fn constant_not_found() {
     let context = TestContext::new();
     let source = source_file!(
         &context,
@@ -1579,7 +1562,6 @@ fn constant_not_found() -> TestResult {
         "  `----",
         "help: are you missing an import?"
     );
-    Ok(())
 }
 
 #[test]
@@ -1696,7 +1678,7 @@ fn mem_operations_with_constants() -> TestResult {
 }
 
 #[test]
-fn const_conversion_failed_to_u16() -> TestResult {
+fn const_conversion_failed_to_u16() {
     // Define constant value greater than u16::MAX
     let constant_value: u64 = u16::MAX as u64 + 1;
 
@@ -1732,11 +1714,10 @@ fn const_conversion_failed_to_u16() -> TestResult {
         "6 |     end",
         "  `----"
     );
-    Ok(())
 }
 
 #[test]
-fn const_conversion_failed_to_u32() -> TestResult {
+fn const_conversion_failed_to_u32() {
     let context = TestContext::default();
     // Define constant value greater than u16::MAX
     let constant_value: u64 = u32::MAX as u64 + 1;
@@ -1767,11 +1748,10 @@ fn const_conversion_failed_to_u32() -> TestResult {
         "5 |     end",
         "  `----"
     );
-    Ok(())
 }
 
 #[test]
-fn deprecated_mem_loadw_instruction() -> TestResult {
+fn deprecated_mem_loadw_instruction() {
     let context = TestContext::default();
 
     let source = source_file!(
@@ -1796,11 +1776,10 @@ fn deprecated_mem_loadw_instruction() -> TestResult {
         "  `----",
         regex!(r#"help:.*use.*mem_loadw_be.*instead"#)
     );
-    Ok(())
 }
 
 #[test]
-fn deprecated_loc_loadw_instruction() -> TestResult {
+fn deprecated_loc_loadw_instruction() {
     let context = TestContext::default();
 
     let source = source_file!(
@@ -1829,11 +1808,10 @@ fn deprecated_loc_loadw_instruction() -> TestResult {
         "  `----",
         regex!(r#"help:.*use.*loc_loadw_be.*instead"#)
     );
-    Ok(())
 }
 
 #[test]
-fn deprecated_loc_storew_instruction() -> TestResult {
+fn deprecated_loc_storew_instruction() {
     let context = TestContext::default();
 
     let source = source_file!(
@@ -1862,7 +1840,6 @@ fn deprecated_loc_storew_instruction() -> TestResult {
         "  `----",
         regex!(r#"help:.*use.*loc_storew_be.*instead"#)
     );
-    Ok(())
 }
 
 #[test]
@@ -1953,7 +1930,7 @@ fn test_push_word_slice() -> TestResult {
 }
 
 #[test]
-fn test_push_word_slice_invalid() -> TestResult {
+fn test_push_word_slice_invalid() {
     let context = TestContext::default();
     let source_invalid_range = source_file!(
         &context,
@@ -2007,8 +1984,6 @@ fn test_push_word_slice_invalid() -> TestResult {
         )
     );
     assert!(context.assemble(source_invalid_constant_type).is_err());
-
-    Ok(())
 }
 
 #[test]
@@ -2687,7 +2662,7 @@ fn control_flow_nesting_depth_boundary() -> TestResult {
 }
 
 #[test]
-fn control_flow_nesting_depth_exceeded() -> TestResult {
+fn control_flow_nesting_depth_exceeded() {
     let context = TestContext::default();
     let source = nested_if_source(MAX_CONTROL_FLOW_NESTING + 1);
     let source = source_file!(&context, source.as_str());
@@ -2695,7 +2670,6 @@ fn control_flow_nesting_depth_exceeded() -> TestResult {
         .assemble(source)
         .expect_err("expected diagnostic to be raised, but compilation succeeded");
     assert_diagnostic!(&error, "control-flow nesting depth exceeded");
-    Ok(())
 }
 
 // PROGRAMS WITH PROCEDURES
@@ -2807,7 +2781,7 @@ fn program_with_proc_locals() -> TestResult {
 }
 
 #[test]
-fn program_with_proc_locals_fail() -> TestResult {
+fn program_with_proc_locals_fail() {
     let context = TestContext::default();
     let source = source_file!(
         &context,
@@ -2840,12 +2814,10 @@ end"
         "7 |     begin",
         "  `----"
     );
-
-    Ok(())
 }
 
 #[test]
-fn program_with_exported_procedure() -> TestResult {
+fn program_with_exported_procedure() {
     let context = TestContext::default();
     let source = source_file!(
         &context,
@@ -2864,7 +2836,6 @@ fn program_with_exported_procedure() -> TestResult {
         "  `----",
         "        help: perhaps you meant to use `proc` instead of `export`?"
     );
-    Ok(())
 }
 
 // PROGRAMS WITH DYNAMIC CODE BLOCKS
@@ -2892,7 +2863,7 @@ fn program_with_dynamic_code_execution_in_new_context() -> TestResult {
 // ================================================================================================
 
 #[test]
-fn program_with_incorrect_mast_root_length() -> TestResult {
+fn program_with_incorrect_mast_root_length() {
     let context = TestContext::default();
     let source = source_file!(&context, "begin call.0x1234 end");
 
@@ -2905,7 +2876,6 @@ fn program_with_incorrect_mast_root_length() -> TestResult {
         "  :            ^^^^^^",
         "  `----"
     );
-    Ok(())
 }
 
 #[test]
@@ -3864,7 +3834,7 @@ fn invalid_if_else_no_matching_end() {
 }
 
 #[test]
-fn invalid_repeat() -> TestResult {
+fn invalid_repeat() {
     let context = TestContext::default();
 
     // unmatched repeat
@@ -3921,22 +3891,20 @@ fn invalid_repeat() -> TestResult {
         "4 |                     add",
         "  `----"
     );
-    Ok(())
 }
 
 #[test]
-fn invalid_repeat_count_zero() -> TestResult {
+fn invalid_repeat_count_zero() {
     let context = TestContext::default();
     let source = source_file!(&context, "begin repeat.0 nop end end");
     let error = context.assemble(source).expect_err("expected repeat.0 to be rejected");
     let rendered =
         format!("{}", crate::diagnostics::reporting::PrintDiagnostic::new_without_color(&error));
     assert!(rendered.contains("invalid repeat count"));
-    Ok(())
 }
 
 #[test]
-fn invalid_repeat_count_zero_with_decorator() -> TestResult {
+fn invalid_repeat_count_zero_with_decorator() {
     let context = TestContext::default();
     let source = source_file!(
         &context,
@@ -3958,11 +3926,10 @@ end"
     let rendered =
         format!("{}", crate::diagnostics::reporting::PrintDiagnostic::new_without_color(&error));
     assert!(rendered.contains("invalid repeat count"));
-    Ok(())
 }
 
 #[test]
-fn invalid_repeat_count_too_large() -> TestResult {
+fn invalid_repeat_count_too_large() {
     let context = TestContext::default();
     let repeat_count = MAX_REPEAT_COUNT + 1;
     let source = source_file!(&context, format!("begin repeat.{repeat_count} nop end end"));
@@ -3972,11 +3939,10 @@ fn invalid_repeat_count_too_large() -> TestResult {
     let rendered =
         format!("{}", crate::diagnostics::reporting::PrintDiagnostic::new_without_color(&error));
     assert!(rendered.contains("invalid repeat count"));
-    Ok(())
 }
 
 #[test]
-fn invalid_repeat_count_constant_zero() -> TestResult {
+fn invalid_repeat_count_constant_zero() {
     let context = TestContext::default();
     let source =
         source_file!(&context, "const REPEAT_COUNT = 0\nbegin repeat.REPEAT_COUNT nop end end");
@@ -3986,11 +3952,10 @@ fn invalid_repeat_count_constant_zero() -> TestResult {
     let rendered =
         format!("{}", crate::diagnostics::reporting::PrintDiagnostic::new_without_color(&error));
     assert!(rendered.contains("invalid repeat count"));
-    Ok(())
 }
 
 #[test]
-fn invalid_repeat_count_constant_too_large() -> TestResult {
+fn invalid_repeat_count_constant_too_large() {
     let context = TestContext::default();
     let repeat_count = MAX_REPEAT_COUNT + 1;
     let source = source_file!(
@@ -4003,11 +3968,10 @@ fn invalid_repeat_count_constant_too_large() -> TestResult {
     let rendered =
         format!("{}", crate::diagnostics::reporting::PrintDiagnostic::new_without_color(&error));
     assert!(rendered.contains("invalid repeat count"));
-    Ok(())
 }
 
 #[test]
-fn repeat_count_constant_at_limit_allowed() -> TestResult {
+fn repeat_count_constant_at_limit_allowed() {
     let context = TestContext::default();
     let source = source_file!(
         &context,
@@ -4016,7 +3980,6 @@ fn repeat_count_constant_at_limit_allowed() -> TestResult {
     context
         .assemble(source)
         .expect("expected repeat count at limit from constant to be accepted");
-    Ok(())
 }
 
 #[test]
@@ -4229,7 +4192,7 @@ end
 }
 
 #[test]
-fn invalid_while() -> TestResult {
+fn invalid_while() {
     let context = TestContext::default();
 
     let source = source_file!(&context, "begin push.1 add while mul end end");
@@ -4267,7 +4230,6 @@ fn invalid_while() -> TestResult {
         "  :                               `-- expected `end` to close `while`",
         "  `----"
     );
-    Ok(())
 }
 
 // COMPILED LIBRARIES

--- a/crates/lib/core/tests/collections/sorted_array.rs
+++ b/crates/lib/core/tests/collections/sorted_array.rs
@@ -567,6 +567,8 @@ fn build_lib_test(source: &str, op_stack: &[u64]) -> miden_utils_testing::Test {
         .with_library(core_lib.library().clone())
 }
 
+// Signatures match the event-handler callback type required by `with_event_handler`.
+#[allow(clippy::unnecessary_wraps)]
 /// Returns `(was_found = false, maybe_value_ptr = 204)` regardless of the actual array. 204 is
 /// past the array's `end_ptr = 112`, so the bounds check must fire.
 fn malicious_lowerbound_oob_above(
@@ -575,6 +577,7 @@ fn malicious_lowerbound_oob_above(
     Ok(vec![AdviceMutation::extend_stack(vec![Felt::new_unchecked(204), Felt::ZERO])])
 }
 
+#[allow(clippy::unnecessary_wraps)]
 /// Returns `(was_found = false, maybe_value_ptr = 40)` which is below `start_ptr = 100`.
 fn malicious_lowerbound_oob_below(
     _process: &ProcessorState,

--- a/crates/lib/core/tests/crypto/falcon.rs
+++ b/crates/lib/core/tests/crypto/falcon.rs
@@ -356,6 +356,8 @@ fn test_mod_12289_rejects_forged_remainder_zero(#[case] a_hi: u64, #[case] a_lo:
     const M_INV: u64 = 15010777177727684609;
 
     // Malicious event handler that always returns remainder = 0.
+    // Signature matches the event-handler callback contract.
+    #[allow(clippy::unnecessary_wraps)]
     fn malicious_falcon_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>, EventError> {
         let a_hi = process.get_stack_item(1).as_canonical_u64();
         let a_lo = process.get_stack_item(2).as_canonical_u64();
@@ -412,6 +414,7 @@ fn test_mod_12289_rejects_forged_addition_overflow() {
     const FORGED_R: u64 = 5_664;
 
     // Malicious event handler that forges q/r to trigger the addition-overflow assertion.
+    #[allow(clippy::unnecessary_wraps)]
     fn malicious_falcon_div(_process: &ProcessorState) -> Result<Vec<AdviceMutation>, EventError> {
         let q_hi = Felt::new_unchecked(FORGED_Q >> 32);
         let q_lo = Felt::new_unchecked(FORGED_Q & 0xffff_ffff);
@@ -452,6 +455,7 @@ fn test_mod_12289_rejects_non_u32_remainder_advice() {
     const FALCON_DIV: EventName =
         EventName::new("miden::core::crypto::dsa::falcon512_poseidon2::falcon_div");
 
+    #[allow(clippy::unnecessary_wraps)]
     fn malicious_falcon_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>, EventError> {
         let a_hi = process.get_stack_item(1).as_canonical_u64();
         let a_lo = process.get_stack_item(2).as_canonical_u64();

--- a/crates/lib/core/tests/stark/mod.rs
+++ b/crates/lib/core/tests/stark/mod.rs
@@ -11,7 +11,7 @@ use miden_core::{
 use miden_processor::{DefaultHost, ExecutionOptions, Program, ProgramInfo};
 use miden_utils_testing::{
     AdviceInputs, ProvingOptions, StackInputs, prove_sync,
-    recursive_verifier::{VerifierData, VerifierError, generate_advice_inputs},
+    recursive_verifier::{VerifierData, generate_advice_inputs},
 };
 use rand::{Rng, RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -27,14 +27,14 @@ mod batch_query_gen;
 #[test]
 fn stark_verifier_e2f4_small() {
     let inputs = fib_stack_inputs();
-    let data = generate_recursive_verifier_data(EXAMPLE_FIB_SMALL, inputs, None).unwrap();
+    let data = generate_recursive_verifier_data(EXAMPLE_FIB_SMALL, inputs, None);
     run_recursive_verifier(&data);
 }
 
 #[test]
 fn stark_verifier_e2f4_large() {
     let inputs = fib_stack_inputs();
-    let data = generate_recursive_verifier_data(EXAMPLE_FIB_LARGE, inputs, None).unwrap();
+    let data = generate_recursive_verifier_data(EXAMPLE_FIB_LARGE, inputs, None);
     run_recursive_verifier(&data);
 }
 
@@ -45,8 +45,7 @@ fn stark_verifier_e2f4_with_kernel_even() {
         EXAMPLE_FIB_KERNEL_SMALL,
         inputs,
         Some(KERNEL_EVEN_NUM_PROC),
-    )
-    .unwrap();
+    );
     run_recursive_verifier(&data);
 }
 
@@ -57,8 +56,7 @@ fn stark_verifier_e2f4_with_kernel_odd() {
         EXAMPLE_FIB_KERNEL_SMALL,
         inputs,
         Some(KERNEL_ODD_NUM_PROC),
-    )
-    .unwrap();
+    );
     run_recursive_verifier(&data);
 }
 
@@ -69,8 +67,7 @@ fn stark_verifier_e2f4_with_kernel_single() {
         EXAMPLE_FIB_KERNEL_SMALL,
         inputs,
         Some(KERNEL_SINGLE_PROC),
-    )
-    .unwrap();
+    );
     run_recursive_verifier(&data);
 }
 
@@ -79,7 +76,7 @@ pub fn generate_recursive_verifier_data(
     source: &str,
     stack_inputs: Vec<u64>,
     kernel: Option<&str>,
-) -> Result<VerifierData, VerifierError> {
+) -> VerifierData {
     let (program, kernel_lib) = {
         match kernel {
             Some(kernel) => {
@@ -126,8 +123,7 @@ pub fn generate_recursive_verifier_data(
         PrecompileTranscriptState::default(),
     );
     let (_, proof_bytes, _precompile_requests) = proof.into_parts();
-    let data = generate_advice_inputs(&proof_bytes, pub_inputs).unwrap();
-    Ok(data)
+    generate_advice_inputs(&proof_bytes, pub_inputs).unwrap()
 }
 
 /// Run the recursive verifier MASM program with the given VerifierData.

--- a/miden-vm/tests/integration/cli/cli_test.rs
+++ b/miden-vm/tests/integration/cli/cli_test.rs
@@ -36,7 +36,7 @@ fn bin_under_test() -> escargot::CargoRun {
 #[test]
 // Tt test might be an overkill to test only that the 'run' cli command
 // outputs steps and ms.
-fn cli_run() -> Result<(), Box<dyn std::error::Error>> {
+fn cli_run() {
     let mut cmd = bin_under_test().command();
 
     cmd.arg("run")
@@ -54,8 +54,6 @@ fn cli_run() -> Result<(), Box<dyn std::error::Error>> {
     // However we the X and the Y can change in future versions.
     // There is no other 'steps in' in the output
     output.assert().stdout(predicate::str::contains("VM cycles"));
-
-    Ok(())
 }
 
 use miden_assembly::Library;
@@ -133,7 +131,7 @@ fn cli_bundle_output() {
 
 // First compile a library to a .masl file, then run a program that uses it.
 #[test]
-fn cli_run_with_lib() -> Result<(), Box<dyn std::error::Error>> {
+fn cli_run_with_lib() {
     let mut cmd = bin_under_test().command();
     cmd.arg("bundle")
         .arg("./tests/integration/cli/data/lib")
@@ -149,13 +147,11 @@ fn cli_run_with_lib() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert().success();
 
     fs::remove_file("cli_run_with_lib.masl").unwrap();
-    Ok(())
 }
 
 #[test]
-fn test_advmap_cli() -> Result<(), Box<dyn std::error::Error>> {
+fn test_advmap_cli() {
     let mut cmd = bin_under_test().command();
     cmd.arg("run").arg("./tests/integration/cli/data/adv_map.masm");
     cmd.assert().success();
-    Ok(())
 }

--- a/processor/src/execution/operations/sys_ops/mod.rs
+++ b/processor/src/execution/operations/sys_ops/mod.rs
@@ -49,6 +49,8 @@ where
 /// Overwrites the top four stack items with the value of the CALLER_HASH register, which is the
 /// hash of the procedure that initiated the most recent SYSCALL, or ZERO if not in a syscall
 /// context.
+// Uniform return type with sibling `op_*` handlers dispatched in `execute_op`.
+#[allow(clippy::unnecessary_wraps)]
 #[inline(always)]
 pub(super) fn op_caller<P: Processor>(
     processor: &mut P,


### PR DESCRIPTION
Running `make clippy` outputs many warnings, which the CI doesn't consider a failure because they are not errors.

This PR converts all warnings to errors, and fixes all clippy errors.