### PR TITLE
Run release metadata tooling from the workflow revision

### DIFF
--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -31,11 +31,15 @@ jobs:
       tag: ${{ steps.prepare.outputs.tag }}
       sha: ${{ steps.prepare.outputs.sha }}
     steps:
-      - name: Checkout repository
+      - name: Checkout release tooling
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-          ref: main
+          # Check out the workflow/tooling revision so scripts/prepare-release.sh
+          # comes from the same commit as this workflow. That script only
+          # resolves metadata; build, artifact, and publish jobs still checkout
+          # needs.prepare-release.outputs.sha from origin/main.
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
       - name: Resolve and validate release commit


### PR DESCRIPTION
`workspace-publish.yml` checked out `main` before running `scripts/prepare-release.sh`, but that script is maintained with the release workflow on `next`. A manual release run from `next` therefore loaded the new workflow, checked out `main`, and then failed because `main` did not contain the script yet.

This changes only the metadata-preparation checkout. That job now checks out the same commit that supplied the workflow, so `scripts/prepare-release.sh` and the workflow stay in sync.

Release provenance is unchanged. `prepare-release.sh` still resolves the release commit from `origin/main`, and the build, artifact upload, and crates publish jobs still checkout `needs.prepare-release.outputs.sha`. In other words, release tooling comes from the workflow revision, while released source and artifacts continue to come from `main`.