### PR TITLE
Complete core debug handler coverage

### DIFF
--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -27,7 +27,7 @@ path = "tests/main.rs"
 
 [features]
 default = ["std"]
-std = ["miden-assembly/std", "miden-utils-sync/std"]
+std = ["miden-assembly/std", "miden-processor/std", "miden-utils-sync/std"]
 constraints-tools = ["std", "dep:miden-air", "dep:miden-ace-codegen"]
 
 [dependencies]

--- a/crates/lib/core/src/handlers/debug.rs
+++ b/crates/lib/core/src/handlers/debug.rs
@@ -89,7 +89,8 @@ impl<W: fmt::Write + Send + Sync + 'static> EventHandler for DebugPrinter<W> {
 
         if id == PRINT_STACK_EVENT_NAME.to_event_id() {
             // Skip position 0 (the event id) so only the user's operand stack is shown. Print the
-            // entire stack (no cap) to mirror the `debug.stack` decorator (`DebugOptions::StackAll`).
+            // entire stack (no cap) to mirror the `debug.stack` decorator
+            // (`DebugOptions::StackAll`).
             let stack = process.get_stack_state();
             let operand_stack = stack.get(1..).unwrap_or(&[]);
             write_stack(w, operand_stack, None, "Stack", process.clock())?;
@@ -121,7 +122,7 @@ impl<W: fmt::Write + Send + Sync + 'static> EventHandler for DebugPrinter<W> {
 
 /// Reads the element at `pos` on the operand stack as a `usize` (saturating).
 fn stack_item_as_usize(process: &ProcessorState, pos: usize) -> usize {
-    process.get_stack_item(pos).as_canonical_u64() as usize
+    usize::try_from(process.get_stack_item(pos).as_canonical_u64()).unwrap_or(usize::MAX)
 }
 
 /// Returns `slice[start..end]`, clamped to the bounds of `slice` and to `start <= end`.

--- a/crates/lib/core/tests/debug.rs
+++ b/crates/lib/core/tests/debug.rs
@@ -87,6 +87,22 @@ fn run_and_capture(source: &str, advice: AdviceInputs) -> String {
     run(source, advice).0
 }
 
+/// Executes `source` against the core library's default host-library conversion. This exercises
+/// the production handler registration path, while capture tests use a custom in-memory printer.
+fn run_with_default_core_handlers(source: &str, advice: AdviceInputs) -> ExecutionOutput {
+    let core_lib = CoreLibrary::default();
+    let assembler = Assembler::default()
+        .with_dynamic_library(&core_lib)
+        .expect("failed to load core library");
+    let program = assembler.assemble_program(source).expect("failed to assemble program");
+    let mut host = DefaultHost::default()
+        .with_library(&core_lib)
+        .expect("failed to load core library handlers");
+
+    execute_sync(&program, StackInputs::default(), advice, &mut host, ExecutionOptions::default())
+        .expect("execution failed")
+}
+
 // CAPTURE TESTS
 // ================================================================================================
 
@@ -161,6 +177,29 @@ fn print_adv_stack_all_outputs_advice_stack() {
 }
 
 #[test]
+fn print_adv_stack_outputs_range() {
+    let advice = AdviceInputs::default().with_stack([
+        Felt::new_unchecked(7),
+        Felt::new_unchecked(8),
+        Felt::new_unchecked(9),
+        Felt::new_unchecked(10),
+    ]);
+    let source = "
+    use miden::core::debug
+    begin
+        push.3 push.1   # [start=1, end=3]
+        exec.debug::print_adv_stack
+    end
+    ";
+    let out = run_and_capture(source, advice);
+    assert!(out.contains("Advice stack state"), "missing header; got:\n{out}");
+    assert!(
+        out.contains(": 8") && out.contains(": 9") && !out.contains(": 7") && !out.contains(": 10"),
+        "unexpected advice stack range; got:\n{out}"
+    );
+}
+
+#[test]
 fn print_adv_map_outputs_values() {
     let key = Word::new([
         Felt::new_unchecked(1),
@@ -216,6 +255,20 @@ fn print_stack_is_stack_neutral() {
     end
     ";
     let (_, output) = run(source, AdviceInputs::default());
+    assert_eq!(output.stack.get_element(0), Some(Felt::new_unchecked(0)));
+}
+
+#[test]
+fn default_core_handlers_run_print_stack() {
+    let source = "
+    use miden::core::debug
+    begin
+        push.1 push.2 push.3
+        exec.debug::print_stack
+        drop drop drop
+    end
+    ";
+    let output = run_with_default_core_handlers(source, AdviceInputs::default());
     assert_eq!(output.stack.get_element(0), Some(Felt::new_unchecked(0)));
 }
 

--- a/processor/src/host/debug.rs
+++ b/processor/src/host/debug.rs
@@ -243,6 +243,11 @@ pub fn write_stack<W: fmt::Write>(
     let num_items = n.unwrap_or(stack.len());
 
     // Write header
+    if num_items == 0 {
+        writeln!(writer, "{label} state in interval [0, 0) before step {clk}:")?;
+        return Ok(());
+    }
+
     let is_partial = num_items < stack.len();
     if is_partial {
         writeln!(writer, "{label} state in interval [0, {}] before step {clk}:", num_items - 1)?
@@ -348,6 +353,14 @@ mod tests {
             out,
             "Stack state in interval [0, 1] before step 4:\n├── 0: 9\n├── 1: 8\n└── (1 more items)\n"
         );
+    }
+
+    #[test]
+    fn write_stack_zero_count_does_not_underflow() {
+        let mut out = String::new();
+        let stack = [Felt::new_unchecked(9), Felt::new_unchecked(8), Felt::new_unchecked(7)];
+        write_stack(&mut out, &stack, Some(0), "Stack", 4u32).unwrap();
+        assert_eq!(out, "Stack state in interval [0, 0) before step 4:\n");
     }
 
     #[test]


### PR DESCRIPTION
- Enabled `miden-processor/std` from `miden-core-lib/std`, so default debug handlers actually print instead of silently no-oping.
- Added production-path coverage using `DefaultHost::with_library(&CoreLibrary::default())`.
- Added direct ranged `print_adv_stack` coverage.
- Hardened advice-stack range conversion against 32-bit usize wrapping.
- Fixed `write_stack(..., Some(0), ...)` underflow and added coverage.
- Let make lint apply the rustfmt wrap that CI was failing on.