### PR TITLE
Fix enum conflict before early return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@
 - Hardened MAST forest and package byte-slice deserialization against fuzzed length fields ([#3088](https://github.com/0xMiden/miden-vm/pull/3088)).
 - [BREAKING] Fixed project artifact reuse to ignore unrelated manifest fields, rejected private cross-module imports, and kept signature-only type imports live ([#3091](https://github.com/0xMiden/miden-vm/pull/3091)).
 - Fixed stale `ReplayProcessor` doc comment links to `ExecutionTracer` after module-structure refactors.
+- Allowed parser-generated empty control-flow forms (`if.<cond> end`, `if.<cond> else end`,
+  `while.true end`, `repeat.<N> end`) and added semantic warnings for empty `while.true` and
+  `repeat` bodies (rejected under `warnings_as_errors` unless intent is explicit via `nop`).
 
 #### Changes
 

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -267,19 +267,13 @@ impl Module {
     /// * The concrete type of the enumeration is not an integral type
     pub fn define_enum(&mut self, ty: EnumType) -> Result<(), SemanticAnalysisError> {
         let repr = ty.ty().clone();
+        let is_c_like = ty.is_c_like();
 
         if !repr.is_integer() {
             return Err(SemanticAnalysisError::InvalidEnumRepr { span: ty.span() });
         }
 
-        // We only define constants for C-like enums
-        if !ty.is_c_like() {
-            self.items.push(Export::Type(ty.into()));
-            return Ok(());
-        }
-
         let export = ty.clone();
-
         let (alias, variants) = ty.into_parts();
 
         if let Some(prev) = self.items.iter().find(|t| t.name() == &alias.name) {
@@ -287,6 +281,12 @@ impl Module {
                 span: alias.span(),
                 prev_span: prev.span(),
             });
+        }
+
+        // We only define constants for C-like enums
+        if !is_c_like {
+            self.push_export(Export::Type(export.into()))?;
+            return Ok(());
         }
 
         let mut values = SmallVec::<[Span<u64>; 8]>::new_const();

--- a/crates/assembly-syntax/src/ast/op.rs
+++ b/crates/assembly-syntax/src/ast/op.rs
@@ -16,9 +16,9 @@ pub enum Op {
     /// Can be either `if`..`end`, or `if`..`else`..`end`.
     If {
         span: SourceSpan,
-        /// This block is always present and non-empty
+        /// This block is always present, but may be empty.
         then_blk: Block,
-        /// This block will be empty if no `else` branch was present
+        /// This block is empty when no `else` branch was present.
         else_blk: Block,
     } = 0,
     /// Represents a condition-controlled loop

--- a/crates/assembly-syntax/src/parser/cst/blocks.rs
+++ b/crates/assembly-syntax/src/parser/cst/blocks.rs
@@ -73,8 +73,15 @@ fn lower_operation(
 
 /// Lowers an `if.true` / `if.false` operation.
 ///
-/// This preserves legacy semantics for empty branches: a missing `then` branch is only tolerated
-/// when an `else` branch exists, in which case the empty side is lowered as an explicit `nop`.
+/// The CST parser can represent empty branches directly, so lowering accepts these forms:
+///
+/// * `if.<cond> end`
+/// * `if.<cond> else end`
+/// * `if.<cond> else <ops> end`
+///
+/// When no source operations are present in either branch, both branches lower to empty blocks.
+/// For non-empty then-branches with omitted/empty else-branches, we preserve legacy behavior and
+/// synthesize a `nop` else-branch.
 fn lower_if_op(context: &mut LoweringContext<'_>, op: &CstIfOp) -> Result<ast::Op, ParsingError> {
     let span = context.parse().span_for_node(op.syntax());
     let cond = parse_if_condition(context, op)?;
@@ -84,30 +91,20 @@ fn lower_if_op(context: &mut LoweringContext<'_>, op: &CstIfOp) -> Result<ast::O
         message: "expected a block body for `if`".to_string(),
     })?;
     let else_node = op.else_block();
-
     let then_has_ops = has_source_operations(&then_node);
-    let else_has_ops = else_node.as_ref().is_some_and(has_source_operations);
 
     let then_blk = if then_has_ops {
         lower_block(context, &then_node)?
-    } else if else_node.is_some() {
-        nop_block(span)
     } else {
-        return Err(ParsingError::InvalidSyntax {
-            span: context.parse().span_for_node(then_node.syntax()),
-            message: "expected a non-empty `if` block".to_string(),
-        });
+        empty_block(context.parse().span_for_node(then_node.syntax()))
     };
 
     let else_blk = match else_node {
-        Some(else_node) => {
-            if !else_has_ops {
-                nop_block(span)
-            } else {
-                lower_block(context, &else_node)?
-            }
-        },
-        None => nop_block(span),
+        Some(else_node) if has_source_operations(&else_node) => lower_block(context, &else_node)?,
+        Some(_else_node) if then_has_ops => nop_block(span),
+        Some(else_node) => empty_block(context.parse().span_for_node(else_node.syntax())),
+        None if then_has_ops => nop_block(span),
+        None => empty_block(span),
     };
 
     if cond {
@@ -121,7 +118,7 @@ fn lower_if_op(context: &mut LoweringContext<'_>, op: &CstIfOp) -> Result<ast::O
     }
 }
 
-/// Lowers a `while.true` operation and enforces a non-empty body.
+/// Lowers a `while.true` operation.
 fn lower_while_op(
     context: &mut LoweringContext<'_>,
     op: &CstWhileOp,
@@ -132,7 +129,7 @@ fn lower_while_op(
         span,
         message: "expected a block body for `while`".to_string(),
     })?;
-    let body = lower_required_block(context, &body, "expected a non-empty `while` block")?;
+    let body = lower_block(context, &body)?;
     Ok(ast::Op::While { span, body })
 }
 
@@ -147,7 +144,7 @@ fn lower_repeat_op(
         span,
         message: "expected a block body for `repeat`".to_string(),
     })?;
-    let body = lower_required_block(context, &body, "expected a non-empty `repeat` block")?;
+    let body = lower_block(context, &body)?;
     Ok(ast::Op::Repeat { span, count, body })
 }
 
@@ -260,6 +257,11 @@ fn header_tokens_before_first_block(
 /// Returns true when the CST block contains at least one explicit source operation.
 fn has_source_operations(block: &CstBlock) -> bool {
     block.operations().next().is_some()
+}
+
+/// Constructs an empty block for source-level empty structured branches/bodies.
+fn empty_block(span: SourceSpan) -> ast::Block {
+    ast::Block::new(span, vec![])
 }
 
 /// Builds the legacy fallback diagnostic for malformed instruction spellings.

--- a/crates/assembly-syntax/src/parser/tests.rs
+++ b/crates/assembly-syntax/src/parser/tests.rs
@@ -1046,7 +1046,7 @@ end
 }
 
 #[test]
-fn cst_backend_rejects_empty_while_blocks() {
+fn cst_backend_accepts_empty_while_blocks() {
     let source = test_source_file(
         "\
 begin
@@ -1056,16 +1056,20 @@ end
 ",
     );
 
-    let _legacy = parse_forms_with_backend(source.clone(), ParserBackend::Legacy)
-        .expect_err("expected empty while block error");
     let cst = parse_forms_with_backend(source, ParserBackend::Cst)
-        .expect_err("expected empty while block error");
-
-    assert_matches!(render_diagnostic(&cst), diag if diag.contains("expected a non-empty `while` block"));
+        .expect("cst backend should accept empty while blocks");
+    let [Form::Begin(block)] = cst.as_slice() else {
+        panic!("expected a single begin block");
+    };
+    let ops = block.iter().collect::<Vec<_>>();
+    let [Op::While { body, .. }] = ops.as_slice() else {
+        panic!("expected one while op, got {ops:?}");
+    };
+    assert!(body.is_empty(), "expected empty while body");
 }
 
 #[test]
-fn cst_backend_rejects_empty_if_then_without_else() {
+fn cst_backend_accepts_empty_if_then_without_else() {
     let source = test_source_file(
         "\
 begin
@@ -1076,10 +1080,45 @@ end
     );
 
     let legacy = parse_forms_with_backend(source.clone(), ParserBackend::Legacy);
-    let cst = parse_forms_with_backend(source, ParserBackend::Cst);
+    assert!(
+        legacy.is_err(),
+        "legacy parser currently rejects empty if-then blocks"
+    );
 
-    assert!(legacy.is_err(), "legacy parser should reject empty if-then blocks");
-    assert!(cst.is_err(), "cst backend should reject empty if-then blocks");
+    let cst = parse_forms_with_backend(source, ParserBackend::Cst)
+        .expect("cst backend should accept empty if-then blocks");
+    let [Form::Begin(block)] = cst.as_slice() else {
+        panic!("expected a single begin block");
+    };
+    let ops = block.iter().collect::<Vec<_>>();
+    let [Op::If { then_blk, else_blk, .. }] = ops.as_slice() else {
+        panic!("expected one if op, got {ops:?}");
+    };
+    assert!(then_blk.is_empty(), "expected empty then branch");
+    assert!(else_blk.is_empty(), "expected empty else branch");
+}
+
+#[test]
+fn cst_backend_accepts_empty_repeat_blocks() {
+    let source = test_source_file(
+        "\
+begin
+    repeat.4
+    end
+end
+",
+    );
+
+    let cst = parse_forms_with_backend(source, ParserBackend::Cst)
+        .expect("cst backend should accept empty repeat blocks");
+    let [Form::Begin(block)] = cst.as_slice() else {
+        panic!("expected a single begin block");
+    };
+    let ops = block.iter().collect::<Vec<_>>();
+    let [Op::Repeat { body, .. }] = ops.as_slice() else {
+        panic!("expected one repeat op, got {ops:?}");
+    };
+    assert!(body.is_empty(), "expected empty repeat body");
 }
 
 #[test]

--- a/crates/assembly-syntax/src/sema/errors.rs
+++ b/crates/assembly-syntax/src/sema/errors.rs
@@ -114,6 +114,28 @@ pub enum SemanticAnalysisError {
         #[label]
         span: SourceSpan,
     },
+    #[error("empty while.true body")]
+    #[diagnostic(
+        severity(Warning),
+        help(
+            "an empty while.true body relies on operand-stack state and may lead to undefined behavior; add an explicit `nop` to acknowledge intent"
+        )
+    )]
+    EmptyWhileBody {
+        #[label]
+        span: SourceSpan,
+    },
+    #[error("empty repeat body")]
+    #[diagnostic(
+        severity(Warning),
+        help(
+            "repeat with an empty body is dead code; add an explicit `nop` to acknowledge intent"
+        )
+    )]
+    EmptyRepeatBody {
+        #[label]
+        span: SourceSpan,
+    },
     #[error("missing import: the referenced module has not been imported")]
     #[diagnostic()]
     MissingImport {

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -16,7 +16,7 @@ use miden_core::{Word, crypto::hash::Poseidon2};
 use miden_debug_types::{SourceFile, SourceManager, Span, Spanned};
 use smallvec::SmallVec;
 
-use self::passes::{LocalInvokeTarget, VerifyInvokeTargets};
+use self::passes::{LocalInvokeTarget, VerifyEmptyControlFlow, VerifyInvokeTargets};
 pub use self::{
     context::AnalysisContext,
     errors::{LimitKind, SemanticAnalysisError, SyntaxError},
@@ -227,6 +227,17 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) {
                 log::debug!(target: "verify-repeat", "visiting procedure {}", procedure.name());
                 {
                     let mut visitor = VerifyRepeatCounts::new(analyzer);
+                    let _ = visitor.visit_procedure(&procedure);
+                }
+
+                // Warn about empty loop/repeat bodies where behavior may be surprising.
+                log::debug!(
+                    target: "verify-empty-control-flow",
+                    "visiting procedure {}",
+                    procedure.name()
+                );
+                {
+                    let mut visitor = VerifyEmptyControlFlow::new(analyzer);
                     let _ = visitor.visit_procedure(&procedure);
                 }
 

--- a/crates/assembly-syntax/src/sema/passes/mod.rs
+++ b/crates/assembly-syntax/src/sema/passes/mod.rs
@@ -1,6 +1,10 @@
 mod const_eval;
+mod verify_empty_control_flow;
 mod verify_invoke;
 mod verify_repeat;
 
 pub(super) use self::verify_invoke::{LocalInvokeTarget, VerifyInvokeTargets};
-pub use self::{const_eval::ConstEvalVisitor, verify_repeat::VerifyRepeatCounts};
+pub use self::{
+    const_eval::ConstEvalVisitor, verify_empty_control_flow::VerifyEmptyControlFlow,
+    verify_repeat::VerifyRepeatCounts,
+};

--- a/crates/assembly-syntax/src/sema/passes/verify_empty_control_flow.rs
+++ b/crates/assembly-syntax/src/sema/passes/verify_empty_control_flow.rs
@@ -1,0 +1,32 @@
+use core::ops::ControlFlow;
+
+use crate::{
+    ast::{Op, Visit, visit::visit_op},
+    sema::{AnalysisContext, SemanticAnalysisError},
+};
+
+pub struct VerifyEmptyControlFlow<'a> {
+    analyzer: &'a mut AnalysisContext,
+}
+
+impl<'a> VerifyEmptyControlFlow<'a> {
+    pub fn new(analyzer: &'a mut AnalysisContext) -> Self {
+        Self { analyzer }
+    }
+}
+
+impl Visit for VerifyEmptyControlFlow<'_> {
+    fn visit_op(&mut self, op: &Op) -> ControlFlow<()> {
+        match op {
+            Op::While { span, body } if body.is_empty() => {
+                self.analyzer.error(SemanticAnalysisError::EmptyWhileBody { span: *span });
+            },
+            Op::Repeat { span, body, .. } if body.is_empty() => {
+                self.analyzer.error(SemanticAnalysisError::EmptyRepeatBody { span: *span });
+            },
+            _ => (),
+        }
+
+        visit_op(self, op)
+    }
+}

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -245,6 +245,48 @@ fn repeat_count_constant_too_large_rejected_in_analysis() {
 }
 
 #[test]
+fn empty_loop_bodies_are_allowed_when_warnings_are_not_errors() {
+    let context = SyntaxTestContext::default();
+    context
+        .parse_program("begin while.true end end")
+        .expect("expected empty while body to be allowed when warnings are not errors");
+    context
+        .parse_program("begin repeat.5 end end")
+        .expect("expected empty repeat body to be allowed when warnings are not errors");
+}
+
+#[test]
+fn empty_while_body_rejected_when_warnings_are_errors() {
+    let context = SyntaxTestContext::new().with_warnings_as_errors(true);
+    let error = context
+        .parse_program("begin while.true end end")
+        .expect_err("expected empty while body warning to fail under warnings_as_errors");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("empty while.true body"));
+}
+
+#[test]
+fn empty_repeat_body_rejected_when_warnings_are_errors() {
+    let context = SyntaxTestContext::new().with_warnings_as_errors(true);
+    let error = context
+        .parse_program("begin repeat.5 end end")
+        .expect_err("expected empty repeat body warning to fail under warnings_as_errors");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("empty repeat body"));
+}
+
+#[test]
+fn explicit_nop_silences_empty_loop_body_warnings() {
+    let context = SyntaxTestContext::new().with_warnings_as_errors(true);
+    context
+        .parse_program("begin while.true nop end end")
+        .expect("expected explicit nop to silence empty while warning");
+    context
+        .parse_program("begin repeat.5 nop end end")
+        .expect("expected explicit nop to silence empty repeat warning");
+}
+
+#[test]
 fn exported_constant_with_private_local_dependency_is_fully_evaluated_in_analysis() {
     let context = SyntaxTestContext::default();
     let module = context

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -181,6 +181,21 @@ fn type_alias_with_name(name: &str) -> TypeAlias {
 }
 
 #[test]
+fn empty_enum_still_reports_type_name_conflicts() {
+    let context = SyntaxTestContext::default();
+    let source = "\
+type thing = felt
+enum thing: u8 {}
+";
+    let error = context
+        .parse_module(source)
+        .expect_err("expected symbol conflict when enum name matches existing type");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert_symbol_conflict(&error, "thing");
+    assert!(rendered.contains("symbol conflict"));
+}
+
+#[test]
 fn repeat_count_zero_rejected_in_analysis() {
     let context = SyntaxTestContext::default();
     let error = context

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -100,31 +100,24 @@ fn simple_instructions() -> TestResult {
     Ok(())
 }
 
-/// TODO(pauls): Do we want to allow this in Miden Assembly?
 #[test]
-#[ignore]
-fn empty_program() -> TestResult {
+fn empty_program_is_rejected() {
     let context = TestContext::default();
     let source = source_file!(&context, "begin end");
-    let program = context.assemble(source)?;
-    insta::assert_snapshot!(program);
-    Ok(())
+    let err = context
+        .assemble(source)
+        .expect_err("expected empty begin/end program to be rejected");
+    assert_diagnostic!(&err, "invalid syntax");
+    assert_diagnostic!(&err, "expected a non-empty entry block");
 }
 
 #[test]
 fn empty_if() {
     let context = TestContext::default();
     let source = source_file!(&context, "begin if.true end end");
-    assert_assembler_diagnostic!(
-        context,
-        source,
-        "invalid syntax: expected a non-empty `if` block",
-        regex!(r#",-\[test[\d]+:1:15\]"#),
-        "1 | begin if.true end end",
-        "  :               ^",
-        "  :               `-- expected a non-empty `if` block",
-        "  `----"
-    );
+    context
+        .assemble(source)
+        .expect("expected empty if to be accepted");
 }
 
 #[test]
@@ -136,26 +129,24 @@ fn empty_if_true_then_branch() -> TestResult {
     Ok(())
 }
 
-/// TODO(pauls): Do we want to allow this in Miden Assembly
 #[test]
-#[ignore]
-fn empty_while() -> TestResult {
+fn empty_while_is_rejected_when_warnings_are_errors() {
     let context = TestContext::default();
     let source = source_file!(&context, "begin while.true end end");
-    let program = context.assemble(source)?;
-    insta::assert_snapshot!(program);
-    Ok(())
+    let err = context
+        .assemble(source)
+        .expect_err("expected empty while body warning to fail under warnings_as_errors");
+    assert_diagnostic!(err, "empty while.true body");
 }
 
-/// TODO(pauls): Do we want to allow this in Miden Assembly
 #[test]
-#[ignore]
-fn empty_repeat() -> TestResult {
+fn empty_repeat_is_rejected_when_warnings_are_errors() {
     let context = TestContext::default();
     let source = source_file!(&context, "begin repeat.5 end end");
-    let program = context.assemble(source)?;
-    insta::assert_snapshot!(program);
-    Ok(())
+    let err = context
+        .assemble(source)
+        .expect_err("expected empty repeat body warning to fail under warnings_as_errors");
+    assert_diagnostic!(err, "empty repeat body");
 }
 
 /// This test ensures that all iterations of a repeat control block are merged into a single basic


### PR DESCRIPTION
## Describe your changes
                                                                                                                                                                                                 
  This PR fixes a semantic consistency bug in enum definition handling.                                                                                                                          
                                                                                                                                                                                                 
  ### What changed                                                                                                                                                                               
  - In `define_enum` (`crates/assembly-syntax/src/ast/module.rs`), enum name conflict validation is now performed **before** the non-C-like early return path.                                   
  - This prevents empty/non-C-like enums from bypassing symbol conflict checks.                                                                                                                  
  - The non-C-like path now uses `push_export(...)` for consistent export insertion behavior.                                                                                                    
  - Added a regression test in `crates/assembly-syntax/src/sema/tests.rs`:                                                                                                                       
    - `empty_enum_still_reports_type_name_conflicts`                                                                                                                                             

  ### Why                                                                                                                                                                                        
  The parser allows empty enums (`enum X: u8 {}`), but the previous control flow could skip conflict checks for that path, creating inconsistent validation behavior across enum forms.          
                                                                                                                                                                                                 
  ## Checklist before requesting a review                                                                                                                                                        
  - [ ] Repo forked and branch created from `next` according to naming convention.                                                                                                               
  - [ ] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).                                                                                                                  
  - [ ] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).                                                                  
  - [ ] Relevant issues are linked in the PR description. (`Fixes #<issue-number>`)                                                                                                              
  - [x] Tests added for new functionality.                                                                                                                                                       
  - [ ] Documentation/comments updated according to changes.                                                                                                                                     
  - [ ] Updated `CHANGELOG.md`.   