### PR TITLE
Fix CodSpeed walltime Criterion integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,7 +1946,6 @@ name = "miden-vm-synthetic-bench"
 version = "0.24.0"
 dependencies = [
  "codspeed-criterion-compat",
- "criterion",
  "miden-processor",
  "miden-vm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,6 @@ wincode       = { version = "0.4.2", default-features = false, features = ["allo
 
 # Third-party crates
 clap            = { version = "4.5", features = ["derive"] }
-codspeed-criterion-compat = { version = "4.6.0" }
 criterion       = { version = "0.7" }
 derive_more     = { version = "2.0", features = ["from"] }
 env_logger      = { version = "0.11" }
@@ -116,4 +115,4 @@ toml = { version = "1.0", default-features = false }
 walkdir = "2.5"
 
 [workspace.lints.rust]
-unexpected_cfgs = { check-cfg = ['cfg(codspeed)', 'cfg(fuzzing)'], level = "warn" }
+unexpected_cfgs = { check-cfg = ['cfg(fuzzing)'], level = "warn" }

--- a/benches/synthetic-bench/Cargo.toml
+++ b/benches/synthetic-bench/Cargo.toml
@@ -19,8 +19,7 @@ serde_json      = { workspace = true, features = ["std"] }
 thiserror       = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
-codspeed-criterion-compat = { workspace = true }
-criterion = { workspace = true }
+criterion = { package = "codspeed-criterion-compat", version = "4.6.0" }
 
 [[bench]]
 name = "synthetic_bench"

--- a/benches/synthetic-bench/benches/synthetic_bench.rs
+++ b/benches/synthetic-bench/benches/synthetic_bench.rs
@@ -26,11 +26,7 @@ use std::{
     cell::RefCell, collections::BTreeSet, hint::black_box, path::PathBuf, rc::Rc, time::Duration,
 };
 
-#[cfg(codspeed)]
-use codspeed_criterion_compat as criterion_backend;
-#[cfg(not(codspeed))]
-use criterion as criterion_backend;
-use criterion_backend::{BatchSize, Criterion, SamplingMode, criterion_group, criterion_main};
+use criterion::{BatchSize, Criterion, SamplingMode, criterion_group, criterion_main};
 use miden_processor::{
     DefaultHost, ExecutionOptions, FastProcessor, StackInputs, advice::AdviceInputs,
 };


### PR DESCRIPTION
The CodSpeed job currently runs the synthetic transaction bench but uploads no walltime results.

The cause is that walltime builds do not set cfg(codspeed), so our manual backend switch selects plain Criterion instead of codspeed-criterion-compat. The bench finishes, but CodSpeed has no result files to process.

This changes the synthetic bench to use codspeed-criterion-compat as the criterion crate, matching CodSpeed’s Rust docs. The compat crate now chooses the right backend for normal Criterion runs, CodSpeed walltime runs, and CodSpeed analysis runs. The old cfg(codspeed) switch and lint allowance are removed.

See #3183, #3179, #3161