### PR TITLE
Fix MASM tooling, source paths, and package edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Preserved `LOGPRECOMPILE` tail stack slots in the AIR, preventing forged values in `stack[12..15]` ([#3244](https://github.com/0xMiden/miden-vm/pull/3244)).
 - Bound memory AIR word addresses to their range-checked decomposition limbs ([#3245](https://github.com/0xMiden/miden-vm/pull/3245)).
 - Rejected oversized AEAD decrypt outputs before reading ciphertext or running host-side decryption ([#3252](https://github.com/0xMiden/miden-vm/pull/3252)).
+- Fixed MASM tooling edge cases around atomic file writes, source URI paths, package loading, local registry state, diagnostics, generated MASM memory addresses, and CST `$...` special identifiers ([#3178](https://github.com/0xMiden/miden-vm/pull/3178)).
 - Replaced `bincode` proof serialization with `wincode` and bounded verifier-side STARK proof deserialization to 64 MiB ([#3148](https://github.com/0xMiden/miden-vm/pull/3148)).
 - [BREAKING] Made `miden-vm run` and `miden-vm prove` fail when the inferred `.inputs` file is missing ([#3236](https://github.com/0xMiden/miden-vm/pull/3236)).
 - [BREAKING] Replaced the Poseidon2 sponge precompile transcript with a 2-to-1 hash folding scheme; the rolling state is itself a complete digest at every step, removing `finalize()` and `PrecompileTranscriptDigest`. The `log_precompile` opcode is reshaped accordingly (helper/stack rename, STMNT placed at stack[4..8]) and the MASM `log_precompile_request` wrapper now computes STMNT via `hmerge`. RELATION_DIGEST bumped ([#3100](https://github.com/0xMiden/miden-vm/pull/3100)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,6 +1652,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
  "thiserror",
  "toml",
  "walkdir",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1652,7 +1652,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,9 +1518,11 @@ dependencies = [
  "miden-assembly-syntax-cst",
  "miden-debug-types",
  "serde",
+ "tempfile",
  "thiserror",
  "toml",
  "walkdir",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,6 +1776,7 @@ dependencies = [
  "env_logger",
  "miden-air",
  "miden-assembly",
+ "miden-assembly-syntax",
  "miden-core",
  "miden-crypto",
  "miden-mast-package",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ thiserror       = { version = "2.0", default-features = false }
 tokio           = { version = "1.48", default-features = false }
 tracing         = { version = "0.1", default-features = false, features = ["attributes"] }
 trybuild        = { version = "1.0" }
+windows-sys     = { version = "0.61.2" }
 
 loom = "0.7"
 miette = { package = "miden-miette", version = "8.0", default-features = false }

--- a/crates/assembly-syntax-cst/src/lexer.rs
+++ b/crates/assembly-syntax-cst/src/lexer.rs
@@ -137,8 +137,12 @@ impl<'input> Lexer<'input> {
     fn lex_identifier(&mut self, start: usize, first: char) -> Token<'input> {
         if first == '$' {
             self.advance_char();
-            self.advance_while(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_');
-            return self.token(SyntaxKind::SpecialIdent, start, self.offset);
+            self.advance_while(|ch| ch.is_ascii_alphanumeric() || ch == '_');
+            let kind = match &self.input[start..self.offset] {
+                "$kernel" | "$exec" => SyntaxKind::SpecialIdent,
+                _ => SyntaxKind::Error,
+            };
+            return self.token(kind, start, self.offset);
         }
 
         self.advance_char();
@@ -391,6 +395,43 @@ mod tests {
         ];
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn rejects_unknown_special_identifiers() {
+        let tokens = tokenize_text("use $foo::bar\nexec.$kernel::bar\nexec.$exec::bar\n");
+        let actual = tokens
+            .iter()
+            .filter(|token| matches!(token.kind(), SyntaxKind::Error | SyntaxKind::SpecialIdent))
+            .map(|token| (token.kind(), token.text().to_string()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec![
+                (SyntaxKind::Error, "$foo".to_string()),
+                (SyntaxKind::SpecialIdent, "$kernel".to_string()),
+                (SyntaxKind::SpecialIdent, "$exec".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_special_identifiers_with_identifier_suffixes() {
+        let tokens = tokenize_text("exec.$execFoo::bar\nexec.$kernelFoo::bar\n");
+        let actual = tokens
+            .iter()
+            .filter(|token| matches!(token.kind(), SyntaxKind::Error | SyntaxKind::SpecialIdent))
+            .map(|token| (token.kind(), token.text().to_string()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual,
+            vec![
+                (SyntaxKind::Error, "$execFoo".to_string()),
+                (SyntaxKind::Error, "$kernelFoo".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/assembly-syntax-cst/src/parser.rs
+++ b/crates/assembly-syntax-cst/src/parser.rs
@@ -2737,6 +2737,26 @@ end
     }
 
     #[test]
+    fn rejects_unknown_special_identifiers() {
+        for source in [
+            "use $foo::bar\n",
+            "begin\n    exec.$foo::bar\nend\n",
+            "begin\n    exec.$execFoo::bar\nend\n",
+            "begin\n    exec.$kernelFoo::bar\nend\n",
+        ] {
+            let parse = parse_text(source);
+            assert!(parse.has_errors(), "expected {source:?} to reject unknown special ident");
+            assert!(parse.diagnostics().iter().any(|diag| diag.labels.as_ref().is_some_and(
+                |labels| {
+                    labels.iter().any(|l| {
+                        l.label().is_some_and(|label| label.contains("unrecognized token"))
+                    })
+                }
+            )));
+        }
+    }
+
+    #[test]
     fn parse_source_file_tracks_source_aware_spans() {
         let source = Arc::new(ManagedSourceFile::new(
             SourceId::new(11),

--- a/crates/assembly-syntax/src/testing/mod.rs
+++ b/crates/assembly-syntax/src/testing/mod.rs
@@ -63,9 +63,7 @@ macro_rules! assert_diagnostic {
 /// Like [assert_diagnostic], but matches each non-empty line of the rendered output to a
 /// corresponding pattern.
 ///
-/// So if the output has 3 lines, the second of which is empty, and you provide 2 patterns, the
-/// assertion passes if the first line matches the first pattern, and the third line matches the
-/// second pattern - the second line is ignored because it is empty.
+/// Empty lines are ignored, but the remaining line count must match the number of patterns.
 #[macro_export]
 macro_rules! assert_diagnostic_lines {
     ($diagnostic:expr, $($expected_lines:expr),+) => {{

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -3943,11 +3943,16 @@ fn emit_const_must_be_event_hash() {
 }
 
 #[test]
-#[should_panic]
-fn test_assert_diagnostic_lines() {
+#[should_panic(expected = "expected 3 lines, but got 1")]
+fn assert_diagnostic_lines_rejects_missing_actual_lines() {
     assert_diagnostic_lines!(report!("the error string"), "the error string", "other", "lines");
 }
 
+#[test]
+#[should_panic(expected = "expected 1 lines, but got 2")]
+fn assert_diagnostic_lines_rejects_extra_actual_lines() {
+    assert_diagnostic_lines!(report!("the first line\nthe second line"), "the first line");
+}
 // MAST TESTS
 // ================================================================================================
 

--- a/crates/assembly/tests/packaging.rs
+++ b/crates/assembly/tests/packaging.rs
@@ -3,6 +3,7 @@
 use std::path::Path;
 
 use miden_assembly::{Report, testing::TestContext};
+use miden_mast_package::TargetType;
 
 pub const FIXTURES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
 
@@ -25,6 +26,46 @@ fn assemble_a_protocol_like_workspace_project() -> Result<(), Report> {
         .join("miden-project.toml");
 
     context.assemble_executable_package(&manifest_path, Some("entry"), None)?;
+
+    Ok(())
+}
+
+/// This test assembles the `userspace` library target of the `protocol` workspace.
+///
+/// The userspace package overrides the workspace `miden-utils` dependency to dynamic linkage and
+/// depends on the workspace `miden-tx` kernel package. Its manifest should therefore record both
+/// packages as runtime dependencies.
+#[test]
+fn assemble_protocol_userspace_dynamic_dependencies() -> Result<(), Report> {
+    let mut context = TestContext::new();
+
+    let manifest_path = Path::new(FIXTURES_DIR)
+        .join("protocol")
+        .join("userspace")
+        .join("miden-project.toml");
+
+    let package = context.assemble_library_package(&manifest_path, None)?;
+    assert_eq!(&package.name, "miden-protocol");
+    assert_eq!(package.kind, TargetType::Library);
+
+    let dependencies = package.manifest.dependencies().collect::<Vec<_>>();
+    assert_eq!(dependencies.len(), 2);
+
+    let utils = dependencies
+        .iter()
+        .copied()
+        .find(|dependency| &dependency.name == "miden-utils")
+        .expect("userspace package should record dynamic miden-utils dependency");
+    assert_eq!(utils.kind, TargetType::Library);
+    assert_eq!(utils.version.to_string(), "0.1.0");
+
+    let tx = dependencies
+        .iter()
+        .copied()
+        .find(|dependency| &dependency.name == "miden-tx")
+        .expect("userspace package should record workspace kernel dependency");
+    assert_eq!(tx.kind, TargetType::Kernel);
+    assert_eq!(tx.version.to_string(), "1.0.0");
 
     Ok(())
 }

--- a/crates/debug-types/src/lib.rs
+++ b/crates/debug-types/src/lib.rs
@@ -149,18 +149,15 @@ fn has_windows_drive_prefix(path: &str) -> bool {
 
 #[cfg(feature = "std")]
 fn has_restricted_scheme_prefix_without_slashes(uri: &str) -> bool {
-    match uri.split_once(':') {
+    matches!(
+        uri.split_once(':'),
         Some((prefix, rest))
             if !rest.starts_with("//")
                 && !prefix.is_empty()
                 && prefix
                     .chars()
-                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.')) =>
-        {
-            true
-        },
-        _ => false,
-    }
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
+    )
 }
 
 #[cfg(feature = "std")]

--- a/crates/debug-types/src/lib.rs
+++ b/crates/debug-types/src/lib.rs
@@ -70,7 +70,7 @@ impl Uri {
 
     /// Returns the scheme portion of this URI, if present.
     pub fn scheme(&self) -> Option<&str> {
-        match self.0.split_once(':') {
+        match self.0.split_once("://") {
             Some((prefix, _))
                 if prefix.contains(|c: char| {
                     !c.is_ascii_alphanumeric() && !matches!(c, '+' | '-' | '.')
@@ -85,49 +85,100 @@ impl Uri {
 
     /// Returns the authority portion of this URI, if present.
     pub fn authority(&self) -> Option<&str> {
-        let uri = self.0.as_ref();
-        let (_, rest) = uri.split_once("//")?;
-        match rest.split_once(['/', '?', '#']) {
+        let rest = self.hierarchical_part();
+        let authority_and_path = rest.strip_prefix("//")?;
+        match authority_and_path.split_once(['/', '?', '#']) {
             Some((authority, _)) => Some(authority),
-            None => Some(rest),
+            None => Some(authority_and_path),
         }
     }
 
     /// Returns the path portion of this URI.
     pub fn path(&self) -> &str {
-        let uri = self.0.as_ref();
-        let path = match uri.split_once("//") {
-            Some((_, rest)) => match rest.find('/').map(|pos| rest.split_at(pos)) {
-                Some((_, path)) => path,
+        let rest = self.hierarchical_part();
+        let path = match rest.strip_prefix("//") {
+            Some(authority_and_path) => match authority_and_path.find('/') {
+                Some(pos) => &authority_and_path[pos..],
                 None => return "",
             },
-            None => match uri.split_once(':') {
-                Some((prefix, _))
-                    if prefix.contains(|c: char| {
-                        !c.is_ascii_alphanumeric() && !matches!(c, '+' | '-' | '.')
-                    }) =>
-                {
-                    uri
-                },
-                Some((_, path)) => path,
-                None => uri,
-            },
+            None => rest,
         };
-        match path.split_once(['?', '#']) {
-            Some((path, _)) => path,
-            None => path,
-        }
+        strip_query_and_fragment(path)
     }
 
     /// Convert this URI to a [std::path::PathBuf], if it represents a file path
     #[cfg(feature = "std")]
     pub fn to_path(&self) -> Option<std::path::PathBuf> {
-        let uri = self.0.as_ref();
-        match uri.split_once("//") {
-            None => Some(std::path::PathBuf::from(uri)),
-            Some(("file", rest)) => Some(std::path::PathBuf::from(rest)),
+        if has_windows_drive_prefix(self.as_str()) {
+            return Some(std::path::PathBuf::from(self.as_str()));
+        }
+
+        match self.scheme() {
+            None if has_restricted_scheme_prefix_without_slashes(self.as_str()) => None,
+            None if self.authority().is_none() => Some(std::path::PathBuf::from(self.as_str())),
+            None => None,
+            Some(scheme)
+                if scheme.eq_ignore_ascii_case("file")
+                    && (matches!(self.authority(), None | Some(""))
+                        || self.authority().is_some_and(|authority| {
+                            authority.eq_ignore_ascii_case("localhost")
+                        })) =>
+            {
+                Some(std::path::PathBuf::from(local_file_uri_path(self.path())))
+            },
             Some(_) => None,
         }
+    }
+
+    fn hierarchical_part(&self) -> &str {
+        match self.scheme() {
+            Some(scheme) => &self.0[scheme.len() + 1..],
+            None => self.0.as_ref(),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+fn has_windows_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'/' | b'\\')
+}
+
+#[cfg(feature = "std")]
+fn has_restricted_scheme_prefix_without_slashes(uri: &str) -> bool {
+    match uri.split_once(':') {
+        Some((prefix, rest))
+            if !rest.starts_with("//")
+                && !prefix.is_empty()
+                && prefix
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.')) =>
+        {
+            true
+        },
+        _ => false,
+    }
+}
+
+#[cfg(feature = "std")]
+fn local_file_uri_path(path: &str) -> &str {
+    match path.strip_prefix('/') {
+        Some(path_without_leading_slash)
+            if has_windows_drive_prefix(path_without_leading_slash) =>
+        {
+            path_without_leading_slash
+        },
+        _ => path,
+    }
+}
+
+fn strip_query_and_fragment(path: &str) -> &str {
+    match path.split_once(['?', '#']) {
+        Some((path, _)) => path,
+        None => path,
     }
 }
 
@@ -266,7 +317,7 @@ mod tests {
     fn uri_scheme_extraction() {
         let relative_file = Uri::new("foo.masm");
         let relative_file_path = Uri::new("./foo.masm");
-        let relative_file_path_with_scheme = Uri::new("file:foo.masm");
+        let relative_file_path_with_colon = Uri::new("file:foo.masm");
         let absolute_file_path = Uri::new("file:///tmp/foo.masm");
         let http_simple_uri = Uri::new("http://www.example.com");
         let http_simple_uri_with_userinfo = Uri::new("http://foo:bar@www.example.com");
@@ -284,7 +335,7 @@ mod tests {
 
         assert_eq!(relative_file.scheme(), None);
         assert_eq!(relative_file_path.scheme(), None);
-        assert_eq!(relative_file_path_with_scheme.scheme(), Some("file"));
+        assert_eq!(relative_file_path_with_colon.scheme(), None);
         assert_eq!(absolute_file_path.scheme(), Some("file"));
         assert_eq!(http_simple_uri.scheme(), Some("http"));
         assert_eq!(http_simple_uri_with_userinfo.scheme(), Some("http"));
@@ -303,8 +354,10 @@ mod tests {
     fn uri_authority_extraction() {
         let relative_file = Uri::new("foo.masm");
         let relative_file_path = Uri::new("./foo.masm");
-        let relative_file_path_with_scheme = Uri::new("file:foo.masm");
+        let relative_file_path_with_empty_segment = Uri::new("foo//bar/baz");
+        let relative_file_path_with_colon = Uri::new("file:foo.masm");
         let absolute_file_path = Uri::new("file:///tmp/foo.masm");
+        let network_path_reference = Uri::new("//www.example.com/api/v1");
         let http_simple_uri = Uri::new("http://www.example.com");
         let http_simple_uri_with_userinfo = Uri::new("http://foo:bar@www.example.com");
         let http_simple_uri_with_userinfo_and_port = Uri::new("http://foo:bar@www.example.com:443");
@@ -321,8 +374,10 @@ mod tests {
 
         assert_eq!(relative_file.authority(), None);
         assert_eq!(relative_file_path.authority(), None);
-        assert_eq!(relative_file_path_with_scheme.authority(), None);
+        assert_eq!(relative_file_path_with_empty_segment.authority(), None);
+        assert_eq!(relative_file_path_with_colon.authority(), None);
         assert_eq!(absolute_file_path.authority(), Some(""));
+        assert_eq!(network_path_reference.authority(), Some("www.example.com"));
         assert_eq!(http_simple_uri.authority(), Some("www.example.com"));
         assert_eq!(http_simple_uri_with_userinfo.authority(), Some("foo:bar@www.example.com"));
         assert_eq!(
@@ -355,8 +410,10 @@ mod tests {
     fn uri_path_extraction() {
         let relative_file = Uri::new("foo.masm");
         let relative_file_path = Uri::new("./foo.masm");
-        let relative_file_path_with_scheme = Uri::new("file:foo.masm");
+        let relative_file_path_with_empty_segment = Uri::new("foo//bar/baz");
+        let relative_file_path_with_colon = Uri::new("file:foo.masm");
         let absolute_file_path = Uri::new("file:///tmp/foo.masm");
+        let network_path_reference = Uri::new("//www.example.com/api/v1");
         let http_simple_uri = Uri::new("http://www.example.com");
         let http_simple_uri_with_userinfo = Uri::new("http://foo:bar@www.example.com");
         let http_simple_uri_with_userinfo_and_port = Uri::new("http://foo:bar@www.example.com:443");
@@ -373,8 +430,10 @@ mod tests {
 
         assert_eq!(relative_file.path(), "foo.masm");
         assert_eq!(relative_file_path.path(), "./foo.masm");
-        assert_eq!(relative_file_path_with_scheme.path(), "foo.masm");
+        assert_eq!(relative_file_path_with_empty_segment.path(), "foo//bar/baz");
+        assert_eq!(relative_file_path_with_colon.path(), "file:foo.masm");
         assert_eq!(absolute_file_path.path(), "/tmp/foo.masm");
+        assert_eq!(network_path_reference.path(), "/api/v1");
         assert_eq!(http_simple_uri.path(), "");
         assert_eq!(http_simple_uri_with_userinfo.path(), "");
         assert_eq!(http_simple_uri_with_userinfo_and_port.path(), "");
@@ -386,5 +445,51 @@ mod tests {
             http_simple_uri_with_userinfo_and_path_and_query_and_fragment.path(),
             "/api/v1/user"
         );
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn uri_file_paths_convert_to_paths() {
+        assert_eq!(Uri::new("foo.masm").to_path(), Some(std::path::PathBuf::from("foo.masm")));
+        assert_eq!(
+            Uri::new("foo#bar?.masm").to_path(),
+            Some(std::path::PathBuf::from("foo#bar?.masm"))
+        );
+        assert_eq!(
+            Uri::new("C:\\tmp\\foo.masm").to_path(),
+            Some(std::path::PathBuf::from("C:\\tmp\\foo.masm"))
+        );
+        assert_eq!(
+            Uri::new("C:/tmp/foo.masm").to_path(),
+            Some(std::path::PathBuf::from("C:/tmp/foo.masm"))
+        );
+        assert_eq!(Uri::new("file:foo.masm").to_path(), None);
+        assert_eq!(
+            Uri::new("file:///tmp/foo.masm").to_path(),
+            Some(std::path::PathBuf::from("/tmp/foo.masm"))
+        );
+        assert_eq!(
+            Uri::new("FILE:///tmp/foo.masm").to_path(),
+            Some(std::path::PathBuf::from("/tmp/foo.masm"))
+        );
+        assert_eq!(
+            Uri::new("File:///tmp/foo.masm").to_path(),
+            Some(std::path::PathBuf::from("/tmp/foo.masm"))
+        );
+        assert_eq!(
+            Uri::new("file:///C:/tmp/foo.masm").to_path(),
+            Some(std::path::PathBuf::from("C:/tmp/foo.masm"))
+        );
+        assert_eq!(
+            Uri::new("file://localhost/tmp/foo.masm").to_path(),
+            Some(std::path::PathBuf::from("/tmp/foo.masm"))
+        );
+        assert_eq!(
+            Uri::new("file://LOCALHOST/tmp/foo.masm").to_path(),
+            Some(std::path::PathBuf::from("/tmp/foo.masm"))
+        );
+        assert_eq!(Uri::new("//www.example.com/api/v1").to_path(), None);
+        assert_eq!(Uri::new("file://www.example.com/tmp/foo.masm").to_path(), None);
+        assert_eq!(Uri::new("memory:foo.masm").to_path(), None);
     }
 }

--- a/crates/lib/core/tests/helpers.rs
+++ b/crates/lib/core/tests/helpers.rs
@@ -11,7 +11,13 @@ pub fn masm_store_felts(felts: &[Felt], base_addr: u32) -> String {
         .enumerate()
         .map(|(i, felt)| {
             let value = felt.as_canonical_u64();
-            format!("push.{value} push.{} mem_store", base_addr + i as u32)
+            let offset = u32::try_from(i).unwrap_or_else(|_| {
+                panic!("too many felts to store from base address {base_addr}")
+            });
+            let addr = base_addr.checked_add(offset).unwrap_or_else(|| {
+                panic!("memory address overflow storing felt {i} from base address {base_addr}")
+            });
+            format!("push.{value} push.{addr} mem_store")
         })
         .collect::<Vec<_>>()
         .join(" ")
@@ -25,4 +31,24 @@ pub fn masm_push_felts(felts: &[Felt]) -> String {
         .map(|felt| format!("push.{}", felt.as_canonical_u64()))
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn masm_store_felts_accepts_last_u32_address() {
+        let source = masm_store_felts(&[Felt::new_unchecked(7)], u32::MAX);
+
+        assert_eq!(source, format!("push.7 push.{} mem_store", u32::MAX));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "memory address overflow storing felt 1 from base address 4294967295"
+    )]
+    fn masm_store_felts_panics_clearly_on_address_overflow() {
+        masm_store_felts(&[Felt::new_unchecked(7), Felt::new_unchecked(11)], u32::MAX);
+    }
 }

--- a/crates/miden-format/Cargo.toml
+++ b/crates/miden-format/Cargo.toml
@@ -27,3 +27,9 @@ serde.workspace = true
 thiserror = { workspace = true, features = ["std"] }
 toml = { workspace = true, features = ["display", "parse", "serde", "std"] }
 walkdir.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/miden-format/Cargo.toml
+++ b/crates/miden-format/Cargo.toml
@@ -29,7 +29,7 @@ toml = { workspace = true, features = ["display", "parse", "serde", "std"] }
 walkdir.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/miden-format/src/config.rs
+++ b/crates/miden-format/src/config.rs
@@ -14,7 +14,12 @@ pub enum ConfigError {
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// The width of an indent (in spaces)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        rename = "indent_width",
+        alias = "indent_size",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub indent_size: Option<u8>,
     /// The maximum length (in characters) of any line before line breaks are introduced
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -89,8 +94,8 @@ impl clap::builder::TypedValueParser for ConfigValueParser {
             let opt = opt.trim();
             let kv = opt.split_once('=').map(|(k, v)| (k.trim(), v.trim()));
             match kv {
-                Some(("indent_size", value)) => {
-                    config.indent_size = Some(parse_u8(value, "indent_size")?);
+                Some(("indent_width" | "indent_size", value)) => {
+                    config.indent_size = Some(parse_u8(value, "indent_width")?);
                 },
                 Some(("max_line_length", value)) => {
                     config.max_line_length = Some(parse_u8(value, "max_line_length")?);
@@ -113,4 +118,36 @@ fn parse_u8(input: &str, prop: &str) -> Result<u8, clap::Error> {
     input.parse::<u8>().map_err(|err| {
         clap::Error::raw(ErrorKind::ValueValidation, format!("invalid value for {prop}: {err}"))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use clap::builder::TypedValueParser;
+
+    use super::*;
+
+    #[test]
+    fn toml_config_accepts_documented_indent_width() {
+        let config: Config = toml::from_str("indent_width = 2").unwrap();
+        assert_eq!(config.indent_size(), 2);
+    }
+
+    #[test]
+    fn toml_config_keeps_indent_size_as_legacy_alias() {
+        let config: Config = toml::from_str("indent_size = 2").unwrap();
+        assert_eq!(config.indent_size(), 2);
+    }
+
+    #[test]
+    fn cli_config_accepts_documented_indent_width() {
+        let command = clap::Command::new("miden-format");
+        let config = ConfigValueParser
+            .parse_ref(&command, None, OsStr::new("indent_width=2,max_line_length=80"))
+            .unwrap();
+
+        assert_eq!(config.indent_size(), 2);
+        assert_eq!(config.max_line_length(), 80);
+    }
 }

--- a/crates/miden-format/src/formatter.rs
+++ b/crates/miden-format/src/formatter.rs
@@ -37,7 +37,7 @@ struct NodeLayout {
     node: SyntaxNode,
     same_line_with_prev: bool,
     blank_lines_before: usize,
-    leading_comments: Vec<String>,
+    leading_comments: Vec<LeadingComment>,
     trailing_comment: Option<String>,
     trailing_comments: Vec<String>,
 }
@@ -45,7 +45,13 @@ struct NodeLayout {
 #[derive(Debug, Default)]
 struct ContainerTail {
     blank_lines_before: usize,
-    leading_comments: Vec<String>,
+    leading_comments: Vec<LeadingComment>,
+}
+
+#[derive(Debug)]
+struct LeadingComment {
+    blank_lines_before: usize,
+    text: String,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -62,7 +68,7 @@ struct Interstice {
     state: IntersticeState,
     same_line_with_prev: bool,
     blank_lines: usize,
-    leading_comments: Vec<String>,
+    leading_comments: Vec<LeadingComment>,
     trailing_comment: Option<String>,
     trailing_comments: Vec<String>,
 }
@@ -127,7 +133,11 @@ impl Interstice {
                 },
                 IntersticeState::StartOfLine => {
                     self.same_line_with_prev = false;
-                    self.leading_comments.push(trimmed_comment(token));
+                    self.leading_comments.push(LeadingComment {
+                        blank_lines_before: self.blank_lines.min(1),
+                        text: trimmed_comment(token),
+                    });
+                    self.blank_lines = 0;
                     self.state = IntersticeState::AfterLeadingComment;
                 },
                 IntersticeState::AfterLeadingComment | IntersticeState::AfterTrailingComment => (),
@@ -1573,13 +1583,8 @@ fn emit_trailing_comments(lines: &mut Vec<String>, comments: &[String], indent: 
 }
 
 fn emit_leading_layout(lines: &mut Vec<String>, entry: &NodeLayout, indent: usize) {
-    if entry.blank_lines_before > 0 && !lines.is_empty() {
-        push_blank_line(lines);
-    }
-
-    for comment in &entry.leading_comments {
-        lines.push(format!("{}{}", indent_string(indent), comment));
-    }
+    emit_leading_comments(lines, &entry.leading_comments, indent);
+    emit_blank_lines_before_syntax(lines, entry.blank_lines_before);
 }
 
 fn emit_tail_layout(lines: &mut Vec<String>, tail: ContainerTail, indent: usize) {
@@ -1587,12 +1592,22 @@ fn emit_tail_layout(lines: &mut Vec<String>, tail: ContainerTail, indent: usize)
         return;
     }
 
-    if tail.blank_lines_before > 0 && !lines.is_empty() {
-        push_blank_line(lines);
-    }
+    emit_leading_comments(lines, &tail.leading_comments, indent);
+    emit_blank_lines_before_syntax(lines, tail.blank_lines_before);
+}
 
-    for comment in tail.leading_comments {
-        lines.push(format!("{}{}", indent_string(indent), comment));
+fn emit_leading_comments(lines: &mut Vec<String>, comments: &[LeadingComment], indent: usize) {
+    for comment in comments {
+        if comment.blank_lines_before > 0 && !lines.is_empty() {
+            push_blank_line(lines);
+        }
+        lines.push(format!("{}{}", indent_string(indent), comment.text));
+    }
+}
+
+fn emit_blank_lines_before_syntax(lines: &mut Vec<String>, blank_lines_before: usize) {
+    if blank_lines_before > 0 && !lines.is_empty() {
+        push_blank_line(lines);
     }
 }
 
@@ -2499,6 +2514,35 @@ pub proc set_item
 
     swapw movup.8
     # => [slot_ptr, VALUE, OLD_VALUE]
+end
+";
+
+        let parse = parse_text(source);
+        assert!(!parse.has_errors(), "{:?}", parse.diagnostics());
+
+        let config = Config::default();
+        let formatted = format_syntax(&config, &parse.syntax());
+        assert_eq!(formatted, source);
+
+        let reparsed = parse_text(&formatted);
+        assert!(!reparsed.has_errors(), "{:?}", reparsed.diagnostics());
+
+        let reformatted = format_syntax(&config, &reparsed.syntax());
+        assert_eq!(reformatted, formatted);
+    }
+
+    #[test]
+    fn preserves_blank_lines_between_root_comment_blocks() {
+        let source = "\
+# PROCEDURES
+# =================================================================================================
+
+# DELTA COMPUTATION
+# -------------------------------------------------------------------------------------------------
+
+#! Computes the commitment to the native account's delta.
+begin
+    nop
 end
 ";
 

--- a/crates/miden-format/src/main.rs
+++ b/crates/miden-format/src/main.rs
@@ -66,6 +66,8 @@ enum CliError {
     InvalidSourceUri { path: String },
     #[error("failed to read source from stdin: {0}")]
     ReadStdin(#[source] io::Error),
+    #[error("failed to write formatted source to stdout: {0}")]
+    WriteStdout(#[source] io::Error),
     #[error("syntax errors were found in the provided inputs")]
     SyntaxErrors,
     #[error("the following inputs are not formatted:\n{0}")]
@@ -154,7 +156,8 @@ fn run() -> Result<(), CliError> {
 
     if cli.stdin {
         if let Some((_, formatted)) = formatted_inputs.into_iter().next() {
-            print!("{formatted}");
+            let mut stdout = io::stdout().lock();
+            write_formatted_stdout(&formatted, &mut stdout)?;
         }
         return Ok(());
     }
@@ -177,6 +180,19 @@ fn run() -> Result<(), CliError> {
 
 fn replace_file_atomically(path: &Path, contents: &[u8]) -> io::Result<()> {
     replace_file_atomically_with(path, |file| file.write_all(contents))
+}
+
+fn write_formatted_stdout(formatted: &str, writer: &mut impl Write) -> Result<(), CliError> {
+    handle_stdout_result(writer.write_all(formatted.as_bytes()))?;
+    handle_stdout_result(writer.flush())
+}
+
+fn handle_stdout_result(result: io::Result<()>) -> Result<(), CliError> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        Err(err) => Err(CliError::WriteStdout(err)),
+    }
 }
 
 fn replace_file_atomically_with(
@@ -385,6 +401,97 @@ mod tests {
 
         assert!(rendered.contains("snippet.masm"));
         assert!(rendered.contains("begin"));
+    }
+
+    struct FailingWriter {
+        kind: ErrorKind,
+    }
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(self.kind, "injected stdout failure"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    struct FlushFailingWriter {
+        kind: ErrorKind,
+        output: Vec<u8>,
+    }
+
+    impl Write for FlushFailingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.output.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(self.kind, "injected stdout flush failure"))
+        }
+    }
+
+    #[test]
+    fn stdout_writer_accepts_broken_pipe() {
+        let mut writer = FailingWriter { kind: ErrorKind::BrokenPipe };
+
+        write_formatted_stdout("begin\nend\n", &mut writer)
+            .expect("broken pipe should be accepted for stdout");
+    }
+
+    #[test]
+    fn stdout_writer_reports_non_broken_pipe_errors() {
+        let mut writer = FailingWriter { kind: ErrorKind::WriteZero };
+
+        let err = write_formatted_stdout("begin\nend\n", &mut writer)
+            .expect_err("non-broken-pipe stdout errors should be reported");
+
+        assert!(matches!(
+            err,
+            CliError::WriteStdout(source) if source.kind() == ErrorKind::WriteZero
+        ));
+    }
+
+    #[test]
+    fn stdout_writer_accepts_broken_pipe_on_flush() {
+        let mut writer = FlushFailingWriter {
+            kind: ErrorKind::BrokenPipe,
+            output: Vec::new(),
+        };
+
+        write_formatted_stdout("begin\nend\n", &mut writer)
+            .expect("broken pipe should be accepted during stdout flush");
+
+        assert_eq!(writer.output, b"begin\nend\n");
+    }
+
+    #[test]
+    fn stdout_writer_reports_non_broken_pipe_flush_errors() {
+        let mut writer = FlushFailingWriter {
+            kind: ErrorKind::WriteZero,
+            output: Vec::new(),
+        };
+
+        let err = write_formatted_stdout("begin\nend\n", &mut writer)
+            .expect_err("non-broken-pipe stdout flush errors should be reported");
+
+        assert!(matches!(
+            err,
+            CliError::WriteStdout(source) if source.kind() == ErrorKind::WriteZero
+        ));
+        assert_eq!(writer.output, b"begin\nend\n");
+    }
+
+    #[test]
+    fn stdout_writer_writes_formatted_source() {
+        let mut output = Vec::new();
+
+        write_formatted_stdout("begin\nend\n", &mut output)
+            .expect("stdout writer should accept writable output");
+
+        assert_eq!(output, b"begin\nend\n");
     }
 
     #[test]

--- a/crates/miden-format/src/main.rs
+++ b/crates/miden-format/src/main.rs
@@ -3,8 +3,8 @@ mod formatter;
 
 use std::{
     fs,
-    io::{self, Read},
-    path::PathBuf,
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
     process::ExitCode,
     sync::Arc,
 };
@@ -21,6 +21,12 @@ use miden_debug_types::{
 };
 
 use self::{config::Config, formatter::format_syntax};
+
+#[derive(Debug)]
+struct Input {
+    source: Arc<SourceFile>,
+    path: Option<PathBuf>,
+}
 
 #[derive(Debug, Parser)]
 #[command(name = "miden-format", version, about = "Format Miden Assembly source files")]
@@ -108,13 +114,14 @@ fn run() -> Result<(), CliError> {
     let mut has_syntax_errors = false;
     let mut formatted_inputs = Vec::with_capacity(inputs.len());
     for input in inputs {
-        let mut parse = parse_source_file(input.clone());
+        let source = input.source.clone();
+        let mut parse = parse_source_file(source.clone());
         if parse.has_errors() {
             has_syntax_errors = true;
             for diagnostic in parse.take_diagnostics() {
                 eprintln!(
                     "{}",
-                    PrintDiagnostic::new(report_parse_diagnostic(input.clone(), diagnostic))
+                    PrintDiagnostic::new(report_parse_diagnostic(source.clone(), diagnostic))
                 );
             }
             continue;
@@ -129,7 +136,8 @@ fn run() -> Result<(), CliError> {
 
     if cli.check {
         let mut mismatches = Vec::new();
-        for (source, formatted) in &formatted_inputs {
+        for (input, formatted) in &formatted_inputs {
+            let source = &input.source;
             if source.as_str() != formatted {
                 mismatches.push(source.uri());
             }
@@ -151,17 +159,15 @@ fn run() -> Result<(), CliError> {
         return Ok(());
     }
 
-    for (source, formatted) in formatted_inputs {
+    for (input, formatted) in formatted_inputs {
+        let source = &input.source;
         if source.as_str() == formatted {
             continue;
         }
 
-        let path = source
-            .uri()
-            .to_path()
-            .ok_or_else(|| CliError::InvalidSourceUri { path: source.uri().to_string() })?;
-        fs::write(path, formatted).map_err(|err| CliError::WriteFile {
-            path: source.uri().to_string(),
+        let path = output_path_for_input(&input)?;
+        replace_file_atomically(path, formatted.as_bytes()).map_err(|err| CliError::WriteFile {
+            path: path.display().to_string(),
             source: err,
         })?;
     }
@@ -169,14 +175,148 @@ fn run() -> Result<(), CliError> {
     Ok(())
 }
 
+fn replace_file_atomically(path: &Path, contents: &[u8]) -> io::Result<()> {
+    replace_file_atomically_with(path, |file| file.write_all(contents))
+}
+
+fn replace_file_atomically_with(
+    path: &Path,
+    write_contents: impl FnOnce(&mut fs::File) -> io::Result<()>,
+) -> io::Result<()> {
+    let path = atomic_replace_target(path)?;
+    let path = path.as_path();
+    ensure_existing_target_is_writable(path)?;
+
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "cannot replace path without file name")
+    })?;
+    let file_name = file_name.to_string_lossy();
+    let temp_path =
+        parent.join(format!(".{file_name}.tmp-{}-{}", std::process::id(), unique_temp_suffix()));
+
+    let mut temp_file = create_temp_file_for_atomic_replace(&temp_path, path)?;
+
+    if let Err(err) = write_contents(&mut temp_file) {
+        drop(temp_file);
+        let _ = fs::remove_file(&temp_path);
+        return Err(err);
+    }
+
+    if let Err(err) = temp_file.sync_all() {
+        drop(temp_file);
+        let _ = fs::remove_file(&temp_path);
+        return Err(err);
+    }
+    drop(temp_file);
+    if let Err(err) = replace_path_atomically(&temp_path, path) {
+        let _ = fs::remove_file(&temp_path);
+        return Err(err);
+    }
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_path_atomically(temp_path: &Path, path: &Path) -> io::Result<()> {
+    fs::rename(temp_path, path)
+}
+
+#[cfg(windows)]
+fn replace_path_atomically(temp_path: &Path, path: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Storage::FileSystem::{
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+    };
+
+    let temp_path = temp_path.as_os_str().encode_wide().chain(Some(0)).collect::<Vec<_>>();
+    let path = path.as_os_str().encode_wide().chain(Some(0)).collect::<Vec<_>>();
+    let result = unsafe {
+        MoveFileExW(
+            temp_path.as_ptr(),
+            path.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+fn atomic_replace_target(path: &Path) -> io::Result<PathBuf> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => fs::canonicalize(path),
+        Ok(_) => Ok(path.to_path_buf()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(path.to_path_buf()),
+        Err(error) => Err(error),
+    }
+}
+
+fn ensure_existing_target_is_writable(path: &Path) -> io::Result<()> {
+    match fs::OpenOptions::new().write(true).open(path) {
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn create_temp_file_for_atomic_replace(
+    temp_path: &Path,
+    target_path: &Path,
+) -> io::Result<fs::File> {
+    let existing_permissions = match fs::metadata(target_path) {
+        Ok(metadata) => Some(metadata.permissions()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error),
+    };
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        options.mode(
+            existing_permissions
+                .as_ref()
+                .map_or(0o600, |permissions| permissions.mode() & 0o777),
+        );
+    }
+
+    let file = options.open(temp_path)?;
+    if let Some(permissions) = existing_permissions
+        && let Err(err) = fs::set_permissions(temp_path, permissions)
+    {
+        drop(file);
+        let _ = fs::remove_file(temp_path);
+        return Err(err);
+    }
+
+    Ok(file)
+}
+
+fn output_path_for_input(input: &Input) -> Result<&Path, CliError> {
+    input
+        .path
+        .as_deref()
+        .ok_or_else(|| CliError::InvalidSourceUri { path: input.source.uri().to_string() })
+}
+
+fn unique_temp_suffix() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default()
+}
+
 fn report_parse_diagnostic(source: Arc<SourceFile>, diagnostic: MietteDiagnostic) -> Report {
     Report::from(diagnostic).with_source_code(source)
 }
 
-fn collect_inputs(
-    cli: &Cli,
-    source_manager: &dyn SourceManager,
-) -> Result<Vec<Arc<SourceFile>>, CliError> {
+fn collect_inputs(cli: &Cli, source_manager: &dyn SourceManager) -> Result<Vec<Input>, CliError> {
     let mut inputs = Vec::with_capacity(cli.paths.len());
 
     if cli.stdin {
@@ -184,7 +324,7 @@ fn collect_inputs(
         let mut source = String::new();
         io::stdin().read_to_string(&mut source).map_err(CliError::ReadStdin)?;
         let source = source_manager.load(SourceLanguage::Masm, Uri::from(path.as_path()), source);
-        inputs.push(source);
+        inputs.push(Input { source, path: None });
         return Ok(inputs);
     }
 
@@ -205,12 +345,13 @@ fn collect_inputs(
                 if entry.path().extension().is_none_or(|ext| !ext.eq_ignore_ascii_case("masm")) {
                     continue;
                 }
-                let source = source_manager.load_file(entry.path())?;
-                inputs.push(source);
+                let path = entry.path().to_path_buf();
+                let source = source_manager.load_file(&path)?;
+                inputs.push(Input { source, path: Some(path) });
             }
         } else {
             let source = source_manager.load_file(path)?;
-            inputs.push(source);
+            inputs.push(Input { source, path: Some(path.clone()) });
         }
     }
 
@@ -219,7 +360,7 @@ fn collect_inputs(
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{io::ErrorKind, path::Path};
 
     use super::*;
 
@@ -244,5 +385,94 @@ mod tests {
 
         assert!(rendered.contains("snippet.masm"));
         assert!(rendered.contains("begin"));
+    }
+
+    #[test]
+    fn atomic_replacement_preserves_original_on_write_failure() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("source.masm");
+        fs::write(&path, "begin\n    push.1\nend\n").expect("failed to write source");
+
+        let error = replace_file_atomically_with(&path, |file| {
+            file.write_all(b"partial replacement")?;
+            Err(io::Error::new(ErrorKind::WriteZero, "injected write failure"))
+        })
+        .expect_err("expected injected write failure");
+
+        assert_eq!(error.kind(), ErrorKind::WriteZero);
+        let contents = fs::read_to_string(&path).expect("failed to read source after failure");
+        assert_eq!(contents, "begin\n    push.1\nend\n");
+    }
+
+    #[test]
+    fn atomic_replacement_overwrites_existing_file() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("source.masm");
+        fs::write(&path, "begin\n    push.1\nend\n").expect("failed to write source");
+
+        replace_file_atomically(&path, b"begin\n    push.2\nend\n")
+            .expect("failed to replace existing source");
+
+        let contents = fs::read_to_string(&path).expect("failed to read source after replace");
+        assert_eq!(contents, "begin\n    push.2\nend\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_replacement_rejects_read_only_existing_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("source.masm");
+        fs::write(&path, "begin\n    push.1\nend\n").expect("failed to write source");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o444))
+            .expect("failed to make source read-only");
+
+        let error = replace_file_atomically(&path, b"begin\n    push.2\nend\n")
+            .expect_err("expected read-only source write to fail");
+
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        let contents = fs::read_to_string(&path).expect("failed to read source after failure");
+        assert_eq!(contents, "begin\n    push.1\nend\n");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644))
+            .expect("failed to restore source permissions");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_replacement_follows_symlinked_source() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let target = dir.path().join("target.masm");
+        let link = dir.path().join("source.masm");
+        fs::write(&target, "begin\n    push.1\nend\n").expect("failed to write target");
+        symlink(&target, &link).expect("failed to create source symlink");
+
+        replace_file_atomically(&link, b"begin\n    push.2\nend\n")
+            .expect("failed to replace symlinked source target");
+
+        assert!(
+            fs::symlink_metadata(&link)
+                .expect("failed to stat source symlink")
+                .file_type()
+                .is_symlink()
+        );
+        let contents = fs::read_to_string(&target).expect("failed to read target after replace");
+        assert_eq!(contents, "begin\n    push.2\nend\n");
+    }
+
+    #[test]
+    fn output_path_uses_original_path_instead_of_source_uri_round_trip() {
+        let source_manager = Arc::new(DefaultSourceManager::default());
+        let source = source_manager.load(
+            SourceLanguage::Masm,
+            Uri::new("file:///source-uri.masm"),
+            "begin\nend\n".to_string(),
+        );
+        let path = PathBuf::from("original-path.masm");
+        let input = Input { source, path: Some(path.clone()) };
+
+        assert_eq!(output_path_for_input(&input).unwrap(), path.as_path());
     }
 }

--- a/crates/package-registry-local/Cargo.toml
+++ b/crates/package-registry-local/Cargo.toml
@@ -29,7 +29,7 @@ thiserror.workspace = true
 toml = { workspace = true, features = ["display", "parse", "serde", "std"] }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 miden-mast-package = { workspace = true, features = ["arbitrary"] }

--- a/crates/package-registry-local/Cargo.toml
+++ b/crates/package-registry-local/Cargo.toml
@@ -28,6 +28,9 @@ serde_json = { workspace = true, features = ["std"] }
 thiserror.workspace = true
 toml = { workspace = true, features = ["display", "parse", "serde", "std"] }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }
+
 [dev-dependencies]
 miden-mast-package = { workspace = true, features = ["arbitrary"] }
 tempfile = { workspace = true, features = ["getrandom"] }

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -1,9 +1,14 @@
 use std::{
     collections::BTreeMap,
-    env, fs,
-    io::{Read, Seek, Write},
+    env,
+    ffi::OsString,
+    fs,
+    io::{self, Read, Write},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use miden_assembly_syntax::Report;
@@ -24,13 +29,13 @@ pub enum LocalRegistryError {
     #[error("missing required environment variable '{var}'")]
     MissingEnv { var: &'static str },
     #[error("failed to read registry index: {0}")]
-    IndexRead(#[source] std::io::Error),
+    IndexRead(#[source] io::Error),
     #[error("failed to seek in registry index stream: {0}")]
-    IndexSeek(#[source] std::io::Error),
+    IndexSeek(#[source] io::Error),
     #[error("failed to lock registry index for reading: {0}")]
     IndexReadLock(#[source] fs::TryLockError),
     #[error("failed to write registry index: {0}")]
-    IndexWrite(#[source] std::io::Error),
+    IndexWrite(#[source] io::Error),
     #[error("failed to lock registry index for writing: {0}")]
     IndexWriteLock(#[source] fs::TryLockError),
     #[error(
@@ -98,6 +103,8 @@ pub struct LocalPackageRegistry {
     index: InMemoryPackageRegistry,
     index_checksum: [u8; 32],
 }
+
+static ATOMIC_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 /// The metadata about a package produced when listing or describing a package in the index
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -167,6 +174,11 @@ impl LocalPackageRegistry {
             fs::create_dir_all(parent).map_err(LocalRegistryError::IndexWrite)?;
         }
         fs::create_dir_all(&artifact_dir).map_err(LocalRegistryError::IndexWrite)?;
+        // Use a stable sidecar lock file rather than locking the index itself. The index is
+        // atomically replaced on writes, so locking the replaceable file would leave stale file
+        // handles on Unix. If no sidecar exists yet, read the atomically replaced index without
+        // creating the lock so read-only registries remain loadable.
+        let _lock_file = open_existing_index_lock_for_read(&index_path)?;
 
         let index_checksum: [u8; 32];
         let index = if index_path.exists() {
@@ -178,15 +190,6 @@ impl LocalPackageRegistry {
             {
                 let mut file =
                     fs::File::open(&index_path).map_err(LocalRegistryError::IndexRead)?;
-                // Acquire a non-exclusive lock on the file for reading, but return an error if
-                // there is an outstanding exclusive lock on the file already.
-                //
-                // This will fail if a handle to the index file has an exclusive lock on it for
-                // writing, see `save` for details.
-                //
-                // Multiple readers can hold this type of lock simultaneously, but a shared lock
-                // cannot be acquired in the presence of an exclusive lock, and vice versa.
-                file.try_lock_shared().map_err(LocalRegistryError::IndexReadLock)?;
                 file.read_to_string(&mut contents).map_err(LocalRegistryError::IndexRead)?;
             }
             let contents = contents.trim();
@@ -363,21 +366,20 @@ impl LocalPackageRegistry {
     ) -> Result<(), LocalRegistryError> {
         let persisted = PersistedIndex { packages: self.index.packages().clone() };
         let contents = toml::to_string_pretty(&persisted)?;
-        let mut file = fs::File::options()
+        let lock_path = lock_path_for_index(&self.index_path);
+        let lock_file = fs::File::options()
             .read(true)
             .write(true)
             .truncate(false)
             .create(true)
-            .open(&self.index_path)
+            .open(lock_path)
             .map_err(LocalRegistryError::IndexWrite)?;
-        // Acquire an exclusive lock for writing the index file, and return an error if we cannot
-        // obtain one due to any other outstanding lock on the file.
+        // Acquire an exclusive lock on the stable sidecar lock file, and return an error if we
+        // cannot obtain one due to any other outstanding registry read or write lock.
         //
-        // This will fail if another write is being performed on the same file, or if the index is
-        // currently being loaded by another process.
-        //
-        // See `load` for the non-exclusive lock obtained for reads
-        file.try_lock().map_err(LocalRegistryError::IndexWriteLock)?;
+        // The index itself is atomically replaced, so locking the index file directly is not safe:
+        // a process that opened the old index before replacement would lock a stale inode.
+        lock_file.try_lock().map_err(LocalRegistryError::IndexWriteLock)?;
 
         // Validate that the contents of the persisted index have not changed under us, by
         // recomputing the checksum of its contents and comparing to when we last loaded the index.
@@ -386,8 +388,11 @@ impl LocalPackageRegistry {
             reason = "checksum validation must read from the already-locked file handle"
         )]
         {
-            let mut prev_contents = Vec::with_capacity(1024);
-            file.read_to_end(&mut prev_contents).map_err(LocalRegistryError::IndexRead)?;
+            let prev_contents = match fs::read(&self.index_path) {
+                Ok(contents) => contents,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => Vec::new(),
+                Err(error) => return Err(LocalRegistryError::IndexRead(error)),
+            };
             let checksum = miden_core::crypto::hash::Sha256::hash(prev_contents.trim_ascii());
             if &self.index_checksum != checksum.as_bytes() {
                 return Err(LocalRegistryError::WriteToStaleIndex);
@@ -400,11 +405,8 @@ impl LocalPackageRegistry {
         // update the in-memory state until we've successfully persisted the index
         let new_checksum = miden_core::crypto::hash::Sha256::hash(contents.as_bytes().trim_ascii());
 
-        // Truncate the file to ensure that if the new index is smaller than the old one, that
-        // we don't end up with a corrupted index.
-        file.rewind().map_err(LocalRegistryError::IndexSeek)?;
-        file.set_len(0).map_err(LocalRegistryError::IndexWrite)?;
-        file.write_all(contents.as_bytes()).map_err(LocalRegistryError::IndexWrite)?;
+        write_file_atomically(&self.index_path, contents.as_bytes())
+            .map_err(LocalRegistryError::IndexWrite)?;
 
         // Update the index checksum for the next write
         self.index_checksum = *new_checksum.as_bytes();
@@ -443,7 +445,7 @@ impl LocalPackageRegistry {
                         Version::new(existing_package.version.clone(), existing_package.digest());
                     if existing_package.name == package.name && existing_version == *version {
                         if &existing_package == package {
-                            fs::write(artifact_path, existing_bytes)
+                            write_file_atomically(artifact_path, &existing_bytes)
                                 .map_err(LocalRegistryError::IndexWrite)
                         } else {
                             Err(LocalRegistryError::DuplicateSemanticVersion {
@@ -452,12 +454,16 @@ impl LocalPackageRegistry {
                             })
                         }
                     } else {
-                        fs::write(artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)
+                        write_file_atomically(artifact_path, bytes)
+                            .map_err(LocalRegistryError::IndexWrite)
                     }
                 },
-                Err(_) => fs::write(artifact_path, bytes).map_err(LocalRegistryError::IndexWrite),
+                Err(_) => write_file_atomically(artifact_path, bytes)
+                    .map_err(LocalRegistryError::IndexWrite),
             },
-            Err(_) => fs::write(artifact_path, bytes).map_err(LocalRegistryError::IndexWrite),
+            Err(_) => {
+                write_file_atomically(artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)
+            },
         }
     }
 
@@ -612,7 +618,7 @@ impl LocalPackageRegistry {
         }
 
         self.register_and_save_with_locked_operation(package.name.clone(), record, || {
-            fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)
+            write_file_atomically(&artifact_path, &bytes).map_err(LocalRegistryError::IndexWrite)
         })?;
 
         Ok(PublishedPackage {
@@ -656,7 +662,7 @@ impl LocalPackageRegistry {
 
         // Persist the updated registry index and artifact under the index write lock.
         self.register_and_save_with_locked_operation(package.name.clone(), record, || {
-            fs::write(&artifact_path, bytes).map_err(LocalRegistryError::IndexWrite)
+            write_file_atomically(&artifact_path, &bytes).map_err(LocalRegistryError::IndexWrite)
         })?;
 
         Ok(PublishedPackage {
@@ -664,6 +670,111 @@ impl LocalPackageRegistry {
             version,
             artifact_path,
         })
+    }
+}
+
+fn lock_path_for_index(index_path: &Path) -> PathBuf {
+    let parent = index_path.parent().unwrap_or_else(|| Path::new("."));
+    let mut file_name = index_path
+        .file_name()
+        .map(OsString::from)
+        .unwrap_or_else(|| OsString::from("index.toml"));
+    file_name.push(".lock");
+    parent.join(file_name)
+}
+
+fn open_existing_index_lock_for_read(
+    index_path: &Path,
+) -> Result<Option<fs::File>, LocalRegistryError> {
+    let lock_path = lock_path_for_index(index_path);
+    let lock_file = match fs::File::options().read(true).open(lock_path) {
+        Ok(lock_file) => lock_file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(LocalRegistryError::IndexRead(error)),
+    };
+    lock_file.try_lock_shared().map_err(LocalRegistryError::IndexReadLock)?;
+    Ok(Some(lock_file))
+}
+
+fn write_file_atomically(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    write_file_atomically_with(path, |file| file.write_all(bytes))
+}
+
+fn write_file_atomically_with(
+    path: &Path,
+    write: impl FnOnce(&mut fs::File) -> io::Result<()>,
+) -> io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "atomic write path has no file name")
+    })?;
+    let counter = ATOMIC_WRITE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut temp_name = OsString::from(".");
+    temp_name.push(file_name);
+    temp_name.push(format!(".tmp-{}-{counter}", std::process::id()));
+    let temp_path = parent.join(temp_name);
+
+    let result = (|| {
+        let existing_permissions = match fs::metadata(path) {
+            Ok(metadata) => Some(metadata.permissions()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error),
+        };
+        let mut open_options = fs::File::options();
+        open_options.write(true).create_new(true);
+
+        #[cfg(unix)]
+        if let Some(permissions) = existing_permissions.as_ref() {
+            use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+            open_options.mode(permissions.mode() & 0o777);
+        }
+
+        let mut temp = open_options.open(&temp_path)?;
+        if let Some(permissions) = existing_permissions {
+            fs::set_permissions(&temp_path, permissions)?;
+        }
+        write(&mut temp)?;
+        temp.sync_all()?;
+        drop(temp);
+        replace_path_atomically(&temp_path, path)?;
+        let _ = fs::File::open(parent).and_then(|dir| dir.sync_all());
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+
+    result
+}
+
+#[cfg(not(windows))]
+fn replace_path_atomically(temp_path: &Path, path: &Path) -> io::Result<()> {
+    fs::rename(temp_path, path)
+}
+
+#[cfg(windows)]
+fn replace_path_atomically(temp_path: &Path, path: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    use windows_sys::Win32::Storage::FileSystem::{
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+    };
+
+    let temp_path = temp_path.as_os_str().encode_wide().chain(Some(0)).collect::<Vec<_>>();
+    let path = path.as_os_str().encode_wide().chain(Some(0)).collect::<Vec<_>>();
+    let result = unsafe {
+        MoveFileExW(
+            temp_path.as_ptr(),
+            path.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
     }
 }
 
@@ -740,6 +851,114 @@ mod tests {
         let index_path = tempdir.path().join("midenup").join("registry").join("index.toml");
         let artifact_dir = tempdir.path().join("sysroot").join("lib");
         LocalPackageRegistry::load(index_path, artifact_dir).expect("failed to load registry")
+    }
+
+    #[test]
+    fn atomic_file_replacement_preserves_existing_file_on_write_failure() {
+        let tempdir = TempDir::new().unwrap();
+        let target = tempdir.path().join("index.toml");
+        fs::write(&target, b"previous index").unwrap();
+
+        let error = write_file_atomically_with(&target, |_file| {
+            Err(io::Error::other("injected write failure"))
+        })
+        .expect_err("injected write failure should be returned");
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(fs::read(&target).unwrap(), b"previous index");
+        let leftovers = fs::read_dir(tempdir.path()).unwrap().count();
+        assert_eq!(leftovers, 1);
+    }
+
+    #[test]
+    fn atomic_file_replacement_overwrites_existing_file() {
+        let tempdir = TempDir::new().unwrap();
+        let target = tempdir.path().join("index.toml");
+        fs::write(&target, b"previous index").unwrap();
+
+        write_file_atomically(&target, b"updated index").unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"updated index");
+    }
+
+    #[test]
+    fn registry_uses_stable_sidecar_lock_file() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+        let lock_path = lock_path_for_index(&registry.index_path);
+        assert_ne!(lock_path, registry.index_path);
+        assert!(!lock_path.exists());
+
+        let package_path = tempdir.path().join("pkg.masp");
+        build_package("pkg", "1.0.0", []).write_to_file(&package_path).unwrap();
+        registry.publish(&package_path).unwrap();
+
+        assert!(lock_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_read_only_registry_without_lock_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tempdir = TempDir::new().unwrap();
+        let index_dir = tempdir.path().join("midenup").join("registry");
+        let artifact_dir = tempdir.path().join("sysroot").join("lib");
+        fs::create_dir_all(&index_dir).unwrap();
+        fs::create_dir_all(&artifact_dir).unwrap();
+        let index_path = index_dir.join("index.toml");
+        fs::write(&index_path, b"").unwrap();
+        let lock_path = lock_path_for_index(&index_path);
+        assert!(!lock_path.exists());
+
+        let index_dir_permissions = fs::metadata(&index_dir).unwrap().permissions();
+        let artifact_dir_permissions = fs::metadata(&artifact_dir).unwrap().permissions();
+        fs::set_permissions(&index_dir, fs::Permissions::from_mode(0o555)).unwrap();
+        fs::set_permissions(&artifact_dir, fs::Permissions::from_mode(0o555)).unwrap();
+
+        let result = LocalPackageRegistry::load(index_path, artifact_dir.clone());
+
+        fs::set_permissions(&index_dir, index_dir_permissions).unwrap();
+        fs::set_permissions(&artifact_dir, artifact_dir_permissions).unwrap();
+
+        let registry = result.expect("read-only registry should load without creating a lock file");
+        assert!(registry.list().is_empty());
+        assert!(!lock_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_file_replacement_preserves_existing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tempdir = TempDir::new().unwrap();
+        let target = tempdir.path().join("index.toml");
+        fs::write(&target, b"previous index").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o600)).unwrap();
+
+        write_file_atomically(&target, b"updated index").unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"updated index");
+        assert_eq!(fs::metadata(&target).unwrap().permissions().mode() & 0o777, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_file_creation_uses_default_permissions_for_new_files() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tempdir = TempDir::new().unwrap();
+        let target = tempdir.path().join("index.toml");
+        let control = tempdir.path().join("control.toml");
+
+        fs::write(&control, b"control").unwrap();
+        write_file_atomically(&target, b"new index").unwrap();
+
+        assert_eq!(fs::read(&target).unwrap(), b"new index");
+        assert_eq!(
+            fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            fs::metadata(&control).unwrap().permissions().mode() & 0o777,
+        );
     }
 
     #[test]

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -383,20 +383,14 @@ impl LocalPackageRegistry {
 
         // Validate that the contents of the persisted index have not changed under us, by
         // recomputing the checksum of its contents and comparing to when we last loaded the index.
-        #[expect(
-            clippy::verbose_file_reads,
-            reason = "checksum validation must read from the already-locked file handle"
-        )]
-        {
-            let prev_contents = match fs::read(&self.index_path) {
-                Ok(contents) => contents,
-                Err(error) if error.kind() == io::ErrorKind::NotFound => Vec::new(),
-                Err(error) => return Err(LocalRegistryError::IndexRead(error)),
-            };
-            let checksum = miden_core::crypto::hash::Sha256::hash(prev_contents.trim_ascii());
-            if &self.index_checksum != checksum.as_bytes() {
-                return Err(LocalRegistryError::WriteToStaleIndex);
-            }
+        let prev_contents = match fs::read(&self.index_path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Vec::new(),
+            Err(error) => return Err(LocalRegistryError::IndexRead(error)),
+        };
+        let checksum = miden_core::crypto::hash::Sha256::hash(prev_contents.trim_ascii());
+        if &self.index_checksum != checksum.as_bytes() {
+            return Err(LocalRegistryError::WriteToStaleIndex);
         }
 
         operation()?;

--- a/crates/package-registry-local/src/main.rs
+++ b/crates/package-registry-local/src/main.rs
@@ -5,13 +5,7 @@ use miden_package_registry::{PackageId, PackageRegistry, Version};
 use miden_package_registry_local::LocalPackageRegistry;
 
 #[derive(Debug, Parser)]
-#[command(
-    name = "miden-registry",
-    version,
-    about,
-    rename_all = "kebab-case",
-    arg_required_else_help(true)
-)]
+#[command(version, about, rename_all = "kebab-case", arg_required_else_help(true))]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -139,8 +133,6 @@ fn run(
 
 #[cfg(test)]
 mod tests {
-    use clap::CommandFactory;
-
     use super::*;
 
     fn empty_test_registry() -> (tempfile::TempDir, LocalPackageRegistry) {
@@ -152,18 +144,6 @@ mod tests {
         .unwrap();
 
         (tempdir, registry)
-    }
-
-    #[test]
-    fn help_uses_public_binary_name() {
-        let mut command = Cli::command();
-        assert_eq!(command.get_name(), "miden-registry");
-
-        let help = command.render_help().to_string();
-        assert!(
-            help.contains("Usage: miden-registry"),
-            "help should advertise the public binary name:\n{help}",
-        );
     }
 
     #[test]

--- a/crates/package-registry-local/src/main.rs
+++ b/crates/package-registry-local/src/main.rs
@@ -49,6 +49,13 @@ fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     let mut registry = LocalPackageRegistry::load_from_env()?;
 
+    run(cli, &mut registry)
+}
+
+fn run(
+    cli: Cli,
+    registry: &mut LocalPackageRegistry,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
     match cli.command {
         Command::Publish { package } => {
             let published = registry.publish(package)?;
@@ -73,7 +80,18 @@ fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
         },
         Command::Show { package, version, quiet, json } => {
             let package_id = PackageId::from(package);
-            let version = version.map(|version| version.parse::<Version>()).transpose()?;
+            let version = match version {
+                Some(version) => match version.parse::<Version>() {
+                    Ok(version) => Some(version),
+                    Err(err) => {
+                        if quiet {
+                            return Ok(ExitCode::from(2));
+                        }
+                        return Err(Box::new(err));
+                    },
+                },
+                None => None,
+            };
             if let Some(summary) = registry.show(&package_id, version.as_ref()) {
                 if json {
                     let mut stdout = std::io::stdout();
@@ -125,6 +143,17 @@ mod tests {
 
     use super::*;
 
+    fn empty_test_registry() -> (tempfile::TempDir, LocalPackageRegistry) {
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let registry = LocalPackageRegistry::load(
+            tempdir.path().join("etc").join("registry").join("index.toml"),
+            tempdir.path().join("lib"),
+        )
+        .unwrap();
+
+        (tempdir, registry)
+    }
+
     #[test]
     fn help_uses_public_binary_name() {
         let mut command = Cli::command();
@@ -135,5 +164,38 @@ mod tests {
             help.contains("Usage: miden-registry"),
             "help should advertise the public binary name:\n{help}",
         );
+    }
+
+    #[test]
+    fn show_quiet_invalid_version_returns_error_code_without_registry_lookup() {
+        let (_tempdir, mut registry) = empty_test_registry();
+        let cli = Cli::parse_from([
+            "miden-registry",
+            "show",
+            "some-package",
+            "--version",
+            "not-a-version",
+            "--quiet",
+        ]);
+
+        let exit_code = run(cli, &mut registry).expect("quiet parse errors should not escape");
+
+        assert_eq!(exit_code, ExitCode::from(2));
+    }
+
+    #[test]
+    fn show_invalid_version_without_quiet_returns_parse_error() {
+        let (_tempdir, mut registry) = empty_test_registry();
+        let cli = Cli::parse_from([
+            "miden-registry",
+            "show",
+            "some-package",
+            "--version",
+            "not-a-version",
+        ]);
+
+        let err = run(cli, &mut registry).expect_err("non-quiet parse errors should escape");
+
+        assert!(err.to_string().contains("invalid semantic version"), "{err}");
     }
 }

--- a/crates/package-registry-local/src/main.rs
+++ b/crates/package-registry-local/src/main.rs
@@ -118,3 +118,22 @@ fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
 
     Ok(ExitCode::SUCCESS)
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    use super::*;
+
+    #[test]
+    fn help_uses_public_binary_name() {
+        let mut command = Cli::command();
+        assert_eq!(command.get_name(), "miden-registry");
+
+        let help = command.render_help().to_string();
+        assert!(
+            help.contains("Usage: miden-registry"),
+            "help should advertise the public binary name:\n{help}",
+        );
+    }
+}

--- a/crates/package-registry/src/lib.rs
+++ b/crates/package-registry/src/lib.rs
@@ -138,7 +138,7 @@ pub trait PackageRegistry {
 
     /// Returns true if any version of `package` exists in the registry.
     fn is_available(&self, package: &PackageId) -> bool {
-        self.available_versions(package).is_some()
+        self.available_versions(package).is_some_and(|versions| !versions.is_empty())
     }
 
     /// Returns true if the specific `version` of `package` exists in the registry.
@@ -346,5 +346,22 @@ mod tests {
         store
             .publish_package(package)
             .expect_err("no package store should still reject publication");
+    }
+
+    #[test]
+    fn package_registry_is_available_requires_at_least_one_version() {
+        struct EmptyVersionRegistry {
+            versions: PackageVersions,
+        }
+
+        impl PackageRegistry for EmptyVersionRegistry {
+            fn available_versions(&self, _package: &PackageId) -> Option<&PackageVersions> {
+                Some(&self.versions)
+            }
+        }
+
+        let registry = EmptyVersionRegistry { versions: BTreeMap::new() };
+
+        assert!(!registry.is_available(&PackageId::from("pkg")));
     }
 }

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -175,6 +175,22 @@ impl Project {
                 Report::msg(format!("could not parse {}: {err}", workspace_manifest.display()))
             })?;
             if contents.contains_key("workspace") {
+                let workspace_file = ast::WorkspaceFile::parse(source.clone())?;
+                let is_workspace_manifest = manifest_path == workspace_manifest;
+
+                if !is_workspace_manifest
+                    && !workspace_declares_member(
+                        &workspace_file,
+                        &workspace_manifest,
+                        manifest_path,
+                    )
+                {
+                    break;
+                }
+                if is_workspace_manifest && name.is_none() {
+                    break;
+                }
+
                 let workspace = Workspace::load(source, source_manager)?;
                 let package = if let Some(package) = workspace
                     .members()
@@ -207,6 +223,27 @@ impl Project {
         let package = Package::load(source)?;
         Ok(Self::Package(package.into()))
     }
+}
+
+#[cfg(all(feature = "std", feature = "serde"))]
+fn workspace_declares_member(
+    workspace: &ast::WorkspaceFile,
+    workspace_manifest: &std::path::Path,
+    manifest_path: &std::path::Path,
+) -> bool {
+    let Some(workspace_root) = workspace_manifest.parent() else {
+        return false;
+    };
+
+    workspace.workspace.members.iter().any(|member| {
+        let member_dir =
+            match absolutize_path(std::path::Path::new(member.inner().path()), workspace_root) {
+                Ok(member_dir) => member_dir,
+                Err(_) => return false,
+            };
+
+        member_dir.join("miden-project.toml") == manifest_path
+    })
 }
 
 /// A utility function for making a path absolute and canonical.

--- a/crates/project/src/lib.rs
+++ b/crates/project/src/lib.rs
@@ -213,6 +213,8 @@ impl Project {
                     break;
                 };
 
+                validate_package_name(name, &package)?;
+
                 return Ok(Self::WorkspacePackage { package, workspace: workspace.into() });
             } else if Some(ancestor) != initial_package_dir {
                 break;
@@ -221,7 +223,33 @@ impl Project {
 
         let source = source_manager.load_file(manifest_path).map_err(Report::msg)?;
         let package = Package::load(source)?;
+        validate_package_name(name, &package)?;
         Ok(Self::Package(package.into()))
+    }
+}
+
+#[cfg(all(feature = "std", feature = "serde"))]
+fn validate_package_name(expected_name: Option<&str>, package: &Package) -> Result<(), Report> {
+    let Some(expected_name) = expected_name else {
+        return Ok(());
+    };
+
+    let actual_name = package.name();
+    if &**actual_name.inner() == expected_name {
+        Ok(())
+    } else if let Some(location) = package.manifest_path() {
+        Err(Report::msg(format!(
+            "dependency '{}' resolved to package '{}' at '{}'",
+            expected_name,
+            actual_name.inner(),
+            location.display()
+        )))
+    } else {
+        Err(Report::msg(format!(
+            "dependency '{}' resolved to package '{}'",
+            expected_name,
+            actual_name.inner(),
+        )))
     }
 }
 

--- a/crates/project/src/tests.rs
+++ b/crates/project/src/tests.rs
@@ -275,6 +275,45 @@ path = "lib.masm"
 }
 
 #[test]
+fn load_package_ignores_broken_workspace_members_when_not_a_member() -> Result<(), Report> {
+    let tempdir = TempDir::new().unwrap();
+    let root = tempdir.path().join("workspace");
+    let vendor_dir = root.join("vendor").join("dep");
+    fs::create_dir_all(&vendor_dir).unwrap();
+
+    fs::write(
+        root.join("miden-project.toml"),
+        r#"[workspace]
+members = ["missing"]
+"#,
+    )
+    .unwrap();
+
+    let vendor_manifest = vendor_dir.join("miden-project.toml");
+    fs::write(
+        &vendor_manifest,
+        r#"[package]
+name = "dep"
+version = "9.0.0"
+
+[lib]
+path = "lib.masm"
+"#,
+    )
+    .unwrap();
+    fs::write(vendor_dir.join("lib.masm"), "export.foo\nend\n").unwrap();
+    let vendor_manifest = vendor_manifest.canonicalize().unwrap();
+
+    let context = TestContext::default();
+    let project = Project::load(&vendor_manifest, &context.source_manager)?;
+
+    assert!(!project.is_workspace_member());
+    assert_eq!(project.manifest_path(), Some(vendor_manifest.as_path()));
+
+    Ok(())
+}
+
+#[test]
 fn load_project_reference_resolves_workspace_manifest_file_inputs() -> Result<(), Report> {
     let tempdir = TempDir::new().unwrap();
     let root = tempdir.path().join("workspace");

--- a/crates/project/src/tests.rs
+++ b/crates/project/src/tests.rs
@@ -356,6 +356,73 @@ path = "lib.masm"
 }
 
 #[test]
+fn load_project_reference_rejects_standalone_package_name_mismatch() {
+    let tempdir = TempDir::new().unwrap();
+    let dep_dir = tempdir.path().join("dep");
+    fs::create_dir_all(&dep_dir).unwrap();
+
+    fs::write(
+        dep_dir.join("miden-project.toml"),
+        r#"[package]
+name = "actual"
+version = "1.0.0"
+
+[lib]
+path = "lib.masm"
+"#,
+    )
+    .unwrap();
+    fs::write(dep_dir.join("lib.masm"), "export.foo\nend\n").unwrap();
+
+    let context = TestContext::default();
+    let err = Project::load_project_reference("expected", &dep_dir, &context.source_manager)
+        .expect_err("package name mismatch should be rejected");
+
+    assert!(
+        format!("{err}").contains("dependency 'expected' resolved to package 'actual'"),
+        "{err}"
+    );
+}
+
+#[test]
+fn load_project_reference_rejects_workspace_member_package_name_mismatch() {
+    let tempdir = TempDir::new().unwrap();
+    let root = tempdir.path().join("workspace");
+    let dep_dir = root.join("dep");
+    fs::create_dir_all(&dep_dir).unwrap();
+
+    fs::write(
+        root.join("miden-project.toml"),
+        r#"[workspace]
+members = ["dep"]
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        dep_dir.join("miden-project.toml"),
+        r#"[package]
+name = "actual"
+version = "1.0.0"
+
+[lib]
+path = "lib.masm"
+"#,
+    )
+    .unwrap();
+    fs::write(dep_dir.join("lib.masm"), "export.foo\nend\n").unwrap();
+
+    let context = TestContext::default();
+    let err = Project::load_project_reference("expected", &dep_dir, &context.source_manager)
+        .expect_err("workspace member package name mismatch should be rejected");
+
+    assert!(
+        format!("{err}").contains("dependency 'expected' resolved to package 'actual'"),
+        "{err}"
+    );
+}
+
+#[test]
 fn workspace_rejects_duplicate_member_package_names() {
     let tempdir = TempDir::new().unwrap();
     let root = tempdir.path().join("workspace");

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -29,6 +29,7 @@ testing = ["arbitrary"]
 [dependencies]
 miden-air.workspace = true
 miden-assembly.workspace = true
+miden-assembly-syntax.workspace = true
 miden-core.workspace = true
 miden-crypto.workspace = true
 miden-mast-package.workspace = true

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -181,7 +181,7 @@ macro_rules! expect_exec_error_matches {
 #[macro_export]
 macro_rules! assert_diagnostic_lines {
     ($diagnostic:expr, $($expected:expr),+) => {{
-        use miden_assembly::testing::Pattern;
+        use $crate::DiagnosticPattern as Pattern;
         let actual = format!("{}", miden_assembly::diagnostics::reporting::PrintDiagnostic::new_without_color($diagnostic));
         let expected = [$(Pattern::from($expected)),*];
         let actual_line_count = actual.lines().filter(|line| !line.trim().is_empty()).count();
@@ -405,7 +405,7 @@ impl Test {
         }
 
         // validate the stack state from the same execution as the memory assertions
-        let result = execution_output.stack.as_int_vec();
+        let result = stack_outputs_as_int_vec(&execution_output.stack);
         let expected = resize_to_min_stack_depth(final_stack);
         assert_eq!(expected, result, "Expected stack to be {:?}, found {:?}", expected, result);
     }
@@ -876,6 +876,9 @@ impl SourceCacheKey {
 pub fn append_word_to_vec(target: &mut Vec<u64>, word: Word) {
     target.extend(word.iter().map(Felt::as_canonical_u64));
 }
+
+#[doc(hidden)]
+pub use miden_assembly_syntax::testing::Pattern as DiagnosticPattern;
 
 /// Converts a slice of Felts into a vector of u64 values.
 pub fn felt_slice_to_ints(values: &[Felt]) -> Vec<u64> {

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -463,13 +463,12 @@ impl Test {
             let _ = env_logger::Builder::from_env("MIDEN_LOG").format_timestamp(None).try_init();
         }
 
-        let (assembler, kernel_lib) = if let Some(kernel) = self.kernel_source.clone() {
+        let (mut assembler, kernel_lib) = if let Some(kernel) = self.kernel_source.clone() {
             let mut parser = Module::parser(Some(ModuleKind::Kernel));
             let kernel = parser.parse(Some(Path::KERNEL), kernel, self.source_manager.clone())?;
             let kernel_lib = Assembler::new(self.source_manager.clone())
                 .assemble_kernel("kernel", kernel, None)
-                .map(Arc::<Package>::from)
-                .unwrap();
+                .map(Arc::<Package>::from)?;
 
             (
                 Assembler::with_kernel(self.source_manager.clone(), kernel_lib.clone())?,
@@ -479,17 +478,17 @@ impl Test {
             (Assembler::new(self.source_manager.clone()), None)
         };
 
-        let mut assembler =
-            self.add_modules.iter().fold(assembler, |mut assembler, (path, source)| {
-                let module = Module::parser(None)
-                    .parse_str(Some(path.as_ref()), source, self.source_manager.clone())
-                    .expect("invalid masm source code");
-                assembler.compile_and_statically_link(module).expect("failed to link module");
-                assembler
-            });
+        for (path, source) in &self.add_modules {
+            let module = Module::parser(None).parse_str(
+                Some(path.as_ref()),
+                source,
+                self.source_manager.clone(),
+            )?;
+            assembler.compile_and_statically_link(module)?;
+        }
         // Debug mode is now always enabled
         for package in &self.libraries {
-            assembler.link_package(package.clone(), Linkage::Dynamic).unwrap();
+            assembler.link_package(package.clone(), Linkage::Dynamic)?;
         }
 
         let result = (
@@ -760,6 +759,35 @@ impl Test {
                 .collect(),
             library_digests: self.libraries.iter().map(|library| library.digest()).collect(),
         }
+    }
+}
+
+#[cfg(all(test, feature = "std", not(target_family = "wasm")))]
+mod tests {
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+
+    use super::*;
+
+    #[test]
+    fn compile_returns_error_for_invalid_kernel_without_panicking() {
+        let test = Test::new("main", "begin push.1 end", false)
+            .with_kernel_source("kernel", "export.invalid begin push.1");
+
+        let result = catch_unwind(AssertUnwindSafe(|| test.compile()));
+
+        assert!(result.is_ok(), "invalid kernel source caused Test::compile() to panic");
+        assert!(result.unwrap().is_err(), "invalid kernel source should return an error");
+    }
+
+    #[test]
+    fn compile_returns_error_for_invalid_extra_module_without_panicking() {
+        let test = Test::new("main", "use.foo::bar\nbegin\n    exec.foo::bar\nend", false)
+            .with_module("foo", "export.bar begin push.1");
+
+        let result = catch_unwind(AssertUnwindSafe(|| test.compile()));
+
+        assert!(result.is_ok(), "invalid extra module source caused Test::compile() to panic");
+        assert!(result.unwrap().is_err(), "invalid extra module source should return an error");
     }
 }
 

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -404,8 +404,10 @@ impl Test {
             );
         }
 
-        // validate the stack states
-        self.expect_stack(final_stack);
+        // validate the stack state from the same execution as the memory assertions
+        let result = execution_output.stack.as_int_vec();
+        let expected = resize_to_min_stack_depth(final_stack);
+        assert_eq!(expected, result, "Expected stack to be {:?}, found {:?}", expected, result);
     }
 
     /// Asserts that executing the test inside a proptest results in the expected final stack state.
@@ -775,7 +777,15 @@ impl Test {
 
 #[cfg(all(test, feature = "std", not(target_family = "wasm")))]
 mod tests {
-    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    use miden_processor::{advice::AdviceMutation, event::EventError};
 
     use super::*;
 
@@ -819,6 +829,33 @@ mod tests {
             miden_assembly::report!("the first line\nthe second line"),
             "the first line"
         );
+    }
+
+    #[test]
+    fn expect_stack_and_memory_executes_once() {
+        const EVENT_NAME: EventName = EventName::new("test::expect_stack_and_memory::once");
+
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let handler_invocations = invocations.clone();
+        let handler = move |_process: &ProcessorState| -> Result<Vec<AdviceMutation>, EventError> {
+            handler_invocations.fetch_add(1, Ordering::SeqCst);
+            Ok(Vec::new())
+        };
+
+        let source = alloc::format!(
+            r#"
+            begin
+                emit.event("{EVENT_NAME}")
+                push.42.1000 mem_store
+            end
+            "#
+        );
+
+        Test::new("main", &source, false)
+            .with_event_handler(EVENT_NAME, handler)
+            .expect_stack_and_memory(&[], 1000, &[42]);
+
+        core::assert_eq!(1, invocations.load(Ordering::SeqCst));
     }
 }
 

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -176,17 +176,28 @@ macro_rules! expect_exec_error_matches {
 /// Like [miden_assembly::testing::assert_diagnostic], but matches each non-empty line of the
 /// rendered output to a corresponding pattern.
 ///
-/// So if the output has 3 lines, the second of which is empty, and you provide 2 patterns, the
-/// assertion passes if the first line matches the first pattern, and the third line matches the
-/// second pattern - the second line is ignored because it is empty.
+/// Empty lines are ignored, but the remaining line count must match the number of patterns.
 #[cfg(not(target_family = "wasm"))]
 #[macro_export]
 macro_rules! assert_diagnostic_lines {
     ($diagnostic:expr, $($expected:expr),+) => {{
         use miden_assembly::testing::Pattern;
         let actual = format!("{}", miden_assembly::diagnostics::reporting::PrintDiagnostic::new_without_color($diagnostic));
-        let lines = actual.lines().filter(|l| !l.trim().is_empty()).zip([$(Pattern::from($expected)),*].into_iter());
-        for (actual_line, expected) in lines {
+        let expected = [$(Pattern::from($expected)),*];
+        let actual_line_count = actual.lines().filter(|line| !line.trim().is_empty()).count();
+        ::core::assert_eq!(
+            actual_line_count,
+            expected.len(),
+            "diagnostic line count mismatch: expected {} non-empty lines, got {}\nactual diagnostic:\n{}",
+            expected.len(),
+            actual_line_count,
+            actual,
+        );
+        for (actual_line, expected) in actual
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .zip(expected.into_iter())
+        {
             expected.assert_match_with_context(actual_line, &actual);
         }
     }};
@@ -788,6 +799,26 @@ mod tests {
 
         assert!(result.is_ok(), "invalid extra module source caused Test::compile() to panic");
         assert!(result.unwrap().is_err(), "invalid extra module source should return an error");
+    }
+
+    #[test]
+    #[should_panic(expected = "diagnostic line count mismatch")]
+    fn assert_diagnostic_lines_rejects_missing_actual_lines() {
+        crate::assert_diagnostic_lines!(
+            miden_assembly::report!("the error string"),
+            "the error string",
+            "other",
+            "lines"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "diagnostic line count mismatch")]
+    fn assert_diagnostic_lines_rejects_extra_actual_lines() {
+        crate::assert_diagnostic_lines!(
+            miden_assembly::report!("the first line\nthe second line"),
+            "the first line"
+        );
     }
 }
 

--- a/miden-vm/tests/integration/operations/field_ops.rs
+++ b/miden-vm/tests/integration/operations/field_ops.rs
@@ -384,8 +384,7 @@ fn exp_bits_length_fail() {
             "12 |",
             "13 | begin exp.u65 exec.truncate_stack end",
             "   :            ^^",
-            "   `----",
-            r#" help: expected primitive opcode (e.g. "add"), or "end", or control flow opcode (e.g. "if.true")"#
+            "   `----"
         );
     }
 }


### PR DESCRIPTION
This PR fixes several small correctness gaps in the MASM-to-MAST assembly path. Per-commit review is advised.

- `miden-format` (#2906) now rewrites files atomically and reports stdout failures in `--stdin` mode. A failed file write no longer risks truncating the source file; formatter-as-filter output treats `BrokenPipe` as normal pipeline termination but reports other write/flush failures.
- Source URI handling now uses a restricted form. Schemes must use `://`; local paths and local `file://` URIs still work; unsupported or non-local URIs do not become paths.
- Package loading now handles a valid non-member package inside a broken workspace and enforces dependency-name expectations for project references. A path dependency that resolves to a package with a different declared name is rejected at the loader boundary.
- Local registry behavior is stricter and safer. It pins the miden-registry CLI name, keeps quiet invalid-version probes quiet, requires at least one version for availability, and writes index/artifact files atomically.
- MASM test helpers now report errors instead of panicking in linked-input compile paths, check diagnostic line counts exactly, reject generated memory addresses that overflow, and assert stack/memory expectations from a single execution.
- Assembly coverage now includes userspace package assembly, ~duplicate debug-decorator MAST nodes~ (edit: removed following #3182), and unknown CST `$...` special identifiers.
- Fixes #3238.