### PR TITLE
Restore DebugVar compatibility APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.23.2 (TBD)
+## v0.23.2 (2026-05-26)
 
 - Restored `DebugVarInfo::set_value_location` and `DebugVarLocation::FrameBase` for debug metadata compatibility ([#3189](https://github.com/0xMiden/miden-vm/pull/3189)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.23.2 (TBD)
+
+- Restored `DebugVarInfo::set_value_location` and `DebugVarLocation::FrameBase` for debug metadata compatibility ([#3189](https://github.com/0xMiden/miden-vm/pull/3189)).
+
 ## v0.23.1 (2026-05-20)
 
 - Restored metadata-neutral MAST node identity so public procedure roots do not depend on debug/decorator metadata shape; this reopens debug metadata precision issues from #2955 and #3054.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "insta",
  "miden-ace-codegen",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "env_logger",
  "insta",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "aho-corasick",
  "env_logger",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "criterion",
  "derive_more",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "bincode",
  "criterion",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1507,7 +1507,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1558,7 +1558,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry-local"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "clap",
  "miden-assembly-syntax",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "insta",
  "itertools 0.14.0",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1632,7 +1632,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "bincode",
  "miden-air",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "miden-crypto",
  "miden-test-serde-macros",
@@ -1740,7 +1740,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "lock_api",
  "loom",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "bincode",
  "miden-air",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "assert_cmd",
  "bincode",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-synthetic-bench"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "criterion",
  "miden-processor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ homepage = "https://miden.xyz"
 repository = "https://github.com/0xMiden/miden-vm"
 exclude = [".github/"]
 rust-version = "1.90"
-version = "0.23.1"
+version = "0.23.2"
 
 [profile.optimized]
 inherits = "release"

--- a/core/src/operations/decorators/debug_var.rs
+++ b/core/src/operations/decorators/debug_var.rs
@@ -94,6 +94,11 @@ impl DebugVarInfo {
     pub fn value_location(&self) -> &DebugVarLocation {
         &self.value_location
     }
+
+    /// Replaces the value location in-place, preserving all other fields.
+    pub fn set_value_location(&mut self, value_location: DebugVarLocation) {
+        self.value_location = value_location;
+    }
 }
 
 /// Serde deserializer for `Arc<str>`.
@@ -148,6 +153,18 @@ pub enum DebugVarLocation {
     /// where offset is typically negative (locals are below FMP).
     /// For example, with 3 locals: local\[0\] has offset -3, local\[2\] has offset -1.
     Local(i16),
+    /// Variable is in WASM linear memory at an address computed from a global base
+    /// plus a byte offset: `value_of(global[global_index]) + byte_offset`.
+    ///
+    /// This corresponds to DWARF's `DW_OP_fbreg` where the frame base is a WASM
+    /// global (typically `__stack_pointer`). The byte offset is divided by the
+    /// element size (4 for i32) to get the Miden memory element address.
+    FrameBase {
+        /// WASM global index whose runtime value provides the base address.
+        global_index: u32,
+        /// Byte offset from the base (may be positive or negative).
+        byte_offset: i64,
+    },
     /// Complex location described by expression bytes.
     /// This is used for variables that require computation to locate,
     /// such as struct fields or array elements.
@@ -161,6 +178,9 @@ impl fmt::Display for DebugVarLocation {
             Self::Memory(addr) => write!(f, "mem[{addr}]"),
             Self::Const(val) => write!(f, "const({})", val.as_canonical_u64()),
             Self::Local(offset) => write!(f, "FMP{offset:+}"),
+            Self::FrameBase { global_index, byte_offset } => {
+                write!(f, "global[{global_index}]{byte_offset:+}")
+            },
             Self::Expression(bytes) => {
                 write!(f, "expr(")?;
                 for (i, byte) in bytes.iter().enumerate() {
@@ -197,6 +217,11 @@ impl Serializable for DebugVarLocation {
                 target.write_u8(3);
                 target.write_bytes(&offset.to_le_bytes());
             },
+            Self::FrameBase { global_index, byte_offset } => {
+                target.write_u8(5);
+                target.write_u32(*global_index);
+                target.write_bytes(&byte_offset.to_le_bytes());
+            },
             Self::Expression(bytes) => {
                 target.write_u8(4);
                 bytes.write_into(target);
@@ -222,6 +247,12 @@ impl Deserializable for DebugVarLocation {
             4 => {
                 let bytes = Vec::<u8>::read_from(source)?;
                 Ok(Self::Expression(bytes))
+            },
+            5 => {
+                let global_index = source.read_u32()?;
+                let bytes = source.read_array::<8>()?;
+                let byte_offset = i64::from_le_bytes(bytes);
+                Ok(Self::FrameBase { global_index, byte_offset })
             },
             _ => Err(DeserializationError::InvalidValue(format!(
                 "invalid DebugVarLocation tag: {tag}"
@@ -304,6 +335,10 @@ mod tests {
         assert_eq!(DebugVarLocation::Const(Felt::new_unchecked(42)).to_string(), "const(42)");
         assert_eq!(DebugVarLocation::Local(-3).to_string(), "FMP-3");
         assert_eq!(
+            DebugVarLocation::FrameBase { global_index: 20, byte_offset: -12 }.to_string(),
+            "global[20]-12"
+        );
+        assert_eq!(
             DebugVarLocation::Expression(vec![0x10, 0x20, 0x30]).to_string(),
             "expr(10 20 30)"
         );
@@ -316,6 +351,7 @@ mod tests {
             DebugVarLocation::Memory(0xdead_beef),
             DebugVarLocation::Const(Felt::new_unchecked(999)),
             DebugVarLocation::Local(-3),
+            DebugVarLocation::FrameBase { global_index: 20, byte_offset: -12 },
             DebugVarLocation::Expression(vec![0x10, 0x20, 0x30]),
         ];
 
@@ -344,5 +380,15 @@ mod tests {
         let mut reader = SliceReader::new(&bytes);
         let deser = DebugVarInfo::read_from(&mut reader).unwrap();
         assert_eq!(deser, var);
+    }
+
+    #[test]
+    fn debug_var_info_set_value_location() {
+        let mut var = DebugVarInfo::new("x", DebugVarLocation::Stack(0));
+        var.set_value_location(DebugVarLocation::FrameBase { global_index: 20, byte_offset: -12 });
+        assert_eq!(
+            var.value_location(),
+            &DebugVarLocation::FrameBase { global_index: 20, byte_offset: -12 }
+        );
     }
 }

--- a/crates/assembly-syntax/src/ast/alias.rs
+++ b/crates/assembly-syntax/src/ast/alias.rs
@@ -130,7 +130,7 @@ impl crate::prettier::PrettyPrint for Alias {
             target => {
                 let prefix = if self.is_absolute() { "::" } else { "" };
                 if self.is_renamed() {
-                    display(format_args!("{}{}->{}", prefix, target, &self.name))
+                    display(format_args!("{}{}->{}", prefix, target, self.name))
                 } else {
                     display(format_args!("{prefix}{target}"))
                 }

--- a/crates/assembly-syntax/src/ast/attribute/mod.rs
+++ b/crates/assembly-syntax/src/ast/attribute/mod.rs
@@ -171,7 +171,7 @@ impl fmt::Display for Attribute {
 impl prettier::PrettyPrint for Attribute {
     fn render(&self) -> prettier::Document {
         use prettier::*;
-        let doc = text(format!("@{}", &self.name()));
+        let doc = text(format!("@{}", self.name()));
         match self {
             Self::Marker(_) => doc,
             Self::List(meta) => {

--- a/crates/assembly-syntax/src/ast/item/index.rs
+++ b/crates/assembly-syntax/src/ast/item/index.rs
@@ -35,7 +35,7 @@ impl ItemIndex {
 
 impl core::fmt::Display for ItemIndex {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", &self.as_usize())
+        write!(f, "{}", self.as_usize())
     }
 }
 
@@ -76,7 +76,7 @@ pub struct GlobalItemIndex {
 
 impl core::fmt::Display for GlobalItemIndex {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}:{}", &self.module, &self.index)
+        write!(f, "{}:{}", self.module, self.index)
     }
 }
 
@@ -109,7 +109,7 @@ impl core::ops::Add<ItemIndex> for ModuleIndex {
 
 impl core::fmt::Display for ModuleIndex {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", &self.as_usize())
+        write!(f, "{}", self.as_usize())
     }
 }
 

--- a/crates/assembly-syntax/src/ast/procedure/procedure.rs
+++ b/crates/assembly-syntax/src/ast/procedure/procedure.rs
@@ -277,11 +277,11 @@ impl crate::prettier::PrettyPrint for Procedure {
             doc += const_text("begin");
         } else {
             if self.num_locals > 0 {
-                doc += text(format!("@locals(\"{}\")", &self.num_locals)) + nl();
+                doc += text(format!("@locals(\"{}\")", self.num_locals)) + nl();
             }
             match self.signature() {
                 Some(sig) if sig.cc != crate::ast::types::CallConv::Fast => {
-                    doc += text(format!("@callconv(\"{}\")", &sig.cc)) + nl();
+                    doc += text(format!("@callconv(\"{}\")", sig.cc)) + nl();
                 },
                 _ => (),
             }

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -385,7 +385,7 @@ impl Assembler {
                 if !self.kernel().is_empty() {
                     return Err(Report::msg(format!(
                         "duplicate kernels present in the dependency graph: '{}@{}' conflicts with another kernel we've already linked",
-                        &package.name, &package.version
+                        package.name, package.version
                     )));
                 }
 
@@ -616,7 +616,7 @@ impl Assembler {
         };
 
         let (mast_forest, id_remappings) = mast_forest_builder.build();
-        for (_proc_name, export) in exports.iter_mut() {
+        for export in exports.values_mut() {
             match export {
                 LibraryExport::Procedure(export) => {
                     if let Some(&new_node_id) = id_remappings.get(&export.node) {

--- a/crates/assembly/src/linker/debug.rs
+++ b/crates/assembly/src/linker/debug.rs
@@ -65,7 +65,7 @@ struct DisplayModuleGraphNode<'a> {
 impl fmt::Debug for DisplayModuleGraphNode<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Node")
-            .field("id", &format_args!("{}", &self.id))
+            .field("id", &format_args!("{}", self.id))
             .field("module", &self.path)
             .field("name", &self.name)
             .field("source", &self.source)

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -594,7 +594,7 @@ impl Linker {
                             // calls/symbol refs
                             let proc = proc.borrow();
                             for invoke in proc.invoked() {
-                                log::debug!(target: "linker", "  | recording {} dependency on {}", invoke.kind, &invoke.target);
+                                log::debug!(target: "linker", "  | recording {} dependency on {}", invoke.kind, invoke.target);
 
                                 let context = SymbolResolutionContext {
                                     span: invoke.span(),

--- a/crates/assembly/src/linker/resolver/symbol_resolver.rs
+++ b/crates/assembly/src/linker/resolver/symbol_resolver.rs
@@ -601,7 +601,7 @@ impl<'a> SymbolResolver<'a> {
     ) -> Result<SymbolResolution, Box<SymbolResolutionError>> {
         let module = &self.graph[module];
         log::debug!(target: "name-resolver::local", "resolving '{symbol}' in module {}", module.path());
-        log::debug!(target: "name-resolver::local", "module status: {:?}", &module.status());
+        log::debug!(target: "name-resolver::local", "module status: {:?}", module.status());
         module.resolve(symbol, self)
     }
 

--- a/crates/assembly/src/project/tests.rs
+++ b/crates/assembly/src/project/tests.rs
@@ -1183,7 +1183,7 @@ end
         package
             .manifest
             .dependencies()
-            .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+            .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
             .collect::<Vec<_>>(),
         vec![format!("runtime@1.0.0#{runtime_digest}")]
     );
@@ -1274,7 +1274,7 @@ dep.workspace = true
         package
             .manifest
             .dependencies()
-            .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+            .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
             .collect::<Vec<_>>(),
         vec![format!("dep@0.2.0#{}", dep010.digest())]
     );
@@ -1339,7 +1339,7 @@ end
     let expected_dependency = first
         .manifest
         .dependencies()
-        .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+        .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
         .collect::<Vec<_>>();
     context.registry().clear_loaded_packages();
 
@@ -1359,7 +1359,7 @@ end
         second
             .manifest
             .dependencies()
-            .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+            .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
             .collect::<Vec<_>>(),
         expected_dependency
     );
@@ -1781,7 +1781,7 @@ end
     let expected_dependency = first
         .manifest
         .dependencies()
-        .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+        .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
         .collect::<Vec<_>>();
     context.registry().clear_loaded_packages();
 
@@ -1814,7 +1814,7 @@ dep = { path = "dep" }
         second
             .manifest
             .dependencies()
-            .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+            .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
             .collect::<Vec<_>>(),
         expected_dependency
     );
@@ -2056,7 +2056,7 @@ end
         package
             .manifest
             .dependencies()
-            .map(|dep| format!("{}@{}#{}", &dep.name, dep.version, dep.digest))
+            .map(|dep| format!("{}@{}#{}", dep.name, dep.version, dep.digest))
             .collect::<Vec<_>>(),
         vec![format!("dep@1.0.0#{dep_digest}")]
     );

--- a/crates/debug-types/src/location.rs
+++ b/crates/debug-types/src/location.rs
@@ -91,7 +91,7 @@ impl FileLineCol {
 
 impl fmt::Display for FileLineCol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{}@{}:{}]", &self.uri, self.line, self.column)
+        write!(f, "[{}@{}:{}]", self.uri, self.line, self.column)
     }
 }
 

--- a/crates/mast-package/src/package/section.rs
+++ b/crates/mast-package/src/package/section.rs
@@ -110,7 +110,7 @@ impl fmt::Debug for Section {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = f.alternate();
         let mut builder = f.debug_struct("Section");
-        builder.field("id", &format_args!("{}", &self.id));
+        builder.field("id", &format_args!("{}", self.id));
         if verbose {
             builder.field("data", &format_args!("{}", DisplayHex(&self.data))).finish()
         } else {

--- a/crates/package-registry/src/resolver/version_set.rs
+++ b/crates/package-registry/src/resolver/version_set.rs
@@ -176,8 +176,8 @@ impl From<SemverPubgrub> for VersionSet {
 impl fmt::Display for VersionSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.digests.as_slice() {
-            [] => write!(f, "{}", &self.range),
-            [digest] => write!(f, "{digest} in {}", &self.range),
+            [] => write!(f, "{}", self.range),
+            [digest] => write!(f, "{digest} in {}", self.range),
             digests => {
                 f.write_str("any of ")?;
                 for (i, digest) in digests.iter().enumerate() {
@@ -186,7 +186,7 @@ impl fmt::Display for VersionSet {
                     }
                     write!(f, "{digest}")?;
                 }
-                write!(f, " in {}", &self.range)
+                write!(f, " in {}", self.range)
             },
         }
     }

--- a/crates/package-registry/src/version.rs
+++ b/crates/package-registry/src/version.rs
@@ -174,7 +174,7 @@ impl Borrow<SemVer> for Version {
 impl fmt::Display for Version {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(digest) = self.digest.as_ref() {
-            write!(f, "{}#{digest}", &self.version)
+            write!(f, "{}#{digest}", self.version)
         } else {
             fmt::Display::fmt(&self.version, f)
         }

--- a/crates/package-registry/src/version_requirement.rs
+++ b/crates/package-registry/src/version_requirement.rs
@@ -100,7 +100,7 @@ impl From<Word> for VersionRequirement {
 impl From<Version> for VersionRequirement {
     fn from(value: Version) -> Self {
         if value.digest.is_none() {
-            Self::Semantic(Span::unknown(format!("={}", &value.version).parse().unwrap()))
+            Self::Semantic(Span::unknown(format!("={}", value.version).parse().unwrap()))
         } else {
             Self::Exact(value)
         }

--- a/crates/project/src/ast/package.rs
+++ b/crates/project/src/ast/package.rs
@@ -260,7 +260,7 @@ impl ProjectFile {
                                 source_file: source,
                                 label: Label::new(
                                     dependency.span(),
-                                    format!("'{}' is not a workspace dependency", &dependency.name),
+                                    format!("'{}' is not a workspace dependency", dependency.name),
                                 ),
                             }
                             .into());

--- a/crates/project/src/package.rs
+++ b/crates/project/src/package.rs
@@ -105,7 +105,7 @@ impl Package {
                 self.lib = Some(Span::unknown(target));
             } else {
                 if self.bins.iter().any(|t| t.name == target.name) {
-                    panic!("duplicate definitions of the same target '{}'", &target.name);
+                    panic!("duplicate definitions of the same target '{}'", target.name);
                 }
                 self.bins.push(Span::unknown(target));
             }

--- a/miden-core-fuzz/Cargo.lock
+++ b/miden-core-fuzz/Cargo.lock
@@ -781,7 +781,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden-assembly"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "derive_more",
  "log",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "miden-crypto",
  "proptest",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "lock_api",
  "loom",

--- a/miden-vm/src/cli/bundle.rs
+++ b/miden-vm/src/cli/bundle.rs
@@ -69,7 +69,7 @@ impl BundleCmd {
                 println!(
                     "Built kernel module {} with library {}",
                     kernel.display(),
-                    &self.dir.display()
+                    self.dir.display()
                 );
             },
             None => {


### PR DESCRIPTION
Restore the public `DebugVar` APIs removed in `bd9192f87c` for backwards compatibility:

- re-add `DebugVarInfo::set_value_location`
- re-add `DebugVarLocation::FrameBase`
- restore `FrameBase` display formatting and binary serialization tag `5`
- add coverage for setter, display, and serialization round trips

This does not make debug vars participate in MAST node dedup identity.