### PR TITLE
fix(ci): drop stale blake3 benchmark release flag

### DIFF
--- a/scripts/blake3_nonregression.py
+++ b/scripts/blake3_nonregression.py
@@ -17,7 +17,6 @@ BENCHMARK_COMMAND = [
     "./target/optimized/miden-vm",
     "prove",
     BENCHMARK_PATH,
-    "--release",
 ]
 
 ANSI_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")


### PR DESCRIPTION
The Blake3 non-regression workflow was still invoking:

```sh
miden-vm prove ... --release
```

`prove --release` was removed when debug decorators were removed (in favor of `--trace`), so the benchmark jobs now fail at CLI argument parsing before collecting measurements.

This updates `scripts/blake3_nonregression.py` to call the current prove CLI shape.