### PR TITLE
Fix enum conflict before early return02

### DIFF
--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -267,19 +267,13 @@ impl Module {
     /// * The concrete type of the enumeration is not an integral type
     pub fn define_enum(&mut self, ty: EnumType) -> Result<(), SemanticAnalysisError> {
         let repr = ty.ty().clone();
+        let is_c_like = ty.is_c_like();
 
         if !repr.is_integer() {
             return Err(SemanticAnalysisError::InvalidEnumRepr { span: ty.span() });
         }
 
-        // We only define constants for C-like enums
-        if !ty.is_c_like() {
-            self.items.push(Export::Type(ty.into()));
-            return Ok(());
-        }
-
         let export = ty.clone();
-
         let (alias, variants) = ty.into_parts();
 
         if let Some(prev) = self.items.iter().find(|t| t.name() == &alias.name) {
@@ -287,6 +281,12 @@ impl Module {
                 span: alias.span(),
                 prev_span: prev.span(),
             });
+        }
+
+        // We only define constants for C-like enums
+        if !is_c_like {
+            self.push_export(Export::Type(export.into()))?;
+            return Ok(());
         }
 
         let mut values = SmallVec::<[Span<u64>; 8]>::new_const();

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -181,6 +181,21 @@ fn type_alias_with_name(name: &str) -> TypeAlias {
 }
 
 #[test]
+fn empty_enum_still_reports_type_name_conflicts() {
+    let context = SyntaxTestContext::default();
+    let source = "\
+type thing = felt
+enum thing: u8 {}
+";
+    let error = context
+        .parse_module(source)
+        .expect_err("expected symbol conflict when enum name matches existing type");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert_symbol_conflict(&error, "thing");
+    assert!(rendered.contains("symbol conflict"));
+}
+
+#[test]
 fn repeat_count_zero_rejected_in_analysis() {
     let context = SyntaxTestContext::default();
     let error = context


### PR DESCRIPTION
 ## Describe your changes
                                                                                                                                                                                                 
  This PR fixes a semantic consistency bug in enum definition handling.                                                                                                                          
                                                                                                                                                                                                 
  ### What changed                                                                                                                                                                               
  - In `define_enum` (`crates/assembly-syntax/src/ast/module.rs`), enum name conflict validation is now performed **before** the non-C-like early return path.                                   
  - This prevents empty/non-C-like enums from bypassing symbol conflict checks.                                                                                                                  
  - The non-C-like path now uses `push_export(...)` for consistent export insertion behavior.                                                                                                    
  - Added a regression test in `crates/assembly-syntax/src/sema/tests.rs`:                                                                                                                       
    - `empty_enum_still_reports_type_name_conflicts`                                                                                                                                             

  ### Why                                                                                                                                                                                        
  The parser allows empty enums (`enum X: u8 {}`), but the previous control flow could skip conflict checks for that path, creating inconsistent validation behavior across enum forms.          
                                                                                                                                                                                                 
  ## Checklist before requesting a review                                                                                                                                                        
  - [ ] Repo forked and branch created from `next` according to naming convention.                                                                                                               
  - [ ] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).                                                                                                                  
  - [ ] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).                                                                  
  - [ ] Relevant issues are linked in the PR description. (`Fixes #<issue-number>`)                                                                                                              
  - [x] Tests added for new functionality.                                                                                                                                                       
  - [ ] Documentation/comments updated according to changes.                                                                                                                                     
  - [ ] Updated `CHANGELOG.md`.   