### PR TITLE
feat: `workflow-publish` forward port

### DIFF
--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -1,26 +1,203 @@
 name: Publish workspace to crates.io
 
+# Keep this workflow file and name stable: crates.io trusted publishing is
+# configured against the GitHub workflow identity. The manual path below is the
+# canonical release path because it stages assets on a draft before anything is
+# public; the release.published path is only a guarded fallback for releases
+# whose assets were already staged by another trusted operator action. Tag
+# rulesets may require deployment to the release environment and may make tags
+# immutable, so failures below print recovery commands instead of suggesting
+# force-pushing, deleting, or moving a tag.
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name for the release (e.g. v0.12.0)'
+        required: true
+        type: string
   release:
     types: [published]
 
 permissions: {}
 
 jobs:
-  publish:
+  prepare-release:
+    name: prepare release metadata
     if: ${{ github.repository_owner == '0xMiden' }}
-    runs-on: warp-ubuntu-latest-x64-8x
+    runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      tag: ${{ steps.prepare.outputs.tag }}
+      sha: ${{ steps.prepare.outputs.sha }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Resolve and validate release commit
+        id: prepare
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          ./scripts/prepare-release.sh
+
+  create-draft:
+    name: create draft release
+    needs: prepare-release
+    if: ${{ github.event_name == 'workflow_dispatch' && github.repository_owner == '0xMiden' }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - name: Create or validate draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          RELEASE_SHA: ${{ needs.prepare-release.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          is_draft="$( { gh release view "${RELEASE_TAG}" --json isDraft -q .isDraft; } 2>/dev/null || echo "release not found" )"
+          case "${is_draft}" in
+            true)
+              draft_sha="$(gh release view "${RELEASE_TAG}" --json targetCommitish -q .targetCommitish)"
+              if [[ "${draft_sha}" != "${RELEASE_SHA}" ]]; then
+                echo "::error::Draft ${RELEASE_TAG} targets ${draft_sha}, expected ${RELEASE_SHA}."
+                echo "::error::Do not retarget the tag or draft to recover. Use a new tag once main points at the intended release commit."
+                echo "::error::Recovery: gh workflow run workspace-publish.yml --ref main -f tag=<new-tag>"
+                exit 1
+              fi
+              ;;
+            false)
+              echo "::error::Release ${RELEASE_TAG} is already published. Refusing to mutate public release assets."
+              echo "::error::If all required assets are already present, the release.published fallback can publish crates."
+              echo "::error::If assets are missing and this release can still be converted back to draft, do that first, then rerun: gh workflow run workspace-publish.yml --ref main -f tag=${RELEASE_TAG}"
+              echo "::error::If release/tag immutability prevents making it draft again, leave this release alone and cut a new tag with: gh workflow run workspace-publish.yml --ref main -f tag=<new-tag>"
+              exit 1
+              ;;
+            "release not found")
+              # This can create the git tag as a side effect. Keep this job in
+              # the release environment so tag rulesets with required
+              # deployments can be satisfied before the immutable tag exists.
+              gh release create "${RELEASE_TAG}" \
+                --draft \
+                --target "${RELEASE_SHA}" \
+                --title "${RELEASE_TAG}"
+              ;;
+            *)
+              echo "::error::Unexpected draft state for ${RELEASE_TAG}: ${is_draft}"
+              echo "::error::Retry after checking the release manually: gh release view ${RELEASE_TAG} --repo ${GH_REPO}"
+              echo "::error::If no release exists, rerun the canonical path: gh workflow run workspace-publish.yml --ref main -f tag=${RELEASE_TAG}"
+              exit 1
+              ;;
+          esac
+
+  upload-artifacts:
+    name: upload pre-built miden-vm executable artifacts
+    needs: [prepare-release, create-draft]
+    if: ${{ github.event_name == 'workflow_dispatch' && github.repository_owner == '0xMiden' }}
+    environment: release
+    permissions:
+      contents: write
       id-token: write
