### PR TITLE
Remove owned decorator storage from MAST nodes (3/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Aligned replay stack word access bounds with `StackInterface`, allowing the maximum valid start index for word reads and writes ([#3014](https://github.com/0xMiden/miden-vm/pull/3014)).
 - [BREAKING] Enabled `clippy::unnecessary_wraps` lint and removed all unnecessary `Option`/`Result` wrappings across the workspace ([#3143](https://github.com/0xMiden/miden-vm/pull/3143)).
 - [BREAKING] Simplified `MastForestBuilder` around builder-local refs and immutable finalized `MastForest`s ([#3139](https://github.com/0xMiden/miden-vm/pull/3139)).
+- [BREAKING] Removed owned decorator storage from MAST nodes; nodes now reference decorators stored in their containing `MastForest` ([#3174](https://github.com/0xMiden/miden-vm/pull/3174)).
 
 #### Fixes
 

--- a/core/src/mast/merger/mod.rs
+++ b/core/src/mast/merger/mod.rs
@@ -651,45 +651,31 @@ impl MastForestMerger {
         let new_node_id = MastNodeId::new_unchecked(
             self.nodes.len().try_into().map_err(|_| MastForestError::TooManyNodes)?,
         );
-        let owned_node = builder.build_with_forced_digest()?;
+        let linked_build = builder.build_linked_with_decorators(new_node_id)?;
 
         let mut children = Vec::new();
-        owned_node.append_children_to(&mut children);
+        linked_build.node.append_children_to(&mut children);
         for child_id in children {
             if child_id.to_usize() >= self.nodes.len() {
                 return Err(MastForestError::NodeIdOverflow(child_id, self.nodes.len()));
             }
         }
 
-        let (before_enter, after_exit, op_indexed_decorators) = {
-            let decorator_lookup_forest = self
-                .decorator_lookup_forest
-                .as_ref()
-                .expect("decorator lookup forest should be initialized before merging nodes");
-            let before_enter = owned_node.before_enter(decorator_lookup_forest).to_vec();
-            let after_exit = owned_node.after_exit(decorator_lookup_forest).to_vec();
-            let op_indexed_decorators = match &owned_node {
-                MastNode::Block(block) => {
-                    block.indexed_decorator_iter(decorator_lookup_forest).collect()
-                },
-                _ => Vec::new(),
-            };
-            (before_enter, after_exit, op_indexed_decorators)
-        };
-
-        if !before_enter.is_empty() || !after_exit.is_empty() {
-            self.debug_info
-                .register_node_decorators(new_node_id, &before_enter, &after_exit);
+        if !linked_build.before_enter.is_empty() || !linked_build.after_exit.is_empty() {
+            self.debug_info.register_node_decorators(
+                new_node_id,
+                &linked_build.before_enter,
+                &linked_build.after_exit,
+            );
         }
-        if matches!(owned_node, MastNode::Block(_)) {
+        if matches!(&linked_build.node, MastNode::Block(_)) {
             self.debug_info
-                .register_op_indexed_decorators(new_node_id, op_indexed_decorators)
+                .register_op_indexed_decorators(new_node_id, linked_build.op_indexed_decorators)
                 .map_err(MastForestError::DecoratorError)?;
         }
 
-        let linked_node = owned_node.into_linked_decorator_store(new_node_id);
         let inserted_id =
-            self.nodes.push(linked_node).map_err(|_| MastForestError::TooManyNodes)?;
+            self.nodes.push(linked_build.node).map_err(|_| MastForestError::TooManyNodes)?;
         debug_assert_eq!(inserted_id, new_node_id);
 
         Ok(new_node_id)

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -523,7 +523,7 @@ fn mast_forest_merge_decorators() {
 
     // Test basic block decorators using new MastForest API
     // The basic block should have Trace(1) and Trace(2) as before-enter decorators at index 0
-    let merged_foo_block_id = merged_foo_block.linked_id().unwrap();
+    let merged_foo_block_id = merged_foo_block.linked_id();
 
     // For basic blocks, we need to combine before_enter, operation-indexed, and after_exit
     // decorators using the helper method

--- a/core/src/mast/merger/tests.rs
+++ b/core/src/mast/merger/tests.rs
@@ -36,6 +36,10 @@ fn block_qux() -> BasicBlockNodeBuilder {
     )
 }
 
+fn block_digest(builder: BasicBlockNodeBuilder) -> Word {
+    builder.into_op_batches_and_digest().unwrap().1
+}
+
 fn register_asm_ops_for_node(
     forest: &mut MastForest,
     node_id: MastNodeId,
@@ -287,8 +291,7 @@ fn mast_forest_merge_duplicate() {
 #[test]
 fn mast_forest_merge_replace_external() {
     let mut forest_a = MastForest::new();
-    let foo_block_a = block_foo().build().unwrap();
-    let id_foo_a = ExternalNodeBuilder::new(foo_block_a.digest())
+    let id_foo_a = ExternalNodeBuilder::new(block_digest(block_foo()))
         .add_to_forest(&mut forest_a)
         .unwrap();
     let id_call_a = CallNodeBuilder::new(id_foo_a).add_to_forest(&mut forest_a).unwrap();
@@ -585,7 +588,7 @@ fn mast_forest_merge_external_node_reference_with_decorator() {
     let deco = forest_a.add_decorator(trace).unwrap();
 
     let foo_node_a = block_foo_with_decorators(&[deco], &[]);
-    let foo_node_digest = block_foo_with_decorators(&[deco], &[]).build().unwrap().digest();
+    let foo_node_digest = block_digest(block_foo_with_decorators(&[deco], &[]));
     let id_foo_a = foo_node_a.add_to_forest(&mut forest_a).unwrap();
 
     forest_a.make_root(id_foo_a);
@@ -648,8 +651,7 @@ fn mast_forest_merge_external_node_with_decorator() {
     let deco1 = forest_a.add_decorator(trace1).unwrap();
     let deco2 = forest_a.add_decorator(trace2).unwrap();
 
-    let external_node_a =
-        external_with_decorators(block_foo().build().unwrap().digest(), &[deco1], &[deco2]);
+    let external_node_a = external_with_decorators(block_digest(block_foo()), &[deco1], &[deco2]);
     let id_external_a = external_node_a.add_to_forest(&mut forest_a).unwrap();
 
     forest_a.make_root(id_external_a);
@@ -712,8 +714,7 @@ fn mast_forest_merge_external_node_and_referenced_node_have_decorators() {
     // Build Forest A
     let deco1_a = forest_a.add_decorator(trace1).unwrap();
 
-    let external_node_a =
-        external_with_decorators(block_foo().build().unwrap().digest(), &[deco1_a], &[]);
+    let external_node_a = external_with_decorators(block_digest(block_foo()), &[deco1_a], &[]);
     let id_external_a = external_node_a.add_to_forest(&mut forest_a).unwrap();
 
     forest_a.make_root(id_external_a);
@@ -783,11 +784,10 @@ fn mast_forest_merge_multiple_external_nodes_with_decorator() {
     let deco2_a = forest_a.add_decorator(trace2).unwrap();
 
     let external_node_a =
-        external_with_decorators(block_foo().build().unwrap().digest(), &[deco1_a], &[deco2_a]);
+        external_with_decorators(block_digest(block_foo()), &[deco1_a], &[deco2_a]);
     let id_external_a = external_node_a.add_to_forest(&mut forest_a).unwrap();
 
-    let external_node_b =
-        external_with_decorators(block_foo().build().unwrap().digest(), &[deco1_a], &[]);
+    let external_node_b = external_with_decorators(block_digest(block_foo()), &[deco1_a], &[]);
     let id_external_b = external_node_b.add_to_forest(&mut forest_a).unwrap();
 
     forest_a.make_root(id_external_a);
@@ -835,7 +835,7 @@ fn mast_forest_merge_multiple_external_nodes_with_decorator() {
 #[test]
 fn mast_forest_merge_preserves_asm_op_mappings_from_external_replacement() {
     let mut forest_with_external = MastForest::new();
-    let foo_digest = block_foo().build().unwrap().digest();
+    let foo_digest = block_digest(block_foo());
     let external_id = ExternalNodeBuilder::new(foo_digest)
         .add_to_forest(&mut forest_with_external)
         .unwrap();
@@ -886,7 +886,7 @@ fn mast_forest_merge_preserves_asm_op_mappings_from_external_replacement() {
 #[test]
 fn mast_forest_merge_external_dependencies() {
     let mut forest_a = MastForest::new();
-    let id_foo_a = ExternalNodeBuilder::new(block_qux().build().unwrap().digest())
+    let id_foo_a = ExternalNodeBuilder::new(block_digest(block_qux()))
         .add_to_forest(&mut forest_a)
         .unwrap();
     let id_call_a = CallNodeBuilder::new(id_foo_a).add_to_forest(&mut forest_a).unwrap();

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -58,10 +58,10 @@ pub use node::arbitrary;
 pub(crate) use node::collect_immediate_placements;
 pub use node::{
     BasicBlockNode, BasicBlockNodeBuilder, CallNode, CallNodeBuilder, DecoratedOpLink,
-    DecoratorOpLinkIterator, DecoratorStore, DynNode, DynNodeBuilder, ExternalNode,
-    ExternalNodeBuilder, JoinNode, JoinNodeBuilder, LoopNode, LoopNodeBuilder,
-    MastForestContributor, MastNode, MastNodeBuilder, MastNodeExt, OP_BATCH_SIZE, OP_GROUP_SIZE,
-    OpBatch, OperationOrDecorator, SplitNode, SplitNodeBuilder,
+    DecoratorOpLinkIterator, DynNode, DynNodeBuilder, ExternalNode, ExternalNodeBuilder, JoinNode,
+    JoinNodeBuilder, LinkedDecoratorStore, LoopNode, LoopNodeBuilder, MastForestContributor,
+    MastNode, MastNodeBuilder, MastNodeExt, OP_BATCH_SIZE, OP_GROUP_SIZE, OpBatch,
+    OperationOrDecorator, SplitNode, SplitNodeBuilder,
 };
 
 #[cfg(feature = "serde")]
@@ -1495,8 +1495,6 @@ pub enum MastForestError {
     TooManyNodes,
     #[error("node id {0} is greater than or equal to forest length {1}")]
     NodeIdOverflow(MastNodeId, usize),
-    #[error("node {0:?} has an unlinked decorator store")]
-    UnlinkedDecoratorStore(MastNodeId),
     #[error("node {node_id:?} has a decorator store linked to {linked_node_id:?}")]
     InvalidDecoratorStoreLink {
         node_id: MastNodeId,
@@ -1547,16 +1545,14 @@ pub enum MastForestError {
     Deserialization(DeserializationError),
 }
 
-// Custom serde implementations for MastForest that handle linked decorators properly
-// by delegating to the existing miden-crypto serialization which already handles
-// the conversion between linked and owned decorator formats.
+// Custom serde implementations for MastForest delegate to the existing miden-crypto
+// serialization, preserving the linked decorator representation.
 #[cfg(feature = "serde")]
 impl Serialize for MastForest {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        // Use the existing miden-crypto serialization which already handles linked decorators
         let bytes = Serializable::to_bytes(self);
         serializer.serialize_bytes(&bytes)
     }

--- a/core/src/mast/node/basic_block_node/arbitrary.rs
+++ b/core/src/mast/node/basic_block_node/arbitrary.rs
@@ -140,51 +140,6 @@ pub fn decorator_id_strategy(max_id: u32) -> impl Strategy<Value = DecoratorId> 
     (0..upper).prop_map(DecoratorId::new_unchecked)
 }
 
-// ---------- Decorator pairs strategy ----------
-
-/// Strategy for generating decorator pairs (usize, DecoratorId)
-pub fn decorator_pairs_strategy(
-    ops_len: usize,
-    max_id: u32,
-    max_pairs: usize,
-) -> impl Strategy<Value = Vec<(usize, DecoratorId)>> {
-    // indices in [0, ops_len); size 0..=max_pairs
-    // Generate, then sort by index to match validation expectations
-    prop::collection::vec((0..ops_len, decorator_id_strategy(max_id)), 0..=max_pairs).prop_map(
-        |mut v| {
-            v.sort_by_key(|(i, _)| *i);
-            v
-        },
-    )
-}
-
-// ---------- Arbitrary for BasicBlockNode ----------
-
-impl Arbitrary for BasicBlockNode {
-    type Parameters = BasicBlockNodeParams;
-    type Strategy = BoxedStrategy<Self>;
-
-    fn arbitrary_with(p: Self::Parameters) -> Self::Strategy {
-        // ensure at least 1 op to satisfy BasicBlockNode::new
-        (op_non_control_sequence_strategy(p.max_ops_len),)
-            .prop_flat_map(move |(ops,)| {
-                let ops_len = ops.len().max(1); // defensive; strategy should ensure ≥1
-                decorator_pairs_strategy(ops_len, p.max_decorator_id_u32, p.max_pairs)
-                    .prop_map(move |decorators| (ops.clone(), decorators))
-            })
-            .prop_filter_map("non-empty ops", |(ops, decorators)| {
-                if ops.is_empty() { None } else { Some((ops, decorators)) }
-            })
-            .prop_map(|(ops, decorators)| {
-                // BasicBlockNode::new_owned_with_decorators will adjust indices for padding and set
-                // be/ae empty.
-                BasicBlockNode::new_owned_with_decorators(ops, decorators)
-                    .expect("non-empty ops; new() only errs on empty ops")
-            })
-            .boxed()
-    }
-}
-
 // ---------- Optional: MastForest strategy (behind feature gate) ----------
 
 /// Parameters for generating MastForest instances
@@ -309,7 +264,7 @@ impl Arbitrary for MastForest {
     /// let forest = MastForest::arbitrary_with(params);
     /// ```
     fn arbitrary_with(params: Self::Parameters) -> Self::Strategy {
-        // BasicBlockNode generation must reference decorator IDs in [0, decorators)
+        // BasicBlockNodeBuilder generation must reference decorator IDs in [0, decorators)
         let bb_params = BasicBlockNodeParams {
             max_decorator_id_u32: params.decorators,
             ..Default::default()
@@ -317,8 +272,11 @@ impl Arbitrary for MastForest {
 
         // Generate nodes in a way that respects topological ordering
         (
-            // Generate basic blocks first (they have no dependencies)
-            prop::collection::vec(any_with::<BasicBlockNode>(bb_params), 1..=*params.blocks.end()),
+            // Generate basic block builders first (they have no dependencies)
+            prop::collection::vec(
+                any_with::<BasicBlockNodeBuilder>(bb_params),
+                1..=*params.blocks.end(),
+            ),
             // Generate decorators
             prop::collection::vec(
                 any::<Decorator>(),
@@ -468,8 +426,7 @@ impl Arbitrary for MastForest {
 
                     // 2) Add basic blocks and collect their IDs
                     let mut basic_block_ids = Vec::new();
-                    for block in basic_blocks {
-                        let builder = block.to_builder(&forest);
+                    for builder in basic_blocks {
                         let node_id =
                             builder.add_to_forest(&mut forest).expect("Failed to add block");
                         basic_block_ids.push(node_id);
@@ -681,13 +638,14 @@ impl Arbitrary for Program {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        // Create a simple strategy that generates a basic block and creates a program from it
-        any_with::<BasicBlockNode>(BasicBlockNodeParams {
+        // Create a simple strategy that generates a basic block builder and creates a program
+        // from it.
+        any_with::<BasicBlockNodeBuilder>(BasicBlockNodeParams {
             max_ops_len: 4, // Keep it small
             max_pairs: 1,   // Fewer decorators
             max_decorator_id_u32: 2,
         })
-        .prop_map(|node| {
+        .prop_map(|builder| {
             // Create a new MastForest
             let mut forest = MastForest::new();
 
@@ -697,8 +655,6 @@ impl Arbitrary for Program {
                 forest.add_decorator(decorator).expect("Failed to add decorator");
             }
 
-            // Add the node to the forest using builder
-            let builder = node.to_builder(&forest);
             let node_id = builder.add_to_forest(&mut forest).expect("Failed to add node");
 
             // Since we added a node, it should be available as a procedure root

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -5,8 +5,8 @@ use crate::{
     Felt, Word, ZERO,
     crypto::hash::Blake3_256,
     mast::{
-        DecoratedLinksIter, DecoratedOpLink, DecoratorId, DecoratorStore, ExecutableMastForest,
-        MastForest, MastForestError, MastNodeFingerprint, MastNodeId, digest,
+        DecoratedLinksIter, DecoratedOpLink, DecoratorId, ExecutableMastForest,
+        LinkedDecoratorStore, MastForest, MastForestError, MastNodeFingerprint, MastNodeId, digest,
     },
     operations::{DecoratorList, Operation},
     prettier::PrettyPrint,
@@ -80,11 +80,11 @@ pub struct BasicBlockNode {
     digest: Word,
     /// Stores both operation-level and node-level decorators
     /// Custom serialization is handled via Serialize/Deserialize impls
-    decorators: DecoratorStore,
+    decorators: LinkedDecoratorStore,
 }
 
 impl BasicBlockNode {
-    pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
+    pub(crate) fn linked_decorator_store_id(&self) -> MastNodeId {
         self.decorators.linked_id()
     }
 }
@@ -196,33 +196,24 @@ impl BasicBlockNode {
         &'a self,
         forest: &'a MastForest,
     ) -> DecoratorOpLinkIterator<'a> {
-        match &self.decorators {
-            DecoratorStore::Owned { decorators, .. } => {
-                DecoratorOpLinkIterator::from_slice(decorators)
-            },
-            DecoratorStore::Linked { id } => {
-                // This is used in MastForestMerger::merge_nodes, which strips the `MastForest` of
-                // some nodes before remapping decorators, so calling
-                // verify_node_in_forest will not work here.
+        let id = self.decorators.linked_id();
+        // This is used in MastForestMerger::merge_nodes, which strips the `MastForest` of
+        // some nodes before remapping decorators, so calling verify_node_in_forest will not work
+        // here.
+        let has_decorators = forest
+            .decorator_links_for_node(id)
+            .map(|links| links.into_iter().next().is_some())
+            .unwrap_or(false);
 
-                // For linked nodes, borrow from forest storage
-                // Check if the node has any decorators at all
-                let has_decorators = forest
-                    .decorator_links_for_node(*id)
-                    .map(|links| links.into_iter().next().is_some())
-                    .unwrap_or(false);
-
-                if !has_decorators {
-                    return DecoratorOpLinkIterator::from_slice(&[]);
-                }
-
-                let view = forest.decorator_links_for_node(*id).expect(
-                    "linked node decorators should be available; forest may be inconsistent",
-                );
-
-                DecoratorOpLinkIterator::from_linked(view.into_iter())
-            },
+        if !has_decorators {
+            return DecoratorOpLinkIterator::from_slice(&[]);
         }
+
+        let view = forest
+            .decorator_links_for_node(id)
+            .expect("linked node decorators should be available; forest may be inconsistent");
+
+        DecoratorOpLinkIterator::from_linked(view.into_iter())
     }
 
     /// Returns an iterator which allows us to iterate through the decorator list of
@@ -247,53 +238,40 @@ impl BasicBlockNode {
         &'a self,
         forest: &'a MastForest,
     ) -> RawDecoratorOpLinkIterator<'a> {
-        match &self.decorators {
-            DecoratorStore::Owned { decorators, before_enter, after_exit } => {
-                RawDecoratorOpLinkIterator::from_slice_iters(
-                    before_enter,
-                    decorators,
-                    after_exit,
-                    &self.op_batches,
-                )
-            },
-            DecoratorStore::Linked { id } => {
-                #[cfg(debug_assertions)]
-                self.verify_node_in_forest(forest);
-                // For linked nodes, borrow from forest storage
-                // Check if the node has any decorators at all
-                let has_decorators = forest
-                    .decorator_links_for_node(*id)
-                    .map(|links| links.into_iter().next().is_some())
-                    .unwrap_or(false);
+        let id = self.decorators.linked_id();
+        #[cfg(debug_assertions)]
+        self.verify_node_in_forest(forest);
 
-                if !has_decorators {
-                    // No operation-level decorators, but still need node-level decorators
-                    let before_enter = forest.before_enter_decorators(*id);
-                    let after_exit = forest.after_exit_decorators(*id);
-                    return RawDecoratorOpLinkIterator::from_slice_iters(
-                        before_enter,
-                        &[],
-                        after_exit,
-                        &self.op_batches,
-                    );
-                }
+        let has_decorators = forest
+            .decorator_links_for_node(id)
+            .map(|links| links.into_iter().next().is_some())
+            .unwrap_or(false);
 
-                let view = forest.decorator_links_for_node(*id).expect(
-                    "linked node decorators should be available; forest may be inconsistent",
-                );
-
-                // Get node-level decorators from NodeToDecoratorIds
-                let before_enter = forest.before_enter_decorators(*id);
-                let after_exit = forest.after_exit_decorators(*id);
-
-                RawDecoratorOpLinkIterator::from_linked(
-                    before_enter,
-                    view.into_iter(),
-                    after_exit,
-                    &self.op_batches,
-                )
-            },
+        if !has_decorators {
+            // No operation-level decorators, but still need node-level decorators.
+            let before_enter = forest.before_enter_decorators(id);
+            let after_exit = forest.after_exit_decorators(id);
+            return RawDecoratorOpLinkIterator::from_slice_iters(
+                before_enter,
+                &[],
+                after_exit,
+                &self.op_batches,
+            );
         }
+
+        let view = forest
+            .decorator_links_for_node(id)
+            .expect("linked node decorators should be available; forest may be inconsistent");
+
+        let before_enter = forest.before_enter_decorators(id);
+        let after_exit = forest.after_exit_decorators(id);
+
+        RawDecoratorOpLinkIterator::from_linked(
+            before_enter,
+            view.into_iter(),
+            after_exit,
+            &self.op_batches,
+        )
     }
 
     /// Returns only the raw op-indexed decorators (without before_enter/after_exit)
@@ -309,27 +287,19 @@ impl BasicBlockNode {
     ///
     /// Stores decorators with raw operation indices for serialization.
     pub fn raw_op_indexed_decorators(&self, forest: &MastForest) -> Vec<(usize, DecoratorId)> {
-        match &self.decorators {
-            DecoratorStore::Owned { decorators, .. } => {
-                RawDecoratorOpLinkIterator::from_slice_iters(&[], decorators, &[], &self.op_batches)
-                    .collect()
-            },
-            DecoratorStore::Linked { id } => {
-                // This can be used while rematerializing linked decorator stores, so avoid
-                // requiring a separate node-in-forest verification pass here.
-
-                let pad2raw = PaddedToRawPrefix::new(self.op_batches());
-                match forest.decorator_links_for_node(*id) {
-                    Ok(links) => links
-                        .into_iter()
-                        .map(|(padded_idx, dec_id)| {
-                            let raw_idx = padded_idx - pad2raw[padded_idx];
-                            (raw_idx, dec_id)
-                        })
-                        .collect(),
-                    Err(_) => Vec::new(), // Return empty if error
-                }
-            },
+        // This can be used while rematerializing linked decorator stores, so avoid requiring a
+        // separate node-in-forest verification pass here.
+        let id = self.decorators.linked_id();
+        let pad2raw = PaddedToRawPrefix::new(self.op_batches());
+        match forest.decorator_links_for_node(id) {
+            Ok(links) => links
+                .into_iter()
+                .map(|(padded_idx, dec_id)| {
+                    let raw_idx = padded_idx - pad2raw[padded_idx];
+                    (raw_idx, dec_id)
+                })
+                .collect(),
+            Err(_) => Vec::new(),
         }
     }
 
@@ -347,18 +317,13 @@ impl BasicBlockNode {
     /// Returns the total number of operations and decorators in this basic block.
     pub fn num_operations_and_decorators(&self, forest: &MastForest) -> u32 {
         let num_ops: usize = self.num_operations() as usize;
-        let num_decorators = match &self.decorators {
-            DecoratorStore::Owned { decorators, .. } => decorators.len(),
-            DecoratorStore::Linked { id } => {
-                #[cfg(debug_assertions)]
-                self.verify_node_in_forest(forest);
-                // For linked nodes, count from forest storage
-                forest
-                    .decorator_links_for_node(*id)
-                    .map(|links| links.into_iter().count())
-                    .unwrap_or(0)
-            },
-        };
+        #[cfg(debug_assertions)]
+        self.verify_node_in_forest(forest);
+
+        let num_decorators = forest
+            .decorator_links_for_node(self.decorators.linked_id())
+            .map(|links| links.into_iter().count())
+            .unwrap_or(0);
 
         (num_ops + num_decorators)
             .try_into()
@@ -384,8 +349,7 @@ impl BasicBlockNode {
     /// - After-exit decorators (by ID)
     /// - Operation-indexed decorators (by iterating and comparing their contents)
     ///
-    /// Unlike the derived PartialEq, this method works correctly with both owned and linked
-    /// decorator storage by accessing the actual decorator data from the forest when needed.
+    /// Unlike the derived PartialEq, this method compares the decorator data through the forest.
     #[cfg(test)]
     pub fn semantic_eq(&self, other: &BasicBlockNode, forest: &MastForest) -> bool {
         // Compare operations by collecting and comparing
@@ -416,8 +380,8 @@ impl BasicBlockNode {
         true
     }
 
-    /// Return the MastNodeId of this `BasicBlockNode`, if in `Linked` state
-    pub fn linked_id(&self) -> Option<MastNodeId> {
+    /// Return the MastNodeId that links this `BasicBlockNode` to its forest decorator storage.
+    pub fn linked_id(&self) -> MastNodeId {
         self.decorators.linked_id()
     }
 }
@@ -702,9 +666,7 @@ impl MastNodeExt for BasicBlockNode {
         F: ExecutableMastForest + ?Sized,
     {
         #[cfg(debug_assertions)]
-        if self.decorators.linked_id().is_some() {
-            self.verify_node_in_forest(forest);
-        }
+        self.verify_node_in_forest(forest);
 
         self.decorators.before_enter(forest)
     }
@@ -714,9 +676,7 @@ impl MastNodeExt for BasicBlockNode {
         F: ExecutableMastForest + ?Sized,
     {
         #[cfg(debug_assertions)]
-        if self.decorators.linked_id().is_some() {
-            self.verify_node_in_forest(forest);
-        }
+        self.verify_node_in_forest(forest);
 
         self.decorators.after_exit(forest)
     }
@@ -768,23 +728,21 @@ impl MastNodeExt for BasicBlockNode {
     where
         F: ExecutableMastForest + ?Sized,
     {
-        if let DecoratorStore::Linked { id } = &self.decorators {
-            // Verify that this node is the one stored at the given ID in the forest
-            let self_ptr = self as *const Self;
-            let forest_node =
-                forest.get_node_by_id(*id).expect("linked node id must be present in forest");
-            let forest_node_ptr = match forest_node {
-                crate::mast::MastNode::Block(block_node) => {
-                    block_node as *const BasicBlockNode as *const ()
-                },
-                _ => panic!("Node type mismatch at {id:?}"),
-            };
-            let self_as_void = self_ptr as *const ();
-            debug_assert_eq!(
-                self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {id:?} to be self"
-            );
-        }
+        let id = self.decorators.linked_id();
+        // Verify that this node is the one stored at the given ID in the forest
+        let self_ptr = self as *const Self;
+        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node_ptr = match forest_node {
+            crate::mast::MastNode::Block(block_node) => {
+                block_node as *const BasicBlockNode as *const ()
+            },
+            _ => panic!("Node type mismatch at {id:?}"),
+        };
+        let self_as_void = self_ptr as *const ();
+        debug_assert_eq!(
+            self_as_void, forest_node_ptr,
+            "Node pointer mismatch: expected node at {id:?} to be self"
+        );
     }
 }
 
@@ -1061,36 +1019,20 @@ impl<'a> OperationOrDecoratorIterator<'a> {
 
     #[inline]
     fn next_decorator_if_due(&mut self) -> Option<OperationOrDecorator<'a>> {
-        match &self.node.decorators {
-            DecoratorStore::Owned { decorators, .. } => {
-                // Simple case for owned decorators - use index lookup
-                if let Some((op_idx, deco)) = decorators.get(self.decorator_list_next_index)
-                    && *op_idx == self.op_index
-                {
-                    self.decorator_list_next_index += 1;
-                    Some(OperationOrDecorator::Decorator(*deco))
-                } else {
-                    None
-                }
-            },
-            DecoratorStore::Linked { id } => {
-                // For linked nodes, use forest access if available
-                if let Some(forest) = self.forest {
-                    // Get decorators for the current operation from the forest
-                    let decorator_ids = forest.decorator_indices_for_op(*id, self.op_index);
+        if let Some(forest) = self.forest {
+            let decorator_ids =
+                forest.decorator_indices_for_op(self.node.decorators.linked_id(), self.op_index);
 
-                    if self.decorator_list_next_index < decorator_ids.len() {
-                        let decorator_id = decorator_ids[self.decorator_list_next_index];
-                        self.decorator_list_next_index += 1;
-                        Some(OperationOrDecorator::Decorator(decorator_id))
-                    } else {
-                        None
-                    }
-                } else {
-                    // No forest access available, can't retrieve decorators
-                    None
-                }
-            },
+            if self.decorator_list_next_index < decorator_ids.len() {
+                let decorator_id = decorator_ids[self.decorator_list_next_index];
+                self.decorator_list_next_index += 1;
+                Some(OperationOrDecorator::Decorator(decorator_id))
+            } else {
+                None
+            }
+        } else {
+            // No forest access available, can't retrieve decorators
+            None
         }
     }
 }
@@ -1540,7 +1482,7 @@ impl BasicBlockNodeBuilder {
         let node = BasicBlockNode {
             op_batches: parts.op_batches,
             digest: parts.digest,
-            decorators: DecoratorStore::Linked { id: node_id },
+            decorators: LinkedDecoratorStore::linked(node_id),
         };
 
         Ok((node, parts.before_enter, parts.after_exit, parts.padded_decorators))
@@ -1604,7 +1546,7 @@ impl MastForestContributor for BasicBlockNodeBuilder {
             .push(crate::mast::MastNode::Block(BasicBlockNode {
                 op_batches,
                 digest,
-                decorators: DecoratorStore::Linked { id: future_node_id },
+                decorators: LinkedDecoratorStore::linked(future_node_id),
             }))
             .map_err(|_| MastForestError::TooManyNodes)?;
 

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -103,43 +103,6 @@ impl BasicBlockNode {
 // ------------------------------------------------------------------------------------------------
 /// Constructors
 impl BasicBlockNode {
-    /// Returns a new [`BasicBlockNode`] instantiated with the specified operations and decorators.
-    ///
-    /// Raw decorator indices are adjusted for padding, matching
-    /// [`BasicBlockNodeBuilder::build`].
-    ///
-    /// Returns an error if:
-    /// - `operations` vector is empty.
-    #[cfg(any(test, feature = "arbitrary"))]
-    pub(crate) fn new_owned_with_decorators(
-        operations: Vec<Operation>,
-        decorators: DecoratorList,
-    ) -> Result<Self, MastForestError> {
-        if operations.is_empty() {
-            return Err(MastForestError::EmptyBasicBlock);
-        }
-        validate_decorator_indices_within_ops(operations.len(), &decorators)?;
-
-        // Validate decorators list (only in debug mode).
-        #[cfg(debug_assertions)]
-        validate_decorators(operations.len(), &decorators);
-
-        let (op_batches, digest) = batch_and_hash_ops(&operations);
-        // the prior line may have inserted some padding Noops in the op_batches
-        // the decorator mapping should still point to the correct operation when that happens
-        let padded_decorators = BasicBlockNode::adjust_decorators(decorators, &op_batches);
-
-        Ok(Self {
-            op_batches,
-            digest,
-            decorators: DecoratorStore::Owned {
-                decorators: padded_decorators,
-                before_enter: Vec::new(),
-                after_exit: Vec::new(),
-            },
-        })
-    }
-
     // Takes a `DecoratorList` which operation indexes are defined against un-padded operations, and
     // adjusts those indexes to point into the padded `&[OpBatches]` passed as argument.
     //
@@ -1421,7 +1384,7 @@ fn batch_ops(ops: &[Operation]) -> Vec<OpBatch> {
 /// decorator indices match the format of the operations:
 /// - `Raw`: decorators have raw (unpadded) indices
 /// - `Batched`: decorators have padded indices
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum OperationData {
     /// Raw operations with raw decorator indices
     Raw {
@@ -1436,7 +1399,7 @@ enum OperationData {
 }
 
 /// Builder for creating [`BasicBlockNode`] instances with decorators.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BasicBlockNodeBuilder {
     operation_data: OperationData,
     before_enter: Vec<DecoratorId>,
@@ -1565,21 +1528,6 @@ impl BasicBlockNodeBuilder {
     pub fn into_op_batches_and_digest(self) -> Result<(Vec<OpBatch>, Word), MastForestError> {
         let parts = self.into_build_parts()?;
         Ok((parts.op_batches, parts.digest))
-    }
-
-    /// Builds the BasicBlockNode with the specified decorators.
-    pub fn build(self) -> Result<BasicBlockNode, MastForestError> {
-        let parts = self.into_build_parts()?;
-
-        Ok(BasicBlockNode {
-            op_batches: parts.op_batches,
-            digest: parts.digest,
-            decorators: DecoratorStore::Owned {
-                decorators: parts.padded_decorators,
-                before_enter: parts.before_enter,
-                after_exit: parts.after_exit,
-            },
-        })
     }
 
     pub(in crate::mast) fn build_linked_with_decorators(

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -84,11 +84,6 @@ pub struct BasicBlockNode {
 }
 
 impl BasicBlockNode {
-    pub(super) fn into_linked_decorator_store(mut self, node_id: MastNodeId) -> Self {
-        self.decorators = DecoratorStore::Linked { id: node_id };
-        self
-    }
-
     pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
         self.decorators.linked_id()
     }
@@ -743,30 +738,24 @@ impl MastNodeExt for BasicBlockNode {
     where
         F: ExecutableMastForest + ?Sized,
     {
-        match &self.decorators {
-            DecoratorStore::Owned { before_enter, .. } => before_enter,
-            DecoratorStore::Linked { id } => {
-                // For linked nodes, get the decorators from the forest's NodeToDecoratorIds
-                #[cfg(debug_assertions)]
-                self.verify_node_in_forest(forest);
-                forest.linked_before_enter_decorators(*id)
-            },
+        #[cfg(debug_assertions)]
+        if self.decorators.linked_id().is_some() {
+            self.verify_node_in_forest(forest);
         }
+
+        self.decorators.before_enter(forest)
     }
 
     fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
     where
         F: ExecutableMastForest + ?Sized,
     {
-        match &self.decorators {
-            DecoratorStore::Owned { after_exit, .. } => after_exit,
-            DecoratorStore::Linked { id } => {
-                // For linked nodes, get the decorators from the forest's NodeToDecoratorIds
-                #[cfg(debug_assertions)]
-                self.verify_node_in_forest(forest);
-                forest.linked_after_exit_decorators(*id)
-            },
+        #[cfg(debug_assertions)]
+        if self.decorators.linked_id().is_some() {
+            self.verify_node_in_forest(forest);
         }
+
+        self.decorators.after_exit(forest)
     }
 
     fn to_display<'a>(&'a self, mast_forest: &'a MastForest) -> Box<dyn fmt::Display + 'a> {
@@ -799,26 +788,7 @@ impl MastNodeExt for BasicBlockNode {
     type Builder = BasicBlockNodeBuilder;
 
     fn to_builder(self, forest: &MastForest) -> Self::Builder {
-        // Extract padded decorators and before_enter/after_exit based on storage type
-        let (padded_decorators, before_enter, after_exit) = match self.decorators {
-            DecoratorStore::Owned { decorators, before_enter, after_exit } => {
-                // Decorators are already padded in Owned storage
-                (decorators, before_enter, after_exit)
-            },
-            DecoratorStore::Linked { id } => {
-                // For linked nodes, get decorators from forest's centralized storage
-                // The decorators are already padded in the centralized storage
-                let padded_decorators: DecoratorList = forest
-                    .debug_info
-                    .decorator_links_for_node(id)
-                    .expect("node must exist in forest")
-                    .into_iter()
-                    .collect();
-                let before_enter = forest.before_enter_decorators(id).to_vec();
-                let after_exit = forest.after_exit_decorators(id).to_vec();
-                (padded_decorators, before_enter, after_exit)
-            },
-        };
+        let (padded_decorators, before_enter, after_exit) = self.decorators.into_parts(forest);
 
         // Preserve the stored batches and digest. Existing nodes may have a forced digest.
         BasicBlockNodeBuilder::from_op_batches_preserving_digest(
@@ -1474,6 +1444,14 @@ pub struct BasicBlockNodeBuilder {
     digest: Option<Word>,
 }
 
+struct BasicBlockBuildParts {
+    op_batches: Vec<OpBatch>,
+    digest: Word,
+    padded_decorators: DecoratorList,
+    before_enter: Vec<DecoratorId>,
+    after_exit: Vec<DecoratorId>,
+}
+
 impl BasicBlockNodeBuilder {
     /// Creates a new builder for a BasicBlockNode with the specified operations and decorators.
     ///
@@ -1539,8 +1517,7 @@ impl BasicBlockNodeBuilder {
         }
     }
 
-    /// Builds the BasicBlockNode with the specified decorators.
-    pub fn build(self) -> Result<BasicBlockNode, MastForestError> {
+    fn into_build_parts(self) -> Result<BasicBlockBuildParts, MastForestError> {
         let (op_batches, digest, padded_decorators) = match self.operation_data {
             OperationData::Raw { operations, decorators } => {
                 if operations.is_empty() {
@@ -1575,15 +1552,50 @@ impl BasicBlockNodeBuilder {
             },
         };
 
-        Ok(BasicBlockNode {
+        Ok(BasicBlockBuildParts {
             op_batches,
             digest,
+            padded_decorators,
+            before_enter: self.before_enter,
+            after_exit: self.after_exit,
+        })
+    }
+
+    /// Returns the padded operation batches and digest without materializing a node.
+    pub fn into_op_batches_and_digest(self) -> Result<(Vec<OpBatch>, Word), MastForestError> {
+        let parts = self.into_build_parts()?;
+        Ok((parts.op_batches, parts.digest))
+    }
+
+    /// Builds the BasicBlockNode with the specified decorators.
+    pub fn build(self) -> Result<BasicBlockNode, MastForestError> {
+        let parts = self.into_build_parts()?;
+
+        Ok(BasicBlockNode {
+            op_batches: parts.op_batches,
+            digest: parts.digest,
             decorators: DecoratorStore::Owned {
-                decorators: padded_decorators,
-                before_enter: self.before_enter.clone(),
-                after_exit: self.after_exit.clone(),
+                decorators: parts.padded_decorators,
+                before_enter: parts.before_enter,
+                after_exit: parts.after_exit,
             },
         })
+    }
+
+    pub(in crate::mast) fn build_linked_with_decorators(
+        self,
+        node_id: MastNodeId,
+    ) -> Result<(BasicBlockNode, Vec<DecoratorId>, Vec<DecoratorId>, DecoratorList), MastForestError>
+    {
+        let parts = self.into_build_parts()?;
+
+        let node = BasicBlockNode {
+            op_batches: parts.op_batches,
+            digest: parts.digest,
+            decorators: DecoratorStore::Linked { id: node_id },
+        };
+
+        Ok((node, parts.before_enter, parts.after_exit, parts.padded_decorators))
     }
 }
 

--- a/core/src/mast/node/basic_block_node/mod.rs
+++ b/core/src/mast/node/basic_block_node/mod.rs
@@ -731,7 +731,8 @@ impl MastNodeExt for BasicBlockNode {
         let id = self.decorators.linked_id();
         // Verify that this node is the one stored at the given ID in the forest
         let self_ptr = self as *const Self;
-        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node =
+            forest.get_node_by_id(id).expect("linked node id must be present in forest");
         let forest_node_ptr = match forest_node {
             crate::mast::MastNode::Block(block_node) => {
                 block_node as *const BasicBlockNode as *const ()

--- a/core/src/mast/node/basic_block_node/op_batch.rs
+++ b/core/src/mast/node/basic_block_node/op_batch.rs
@@ -624,7 +624,7 @@ mod op_batch_tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::mast::{BasicBlockNode, arbitrary::BasicBlockNodeParams};
+    use crate::mast::{BasicBlockNodeBuilder, arbitrary::op_non_control_sequence_strategy};
 
     #[test]
     fn test_op_idx_in_batch_to_group() {
@@ -760,18 +760,17 @@ mod op_batch_tests {
     proptest! {
         #[test]
         fn test_op_batch_iterator_arbitrary_large_block(
-            // Generate BasicBlockNodes with 73-200 operations to ensure multiple batches
-            basic_block in any_with::<BasicBlockNode>(BasicBlockNodeParams {
-                max_ops_len: 200,        // Generate blocks with up to 200 operations
-                max_pairs: 30,           // Allow more decorators
-                max_decorator_id_u32: 100,
-            })
+            // Generate operation sequences large enough to exercise multiple batches.
+            ops in op_non_control_sequence_strategy(200)
         ) {
-            // Verify that we actually have a multi-batch block
-            prop_assume!(basic_block.num_operations() > 72, "Need multiple batches for meaningful testing");
+            prop_assume!(ops.len() > 72, "Need multiple batches for meaningful testing");
+
+            let (op_batches, _) = BasicBlockNodeBuilder::new(ops, Vec::new())
+                .into_op_batches_and_digest()
+                .expect("non-empty generated operations should build");
 
             // Test all batches in the basic block
-            for batch in basic_block.op_batches() {
+            for batch in &op_batches {
                 // Verify iterator results match op_idx_in_batch_to_group for every operation
                 for (op_idx_in_batch, (group_idx, op_idx_in_group, _op)) in
                     batch.iter_with_groups().enumerate()

--- a/core/src/mast/node/basic_block_node/tests.rs
+++ b/core/src/mast/node/basic_block_node/tests.rs
@@ -6,7 +6,7 @@ use super::*;
 use crate::{
     Felt, ONE, Word,
     chiplets::hasher,
-    mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, MastNodeExt},
+    mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, MastNodeExt, MastNodeId},
     operations::Decorator,
     utils::IndexVec,
 };
@@ -358,7 +358,7 @@ fn basic_block_from_batch(batch: OpBatch) -> BasicBlockNode {
     BasicBlockNode {
         op_batches,
         digest,
-        decorators: DecoratorStore::default(),
+        decorators: DecoratorStore::Linked { id: MastNodeId::new_unchecked(0) },
     }
 }
 
@@ -366,11 +366,7 @@ fn basic_block_from_batches(op_batches: Vec<OpBatch>) -> BasicBlockNode {
     BasicBlockNode {
         op_batches,
         digest: Word::default(),
-        decorators: DecoratorStore::Owned {
-            decorators: DecoratorList::new(),
-            before_enter: Vec::new(),
-            after_exit: Vec::new(),
-        },
+        decorators: DecoratorStore::Linked { id: MastNodeId::new_unchecked(0) },
     }
 }
 

--- a/core/src/mast/node/basic_block_node/tests.rs
+++ b/core/src/mast/node/basic_block_node/tests.rs
@@ -349,10 +349,17 @@ fn build_group_chunks(batches: &[OpBatch]) -> impl Iterator<Item = &[Operation]>
 
 fn basic_block_from_batch(batch: OpBatch) -> BasicBlockNode {
     let digest = hasher::hash_elements(batch.groups());
-    BasicBlockNodeBuilder::from_op_batches(vec![batch], Vec::new(), digest)
-        .expect("digest must match batched operations")
-        .build()
-        .expect("basic block should build")
+    let (op_batches, digest) =
+        BasicBlockNodeBuilder::from_op_batches(vec![batch], Vec::new(), digest)
+            .expect("digest must match batched operations")
+            .into_op_batches_and_digest()
+            .expect("basic block should build");
+
+    BasicBlockNode {
+        op_batches,
+        digest,
+        decorators: DecoratorStore::default(),
+    }
 }
 
 fn basic_block_from_batches(op_batches: Vec<OpBatch>) -> BasicBlockNode {
@@ -1058,7 +1065,7 @@ fn test_basic_block_fingerprint_uses_forced_digest() {
     );
 }
 
-/// Test that BasicBlockNode -> to_builder -> build preserves structure and decorators
+/// Test that BasicBlockNode -> to_builder preserves structure and decorators.
 #[test]
 fn test_to_builder_identity() {
     let ops = vec![
@@ -1073,17 +1080,6 @@ fn test_to_builder_identity() {
     let deco2 = forest.add_decorator(Decorator::Trace(2)).unwrap();
     let decorators = vec![(0, deco1), (2, deco2)];
 
-    // Test Owned storage: node -> builder -> node
-    let owned = BasicBlockNodeBuilder::new(ops.clone(), decorators.clone())
-        .with_before_enter(vec![deco1])
-        .with_after_exit(vec![deco2])
-        .build()
-        .unwrap();
-    let owned_rt = owned.clone().to_builder(&forest).build().unwrap();
-    assert_eq!(owned.op_batches, owned_rt.op_batches);
-    assert_eq!(owned.digest, owned_rt.digest);
-
-    // Test Linked storage: node in forest -> builder -> node
     let node_id = BasicBlockNodeBuilder::new(ops, decorators)
         .with_before_enter(vec![deco1])
         .with_after_exit(vec![deco2])
@@ -1093,13 +1089,14 @@ fn test_to_builder_identity() {
         crate::mast::MastNode::Block(block) => block.clone(),
         _ => panic!("Expected BasicBlockNode"),
     };
-    let linked_rt = linked.clone().to_builder(&forest).build().unwrap();
-    assert_eq!(linked.op_batches, linked_rt.op_batches);
-    assert_eq!(linked.digest, linked_rt.digest);
+    let (roundtrip_batches, roundtrip_digest) =
+        linked.clone().to_builder(&forest).into_op_batches_and_digest().unwrap();
+    assert_eq!(linked.op_batches, roundtrip_batches);
+    assert_eq!(linked.digest, roundtrip_digest);
 }
 
 proptest! {
-    /// Proptest: verify to_builder identity for arbitrary BasicBlockNodes
+    /// Proptest: verify to_builder identity for arbitrary linked BasicBlockNodes.
     #[test]
     fn proptest_to_builder_identity(ops in op_non_control_sequence_strategy(20)) {
         let mut forest = MastForest::new();
@@ -1119,18 +1116,6 @@ proptest! {
             .map(|((idx, _), &dec_id)| (idx, dec_id))
             .collect();
 
-        // Test with Owned storage
-        let original = BasicBlockNodeBuilder::new(ops.clone(), decorators.clone())
-            .build()
-            .unwrap();
-
-        let builder = original.clone().to_builder(&forest);
-        let roundtrip = builder.build().unwrap();
-
-        prop_assert_eq!(original.op_batches, roundtrip.op_batches);
-        prop_assert_eq!(original.digest, roundtrip.digest);
-
-        // Test with Linked storage
         let node_id = BasicBlockNodeBuilder::new(ops, decorators)
             .add_to_forest(&mut forest)
             .unwrap();
@@ -1140,10 +1125,13 @@ proptest! {
             _ => panic!("Expected BasicBlockNode"),
         };
 
-        let builder2 = linked_node.clone().to_builder(&forest);
-        let roundtrip2 = builder2.build().unwrap();
+        let (roundtrip_batches, roundtrip_digest) = linked_node
+            .clone()
+            .to_builder(&forest)
+            .into_op_batches_and_digest()
+            .unwrap();
 
-        prop_assert_eq!(linked_node.op_batches, roundtrip2.op_batches);
-        prop_assert_eq!(linked_node.digest, roundtrip2.digest);
+        prop_assert_eq!(linked_node.op_batches, roundtrip_batches);
+        prop_assert_eq!(linked_node.digest, roundtrip_digest);
     }
 }

--- a/core/src/mast/node/basic_block_node/tests.rs
+++ b/core/src/mast/node/basic_block_node/tests.rs
@@ -618,13 +618,29 @@ fn decorator_strategy(
     nops: usize,
     max_decorators: usize,
 ) -> BoxedStrategy<Vec<(usize, DecoratorId)>> {
+    decorator_strategy_with_min_len(nops, max_decorators, 0)
+}
+
+fn non_empty_decorator_strategy(
+    nops: usize,
+    max_decorators: usize,
+) -> BoxedStrategy<Vec<(usize, DecoratorId)>> {
+    decorator_strategy_with_min_len(nops, max_decorators, 1)
+}
+
+fn decorator_strategy_with_min_len(
+    nops: usize,
+    max_decorators: usize,
+    min_decorators: usize,
+) -> BoxedStrategy<Vec<(usize, DecoratorId)>> {
     if nops == 0 {
         return Just(Vec::new()).boxed();
     }
 
+    let min_decorators = min_decorators.min(max_decorators);
     prop::collection::vec(
         (0..nops, any::<u32>().prop_map(DecoratorId::new_unchecked)),
-        0..=max_decorators,
+        min_decorators..=max_decorators,
     )
     .prop_map(move |mut decorators| {
         // Sort decorators by index to satisfy the BasicBlockNode requirement
@@ -643,23 +659,41 @@ fn decorator_list_strategy(
         .prop_flat_map(|ops| (Just(ops.clone()), decorator_strategy(ops.len(), ops.len())))
 }
 
+fn non_empty_decorator_list_strategy(
+    ops_num: usize,
+) -> impl Strategy<Value = (Vec<Operation>, Vec<(usize, DecoratorId)>)> {
+    op_non_control_sequence_strategy(ops_num).prop_flat_map(|ops| {
+        (Just(ops.clone()), non_empty_decorator_strategy(ops.len(), ops.len()))
+    })
+}
+
+fn add_decorators_to_forest(
+    forest: &mut MastForest,
+    decorators: &[(usize, DecoratorId)],
+) -> Vec<(usize, DecoratorId)> {
+    decorators
+        .iter()
+        .map(|(idx, decorator_id)| {
+            let value = u32::from(*decorator_id);
+            let decorator_id = forest.add_decorator(Decorator::Trace(value)).unwrap();
+            (*idx, decorator_id)
+        })
+        .collect()
+}
+
 proptest! {
     /// Test that the raw_decorator_iter() method correctly preserves the original decorator list.
     /// Given random operations and decorators with indices in the valid range,
     /// creating a BasicBlock and then collecting its raw decorators should yield the original list.
     #[test]
     fn test_raw_decorator_iter_preserves_decorators(
-        (ops, decs) in decorator_list_strategy(20)
+        (ops, decs) in non_empty_decorator_list_strategy(20)
     ) {
         // Create a basic block with the generated operations and decorators using linked storage
         let mut dummy_forest = MastForest::new();
 
-        // Convert decorators to use forest's decorator IDs
-        let forest_decorators: Vec<(usize, DecoratorId)> = decs
-            .iter()
-            .map(|(idx, decorator_id)| (*idx, *decorator_id))
-            .collect();
-
+        let forest_decorators = add_decorators_to_forest(&mut dummy_forest, &decs);
+        let expected_decorators = forest_decorators.clone();
         let node_id = BasicBlockNodeBuilder::new(ops, forest_decorators)
             .add_to_forest(&mut dummy_forest)
             .unwrap();
@@ -669,7 +703,7 @@ proptest! {
         let collected_decorators: Vec<(usize, DecoratorId)> = block.raw_decorator_iter(&dummy_forest).collect();
 
         // The collected decorators should match the original decorators
-        prop_assert_eq!(collected_decorators, decs);
+        prop_assert_eq!(collected_decorators, expected_decorators);
     }
 }
 
@@ -867,11 +901,7 @@ proptest! {
 
         // Build BasicBlockNode using linked storage (this applies padding)
         let mut forest = MastForest::new();
-        // Convert decorators to use forest's decorator IDs
-        let forest_decorators: Vec<(usize, DecoratorId)> = decorators
-            .iter()
-            .map(|(idx, decorator_id)| (*idx, *decorator_id))
-            .collect();
+        let forest_decorators = add_decorators_to_forest(&mut forest, &decorators);
         let node_id = BasicBlockNodeBuilder::new(ops.clone(), forest_decorators)
             .add_to_forest(&mut forest)
             .unwrap();
@@ -930,16 +960,13 @@ proptest! {
     #[test]
     fn proptest_decorator_iterator_invertibility(
         (ops, decorators) in
-        decorator_list_strategy(72)
+        non_empty_decorator_list_strategy(72)
     ) {
         // Build BasicBlockNode using linked storage
         let mut forest = MastForest::new();
-        // Convert decorators to use forest's decorator IDs
-        let forest_decorators: Vec<(usize, DecoratorId)> = decorators
-            .iter()
-            .map(|(idx, decorator_id)| (*idx, *decorator_id))
-            .collect();
-        let node_id = BasicBlockNodeBuilder::new(ops.clone(), forest_decorators)
+        let forest_decorators = add_decorators_to_forest(&mut forest, &decorators);
+        let expected_decorators = forest_decorators.clone();
+        let node_id = BasicBlockNodeBuilder::new(ops, forest_decorators)
             .add_to_forest(&mut forest)
             .unwrap();
         let block = forest.get_node_by_id(node_id).unwrap().unwrap_basic_block();
@@ -950,14 +977,7 @@ proptest! {
         // Collect all decorators from the iterator
         let collected_decorators: Vec<_> = raw_iter.collect();
 
-        // Verify decorators maintain order with corrected indices
-        for (collected_idx, &(_expected_raw_idx, expected_id)) in decorators.iter().enumerate() {
-            if collected_idx < collected_decorators.len() {
-                let (actual_raw_idx, actual_id) = collected_decorators[collected_idx];
-                prop_assert_eq!(actual_id, expected_id);
-                prop_assert!(actual_raw_idx <= ops.len()); // Should be a valid raw index
-            }
-        }
+        prop_assert_eq!(collected_decorators, expected_decorators);
     }
 }
 

--- a/core/src/mast/node/basic_block_node/tests.rs
+++ b/core/src/mast/node/basic_block_node/tests.rs
@@ -358,7 +358,7 @@ fn basic_block_from_batch(batch: OpBatch) -> BasicBlockNode {
     BasicBlockNode {
         op_batches,
         digest,
-        decorators: DecoratorStore::Linked { id: MastNodeId::new_unchecked(0) },
+        decorators: LinkedDecoratorStore::linked(MastNodeId::new_unchecked(0)),
     }
 }
 
@@ -366,7 +366,7 @@ fn basic_block_from_batches(op_batches: Vec<OpBatch>) -> BasicBlockNode {
     BasicBlockNode {
         op_batches,
         digest: Word::default(),
-        decorators: DecoratorStore::Linked { id: MastNodeId::new_unchecked(0) },
+        decorators: LinkedDecoratorStore::linked(MastNodeId::new_unchecked(0)),
     }
 }
 

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -35,7 +35,6 @@ use crate::{
 /// - A syscall: the callee is executed in the root context.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "arbitrary", test), miden_test_serde_macros::serde_test)]
 pub struct CallNode {
     callee: MastNodeId,
     is_syscall: bool,
@@ -293,38 +292,6 @@ impl MastNodeExt for CallNode {
     }
 }
 
-// ARBITRARY IMPLEMENTATION
-// ================================================================================================
-
-#[cfg(all(feature = "arbitrary", test))]
-impl proptest::prelude::Arbitrary for CallNode {
-    type Parameters = ();
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        use proptest::prelude::*;
-
-        use crate::Felt;
-
-        // Generate callee, digest, and whether it's a syscall
-        (any::<MastNodeId>(), any::<[u64; 4]>(), any::<bool>())
-            .prop_map(|(callee, digest_array, is_syscall)| {
-                // Generate a random digest
-                let digest = Word::from(digest_array.map(Felt::new_unchecked));
-                // Construct directly to avoid MastForest validation for arbitrary data
-                CallNode {
-                    callee,
-                    is_syscall,
-                    digest,
-                    decorator_store: DecoratorStore::default(),
-                }
-            })
-            .no_shrink()  // Pure random values, no meaningful shrinking pattern
-            .boxed()
-    }
-
-    type Strategy = proptest::prelude::BoxedStrategy<Self>;
-}
-
 // ------------------------------------------------------------------------------------------------
 /// Builder for creating [`CallNode`] instances with decorators.
 #[derive(Debug)]
@@ -357,44 +324,6 @@ impl CallNodeBuilder {
             after_exit: Vec::new(),
             digest: None,
         }
-    }
-
-    /// Builds the CallNode with the specified decorators.
-    pub fn build(self, mast_forest: &MastForest) -> Result<CallNode, MastForestError> {
-        NodeBuilderLifecycle::validate_children(mast_forest, &[self.callee])?;
-
-        let lifecycle =
-            NodeBuilderLifecycle::new(&self.before_enter, &self.after_exit, self.digest);
-        let digest = lifecycle.digest_or_compute(|| {
-            let callee_digest = mast_forest[self.callee].digest();
-
-            digest::call_digest(callee_digest, self.is_syscall)
-        });
-
-        Ok(CallNode {
-            callee: self.callee,
-            is_syscall: self.is_syscall,
-            digest,
-            decorator_store: DecoratorStore::new_owned_with_decorators(
-                self.before_enter,
-                self.after_exit,
-            ),
-        })
-    }
-
-    pub(in crate::mast) fn build_with_forced_digest(self) -> Result<CallNode, MastForestError> {
-        let digest = NodeBuilderLifecycle::new(&self.before_enter, &self.after_exit, self.digest)
-            .forced_digest()?;
-
-        Ok(CallNode {
-            callee: self.callee,
-            is_syscall: self.is_syscall,
-            digest,
-            decorator_store: DecoratorStore::new_owned_with_decorators(
-                self.before_enter,
-                self.after_exit,
-            ),
-        })
     }
 
     pub(in crate::mast) fn build_linked_with_decorators(

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -277,7 +277,8 @@ impl MastNodeExt for CallNode {
         let id = self.decorator_store.linked_id();
         // Verify that this node is the one stored at the given ID in the forest
         let self_ptr = self as *const Self;
-        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node =
+            forest.get_node_by_id(id).expect("linked node id must be present in forest");
         let forest_node_ptr = match forest_node {
             MastNode::Call(call_node) => call_node as *const CallNode as *const (),
             _ => panic!("Node type mismatch at {id:?}"),

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -44,11 +44,6 @@ pub struct CallNode {
 }
 
 impl CallNode {
-    pub(super) fn into_linked_decorator_store(mut self, node_id: MastNodeId) -> Self {
-        self.decorator_store = DecoratorStore::Linked { id: node_id };
-        self
-    }
-
     pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
         self.decorator_store.linked_id()
     }
@@ -262,36 +257,17 @@ impl MastNodeExt for CallNode {
     type Builder = CallNodeBuilder;
 
     fn to_builder(self, forest: &MastForest) -> Self::Builder {
-        // Extract decorators from decorator_store if in Owned state
-        match self.decorator_store {
-            DecoratorStore::Owned { before_enter, after_exit, .. } => {
-                let mut builder = if self.is_syscall {
-                    CallNodeBuilder::new_syscall(self.callee)
-                } else {
-                    CallNodeBuilder::new(self.callee)
-                };
-                builder = builder
-                    .with_before_enter(before_enter)
-                    .with_after_exit(after_exit)
-                    .with_digest(self.digest);
-                builder
-            },
-            DecoratorStore::Linked { id } => {
-                // Extract decorators from forest storage when in Linked state
-                let before_enter = forest.before_enter_decorators(id).to_vec();
-                let after_exit = forest.after_exit_decorators(id).to_vec();
-                let mut builder = if self.is_syscall {
-                    CallNodeBuilder::new_syscall(self.callee)
-                } else {
-                    CallNodeBuilder::new(self.callee)
-                };
-                builder = builder
-                    .with_before_enter(before_enter)
-                    .with_after_exit(after_exit)
-                    .with_digest(self.digest);
-                builder
-            },
-        }
+        let (before_enter, after_exit) = self.decorator_store.into_node_level_decorators(forest);
+        let builder = if self.is_syscall {
+            CallNodeBuilder::new_syscall(self.callee)
+        } else {
+            CallNodeBuilder::new(self.callee)
+        };
+
+        builder
+            .with_before_enter(before_enter)
+            .with_after_exit(after_exit)
+            .with_digest(self.digest)
     }
 
     #[cfg(debug_assertions)]
@@ -419,6 +395,32 @@ impl CallNodeBuilder {
                 self.after_exit,
             ),
         })
+    }
+
+    pub(in crate::mast) fn build_linked_with_decorators(
+        self,
+        node_id: MastNodeId,
+    ) -> Result<(CallNode, Vec<DecoratorId>, Vec<DecoratorId>), MastForestError> {
+        let Self {
+            callee,
+            is_syscall,
+            before_enter,
+            after_exit,
+            digest,
+        } = self;
+        let digest =
+            NodeBuilderLifecycle::new(&before_enter, &after_exit, digest).forced_digest()?;
+
+        Ok((
+            CallNode {
+                callee,
+                is_syscall,
+                digest,
+                decorator_store: DecoratorStore::Linked { id: node_id },
+            },
+            before_enter,
+            after_exit,
+        ))
     }
 }
 

--- a/core/src/mast/node/call_node.rs
+++ b/core/src/mast/node/call_node.rs
@@ -17,7 +17,7 @@ use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     mast::{
-        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        DecoratorId, ExecutableMastForest, LinkedDecoratorStore, MastForest, MastForestError,
         MastNodeFingerprint, MastNodeId, digest,
     },
     operations::opcodes,
@@ -39,11 +39,11 @@ pub struct CallNode {
     callee: MastNodeId,
     is_syscall: bool,
     digest: Word,
-    decorator_store: DecoratorStore,
+    decorator_store: LinkedDecoratorStore,
 }
 
 impl CallNode {
-    pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
+    pub(crate) fn linked_decorator_store_id(&self) -> MastNodeId {
         self.decorator_store.linked_id()
     }
 }
@@ -274,21 +274,19 @@ impl MastNodeExt for CallNode {
     where
         F: ExecutableMastForest + ?Sized,
     {
-        if let Some(id) = self.decorator_store.linked_id() {
-            // Verify that this node is the one stored at the given ID in the forest
-            let self_ptr = self as *const Self;
-            let forest_node =
-                forest.get_node_by_id(id).expect("linked node id must be present in forest");
-            let forest_node_ptr = match forest_node {
-                MastNode::Call(call_node) => call_node as *const CallNode as *const (),
-                _ => panic!("Node type mismatch at {id:?}"),
-            };
-            let self_as_void = self_ptr as *const ();
-            debug_assert_eq!(
-                self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {id:?} to be self"
-            );
-        }
+        let id = self.decorator_store.linked_id();
+        // Verify that this node is the one stored at the given ID in the forest
+        let self_ptr = self as *const Self;
+        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node_ptr = match forest_node {
+            MastNode::Call(call_node) => call_node as *const CallNode as *const (),
+            _ => panic!("Node type mismatch at {id:?}"),
+        };
+        let self_as_void = self_ptr as *const ();
+        debug_assert_eq!(
+            self_as_void, forest_node_ptr,
+            "Node pointer mismatch: expected node at {id:?} to be self"
+        );
     }
 }
 
@@ -345,7 +343,7 @@ impl CallNodeBuilder {
                 callee,
                 is_syscall,
                 digest,
-                decorator_store: DecoratorStore::Linked { id: node_id },
+                decorator_store: LinkedDecoratorStore::linked(node_id),
             },
             before_enter,
             after_exit,
@@ -371,7 +369,7 @@ impl MastForestContributor for CallNodeBuilder {
                 callee: self.callee,
                 is_syscall: self.is_syscall,
                 digest,
-                decorator_store: DecoratorStore::Linked { id: future_node_id },
+                decorator_store: LinkedDecoratorStore::linked(future_node_id),
             }
             .into()
         })

--- a/core/src/mast/node/decorator_store.rs
+++ b/core/src/mast/node/decorator_store.rs
@@ -8,106 +8,62 @@ use crate::{
     operations::DecoratorList,
 };
 
-/// A data structure for storing decorators for MAST nodes, including both
-/// operation-level decorators and node-level decorators (before_enter/after_exit).
+/// A link from a MAST node to its forest-owned operation-level and node-level decorators.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum DecoratorStore {
-    /// The decorators are owned by this node. This is the case for nodes
-    /// which have not yet been inserted into a MAST forest.
-    Owned {
-        /// Operation-level decorators indexed by operation position
-        /// (Note: Only used by BasicBlockNode, other nodes will have empty decorators)
-        decorators: DecoratorList,
-        /// Node-level decorators executed before entering the node
-        before_enter: Vec<DecoratorId>,
-        /// Node-level decorators executed after exiting the node
-        after_exit: Vec<DecoratorId>,
-    },
+pub struct LinkedDecoratorStore {
     /// The decorators are stored in a MAST forest and can be accessed via
     /// this node's ID. All decorator reads borrow from the forest's storage.
-    Linked { id: MastNodeId },
+    id: MastNodeId,
 }
 
-impl Default for DecoratorStore {
-    fn default() -> Self {
-        Self::Owned {
-            decorators: DecoratorList::new(),
-            before_enter: Vec::new(),
-            after_exit: Vec::new(),
-        }
+impl LinkedDecoratorStore {
+    pub(crate) const fn linked(id: MastNodeId) -> Self {
+        Self { id }
     }
-}
 
-impl DecoratorStore {
-    /// Get the before_enter decorators, borrowing from the forest if linked
+    /// Get the before_enter decorators, borrowing from the forest.
     pub fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
     where
         F: ExecutableMastForest + ?Sized,
     {
-        match self {
-            DecoratorStore::Owned { before_enter, .. } => before_enter,
-            DecoratorStore::Linked { id } => forest.linked_before_enter_decorators(*id),
-        }
+        forest.linked_before_enter_decorators(self.id)
     }
 
-    /// Get the after_exit decorators, borrowing from the forest if linked
+    /// Get the after_exit decorators, borrowing from the forest.
     pub fn after_exit<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
     where
         F: ExecutableMastForest + ?Sized,
     {
-        match self {
-            DecoratorStore::Owned { after_exit, .. } => after_exit,
-            DecoratorStore::Linked { id } => forest.linked_after_exit_decorators(*id),
-        }
+        forest.linked_after_exit_decorators(self.id)
     }
 
     pub(crate) fn into_node_level_decorators(
         self,
         forest: &MastForest,
     ) -> (Vec<DecoratorId>, Vec<DecoratorId>) {
-        match self {
-            DecoratorStore::Owned { before_enter, after_exit, .. } => (before_enter, after_exit),
-            DecoratorStore::Linked { id } => (
-                forest.before_enter_decorators(id).to_vec(),
-                forest.after_exit_decorators(id).to_vec(),
-            ),
-        }
+        (
+            forest.before_enter_decorators(self.id).to_vec(),
+            forest.after_exit_decorators(self.id).to_vec(),
+        )
     }
 
     pub(crate) fn into_parts(
         self,
         forest: &MastForest,
     ) -> (DecoratorList, Vec<DecoratorId>, Vec<DecoratorId>) {
-        match self {
-            DecoratorStore::Owned { decorators, before_enter, after_exit } => {
-                (decorators, before_enter, after_exit)
-            },
-            DecoratorStore::Linked { id } => {
-                let decorators = forest
-                    .decorator_links_for_node(id)
-                    .expect(
-                        "linked node decorators should be available; forest may be inconsistent",
-                    )
-                    .into_iter()
-                    .collect();
-                let before_enter = forest.before_enter_decorators(id).to_vec();
-                let after_exit = forest.after_exit_decorators(id).to_vec();
-                (decorators, before_enter, after_exit)
-            },
-        }
+        let decorators = forest
+            .decorator_links_for_node(self.id)
+            .expect("linked node decorators should be available; forest may be inconsistent")
+            .into_iter()
+            .collect();
+        let before_enter = forest.before_enter_decorators(self.id).to_vec();
+        let after_exit = forest.after_exit_decorators(self.id).to_vec();
+        (decorators, before_enter, after_exit)
     }
 
-    /// Check if this store is in the Linked state
-    pub fn is_linked(&self) -> bool {
-        matches!(self, DecoratorStore::Linked { .. })
-    }
-
-    /// Get the node ID if this store is in the Linked state
-    pub fn linked_id(&self) -> Option<MastNodeId> {
-        match self {
-            DecoratorStore::Linked { id } => Some(*id),
-            DecoratorStore::Owned { .. } => None,
-        }
+    /// Get the node ID that links this store to its MAST forest.
+    pub fn linked_id(&self) -> MastNodeId {
+        self.id
     }
 }

--- a/core/src/mast/node/decorator_store.rs
+++ b/core/src/mast/node/decorator_store.rs
@@ -40,18 +40,6 @@ impl Default for DecoratorStore {
 }
 
 impl DecoratorStore {
-    /// Create a new Owned decorator store with the specified before/after decorators
-    pub fn new_owned_with_decorators(
-        before_enter: Vec<DecoratorId>,
-        after_exit: Vec<DecoratorId>,
-    ) -> Self {
-        Self::Owned {
-            decorators: DecoratorList::new(),
-            before_enter,
-            after_exit,
-        }
-    }
-
     /// Get the before_enter decorators, borrowing from the forest if linked
     pub fn before_enter<'a, F>(&'a self, forest: &'a F) -> &'a [DecoratorId]
     where

--- a/core/src/mast/node/decorator_store.rs
+++ b/core/src/mast/node/decorator_store.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    mast::{DecoratorId, ExecutableMastForest, MastNodeId},
+    mast::{DecoratorId, ExecutableMastForest, MastForest, MastNodeId},
     operations::DecoratorList,
 };
 
@@ -71,6 +71,42 @@ impl DecoratorStore {
         match self {
             DecoratorStore::Owned { after_exit, .. } => after_exit,
             DecoratorStore::Linked { id } => forest.linked_after_exit_decorators(*id),
+        }
+    }
+
+    pub(crate) fn into_node_level_decorators(
+        self,
+        forest: &MastForest,
+    ) -> (Vec<DecoratorId>, Vec<DecoratorId>) {
+        match self {
+            DecoratorStore::Owned { before_enter, after_exit, .. } => (before_enter, after_exit),
+            DecoratorStore::Linked { id } => (
+                forest.before_enter_decorators(id).to_vec(),
+                forest.after_exit_decorators(id).to_vec(),
+            ),
+        }
+    }
+
+    pub(crate) fn into_parts(
+        self,
+        forest: &MastForest,
+    ) -> (DecoratorList, Vec<DecoratorId>, Vec<DecoratorId>) {
+        match self {
+            DecoratorStore::Owned { decorators, before_enter, after_exit } => {
+                (decorators, before_enter, after_exit)
+            },
+            DecoratorStore::Linked { id } => {
+                let decorators = forest
+                    .decorator_links_for_node(id)
+                    .expect(
+                        "linked node decorators should be available; forest may be inconsistent",
+                    )
+                    .into_iter()
+                    .collect();
+                let before_enter = forest.before_enter_decorators(id).to_vec();
+                let after_exit = forest.after_exit_decorators(id).to_vec();
+                (decorators, before_enter, after_exit)
+            },
         }
     }
 

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -10,7 +10,7 @@ use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     mast::{
-        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        DecoratorId, ExecutableMastForest, LinkedDecoratorStore, MastForest, MastForestError,
         MastNodeFingerprint, MastNodeId, digest,
     },
     operations::opcodes,
@@ -27,11 +27,11 @@ use crate::{
 pub struct DynNode {
     is_dyncall: bool,
     digest: Word,
-    decorator_store: DecoratorStore,
+    decorator_store: LinkedDecoratorStore,
 }
 
 impl DynNode {
-    pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
+    pub(crate) fn linked_decorator_store_id(&self) -> MastNodeId {
         self.decorator_store.linked_id()
     }
 }
@@ -250,21 +250,19 @@ impl MastNodeExt for DynNode {
     where
         F: ExecutableMastForest + ?Sized,
     {
-        if let Some(id) = self.decorator_store.linked_id() {
-            // Verify that this node is the one stored at the given ID in the forest
-            let self_ptr = self as *const Self;
-            let forest_node =
-                forest.get_node_by_id(id).expect("linked node id must be present in forest");
-            let forest_node_ptr = match forest_node {
-                MastNode::Dyn(dyn_node) => dyn_node as *const DynNode as *const (),
-                _ => panic!("Node type mismatch at {id:?}"),
-            };
-            let self_as_void = self_ptr as *const ();
-            debug_assert_eq!(
-                self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {id:?} to be self"
-            );
-        }
+        let id = self.decorator_store.linked_id();
+        // Verify that this node is the one stored at the given ID in the forest
+        let self_ptr = self as *const Self;
+        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node_ptr = match forest_node {
+            MastNode::Dyn(dyn_node) => dyn_node as *const DynNode as *const (),
+            _ => panic!("Node type mismatch at {id:?}"),
+        };
+        let self_as_void = self_ptr as *const ();
+        debug_assert_eq!(
+            self_as_void, forest_node_ptr,
+            "Node pointer mismatch: expected node at {id:?} to be self"
+        );
     }
 }
 
@@ -319,7 +317,7 @@ impl DynNodeBuilder {
             DynNode {
                 is_dyncall,
                 digest,
-                decorator_store: DecoratorStore::Linked { id: node_id },
+                decorator_store: LinkedDecoratorStore::linked(node_id),
             },
             before_enter,
             after_exit,
@@ -351,7 +349,7 @@ impl MastForestContributor for DynNodeBuilder {
                 DynNode {
                     is_dyncall: self.is_dyncall,
                     digest,
-                    decorator_store: DecoratorStore::Linked { id: future_node_id },
+                    decorator_store: LinkedDecoratorStore::linked(future_node_id),
                 }
                 .into(),
             )

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -32,11 +32,6 @@ pub struct DynNode {
 }
 
 impl DynNode {
-    pub(super) fn into_linked_decorator_store(mut self, node_id: MastNodeId) -> Self {
-        self.decorator_store = DecoratorStore::Linked { id: node_id };
-        self
-    }
-
     pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
         self.decorator_store.linked_id()
     }
@@ -238,36 +233,17 @@ impl MastNodeExt for DynNode {
     type Builder = DynNodeBuilder;
 
     fn to_builder(self, forest: &MastForest) -> Self::Builder {
-        // Extract decorators from decorator_store if in Owned state
-        match self.decorator_store {
-            DecoratorStore::Owned { before_enter, after_exit, .. } => {
-                let mut builder = if self.is_dyncall {
-                    DynNodeBuilder::new_dyncall()
-                } else {
-                    DynNodeBuilder::new_dyn()
-                };
-                builder = builder
-                    .with_before_enter(before_enter)
-                    .with_after_exit(after_exit)
-                    .with_digest(self.digest);
-                builder
-            },
-            DecoratorStore::Linked { id } => {
-                // Extract decorators from forest storage when in Linked state
-                let before_enter = forest.before_enter_decorators(id).to_vec();
-                let after_exit = forest.after_exit_decorators(id).to_vec();
-                let mut builder = if self.is_dyncall {
-                    DynNodeBuilder::new_dyncall()
-                } else {
-                    DynNodeBuilder::new_dyn()
-                };
-                builder = builder
-                    .with_before_enter(before_enter)
-                    .with_after_exit(after_exit)
-                    .with_digest(self.digest);
-                builder
-            },
-        }
+        let (before_enter, after_exit) = self.decorator_store.into_node_level_decorators(forest);
+        let builder = if self.is_dyncall {
+            DynNodeBuilder::new_dyncall()
+        } else {
+            DynNodeBuilder::new_dyn()
+        };
+
+        builder
+            .with_before_enter(before_enter)
+            .with_after_exit(after_exit)
+            .with_digest(self.digest)
     }
 
     #[cfg(debug_assertions)]
@@ -367,6 +343,33 @@ impl DynNodeBuilder {
                 self.after_exit,
             ),
         }
+    }
+
+    pub(in crate::mast) fn build_linked_with_decorators(
+        self,
+        node_id: MastNodeId,
+    ) -> (DynNode, Vec<DecoratorId>, Vec<DecoratorId>) {
+        let Self {
+            is_dyncall,
+            before_enter,
+            after_exit,
+            digest,
+        } = self;
+        let digest = if let Some(forced_digest) = digest {
+            forced_digest
+        } else {
+            digest::dyn_digest(is_dyncall)
+        };
+
+        (
+            DynNode {
+                is_dyncall,
+                digest,
+                decorator_store: DecoratorStore::Linked { id: node_id },
+            },
+            before_enter,
+            after_exit,
+        )
     }
 }
 

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -24,7 +24,6 @@ use crate::{
 /// A Dyn node specifies that the node to be executed next is defined dynamically via the stack.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "arbitrary", test), miden_test_serde_macros::serde_test)]
 pub struct DynNode {
     is_dyncall: bool,
     digest: Word,
@@ -269,32 +268,6 @@ impl MastNodeExt for DynNode {
     }
 }
 
-// ARBITRARY IMPLEMENTATION
-// ================================================================================================
-
-#[cfg(all(feature = "arbitrary", test))]
-impl proptest::prelude::Arbitrary for DynNode {
-    type Parameters = ();
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        use proptest::prelude::*;
-
-        // Generate whether it's a dyncall or dynexec
-        any::<bool>()
-            .prop_map(|is_dyncall| {
-                if is_dyncall {
-                    DynNodeBuilder::new_dyncall().build()
-                } else {
-                    DynNodeBuilder::new_dyn().build()
-                }
-            })
-            .no_shrink()  // Pure random values, no meaningful shrinking pattern
-            .boxed()
-    }
-
-    type Strategy = proptest::prelude::BoxedStrategy<Self>;
-}
-
 // ------------------------------------------------------------------------------------------------
 /// Builder for creating [`DynNode`] instances with decorators.
 #[derive(Debug)]
@@ -323,25 +296,6 @@ impl DynNodeBuilder {
             before_enter: Vec::new(),
             after_exit: Vec::new(),
             digest: None,
-        }
-    }
-
-    /// Builds the DynNode with the specified decorators.
-    pub fn build(self) -> DynNode {
-        // Use the forced digest if provided, otherwise use the default digest
-        let digest = if let Some(forced_digest) = self.digest {
-            forced_digest
-        } else {
-            digest::dyn_digest(self.is_dyncall)
-        };
-
-        DynNode {
-            is_dyncall: self.is_dyncall,
-            digest,
-            decorator_store: DecoratorStore::new_owned_with_decorators(
-                self.before_enter,
-                self.after_exit,
-            ),
         }
     }
 

--- a/core/src/mast/node/dyn_node.rs
+++ b/core/src/mast/node/dyn_node.rs
@@ -253,7 +253,8 @@ impl MastNodeExt for DynNode {
         let id = self.decorator_store.linked_id();
         // Verify that this node is the one stored at the given ID in the forest
         let self_ptr = self as *const Self;
-        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node =
+            forest.get_node_by_id(id).expect("linked node id must be present in forest");
         let forest_node_ptr = match forest_node {
             MastNode::Dyn(dyn_node) => dyn_node as *const DynNode as *const (),
             _ => panic!("Node type mismatch at {id:?}"),

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -12,7 +12,7 @@ use super::{MastForestContributor, MastNodeExt};
 use crate::{
     Felt, Word,
     mast::{
-        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        DecoratorId, ExecutableMastForest, LinkedDecoratorStore, MastForest, MastForestError,
         MastNodeFingerprint, MastNodeId,
     },
     utils::LookupByIdx,
@@ -33,11 +33,11 @@ use crate::{
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ExternalNode {
     digest: Word,
-    decorator_store: DecoratorStore,
+    decorator_store: LinkedDecoratorStore,
 }
 
 impl ExternalNode {
-    pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
+    pub(crate) fn linked_decorator_store_id(&self) -> MastNodeId {
         self.decorator_store.linked_id()
     }
 }
@@ -204,23 +204,21 @@ impl MastNodeExt for ExternalNode {
     where
         F: ExecutableMastForest + ?Sized,
     {
-        if let Some(id) = self.decorator_store.linked_id() {
-            // Verify that this node is the one stored at the given ID in the forest
-            let self_ptr = self as *const Self;
-            let forest_node =
-                forest.get_node_by_id(id).expect("linked node id must be present in forest");
-            let forest_node_ptr = match forest_node {
-                crate::mast::MastNode::External(external) => {
-                    external as *const ExternalNode as *const ()
-                },
-                _ => panic!("Node type mismatch at {id:?}"),
-            };
-            let self_as_void = self_ptr as *const ();
-            debug_assert_eq!(
-                self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {id:?} to be self"
-            );
-        }
+        let id = self.decorator_store.linked_id();
+        // Verify that this node is the one stored at the given ID in the forest
+        let self_ptr = self as *const Self;
+        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node_ptr = match forest_node {
+            crate::mast::MastNode::External(external) => {
+                external as *const ExternalNode as *const ()
+            },
+            _ => panic!("Node type mismatch at {id:?}"),
+        };
+        let self_as_void = self_ptr as *const ();
+        debug_assert_eq!(
+            self_as_void, forest_node_ptr,
+            "Node pointer mismatch: expected node at {id:?} to be self"
+        );
     }
 }
 
@@ -250,7 +248,7 @@ impl ExternalNodeBuilder {
         (
             ExternalNode {
                 digest: self.digest,
-                decorator_store: DecoratorStore::Linked { id: node_id },
+                decorator_store: LinkedDecoratorStore::linked(node_id),
             },
             self.before_enter,
             self.after_exit,
@@ -274,7 +272,7 @@ impl MastForestContributor for ExternalNodeBuilder {
             .push(
                 ExternalNode {
                     digest: self.digest,
-                    decorator_store: DecoratorStore::Linked { id: future_node_id },
+                    decorator_store: LinkedDecoratorStore::linked(future_node_id),
                 }
                 .into(),
             )

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -38,11 +38,6 @@ pub struct ExternalNode {
 }
 
 impl ExternalNode {
-    pub(super) fn into_linked_decorator_store(mut self, node_id: MastNodeId) -> Self {
-        self.decorator_store = DecoratorStore::Linked { id: node_id };
-        self
-    }
-
     pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
         self.decorator_store.linked_id()
     }
@@ -198,22 +193,11 @@ impl MastNodeExt for ExternalNode {
     type Builder = ExternalNodeBuilder;
 
     fn to_builder(self, forest: &MastForest) -> Self::Builder {
-        // Extract decorators from decorator_store if in Owned state
-        match self.decorator_store {
-            DecoratorStore::Owned { before_enter, after_exit, .. } => {
-                let mut builder = ExternalNodeBuilder::new(self.digest);
-                builder = builder.with_before_enter(before_enter).with_after_exit(after_exit);
-                builder
-            },
-            DecoratorStore::Linked { id } => {
-                // Extract decorators from forest storage when in Linked state
-                let before_enter = forest.before_enter_decorators(id).to_vec();
-                let after_exit = forest.after_exit_decorators(id).to_vec();
-                let mut builder = ExternalNodeBuilder::new(self.digest);
-                builder = builder.with_before_enter(before_enter).with_after_exit(after_exit);
-                builder
-            },
-        }
+        let (before_enter, after_exit) = self.decorator_store.into_node_level_decorators(forest);
+
+        ExternalNodeBuilder::new(self.digest)
+            .with_before_enter(before_enter)
+            .with_after_exit(after_exit)
     }
 
     #[cfg(debug_assertions)]
@@ -294,6 +278,20 @@ impl ExternalNodeBuilder {
                 self.after_exit,
             ),
         }
+    }
+
+    pub(in crate::mast) fn build_linked_with_decorators(
+        self,
+        node_id: MastNodeId,
+    ) -> (ExternalNode, Vec<DecoratorId>, Vec<DecoratorId>) {
+        (
+            ExternalNode {
+                digest: self.digest,
+                decorator_store: DecoratorStore::Linked { id: node_id },
+            },
+            self.before_enter,
+            self.after_exit,
+        )
     }
 }
 

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -31,7 +31,6 @@ use crate::{
 /// node can be swapped with the actual subtree that it represents without changing the MAST root.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "arbitrary", test), miden_test_serde_macros::serde_test)]
 pub struct ExternalNode {
     digest: Word,
     decorator_store: DecoratorStore,
@@ -225,31 +224,6 @@ impl MastNodeExt for ExternalNode {
     }
 }
 
-// ARBITRARY IMPLEMENTATION
-// ================================================================================================
-
-#[cfg(all(feature = "arbitrary", test))]
-impl proptest::prelude::Arbitrary for ExternalNode {
-    type Parameters = ();
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        use proptest::prelude::*;
-
-        use crate::Felt;
-
-        // Generate a random Word to use as the procedure hash/digest
-        any::<[u64; 4]>()
-            .prop_map(|[a, b, c, d]| {
-                let word = Word::from([Felt::new_unchecked(a), Felt::new_unchecked(b), Felt::new_unchecked(c), Felt::new_unchecked(d)]);
-                ExternalNodeBuilder::new(word).build()
-            })
-            .no_shrink()  // Pure random values, no meaningful shrinking pattern
-            .boxed()
-    }
-
-    type Strategy = proptest::prelude::BoxedStrategy<Self>;
-}
-
 // ------------------------------------------------------------------------------------------------
 /// Builder for creating [`ExternalNode`] instances with decorators.
 #[derive(Debug)]
@@ -266,17 +240,6 @@ impl ExternalNodeBuilder {
             digest,
             before_enter: Vec::new(),
             after_exit: Vec::new(),
-        }
-    }
-
-    /// Builds the ExternalNode with the specified decorators.
-    pub fn build(self) -> ExternalNode {
-        ExternalNode {
-            digest: self.digest,
-            decorator_store: DecoratorStore::new_owned_with_decorators(
-                self.before_enter,
-                self.after_exit,
-            ),
         }
     }
 

--- a/core/src/mast/node/external.rs
+++ b/core/src/mast/node/external.rs
@@ -207,7 +207,8 @@ impl MastNodeExt for ExternalNode {
         let id = self.decorator_store.linked_id();
         // Verify that this node is the one stored at the given ID in the forest
         let self_ptr = self as *const Self;
-        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node =
+            forest.get_node_by_id(id).expect("linked node id must be present in forest");
         let forest_node_ptr = match forest_node {
             crate::mast::MastNode::External(external) => {
                 external as *const ExternalNode as *const ()

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -263,7 +263,8 @@ impl MastNodeExt for JoinNode {
         let id = self.decorator_store.linked_id();
         // Verify that this node is the one stored at the given ID in the forest
         let self_ptr = self as *const Self;
-        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node =
+            forest.get_node_by_id(id).expect("linked node id must be present in forest");
         let forest_node_ptr = match forest_node {
             MastNode::Join(join_node) => join_node as *const JoinNode as *const (),
             _ => panic!("Node type mismatch at {id:?}"),

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -36,11 +36,6 @@ pub struct JoinNode {
 }
 
 impl JoinNode {
-    pub(super) fn into_linked_decorator_store(mut self, node_id: MastNodeId) -> Self {
-        self.decorator_store = DecoratorStore::Linked { id: node_id };
-        self
-    }
-
     pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
         self.decorator_store.linked_id()
     }
@@ -254,28 +249,12 @@ impl MastNodeExt for JoinNode {
     type Builder = JoinNodeBuilder;
 
     fn to_builder(self, forest: &MastForest) -> Self::Builder {
-        // Extract decorators from decorator_store if in Owned state
-        match self.decorator_store {
-            DecoratorStore::Owned { before_enter, after_exit, .. } => {
-                let mut builder = JoinNodeBuilder::new(self.children);
-                builder = builder
-                    .with_before_enter(before_enter)
-                    .with_after_exit(after_exit)
-                    .with_digest(self.digest);
-                builder
-            },
-            DecoratorStore::Linked { id } => {
-                // Extract decorators from forest storage when in Linked state
-                let before_enter = forest.before_enter_decorators(id).to_vec();
-                let after_exit = forest.after_exit_decorators(id).to_vec();
-                let mut builder = JoinNodeBuilder::new(self.children);
-                builder = builder
-                    .with_before_enter(before_enter)
-                    .with_after_exit(after_exit)
-                    .with_digest(self.digest);
-                builder
-            },
-        }
+        let (before_enter, after_exit) = self.decorator_store.into_node_level_decorators(forest);
+
+        JoinNodeBuilder::new(self.children)
+            .with_before_enter(before_enter)
+            .with_after_exit(after_exit)
+            .with_digest(self.digest)
     }
 
     #[cfg(debug_assertions)]
@@ -388,6 +367,30 @@ impl JoinNodeBuilder {
                 self.after_exit,
             ),
         })
+    }
+
+    pub(in crate::mast) fn build_linked_with_decorators(
+        self,
+        node_id: MastNodeId,
+    ) -> Result<(JoinNode, Vec<DecoratorId>, Vec<DecoratorId>), MastForestError> {
+        let Self {
+            children,
+            before_enter,
+            after_exit,
+            digest,
+        } = self;
+        let digest =
+            NodeBuilderLifecycle::new(&before_enter, &after_exit, digest).forced_digest()?;
+
+        Ok((
+            JoinNode {
+                children,
+                digest,
+                decorator_store: DecoratorStore::Linked { id: node_id },
+            },
+            before_enter,
+            after_exit,
+        ))
     }
 }
 

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -13,7 +13,7 @@ use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     mast::{
-        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        DecoratorId, ExecutableMastForest, LinkedDecoratorStore, MastForest, MastForestError,
         MastNodeFingerprint, MastNodeId, digest,
     },
     operations::opcodes,
@@ -31,11 +31,11 @@ use crate::{
 pub struct JoinNode {
     children: [MastNodeId; 2],
     digest: Word,
-    decorator_store: DecoratorStore,
+    decorator_store: LinkedDecoratorStore,
 }
 
 impl JoinNode {
-    pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
+    pub(crate) fn linked_decorator_store_id(&self) -> MastNodeId {
         self.decorator_store.linked_id()
     }
 }
@@ -149,8 +149,7 @@ impl JoinNode {
     /// Checks if two JoinNodes are semantically equal (i.e., they represent the same join
     /// operation).
     ///
-    /// Unlike the derived PartialEq, this method works correctly with both owned and linked
-    /// decorator storage by accessing the actual decorator data from the forest when needed.
+    /// Unlike the derived PartialEq, this method compares the decorator data through the forest.
     #[cfg(test)]
     pub fn semantic_eq(&self, other: &JoinNode, forest: &MastForest) -> bool {
         // Compare children
@@ -261,21 +260,19 @@ impl MastNodeExt for JoinNode {
     where
         F: ExecutableMastForest + ?Sized,
     {
-        if let Some(id) = self.decorator_store.linked_id() {
-            // Verify that this node is the one stored at the given ID in the forest
-            let self_ptr = self as *const Self;
-            let forest_node =
-                forest.get_node_by_id(id).expect("linked node id must be present in forest");
-            let forest_node_ptr = match forest_node {
-                MastNode::Join(join_node) => join_node as *const JoinNode as *const (),
-                _ => panic!("Node type mismatch at {id:?}"),
-            };
-            let self_as_void = self_ptr as *const ();
-            debug_assert_eq!(
-                self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {id:?} to be self"
-            );
-        }
+        let id = self.decorator_store.linked_id();
+        // Verify that this node is the one stored at the given ID in the forest
+        let self_ptr = self as *const Self;
+        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node_ptr = match forest_node {
+            MastNode::Join(join_node) => join_node as *const JoinNode as *const (),
+            _ => panic!("Node type mismatch at {id:?}"),
+        };
+        let self_as_void = self_ptr as *const ();
+        debug_assert_eq!(
+            self_as_void, forest_node_ptr,
+            "Node pointer mismatch: expected node at {id:?} to be self"
+        );
     }
 }
 
@@ -317,7 +314,7 @@ impl JoinNodeBuilder {
             JoinNode {
                 children,
                 digest,
-                decorator_store: DecoratorStore::Linked { id: node_id },
+                decorator_store: LinkedDecoratorStore::linked(node_id),
             },
             before_enter,
             after_exit,
@@ -343,7 +340,7 @@ impl MastForestContributor for JoinNodeBuilder {
             JoinNode {
                 children: self.children,
                 digest,
-                decorator_store: DecoratorStore::Linked { id: future_node_id },
+                decorator_store: LinkedDecoratorStore::linked(future_node_id),
             }
             .into()
         })

--- a/core/src/mast/node/join_node.rs
+++ b/core/src/mast/node/join_node.rs
@@ -28,7 +28,6 @@ use crate::{
 /// first child first and the second child second.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "arbitrary", test), miden_test_serde_macros::serde_test)]
 pub struct JoinNode {
     children: [MastNodeId; 2],
     digest: Word,
@@ -280,37 +279,6 @@ impl MastNodeExt for JoinNode {
     }
 }
 
-// ARBITRARY IMPLEMENTATION
-// ================================================================================================
-
-#[cfg(all(feature = "arbitrary", test))]
-impl proptest::prelude::Arbitrary for JoinNode {
-    type Parameters = ();
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        use proptest::prelude::*;
-
-        use crate::Felt;
-
-        // Generate two MastNodeId values and digest for the children
-        (any::<MastNodeId>(), any::<MastNodeId>(), any::<[u64; 4]>())
-            .prop_map(|(first_child, second_child, digest_array)| {
-                // Generate a random digest
-                let digest = Word::from(digest_array.map(Felt::new_unchecked));
-                // Construct directly to avoid MastForest validation for arbitrary data
-                JoinNode {
-                    children: [first_child, second_child],
-                    digest,
-                    decorator_store: DecoratorStore::default(),
-                }
-            })
-            .no_shrink()  // Pure random values, no meaningful shrinking pattern
-            .boxed()
-    }
-
-    type Strategy = proptest::prelude::BoxedStrategy<Self>;
-}
-
 // ------------------------------------------------------------------------------------------------
 /// Builder for creating [`JoinNode`] instances with decorators.
 #[derive(Debug)]
@@ -330,43 +298,6 @@ impl JoinNodeBuilder {
             after_exit: Vec::new(),
             digest: None,
         }
-    }
-
-    /// Builds the JoinNode with the specified decorators.
-    pub fn build(self, mast_forest: &MastForest) -> Result<JoinNode, MastForestError> {
-        NodeBuilderLifecycle::validate_children(mast_forest, &self.children)?;
-
-        let lifecycle =
-            NodeBuilderLifecycle::new(&self.before_enter, &self.after_exit, self.digest);
-        let digest = lifecycle.digest_or_compute(|| {
-            let left_child_hash = mast_forest[self.children[0]].digest();
-            let right_child_hash = mast_forest[self.children[1]].digest();
-
-            digest::join_digest(left_child_hash, right_child_hash)
-        });
-
-        Ok(JoinNode {
-            children: self.children,
-            digest,
-            decorator_store: DecoratorStore::new_owned_with_decorators(
-                self.before_enter,
-                self.after_exit,
-            ),
-        })
-    }
-
-    pub(in crate::mast) fn build_with_forced_digest(self) -> Result<JoinNode, MastForestError> {
-        let digest = NodeBuilderLifecycle::new(&self.before_enter, &self.after_exit, self.digest)
-            .forced_digest()?;
-
-        Ok(JoinNode {
-            children: self.children,
-            digest,
-            decorator_store: DecoratorStore::new_owned_with_decorators(
-                self.before_enter,
-                self.after_exit,
-            ),
-        })
     }
 
     pub(in crate::mast) fn build_linked_with_decorators(

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -213,7 +213,8 @@ impl MastNodeExt for LoopNode {
         let id = self.decorator_store.linked_id();
         // Verify that this node is the one stored at the given ID in the forest
         let self_ptr = self as *const Self;
-        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node =
+            forest.get_node_by_id(id).expect("linked node id must be present in forest");
         let forest_node_ptr = match forest_node {
             MastNode::Loop(loop_node) => loop_node as *const LoopNode as *const (),
             _ => panic!("Node type mismatch at {id:?}"),

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -13,7 +13,7 @@ use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     mast::{
-        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        DecoratorId, ExecutableMastForest, LinkedDecoratorStore, MastForest, MastForestError,
         MastNodeFingerprint, MastNodeId, digest,
     },
     operations::opcodes,
@@ -35,11 +35,11 @@ use crate::{
 pub struct LoopNode {
     body: MastNodeId,
     digest: Word,
-    decorator_store: DecoratorStore,
+    decorator_store: LinkedDecoratorStore,
 }
 
 impl LoopNode {
-    pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
+    pub(crate) fn linked_decorator_store_id(&self) -> MastNodeId {
         self.decorator_store.linked_id()
     }
 }
@@ -210,21 +210,19 @@ impl MastNodeExt for LoopNode {
     where
         F: ExecutableMastForest + ?Sized,
     {
-        if let Some(id) = self.decorator_store.linked_id() {
-            // Verify that this node is the one stored at the given ID in the forest
-            let self_ptr = self as *const Self;
-            let forest_node =
-                forest.get_node_by_id(id).expect("linked node id must be present in forest");
-            let forest_node_ptr = match forest_node {
-                MastNode::Loop(loop_node) => loop_node as *const LoopNode as *const (),
-                _ => panic!("Node type mismatch at {id:?}"),
-            };
-            let self_as_void = self_ptr as *const ();
-            debug_assert_eq!(
-                self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {id:?} to be self"
-            );
-        }
+        let id = self.decorator_store.linked_id();
+        // Verify that this node is the one stored at the given ID in the forest
+        let self_ptr = self as *const Self;
+        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node_ptr = match forest_node {
+            MastNode::Loop(loop_node) => loop_node as *const LoopNode as *const (),
+            _ => panic!("Node type mismatch at {id:?}"),
+        };
+        let self_as_void = self_ptr as *const ();
+        debug_assert_eq!(
+            self_as_void, forest_node_ptr,
+            "Node pointer mismatch: expected node at {id:?} to be self"
+        );
     }
 }
 
@@ -261,7 +259,7 @@ impl LoopNodeBuilder {
             LoopNode {
                 body,
                 digest,
-                decorator_store: DecoratorStore::Linked { id: node_id },
+                decorator_store: LinkedDecoratorStore::linked(node_id),
             },
             before_enter,
             after_exit,
@@ -286,7 +284,7 @@ impl MastForestContributor for LoopNodeBuilder {
             LoopNode {
                 body: self.body,
                 digest,
-                decorator_store: DecoratorStore::Linked { id: future_node_id },
+                decorator_store: LinkedDecoratorStore::linked(future_node_id),
             }
             .into()
         })

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -32,7 +32,6 @@ use crate::{
 /// fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "arbitrary", test), miden_test_serde_macros::serde_test)]
 pub struct LoopNode {
     body: MastNodeId,
     digest: Word,
@@ -229,37 +228,6 @@ impl MastNodeExt for LoopNode {
     }
 }
 
-// ARBITRARY IMPLEMENTATION
-// ================================================================================================
-
-#[cfg(all(feature = "arbitrary", test))]
-impl proptest::prelude::Arbitrary for LoopNode {
-    type Parameters = ();
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        use proptest::prelude::*;
-
-        use crate::Felt;
-
-        // Generate one MastNodeId value and digest for the body
-        (any::<MastNodeId>(), any::<[u64; 4]>())
-            .prop_map(|(body, digest_array)| {
-                // Generate a random digest
-                let digest = Word::from(digest_array.map(Felt::new_unchecked));
-                // Construct directly to avoid MastForest validation for arbitrary data
-                LoopNode {
-                    body,
-                    digest,
-                    decorator_store: DecoratorStore::default(),
-                }
-            })
-            .no_shrink()  // Pure random values, no meaningful shrinking pattern
-            .boxed()
-    }
-
-    type Strategy = proptest::prelude::BoxedStrategy<Self>;
-}
-
 // ------------------------------------------------------------------------------------------------
 /// Builder for creating [`LoopNode`] instances with decorators.
 #[derive(Debug)]
@@ -279,42 +247,6 @@ impl LoopNodeBuilder {
             after_exit: Vec::new(),
             digest: None,
         }
-    }
-
-    /// Builds the LoopNode with the specified decorators.
-    pub fn build(self, mast_forest: &MastForest) -> Result<LoopNode, MastForestError> {
-        NodeBuilderLifecycle::validate_children(mast_forest, &[self.body])?;
-
-        let lifecycle =
-            NodeBuilderLifecycle::new(&self.before_enter, &self.after_exit, self.digest);
-        let digest = lifecycle.digest_or_compute(|| {
-            let body_hash = mast_forest[self.body].digest();
-
-            digest::loop_digest(body_hash)
-        });
-
-        Ok(LoopNode {
-            body: self.body,
-            digest,
-            decorator_store: DecoratorStore::new_owned_with_decorators(
-                self.before_enter,
-                self.after_exit,
-            ),
-        })
-    }
-
-    pub(in crate::mast) fn build_with_forced_digest(self) -> Result<LoopNode, MastForestError> {
-        let digest = NodeBuilderLifecycle::new(&self.before_enter, &self.after_exit, self.digest)
-            .forced_digest()?;
-
-        Ok(LoopNode {
-            body: self.body,
-            digest,
-            decorator_store: DecoratorStore::new_owned_with_decorators(
-                self.before_enter,
-                self.after_exit,
-            ),
-        })
     }
 
     pub(in crate::mast) fn build_linked_with_decorators(

--- a/core/src/mast/node/loop_node.rs
+++ b/core/src/mast/node/loop_node.rs
@@ -40,11 +40,6 @@ pub struct LoopNode {
 }
 
 impl LoopNode {
-    pub(super) fn into_linked_decorator_store(mut self, node_id: MastNodeId) -> Self {
-        self.decorator_store = DecoratorStore::Linked { id: node_id };
-        self
-    }
-
     pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
         self.decorator_store.linked_id()
     }
@@ -203,28 +198,12 @@ impl MastNodeExt for LoopNode {
     type Builder = LoopNodeBuilder;
 
     fn to_builder(self, forest: &MastForest) -> Self::Builder {
-        // Extract decorators from decorator_store if in Owned state
-        match self.decorator_store {
-            DecoratorStore::Owned { before_enter, after_exit, .. } => {
-                let mut builder = LoopNodeBuilder::new(self.body);
-                builder = builder
-                    .with_before_enter(before_enter)
-                    .with_after_exit(after_exit)
-                    .with_digest(self.digest);
-                builder
-            },
-            DecoratorStore::Linked { id } => {
-                // Extract decorators from forest storage when in Linked state
-                let before_enter = forest.before_enter_decorators(id).to_vec();
-                let after_exit = forest.after_exit_decorators(id).to_vec();
-                let mut builder = LoopNodeBuilder::new(self.body);
-                builder = builder
-                    .with_before_enter(before_enter)
-                    .with_after_exit(after_exit)
-                    .with_digest(self.digest);
-                builder
-            },
-        }
+        let (before_enter, after_exit) = self.decorator_store.into_node_level_decorators(forest);
+
+        LoopNodeBuilder::new(self.body)
+            .with_before_enter(before_enter)
+            .with_after_exit(after_exit)
+            .with_digest(self.digest)
     }
 
     #[cfg(debug_assertions)]
@@ -336,6 +315,25 @@ impl LoopNodeBuilder {
                 self.after_exit,
             ),
         })
+    }
+
+    pub(in crate::mast) fn build_linked_with_decorators(
+        self,
+        node_id: MastNodeId,
+    ) -> Result<(LoopNode, Vec<DecoratorId>, Vec<DecoratorId>), MastForestError> {
+        let Self { body, before_enter, after_exit, digest } = self;
+        let digest =
+            NodeBuilderLifecycle::new(&before_enter, &after_exit, digest).forced_digest()?;
+
+        Ok((
+            LoopNode {
+                body,
+                digest,
+                decorator_store: DecoratorStore::Linked { id: node_id },
+            },
+            before_enter,
+            after_exit,
+        ))
     }
 }
 

--- a/core/src/mast/node/mast_forest_contributor.rs
+++ b/core/src/mast/node/mast_forest_contributor.rs
@@ -9,6 +9,7 @@ use super::{
 use crate::{
     Word,
     mast::{DecoratorId, MastForest, MastForestError, MastNode, MastNodeFingerprint, MastNodeId},
+    operations::DecoratorList,
     utils::{Idx, LookupByIdx},
 };
 
@@ -146,6 +147,13 @@ pub enum MastNodeBuilder {
     Split(SplitNodeBuilder),
 }
 
+pub(in crate::mast) struct LinkedMastNodeBuild {
+    pub node: MastNode,
+    pub before_enter: Vec<DecoratorId>,
+    pub after_exit: Vec<DecoratorId>,
+    pub op_indexed_decorators: DecoratorList,
+}
+
 impl MastNodeBuilder {
     /// Build the node from this builder.
     ///
@@ -182,7 +190,85 @@ impl MastNodeBuilder {
 
     #[doc(hidden)]
     pub fn build_linked(self, node_id: MastNodeId) -> Result<MastNode, MastForestError> {
-        Ok(self.build_with_forced_digest()?.into_linked_decorator_store(node_id))
+        self.build_linked_with_decorators(node_id).map(|build| build.node)
+    }
+
+    pub(in crate::mast) fn build_linked_with_decorators(
+        self,
+        node_id: MastNodeId,
+    ) -> Result<LinkedMastNodeBuild, MastForestError> {
+        match self {
+            MastNodeBuilder::BasicBlock(builder) => {
+                let (node, before_enter, after_exit, op_indexed_decorators) =
+                    builder.build_linked_with_decorators(node_id)?;
+                Ok(LinkedMastNodeBuild {
+                    node: node.into(),
+                    before_enter,
+                    after_exit,
+                    op_indexed_decorators,
+                })
+            },
+            MastNodeBuilder::Call(builder) => {
+                let (node, before_enter, after_exit) =
+                    builder.build_linked_with_decorators(node_id)?;
+                Ok(LinkedMastNodeBuild {
+                    node: node.into(),
+                    before_enter,
+                    after_exit,
+                    op_indexed_decorators: DecoratorList::new(),
+                })
+            },
+            MastNodeBuilder::Dyn(builder) => {
+                let (node, before_enter, after_exit) =
+                    builder.build_linked_with_decorators(node_id);
+                Ok(LinkedMastNodeBuild {
+                    node: node.into(),
+                    before_enter,
+                    after_exit,
+                    op_indexed_decorators: DecoratorList::new(),
+                })
+            },
+            MastNodeBuilder::External(builder) => {
+                let (node, before_enter, after_exit) =
+                    builder.build_linked_with_decorators(node_id);
+                Ok(LinkedMastNodeBuild {
+                    node: node.into(),
+                    before_enter,
+                    after_exit,
+                    op_indexed_decorators: DecoratorList::new(),
+                })
+            },
+            MastNodeBuilder::Join(builder) => {
+                let (node, before_enter, after_exit) =
+                    builder.build_linked_with_decorators(node_id)?;
+                Ok(LinkedMastNodeBuild {
+                    node: node.into(),
+                    before_enter,
+                    after_exit,
+                    op_indexed_decorators: DecoratorList::new(),
+                })
+            },
+            MastNodeBuilder::Loop(builder) => {
+                let (node, before_enter, after_exit) =
+                    builder.build_linked_with_decorators(node_id)?;
+                Ok(LinkedMastNodeBuild {
+                    node: node.into(),
+                    before_enter,
+                    after_exit,
+                    op_indexed_decorators: DecoratorList::new(),
+                })
+            },
+            MastNodeBuilder::Split(builder) => {
+                let (node, before_enter, after_exit) =
+                    builder.build_linked_with_decorators(node_id)?;
+                Ok(LinkedMastNodeBuild {
+                    node: node.into(),
+                    before_enter,
+                    after_exit,
+                    op_indexed_decorators: DecoratorList::new(),
+                })
+            },
+        }
     }
 }
 

--- a/core/src/mast/node/mast_forest_contributor.rs
+++ b/core/src/mast/node/mast_forest_contributor.rs
@@ -683,7 +683,7 @@ mod round_trip_tests {
             .expect("decorated loop should be added to the forest");
 
         let loop_node = forest[loop_id].unwrap_loop();
-        assert_eq!(loop_node.linked_decorator_store_id(), Some(loop_id));
+        assert_eq!(loop_node.linked_decorator_store_id(), loop_id);
         assert_eq!(loop_node.before_enter(&forest), &[before]);
         assert_eq!(loop_node.after_exit(&forest), &[after]);
     }

--- a/core/src/mast/node/mast_forest_contributor.rs
+++ b/core/src/mast/node/mast_forest_contributor.rs
@@ -6,11 +6,13 @@ use super::{
     BasicBlockNodeBuilder, CallNodeBuilder, DynNodeBuilder, ExternalNodeBuilder, JoinNodeBuilder,
     LoopNodeBuilder, SplitNodeBuilder,
 };
+#[cfg(any(test, feature = "arbitrary", feature = "testing"))]
+use crate::utils::Idx;
 use crate::{
     Word,
     mast::{DecoratorId, MastForest, MastForestError, MastNode, MastNodeFingerprint, MastNodeId},
     operations::DecoratorList,
-    utils::{Idx, LookupByIdx},
+    utils::LookupByIdx,
 };
 
 pub trait MastForestContributor {
@@ -72,6 +74,7 @@ impl<'a> NodeBuilderLifecycle<'a> {
         Self { before_enter, after_exit, digest }
     }
 
+    #[cfg(any(test, feature = "arbitrary", feature = "testing"))]
     pub(super) fn validate_children(
         forest: &MastForest,
         children: &[MastNodeId],
@@ -155,39 +158,6 @@ pub(in crate::mast) struct LinkedMastNodeBuild {
 }
 
 impl MastNodeBuilder {
-    /// Build the node from this builder.
-    ///
-    /// For nodes that depend on a MastForest (Call, Join, Loop, Split), the forest is required.
-    /// For nodes that don't depend on a MastForest (BasicBlock, Dyn, External), the forest is
-    /// ignored.
-    pub fn build(self, mast_forest: &MastForest) -> Result<MastNode, MastForestError> {
-        match self {
-            MastNodeBuilder::BasicBlock(builder) => Ok(builder.build()?.into()),
-            MastNodeBuilder::Call(builder) => Ok(builder.build(mast_forest)?.into()),
-            MastNodeBuilder::Dyn(builder) => Ok(builder.build().into()),
-            MastNodeBuilder::External(builder) => Ok(builder.build().into()),
-            MastNodeBuilder::Join(builder) => Ok(builder.build(mast_forest)?.into()),
-            MastNodeBuilder::Loop(builder) => Ok(builder.build(mast_forest)?.into()),
-            MastNodeBuilder::Split(builder) => Ok(builder.build(mast_forest)?.into()),
-        }
-    }
-
-    /// Build the node from this builder without reading child nodes from a forest.
-    ///
-    /// Forest-dependent node kinds require a forced digest. This is intended for assembly-time
-    /// builders that already computed the digest from builder-local child references.
-    pub fn build_with_forced_digest(self) -> Result<MastNode, MastForestError> {
-        match self {
-            MastNodeBuilder::BasicBlock(builder) => Ok(builder.build()?.into()),
-            MastNodeBuilder::Call(builder) => Ok(builder.build_with_forced_digest()?.into()),
-            MastNodeBuilder::Dyn(builder) => Ok(builder.build().into()),
-            MastNodeBuilder::External(builder) => Ok(builder.build().into()),
-            MastNodeBuilder::Join(builder) => Ok(builder.build_with_forced_digest()?.into()),
-            MastNodeBuilder::Loop(builder) => Ok(builder.build_with_forced_digest()?.into()),
-            MastNodeBuilder::Split(builder) => Ok(builder.build_with_forced_digest()?.into()),
-        }
-    }
-
     #[doc(hidden)]
     pub fn build_linked(self, node_id: MastNodeId) -> Result<MastNode, MastForestError> {
         self.build_linked_with_decorators(node_id).map(|build| build.node)
@@ -572,13 +542,16 @@ mod round_trip_tests {
         let join_id = join_builder1.add_to_forest(&mut forest).unwrap();
 
         // perform round-trip
-        let join_node = forest.get_node_by_id(join_id).unwrap();
-        let rebuilt_node = join_node.clone().to_builder(&forest).build(&forest).unwrap();
+        let join_node = forest.get_node_by_id(join_id).unwrap().clone();
+        let rebuilt_id = join_node.to_builder(&forest).add_to_forest(&mut forest).unwrap();
+        let original_node = forest.get_node_by_id(join_id).unwrap();
+        let rebuilt_node = forest.get_node_by_id(rebuilt_id).unwrap();
 
-        // Use semantic equality to handle decorator store state differences
-        match (join_node, &rebuilt_node) {
+        match (original_node, rebuilt_node) {
             (MastNode::Join(original), MastNode::Join(rebuilt)) => {
-                assert!(original.semantic_eq(rebuilt, &forest));
+                assert_eq!(original.first(), rebuilt.first());
+                assert_eq!(original.second(), rebuilt.second());
+                assert_eq!(original.digest(), rebuilt.digest());
             },
             _ => panic!("Both nodes should be Join nodes"),
         }
@@ -652,9 +625,10 @@ mod round_trip_tests {
             Felt::new_unchecked(16),
         ]);
         let children = [MastNodeId::new_unchecked(10), MastNodeId::new_unchecked(11)];
+        let node_id = MastNodeId::new_unchecked(0);
 
         let node = MastNodeBuilder::Join(JoinNodeBuilder::new(children).with_digest(forced_digest))
-            .build_with_forced_digest()
+            .build_linked(node_id)
             .expect("forced-digest join should build without reading a forest");
 
         let MastNode::Join(node) = node else {
@@ -665,7 +639,7 @@ mod round_trip_tests {
 
         assert!(
             MastNodeBuilder::Join(JoinNodeBuilder::new(children))
-                .build_with_forced_digest()
+                .build_linked(node_id)
                 .is_err(),
             "control-flow nodes require a forced digest when built without a forest"
         );
@@ -678,19 +652,19 @@ mod round_trip_tests {
         let missing_child = MastNodeId::new_unchecked(99);
 
         assert!(matches!(
-            LoopNodeBuilder::new(missing_child).build(&forest),
+            LoopNodeBuilder::new(missing_child).add_to_forest(&mut forest),
             Err(MastForestError::NodeIdOverflow(node_id, _)) if node_id == missing_child
         ));
         assert!(matches!(
-            CallNodeBuilder::new(missing_child).build(&forest),
+            CallNodeBuilder::new(missing_child).add_to_forest(&mut forest),
             Err(MastForestError::NodeIdOverflow(node_id, _)) if node_id == missing_child
         ));
         assert!(matches!(
-            JoinNodeBuilder::new([valid_child, missing_child]).build(&forest),
+            JoinNodeBuilder::new([valid_child, missing_child]).add_to_forest(&mut forest),
             Err(MastForestError::NodeIdOverflow(node_id, _)) if node_id == missing_child
         ));
         assert!(matches!(
-            SplitNodeBuilder::new([missing_child, valid_child]).build(&forest),
+            SplitNodeBuilder::new([missing_child, valid_child]).add_to_forest(&mut forest),
             Err(MastForestError::NodeIdOverflow(node_id, _)) if node_id == missing_child
         ));
     }
@@ -733,15 +707,15 @@ mod round_trip_tests {
             .with_after_exit([after])
             .with_digest(forced_digest)
             .remap_children(&remapping);
-        let node = builder
-            .build_with_forced_digest()
+        let (node, before_enter, after_exit) = builder
+            .build_linked_with_decorators(MastNodeId::new_unchecked(0))
             .expect("forced-digest remapped join should build without a forest");
 
         assert_eq!(node.first(), remapped_first);
         assert_eq!(node.second(), remapped_second);
         assert_eq!(node.digest(), forced_digest);
-        assert_eq!(node.before_enter(&MastForest::new()), &[before]);
-        assert_eq!(node.after_exit(&MastForest::new()), &[after]);
+        assert_eq!(before_enter, &[before]);
+        assert_eq!(after_exit, &[after]);
     }
 
     #[test]

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -208,18 +208,6 @@ impl MastNode {
         }
     }
 
-    pub(in crate::mast) fn into_linked_decorator_store(self, node_id: MastNodeId) -> Self {
-        match self {
-            Self::Block(node) => Self::Block(node.into_linked_decorator_store(node_id)),
-            Self::Join(node) => Self::Join(node.into_linked_decorator_store(node_id)),
-            Self::Split(node) => Self::Split(node.into_linked_decorator_store(node_id)),
-            Self::Loop(node) => Self::Loop(node.into_linked_decorator_store(node_id)),
-            Self::Call(node) => Self::Call(node.into_linked_decorator_store(node_id)),
-            Self::Dyn(node) => Self::Dyn(node.into_linked_decorator_store(node_id)),
-            Self::External(node) => Self::External(node.into_linked_decorator_store(node_id)),
-        }
-    }
-
     pub(crate) fn validate_decorator_store_link(
         &self,
         node_id: MastNodeId,

--- a/core/src/mast/node/mod.rs
+++ b/core/src/mast/node/mod.rs
@@ -36,7 +36,7 @@ mod mast_forest_contributor;
 pub use mast_forest_contributor::{MastForestContributor, MastNodeBuilder};
 
 mod decorator_store;
-pub use decorator_store::DecoratorStore;
+pub use decorator_store::LinkedDecoratorStore;
 
 use super::DecoratorId;
 use crate::mast::{ExecutableMastForest, MastForest, MastForestError, MastNodeId};
@@ -222,12 +222,10 @@ impl MastNode {
             Self::External(node) => node.linked_decorator_store_id(),
         };
 
-        match linked_node_id {
-            Some(linked_node_id) if linked_node_id == node_id => Ok(()),
-            Some(linked_node_id) => {
-                Err(MastForestError::InvalidDecoratorStoreLink { node_id, linked_node_id })
-            },
-            None => Err(MastForestError::UnlinkedDecoratorStore(node_id)),
+        if linked_node_id == node_id {
+            Ok(())
+        } else {
+            Err(MastForestError::InvalidDecoratorStoreLink { node_id, linked_node_id })
         }
     }
 }

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -40,11 +40,6 @@ pub struct SplitNode {
 }
 
 impl SplitNode {
-    pub(super) fn into_linked_decorator_store(mut self, node_id: MastNodeId) -> Self {
-        self.decorator_store = DecoratorStore::Linked { id: node_id };
-        self
-    }
-
     pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
         self.decorator_store.linked_id()
     }
@@ -214,28 +209,12 @@ impl MastNodeExt for SplitNode {
     type Builder = SplitNodeBuilder;
 
     fn to_builder(self, forest: &MastForest) -> Self::Builder {
-        // Extract decorators from decorator_store if in Owned state
-        match self.decorator_store {
-            DecoratorStore::Owned { before_enter, after_exit, .. } => {
-                let mut builder = SplitNodeBuilder::new(self.branches);
-                builder = builder
-                    .with_before_enter(before_enter)
-                    .with_after_exit(after_exit)
-                    .with_digest(self.digest);
-                builder
-            },
-            DecoratorStore::Linked { id } => {
-                // Extract decorators from forest storage when in Linked state
-                let before_enter = forest.before_enter_decorators(id).to_vec();
-                let after_exit = forest.after_exit_decorators(id).to_vec();
-                let mut builder = SplitNodeBuilder::new(self.branches);
-                builder = builder
-                    .with_before_enter(before_enter)
-                    .with_after_exit(after_exit)
-                    .with_digest(self.digest);
-                builder
-            },
-        }
+        let (before_enter, after_exit) = self.decorator_store.into_node_level_decorators(forest);
+
+        SplitNodeBuilder::new(self.branches)
+            .with_before_enter(before_enter)
+            .with_after_exit(after_exit)
+            .with_digest(self.digest)
     }
 
     #[cfg(debug_assertions)]
@@ -348,6 +327,30 @@ impl SplitNodeBuilder {
                 self.after_exit,
             ),
         })
+    }
+
+    pub(in crate::mast) fn build_linked_with_decorators(
+        self,
+        node_id: MastNodeId,
+    ) -> Result<(SplitNode, Vec<DecoratorId>, Vec<DecoratorId>), MastForestError> {
+        let Self {
+            branches,
+            before_enter,
+            after_exit,
+            digest,
+        } = self;
+        let digest =
+            NodeBuilderLifecycle::new(&before_enter, &after_exit, digest).forced_digest()?;
+
+        Ok((
+            SplitNode {
+                branches,
+                digest,
+                decorator_store: DecoratorStore::Linked { id: node_id },
+            },
+            before_enter,
+            after_exit,
+        ))
     }
 }
 

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -32,7 +32,6 @@ use crate::{
 /// the value is neither `0` nor `1`, the execution fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(all(feature = "arbitrary", test), miden_test_serde_macros::serde_test)]
 pub struct SplitNode {
     branches: [MastNodeId; 2],
     digest: Word,
@@ -240,37 +239,6 @@ impl MastNodeExt for SplitNode {
     }
 }
 
-// ARBITRARY IMPLEMENTATION
-// ================================================================================================
-
-#[cfg(all(feature = "arbitrary", test))]
-impl proptest::prelude::Arbitrary for SplitNode {
-    type Parameters = ();
-
-    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        use proptest::prelude::*;
-
-        use crate::Felt;
-
-        // Generate two MastNodeId values and digest for the children
-        (any::<MastNodeId>(), any::<MastNodeId>(), any::<[u64; 4]>())
-            .prop_map(|(true_branch, false_branch, digest_array)| {
-                // Generate a random digest
-                let digest = Word::from(digest_array.map(Felt::new_unchecked));
-                // Construct directly to avoid MastForest validation for arbitrary data
-                SplitNode {
-                    branches: [true_branch, false_branch],
-                    digest,
-                    decorator_store: DecoratorStore::default(),
-                }
-            })
-            .no_shrink()  // Pure random values, no meaningful shrinking pattern
-            .boxed()
-    }
-
-    type Strategy = proptest::prelude::BoxedStrategy<Self>;
-}
-
 // ------------------------------------------------------------------------------------------------
 /// Builder for creating [`SplitNode`] instances with decorators.
 #[derive(Debug)]
@@ -290,43 +258,6 @@ impl SplitNodeBuilder {
             after_exit: Vec::new(),
             digest: None,
         }
-    }
-
-    /// Builds the SplitNode with the specified decorators.
-    pub fn build(self, mast_forest: &MastForest) -> Result<SplitNode, MastForestError> {
-        NodeBuilderLifecycle::validate_children(mast_forest, &self.branches)?;
-
-        let lifecycle =
-            NodeBuilderLifecycle::new(&self.before_enter, &self.after_exit, self.digest);
-        let digest = lifecycle.digest_or_compute(|| {
-            let true_branch_hash = mast_forest[self.branches[0]].digest();
-            let false_branch_hash = mast_forest[self.branches[1]].digest();
-
-            digest::split_digest(true_branch_hash, false_branch_hash)
-        });
-
-        Ok(SplitNode {
-            branches: self.branches,
-            digest,
-            decorator_store: DecoratorStore::new_owned_with_decorators(
-                self.before_enter,
-                self.after_exit,
-            ),
-        })
-    }
-
-    pub(in crate::mast) fn build_with_forced_digest(self) -> Result<SplitNode, MastForestError> {
-        let digest = NodeBuilderLifecycle::new(&self.before_enter, &self.after_exit, self.digest)
-            .forced_digest()?;
-
-        Ok(SplitNode {
-            branches: self.branches,
-            digest,
-            decorator_store: DecoratorStore::new_owned_with_decorators(
-                self.before_enter,
-                self.after_exit,
-            ),
-        })
     }
 
     pub(in crate::mast) fn build_linked_with_decorators(

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -13,7 +13,7 @@ use crate::mast::MastNode;
 use crate::{
     Felt, Word,
     mast::{
-        DecoratorId, DecoratorStore, ExecutableMastForest, MastForest, MastForestError,
+        DecoratorId, ExecutableMastForest, LinkedDecoratorStore, MastForest, MastForestError,
         MastNodeFingerprint, MastNodeId, digest,
     },
     operations::opcodes,
@@ -35,11 +35,11 @@ use crate::{
 pub struct SplitNode {
     branches: [MastNodeId; 2],
     digest: Word,
-    decorator_store: DecoratorStore,
+    decorator_store: LinkedDecoratorStore,
 }
 
 impl SplitNode {
-    pub(crate) fn linked_decorator_store_id(&self) -> Option<MastNodeId> {
+    pub(crate) fn linked_decorator_store_id(&self) -> MastNodeId {
         self.decorator_store.linked_id()
     }
 }
@@ -221,21 +221,19 @@ impl MastNodeExt for SplitNode {
     where
         F: ExecutableMastForest + ?Sized,
     {
-        if let Some(id) = self.decorator_store.linked_id() {
-            // Verify that this node is the one stored at the given ID in the forest
-            let self_ptr = self as *const Self;
-            let forest_node =
-                forest.get_node_by_id(id).expect("linked node id must be present in forest");
-            let forest_node_ptr = match forest_node {
-                MastNode::Split(split_node) => split_node as *const SplitNode as *const (),
-                _ => panic!("Node type mismatch at {id:?}"),
-            };
-            let self_as_void = self_ptr as *const ();
-            debug_assert_eq!(
-                self_as_void, forest_node_ptr,
-                "Node pointer mismatch: expected node at {id:?} to be self"
-            );
-        }
+        let id = self.decorator_store.linked_id();
+        // Verify that this node is the one stored at the given ID in the forest
+        let self_ptr = self as *const Self;
+        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node_ptr = match forest_node {
+            MastNode::Split(split_node) => split_node as *const SplitNode as *const (),
+            _ => panic!("Node type mismatch at {id:?}"),
+        };
+        let self_as_void = self_ptr as *const ();
+        debug_assert_eq!(
+            self_as_void, forest_node_ptr,
+            "Node pointer mismatch: expected node at {id:?} to be self"
+        );
     }
 }
 
@@ -277,7 +275,7 @@ impl SplitNodeBuilder {
             SplitNode {
                 branches,
                 digest,
-                decorator_store: DecoratorStore::Linked { id: node_id },
+                decorator_store: LinkedDecoratorStore::linked(node_id),
             },
             before_enter,
             after_exit,
@@ -303,7 +301,7 @@ impl MastForestContributor for SplitNodeBuilder {
             SplitNode {
                 branches: self.branches,
                 digest,
-                decorator_store: DecoratorStore::Linked { id: future_node_id },
+                decorator_store: LinkedDecoratorStore::linked(future_node_id),
             }
             .into()
         })

--- a/core/src/mast/node/split_node.rs
+++ b/core/src/mast/node/split_node.rs
@@ -224,7 +224,8 @@ impl MastNodeExt for SplitNode {
         let id = self.decorator_store.linked_id();
         // Verify that this node is the one stored at the given ID in the forest
         let self_ptr = self as *const Self;
-        let forest_node = forest.get_node_by_id(id).expect("linked node id must be present in forest");
+        let forest_node =
+            forest.get_node_by_id(id).expect("linked node id must be present in forest");
         let forest_node_ptr = match forest_node {
             MastNode::Split(split_node) => split_node as *const SplitNode as *const (),
             _ => panic!("Node type mismatch at {id:?}"),

--- a/core/src/mast/tests.rs
+++ b/core/src/mast/tests.rs
@@ -897,9 +897,9 @@ fn test_mast_forest_compaction_comprehensive() {
 
     // === External nodes with after-exit decorators ===
     let external_digest = BasicBlockNodeBuilder::new(vec![Operation::Neg], Vec::new())
-        .build()
+        .into_op_batches_and_digest()
         .unwrap()
-        .digest();
+        .1;
     let external_no_deco = crate::mast::ExternalNodeBuilder::new(external_digest)
         .add_to_forest(&mut forest)
         .unwrap();

--- a/core/src/mast/tests.rs
+++ b/core/src/mast/tests.rs
@@ -522,7 +522,7 @@ fn test_mast_forest_roundtrip_with_basic_blocks_and_decorators() {
 
 #[test]
 #[cfg(feature = "serde")]
-fn test_mast_forest_serde_converts_linked_to_owned_decorators() {
+fn test_mast_forest_serde_preserves_linked_decorators() {
     let mut forest = MastForest::new();
 
     // Create decorators
@@ -611,7 +611,7 @@ fn test_mast_forest_serde_converts_linked_to_owned_decorators() {
 }
 
 #[test]
-fn test_mast_forest_serializable_converts_linked_to_owned_decorators() {
+fn test_mast_forest_serializable_preserves_linked_decorators() {
     let mut forest = MastForest::new();
 
     // Create decorators
@@ -681,7 +681,7 @@ fn test_mast_forest_serializable_converts_linked_to_owned_decorators() {
         original_block.indexed_decorator_iter(&forest).collect::<Vec<_>>();
     assert_eq!(
         original_decorators_final, deserialized_decorators,
-        "Decorators should be functionally equal despite different storage representations"
+        "Decorators should be functionally equal after round-trip serialization"
     );
 
     // Final verification: check that the deserialized forest still works correctly

--- a/core/src/mast/tests.rs
+++ b/core/src/mast/tests.rs
@@ -9,8 +9,9 @@ use crate::{
     chiplets::hasher,
     mast::{
         BasicBlockNodeBuilder, CallNodeBuilder, DebugInfo, DecoratorId, DynNode, DynNodeBuilder,
-        JoinNodeBuilder, MastForest, MastForestContributor, MastForestError, MastForestParts,
-        MastNode, MastNodeBuilder, MastNodeExt, MastNodeId, SplitNodeBuilder,
+        ExternalNodeBuilder, JoinNodeBuilder, LoopNodeBuilder, MastForest, MastForestContributor,
+        MastForestError, MastForestParts, MastNode, MastNodeBuilder, MastNodeExt, MastNodeId,
+        SplitNodeBuilder,
     },
     operations::{AssemblyOp, DebugOptions, Decorator, Operation},
     program::{Kernel, ProgramInfo},
@@ -81,6 +82,70 @@ fn from_parts_rejects_invalid_debug_info() {
         MastForest::from_parts(forest_parts_with_node_and_debug_info(node, debug_info)),
         Err(MastForestError::InvalidDebugInfo(_))
     ));
+}
+
+#[test]
+fn linked_decorator_store_reads_node_level_decorators_for_non_basic_nodes() {
+    let mut forest = MastForest::new();
+    let before = forest.add_decorator(Decorator::Trace(10)).unwrap();
+    let after = forest.add_decorator(Decorator::Trace(20)).unwrap();
+    let expected_before = [before];
+    let expected_after = [after];
+
+    let left = BasicBlockNodeBuilder::new(vec![Operation::Push(Felt::new_unchecked(1))], vec![])
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let right = BasicBlockNodeBuilder::new(vec![Operation::Push(Felt::new_unchecked(2))], vec![])
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let body = BasicBlockNodeBuilder::new(vec![Operation::Add], vec![])
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let external_digest = BasicBlockNodeBuilder::new(vec![Operation::Mul], vec![])
+        .into_op_batches_and_digest()
+        .unwrap()
+        .1;
+
+    let node_ids = [
+        JoinNodeBuilder::new([left, right])
+            .with_before_enter(expected_before)
+            .with_after_exit(expected_after)
+            .add_to_forest(&mut forest)
+            .unwrap(),
+        SplitNodeBuilder::new([left, right])
+            .with_before_enter(expected_before)
+            .with_after_exit(expected_after)
+            .add_to_forest(&mut forest)
+            .unwrap(),
+        LoopNodeBuilder::new(body)
+            .with_before_enter(expected_before)
+            .with_after_exit(expected_after)
+            .add_to_forest(&mut forest)
+            .unwrap(),
+        CallNodeBuilder::new(body)
+            .with_before_enter(expected_before)
+            .with_after_exit(expected_after)
+            .add_to_forest(&mut forest)
+            .unwrap(),
+        DynNodeBuilder::new_dyn()
+            .with_before_enter(expected_before)
+            .with_after_exit(expected_after)
+            .add_to_forest(&mut forest)
+            .unwrap(),
+        ExternalNodeBuilder::new(external_digest)
+            .with_before_enter(expected_before)
+            .with_after_exit(expected_after)
+            .add_to_forest(&mut forest)
+            .unwrap(),
+    ];
+
+    for node_id in node_ids {
+        let node = &forest[node_id];
+        assert_eq!(node.before_enter(&forest), expected_before);
+        assert_eq!(node.after_exit(&forest), expected_after);
+        assert_eq!(forest.before_enter_decorators(node_id), expected_before);
+        assert_eq!(forest.after_exit_decorators(node_id), expected_after);
+    }
 }
 
 proptest! {
@@ -852,9 +917,8 @@ fn test_mast_forest_compaction_comprehensive() {
     let loop_body = BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Add], Vec::new())
         .add_to_forest(&mut forest)
         .unwrap();
-    let loop_no_deco =
-        crate::mast::LoopNodeBuilder::new(loop_body).add_to_forest(&mut forest).unwrap();
-    let loop_with_before_deco = crate::mast::LoopNodeBuilder::new(loop_body)
+    let loop_no_deco = LoopNodeBuilder::new(loop_body).add_to_forest(&mut forest).unwrap();
+    let loop_with_before_deco = LoopNodeBuilder::new(loop_body)
         .with_before_enter(vec![debug_deco])
         .add_to_forest(&mut forest)
         .unwrap();
@@ -887,10 +951,9 @@ fn test_mast_forest_compaction_comprehensive() {
         .into_op_batches_and_digest()
         .unwrap()
         .1;
-    let external_no_deco = crate::mast::ExternalNodeBuilder::new(external_digest)
-        .add_to_forest(&mut forest)
-        .unwrap();
-    let external_with_after_deco = crate::mast::ExternalNodeBuilder::new(external_digest)
+    let external_no_deco =
+        ExternalNodeBuilder::new(external_digest).add_to_forest(&mut forest).unwrap();
+    let external_with_after_deco = ExternalNodeBuilder::new(external_digest)
         .with_after_exit(vec![trace_deco])
         .add_to_forest(&mut forest)
         .unwrap();

--- a/core/src/mast/tests.rs
+++ b/core/src/mast/tests.rs
@@ -47,19 +47,6 @@ fn forest_parts_with_node_and_debug_info(node: MastNode, debug_info: DebugInfo) 
 }
 
 #[test]
-fn from_parts_rejects_unlinked_decorator_store() {
-    let node = BasicBlockNodeBuilder::new(vec![Operation::Push(Felt::new_unchecked(1))], vec![])
-        .build()
-        .unwrap()
-        .into();
-
-    assert_eq!(
-        MastForest::from_parts(forest_parts_with_node(node)),
-        Err(MastForestError::UnlinkedDecoratorStore(MastNodeId::new_unchecked(0)))
-    );
-}
-
-#[test]
 fn from_parts_rejects_mislinked_decorator_store() {
     let node = MastNodeBuilder::BasicBlock(BasicBlockNodeBuilder::new(
         vec![Operation::Push(Felt::new_unchecked(1))],

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -947,11 +947,10 @@ fn compute_operations_and_adjust_mappings(
 fn batch_basic_block_operations(
     operations: Vec<Operation>,
 ) -> Result<(Vec<OpBatch>, Word), Report> {
-    let block = BasicBlockNodeBuilder::new(operations, Vec::new())
-        .build()
+    BasicBlockNodeBuilder::new(operations, Vec::new())
+        .into_op_batches_and_digest()
         .into_diagnostic()
-        .wrap_err("assembler failed to build new basic block")?;
-    Ok((block.op_batches().to_vec(), block.digest()))
+        .wrap_err("assembler failed to build new basic block")
 }
 
 fn build_pending_node_with_final_ids(

--- a/miden-vm/tests/integration/operations/io_ops/env_ops.rs
+++ b/miden-vm/tests/integration/operations/io_ops/env_ops.rs
@@ -1,8 +1,7 @@
 use miden_core::{
     FMP_INIT_VALUE,
     mast::{
-        BasicBlockNodeBuilder, CallNodeBuilder, MastForest, MastForestContributor, MastNode,
-        MastNodeExt,
+        BasicBlockNodeBuilder, CallNodeBuilder, MastForest, MastForestContributor, MastNodeExt,
     },
     operations::Operation,
 };
@@ -199,9 +198,10 @@ fn build_bar_hash() -> [u64; 4] {
         .add_to_forest(&mut mast_forest)
         .unwrap();
 
-    let bar_root: MastNode =
-        CallNodeBuilder::new_syscall(foo_root_id).build(&mast_forest).unwrap().into();
-    let bar_hash: Word = bar_root.digest();
+    let bar_root_id = CallNodeBuilder::new_syscall(foo_root_id)
+        .add_to_forest(&mut mast_forest)
+        .unwrap();
+    let bar_hash: Word = mast_forest[bar_root_id].digest();
     [
         bar_hash[0].as_canonical_u64(),
         bar_hash[1].as_canonical_u64(),

--- a/processor/src/execution/basic_block.rs
+++ b/processor/src/execution/basic_block.rs
@@ -251,9 +251,7 @@ where
     let batch = &basic_block.op_batches()[batch_index];
 
     // Get the node ID once since it doesn't change within the loop
-    let node_id = basic_block
-        .linked_id()
-        .expect("basic block node should be linked when executing operations");
+    let node_id = basic_block.linked_id();
 
     // Execute operations in the batch one by one
     for (op_idx_in_batch, op) in batch.ops().iter().enumerate().skip(start_op_idx) {

--- a/processor/src/trace/chiplets/hasher/tests.rs
+++ b/processor/src/trace/chiplets/hasher/tests.rs
@@ -830,10 +830,10 @@ fn check_memoized_trace(
 fn make_basic_block_batches(ops: Vec<miden_core::operations::Operation>) -> Vec<OpBatch> {
     use miden_core::mast::BasicBlockNodeBuilder;
 
-    let node = BasicBlockNodeBuilder::new(ops, Vec::new())
-        .build()
-        .expect("failed to build basic block");
-    node.op_batches().to_vec()
+    BasicBlockNodeBuilder::new(ops, Vec::new())
+        .into_op_batches_and_digest()
+        .expect("failed to build basic block")
+        .0
 }
 
 /// Creates a single OpBatch with a distinct operation (Pad) for testing.


### PR DESCRIPTION
This closes #2411 by making MAST nodes keep decorator links instead of owned decorator data.

Before this change, nodes could carry their own decorator payloads. That made cloned, merged, and imported forests harder to reason about because decorator data could live in more than one place. The forest now owns decorators once, and nodes refer to them through LinkedDecoratorStore.

This keeps MastForest as the source of truth for decorators, removes standalone owned-node construction, and shrinks the node constructors around the linked-store model.

The public behavior is unchanged: decorators still attach to nodes and survive construction, merge, serialization, and execution. The internal model is simpler: node structure points to forest-owned decorator records instead of copying them.

Closes #2411.