### PR TITLE
fix(utils-core-derive): correct derive macro panic message

### DIFF
--- a/crates/utils-core-derive/src/lib.rs
+++ b/crates/utils-core-derive/src/lib.rs
@@ -274,7 +274,7 @@ pub fn derive_mast_forest_contributor(input: TokenStream) -> TokenStream {
     // Parse the data to ensure it's an enum
     let enum_data = match &input.data {
         Data::Enum(data) => data,
-        _ => panic!("EnumThispatch can only be derived for enums"),
+        _ => panic!("MastForestContributor can only be derived for enums"),
     };
 
     // Extract variant information


### PR DESCRIPTION
The `derive_mast_forest_contributor` macro returned a stale copy-paste panic message referencing `EnumThispatch`, which does not correspond to any derive macro in this crate.

This updates the diagnostic to correctly reference`MastForestContributor`, improving compiler output clarity when the derive is used on a non-enum type.