-    environment: release  # Optional: for enhanced security
+      attestations: write
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        target: [aarch64-apple-darwin, x86_64-unknown-linux-gnu]
+        exclude:
+          - os: macos-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.prepare-release.outputs.sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/cleanup-runner
+      - name: Install Rust
+        run: |
+          rustup update --no-self-update
+          rustc --version
+      - name: Add target
+        run: |
+          rustup target add ${{ matrix.target }}
+      - name: Build miden-vm
+        run: |
+          BUILD_TARGET=${{ matrix.target }} make exec-dist
+      - name: Prepare artifact
+        run: |
+          mv target/${{ matrix.target }}/optimized/miden-vm miden-vm-${{ matrix.target }}
+      - name: Attest miden-vm
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: miden-vm-${{ matrix.target }}
+      - name: Upload
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Reruns are safe after partial artifact upload: --clobber replaces
+          # existing draft assets instead of failing on "already exists".
+          gh release upload --clobber "${RELEASE_TAG}" miden-vm-${{ matrix.target }}
+      # Since the core.masp package is triplet independent, we only build it once.
+      - name: Install nightly
+        if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          rustup update --no-self-update nightly
+      - name: Build core.masp
+        if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          make packages
+      - name: Prepare artifact
+        if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          mv target/packages/miden-core.masp core.masp
+      - name: Attest core.masp
+        if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: core.masp
+      - name: Upload core.masp
+        if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
+        env:
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Reruns are safe after partial artifact upload: --clobber replaces
+          # existing draft assets instead of failing on "already exists".
+          gh release upload --clobber "${RELEASE_TAG}" core.masp
+
+  publish:
+    name: publish workspace crates
+    needs: [prepare-release, upload-artifacts]
+    if: ${{ always() && github.repository_owner == '0xMiden' && needs.prepare-release.result == 'success' && (github.event_name == 'release' || needs.upload-artifacts.result == 'success') }}
+    runs-on: warp-ubuntu-latest-x64-8x
+    environment: release
+    permissions:
+      contents: read
+      id-token: write  # Required for OIDC token exchange with crates.io
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ needs.prepare-release.outputs.sha }}
           persist-credentials: false
 
       - name: Authenticate with crates.io
@@ -34,3 +211,26 @@ jobs:
           verify-main-head: "true"
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  publish-github-release:
+    name: publish GitHub release
+    needs: [prepare-release, publish]
+    if: ${{ github.event_name == 'workflow_dispatch' && github.repository_owner == '0xMiden' }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - name: Publish draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          release_id="$(gh release view "${RELEASE_TAG}" --json databaseId -q .databaseId)"
+          gh api \
+            --method PATCH \
+            "repos/${GH_REPO}/releases/${release_id}" \
+            -F draft=false

--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -4,14 +4,15 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-  id-token: write  # Required for OIDC token exchange
+permissions: {}
 
 jobs:
   publish:
     if: ${{ github.repository_owner == '0xMiden' }}
     runs-on: warp-ubuntu-latest-x64-8x
+    permissions:
+      contents: read
+      id-token: write
     environment: release  # Optional: for enhanced security
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - [BREAKING] Updated the Miden crypto stack to `miden-crypto` v0.25, and switched SMT leaf hashing to use Poseidon2 domain separation so masm-side leaf digests match `SmtLeaf::hash()` ([#3095](https://github.com/0xMiden/miden-vm/pull/3095)).
 - [BREAKING] Reject post-last operation-indexed decorators in block assembly and serialized MAST forests; use `after_exit` for decorators that run after a block exits ([#3114](https://github.com/0xMiden/miden-vm/pull/3114)).
 - [BREAKING] Removed `Continuation::AfterExitDecoratorsBasicBlock`. New MAST merges operation-indexed decorators at the post-last-op sentinel index into `after_exit` at build time; execution uses `AfterExitDecorators` only, with legacy forests still supported ([#2633](https://github.com/0xMiden/miden-vm/issues/2633)).
+- Drop dead `clk` argument from u32 range-check ([#3135](https://github.com/0xMiden/miden-vm/issues/3135)).
 - Added binary artifact compilation to CI to aid `midenup`'s installation speed ([#3029](https://github.com/0xMiden/miden-vm/pull/3029)).
 
 ## 0.22.3 (2026-05-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - [BREAKING] Updated the Miden crypto stack to `miden-crypto` v0.25, and switched SMT leaf hashing to use Poseidon2 domain separation so masm-side leaf digests match `SmtLeaf::hash()` ([#3095](https://github.com/0xMiden/miden-vm/pull/3095)).
 - [BREAKING] Reject post-last operation-indexed decorators in block assembly and serialized MAST forests; use `after_exit` for decorators that run after a block exits ([#3114](https://github.com/0xMiden/miden-vm/pull/3114)).
 - [BREAKING] Removed `Continuation::AfterExitDecoratorsBasicBlock`. New MAST merges operation-indexed decorators at the post-last-op sentinel index into `after_exit` at build time; execution uses `AfterExitDecorators` only, with legacy forests still supported ([#2633](https://github.com/0xMiden/miden-vm/issues/2633)).
+- Added binary artifact compilation to CI to aid `midenup`'s installation speed ([#3029](https://github.com/0xMiden/miden-vm/pull/3029)).
 
 ## 0.22.3 (2026-05-01)
 

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ FEATURES_CONCURRENT_EXEC := --features concurrent,executable
 FEATURES_METAL_EXEC      := --features concurrent,executable,tracing-forest
 FEATURES_LOG_TREE        := --features concurrent,executable,tracing-forest
 
+# Target triple used when producing release artifacts. Defaults to the host's triple.
+BUILD_TARGET             ?= $(shell rustc -vV | grep host | awk '{print $$2}')
+
 # Per-crate default features
 FEATURES_air             := testing
 FEATURES_assembly        := testing
@@ -236,6 +239,15 @@ check-constraints: ## Check core-lib constraint artifacts for drift
 .PHONY: exec-info
 exec-info: ## Builds an executable with log tree enabled
 	cargo build --profile optimized $(FEATURES_LOG_TREE)
+
+.PHONY: exec-dist
+exec-dist: ## Builds the CLI for $(BUILD_TARGET) with --locked (for release artifact uploads)
+# NOTE: the resulting binary is stores in target/<$(BUILD_TARGET)>/optimized/
+	cargo build -p miden-vm --bin miden-vm --profile optimized $(FEATURES_CONCURRENT_EXEC) --target $(BUILD_TARGET) --locked
+
+.PHONY: packages
+packages: ## Builds .masp packages and store them in target/packages
+	cargo +nightly -Zscript scripts/generate-package.rs
 
 # --- examples ------------------------------------------------------------------------------------
 

--- a/scripts/generate-package.rs
+++ b/scripts/generate-package.rs
@@ -1,0 +1,38 @@
+#!/usr/bin/env -S cargo +nightly -Zscript
+
+---
+[dependencies]
+miden-assembly = { path = "../crates/assembly" }
+miden-package-registry = { path = "../crates/package-registry" }
+---
+
+use std::env;
+
+use miden_assembly::{Assembler, ProjectTargetSelector, Report, diagnostics::IntoDiagnostic};
+use miden_package_registry::InMemoryPackageRegistry;
+
+fn main() -> Result<(), Report> {
+    // We obtain the workspace root like so becaue CARGO_TARGET_DIR is not set
+    // for cargo scripts.
+    // This does mean that this script is only intended to be run from the
+    // project's rootk.
+    let workspace_root = env::current_dir().expect("could not read PWD");
+    let core_lib_project_dir = workspace_root.join("crates/lib/core/asm");
+
+    let target_dir = workspace_root.join("target");
+    let packages_dir = target_dir.join("packages");
+    std::fs::create_dir_all(&packages_dir).unwrap_or_else(|_| {
+        panic!("could not create packages/ directory in {}", packages_dir.display())
+    });
+
+    let assembler = Assembler::default();
+    let mut registry = InMemoryPackageRegistry::default();
+    let mut project_assembler = assembler
+        .for_project_at_path(core_lib_project_dir.join("miden-project.toml"), &mut registry)?;
+    let package = project_assembler.assemble(ProjectTargetSelector::Library, "release")?;
+
+    package.write_masp_file(&packages_dir).into_diagnostic()?;
+
+    println!("wrote miden-core.masp to {}", packages_dir.display());
+    Ok(())
+}

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# RELEASE_TAG, EVENT_NAME, GH_TOKEN, GH_REPO, GITHUB_OUTPUT are set on the
+# workspace-publish.yml workflow.
+
+set -euo pipefail
+
+git fetch origin main --depth=1
+main_sha="$(git rev-parse origin/main)"
+
+if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+    # Canonical release path: operators provide only the tag. The commit is
+    # derived from origin/main so release assets, crates, and the GitHub
+    # release all point at the same protected revision.
+    release_sha="${main_sha}"
+
+    if git rev-parse --verify --quiet "refs/tags/${RELEASE_TAG}^{commit}" >/dev/null; then
+        tag_sha="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+        if [[ "${tag_sha}" != "${release_sha}" ]]; then
+            echo "::error::Existing tag ${RELEASE_TAG} points at ${tag_sha}, expected ${release_sha}."
+            echo "::error::Tags are immutable under the release ruleset. Do not move or delete ${RELEASE_TAG}; choose a new tag after main points at the intended release commit."
+            echo "::error::Recovery: gh workflow run workspace-publish.yml --ref main -f tag=<new-tag>"
+            exit 1
+        fi
+    fi
+else
+    # Guardrail path: a release is already public. We do not build or
+    # upload assets here, because doing so would recreate the public-first
+    # race this workflow is meant to avoid. Instead, require the expected
+    # assets to already be present before crates are published.
+    git fetch origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}" --force --depth=1
+    release_sha="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+
+    if [[ "${release_sha}" != "${main_sha}" ]]; then
+        echo "::error::Release tag ${RELEASE_TAG} points at ${release_sha}, but origin/main is ${main_sha}."
+        echo "::error::Tags are immutable under the release ruleset. Do not move or delete ${RELEASE_TAG}; publish a follow-up release from the current main commit instead."
+        echo "::error::Recovery: gh workflow run workspace-publish.yml --ref main -f tag=<new-tag>"
+        exit 1
+    fi
+
+    release_assets="$(gh release view "${RELEASE_TAG}" --json assets -q '.assets[].name')"
+    required_assets=(
+        "miden-vm-aarch64-apple-darwin"
+        "miden-vm-x86_64-unknown-linux-gnu"
+        "core.masp"
+    )
+
+    missing=0
+    for asset in "${required_assets[@]}"; do
+        if ! grep -Fxq "${asset}" <<< "${release_assets}"; then
+            echo "::error::Release ${RELEASE_TAG} is already public but is missing required asset ${asset}."
+            missing=1
+        fi
+    done
+
+    if [[ "${missing}" -ne 0 ]]; then
+        echo "::error::This fallback never builds assets after a release is public."
+        echo "::error::If this release can still be converted back to draft, do that first, then rerun: gh workflow run workspace-publish.yml --ref main -f tag=${RELEASE_TAG}"
+        echo "::error::If release/tag immutability prevents making it draft again, leave this release alone and cut a new tag with: gh workflow run workspace-publish.yml --ref main -f tag=<new-tag>"
+        exit 1
+    fi
+fi
+
+echo "tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+echo "sha=${release_sha}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Related https://github.com/0xMiden/miden-vm/issues/3198

This PR forward ports the newly modified `workflow-publish.yml` to enable the creation of releases from the main branch. 