### PR TITLE
perf: O(log n) name conflict checks in Module via BTreeMap index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Removed overly aggressive validation check that prevented defining virtual executable targets in Miden projects
 
 #### Enhancements
+- Improved O(n²) to O(log n) name conflict checks in `Module::define_*` methods by introducing a `BTreeMap` name index; also narrowed `items_mut()` to return an iterator instead of `&mut Vec<Export>` to preserve the index invariant ([#3218](https://github.com/0xMiden/miden-vm/pull/3218)).
 
 - Added a `RELEASE_PROCEDURE` file ([#3199](https://github.com/0xMiden/miden-vm/pull/3199)).
 - Added enum and `u256` records to `.debug_types` metadata so debuggers can preserve those type identities ([#3227](https://github.com/0xMiden/miden-vm/pull/3227)).

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -549,10 +549,10 @@ impl Module {
     pub fn items(&self) -> &[Export] {
         &self.items
     }
-
-    /// Get a mutable reference to the storage for items defined in this module
-    pub fn items_mut(&mut self) -> &mut Vec<Export> {
-        &mut self.items
+    /// Returns a mutable iterator over the items in this module.
+    /// Note: does not expose `Vec` directly to preserve the `name_map` invariant.
+    pub fn items_mut(&mut self) -> impl Iterator<Item = &mut Export> {
+        self.items.iter_mut()
     }
 
     /// Returns items exported from this module.

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -155,6 +155,8 @@ pub struct Module {
     /// Maps export name to its position in `items`, for O(log n) conflict checks.
     /// Must be kept in sync with `items` via `push_export`.
     name_map: BTreeMap<String, usize>,
+    /// Whether mutable item access may have changed item names without updating `name_map`.
+    name_map_dirty: bool,
     /// AdviceMap that this module expects to be loaded in the host before executing.
     pub(crate) advice_map: AdviceMap,
 }
@@ -184,6 +186,7 @@ impl Module {
             kind,
             items: Default::default(),
             name_map: BTreeMap::new(),
+            name_map_dirty: false,
             advice_map: Default::default(),
         }
     }
@@ -238,6 +241,7 @@ impl Module {
 
     pub(crate) fn push_export(&mut self, item: Export) -> Result<(), SemanticAnalysisError> {
         self.ensure_item_capacity(item.span())?;
+        self.ensure_name_map_current();
         let idx = self.items.len();
         let prev = self.name_map.insert(item.name().to_string(), idx);
         debug_assert!(prev.is_none(), "duplicate export inserted via push_export: {}", item.name());
@@ -245,15 +249,29 @@ impl Module {
         Ok(())
     }
 
+    fn ensure_name_map_current(&mut self) {
+        if !self.name_map_dirty {
+            return;
+        }
+
+        self.name_map.clear();
+        self.name_map.extend(
+            self.items.iter().enumerate().map(|(idx, item)| (item.name().to_string(), idx)),
+        );
+        self.name_map_dirty = false;
+    }
+
     /// Takes all items from this module, clearing the name index.
     /// Used by the linker to consume module contents.
     pub fn take_items(&mut self) -> Vec<Export> {
         self.name_map.clear();
+        self.name_map_dirty = false;
         core::mem::take(&mut self.items)
     }
 
     /// Defines a constant, raising an error if the constant conflicts with a previous definition
     pub fn define_constant(&mut self, constant: Constant) -> Result<(), SemanticAnalysisError> {
+        self.ensure_name_map_current();
         if let Some(&idx) = self.name_map.get(constant.name.as_str()) {
             return Err(SemanticAnalysisError::SymbolConflict {
                 span: constant.span,
@@ -265,6 +283,7 @@ impl Module {
 
     /// Defines a type alias, raising an error if the alias conflicts with a previous definition
     pub fn define_type(&mut self, ty: TypeAlias) -> Result<(), SemanticAnalysisError> {
+        self.ensure_name_map_current();
         if let Some(&idx) = self.name_map.get(ty.name().as_str()) {
             return Err(SemanticAnalysisError::SymbolConflict {
                 span: ty.span(),
@@ -284,6 +303,7 @@ impl Module {
     ///   with the same name as any of the variants of the given enum type, is already defined
     /// * The concrete type of the enumeration is not an integral type
     pub fn define_enum(&mut self, ty: EnumType) -> Result<(), SemanticAnalysisError> {
+        self.ensure_name_map_current();
         let repr = ty.ty().clone();
         let is_c_like = ty.is_c_like();
 
@@ -367,6 +387,7 @@ impl Module {
         procedure: Procedure,
         _source_manager: Arc<dyn SourceManager>,
     ) -> Result<(), SemanticAnalysisError> {
+        self.ensure_name_map_current();
         if let Some(&idx) = self.name_map.get(procedure.name().as_str()) {
             return Err(SemanticAnalysisError::SymbolConflict {
                 span: procedure.span(),
@@ -383,6 +404,7 @@ impl Module {
         item: Alias,
         _source_manager: Arc<dyn SourceManager>,
     ) -> Result<(), SemanticAnalysisError> {
+        self.ensure_name_map_current();
         if self.is_kernel() && item.visibility().is_public() {
             return Err(SemanticAnalysisError::ReexportFromKernel { span: item.span() });
         }
@@ -498,6 +520,7 @@ impl Module {
 
     /// Same as [Module::constants], but returns mutable references.
     pub fn constants_mut(&mut self) -> impl Iterator<Item = &mut Constant> + '_ {
+        self.name_map_dirty = true;
         self.items.iter_mut().filter_map(|item| match item {
             Export::Constant(item) => Some(item),
             _ => None,
@@ -514,6 +537,7 @@ impl Module {
 
     /// Same as [Module::types], but returns mutable references.
     pub fn types_mut(&mut self) -> impl Iterator<Item = &mut TypeDecl> + '_ {
+        self.name_map_dirty = true;
         self.items.iter_mut().filter_map(|item| match item {
             Export::Type(item) => Some(item),
             _ => None,
@@ -530,6 +554,7 @@ impl Module {
 
     /// Same as [Module::procedures], but returns mutable references.
     pub fn procedures_mut(&mut self) -> impl Iterator<Item = &mut Procedure> + '_ {
+        self.name_map_dirty = true;
         self.items.iter_mut().filter_map(|item| match item {
             Export::Procedure(item) => Some(item),
             _ => None,
@@ -546,6 +571,7 @@ impl Module {
 
     /// Same as [Module::aliases], but returns mutable references.
     pub fn aliases_mut(&mut self) -> impl Iterator<Item = &mut Alias> + '_ {
+        self.name_map_dirty = true;
         self.items.iter_mut().filter_map(|item| match item {
             Export::Alias(item) => Some(item),
             _ => None,
@@ -559,6 +585,7 @@ impl Module {
     /// Returns a mutable iterator over the items in this module.
     /// Note: does not expose `Vec` directly to preserve the `name_map` invariant.
     pub fn items_mut(&mut self) -> impl Iterator<Item = &mut Export> {
+        self.name_map_dirty = true;
         self.items.iter_mut()
     }
 
@@ -649,6 +676,7 @@ impl Module {
 
     /// Same as [Module::get_import], but returns a mutable reference to the [Alias]
     pub fn get_import_mut(&mut self, module_name: &str) -> Option<&mut Alias> {
+        self.name_map_dirty = true;
         self.items.iter_mut().find_map(|item| match item {
             Export::Alias(item) if item.name().as_str() == module_name => Some(item),
             _ => None,
@@ -686,6 +714,7 @@ impl core::ops::Index<ItemIndex> for Module {
 impl core::ops::IndexMut<ItemIndex> for Module {
     #[inline]
     fn index_mut(&mut self, index: ItemIndex) -> &mut Self::Output {
+        self.name_map_dirty = true;
         &mut self.items[index.as_usize()]
     }
 }

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -1,4 +1,10 @@
-use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
+use alloc::{
+    boxed::Box,
+    collections::BTreeMap,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
 use core::fmt;
 
 use miden_core::{
@@ -146,6 +152,9 @@ pub struct Module {
     kind: ModuleKind,
     /// The items (defined or re-exported) in the module body.
     pub(crate) items: Vec<Export>,
+    /// Maps export name to its position in `items`, for O(log n) conflict checks.
+    /// Must be kept in sync with `items` via `push_export`.
+    name_map: BTreeMap<String, usize>,
     /// AdviceMap that this module expects to be loaded in the host before executing.
     pub(crate) advice_map: AdviceMap,
 }
@@ -174,6 +183,7 @@ impl Module {
             path,
             kind,
             items: Default::default(),
+            name_map: BTreeMap::new(),
             advice_map: Default::default(),
         }
     }
@@ -228,32 +238,40 @@ impl Module {
 
     pub(crate) fn push_export(&mut self, item: Export) -> Result<(), SemanticAnalysisError> {
         self.ensure_item_capacity(item.span())?;
+        let idx = self.items.len();
+        let prev = self.name_map.insert(item.name().to_string(), idx);
+        debug_assert!(prev.is_none(), "duplicate export inserted via push_export: {}", item.name());
         self.items.push(item);
         Ok(())
     }
 
+    /// Takes all items from this module, clearing the name index.
+    /// Used by the linker to consume module contents.
+    pub fn take_items(&mut self) -> Vec<Export> {
+        self.name_map.clear();
+        core::mem::take(&mut self.items)
+    }
+
     /// Defines a constant, raising an error if the constant conflicts with a previous definition
     pub fn define_constant(&mut self, constant: Constant) -> Result<(), SemanticAnalysisError> {
-        if let Some(prev) = self.items.iter().find(|item| item.name() == &constant.name) {
+        if let Some(&idx) = self.name_map.get(constant.name.as_str()) {
             return Err(SemanticAnalysisError::SymbolConflict {
                 span: constant.span,
-                prev_span: prev.span(),
+                prev_span: self.items[idx].span(),
             });
         }
-        self.push_export(Export::Constant(constant))?;
-        Ok(())
+        self.push_export(Export::Constant(constant))
     }
 
     /// Defines a type alias, raising an error if the alias conflicts with a previous definition
     pub fn define_type(&mut self, ty: TypeAlias) -> Result<(), SemanticAnalysisError> {
-        if let Some(prev) = self.items.iter().find(|item| item.name() == ty.name()) {
+        if let Some(&idx) = self.name_map.get(ty.name().as_str()) {
             return Err(SemanticAnalysisError::SymbolConflict {
                 span: ty.span(),
-                prev_span: prev.span(),
+                prev_span: self.items[idx].span(),
             });
         }
-        self.push_export(Export::Type(ty.into()))?;
-        Ok(())
+        self.push_export(Export::Type(ty.into()))
     }
 
     /// Define a new enum type `ty` with `visibility`
@@ -275,11 +293,10 @@ impl Module {
 
         let export = ty.clone();
         let (alias, variants) = ty.into_parts();
-
-        if let Some(prev) = self.items.iter().find(|t| t.name() == &alias.name) {
+        if let Some(&idx) = self.name_map.get(alias.name.as_str()) {
             return Err(SemanticAnalysisError::SymbolConflict {
                 span: alias.span(),
-                prev_span: prev.span(),
+                prev_span: self.items[idx].span(),
             });
         }
 
@@ -343,16 +360,13 @@ impl Module {
         procedure: Procedure,
         _source_manager: Arc<dyn SourceManager>,
     ) -> Result<(), SemanticAnalysisError> {
-        if let Some(prev) =
-            self.items.iter().find(|item| item.name().as_str() == procedure.name().as_str())
-        {
+        if let Some(&idx) = self.name_map.get(procedure.name().as_str()) {
             return Err(SemanticAnalysisError::SymbolConflict {
                 span: procedure.span(),
-                prev_span: prev.name().span(),
+                prev_span: self.items[idx].name().span(),
             });
         }
-        self.push_export(Export::Procedure(procedure))?;
-        Ok(())
+        self.push_export(Export::Procedure(procedure))
     }
 
     /// Defines an item alias, raising an error if the alias is invalid, or conflicts with a
@@ -365,18 +379,13 @@ impl Module {
         if self.is_kernel() && item.visibility().is_public() {
             return Err(SemanticAnalysisError::ReexportFromKernel { span: item.span() });
         }
-        if let Some(prev) = self
-            .items
-            .iter()
-            .find(|existing| existing.name().as_str() == item.name().as_str())
-        {
+        if let Some(&idx) = self.name_map.get(item.name().as_str()) {
             return Err(SemanticAnalysisError::SymbolConflict {
                 span: item.name().span(),
-                prev_span: prev.name().span(),
+                prev_span: self.items[idx].name().span(),
             });
         }
-        self.push_export(Export::Alias(item))?;
-        Ok(())
+        self.push_export(Export::Alias(item))
     }
 }
 

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -305,6 +305,13 @@ impl Module {
             self.push_export(Export::Type(export.into()))?;
             return Ok(());
         }
+        // Check that no variant name conflicts with the enum type name itself
+        if let Some(conflict) = variants.iter().find(|v| v.name.as_str() == alias.name.as_str()) {
+            return Err(SemanticAnalysisError::SymbolConflict {
+                span: conflict.name.span(),
+                prev_span: alias.span(),
+            });
+        }
 
         let mut values = SmallVec::<[Span<u64>; 8]>::new_const();
 

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -147,7 +147,7 @@ pub fn analyze(
 
     // Simplify all constant declarations
     analyzer.simplify_constants();
-    for item in module.items_mut().iter_mut() {
+    for item in module.items_mut() {
         let Export::Constant(constant) = item else {
             continue;
         };

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -201,7 +201,7 @@ fn visit_items(module: &mut Module, analyzer: &mut AnalysisContext) {
             .map(|item| (item.name().as_str().to_string(), LocalInvokeTarget::from(item))),
     );
     let mut used_aliases = BTreeSet::default();
-    let mut items = VecDeque::from(core::mem::take(&mut module.items));
+    let mut items = VecDeque::from(module.take_items());
     while let Some(item) = items.pop_front() {
         match item {
             Export::Procedure(mut procedure) => {

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -297,3 +297,35 @@ fn define_items_detect_cross_kind_duplicates_for_all_pairs_and_orders() {
         }
     }
 }
+
+#[test]
+fn name_map_stays_consistent_after_take_items() {
+    // Verify that take_items() clears the name index, so re-adding the same
+    // name after a take does not trigger a false conflict.
+    let mut module = Module::new(ModuleKind::Library, Path::new("mod"));
+    module
+        .define_constant(constant_with_name("foo"))
+        .expect("first insertion should succeed");
+
+    let _items = module.take_items();
+
+    // After take_items(), name_map is cleared — same name should succeed again.
+    module
+        .define_constant(constant_with_name("foo"))
+        .expect("re-insertion after take_items should succeed");
+}
+
+#[test]
+fn name_map_detects_conflict_via_define_api() {
+    // Verify that duplicate names are detected through the define_* API.
+    let mut module = Module::new(ModuleKind::Library, Path::new("mod"));
+    module
+        .define_constant(constant_with_name("dup"))
+        .expect("first insertion should succeed");
+
+    let result = module.define_constant(constant_with_name("dup"));
+    assert!(
+        matches!(result, Err(SemanticAnalysisError::SymbolConflict { .. })),
+        "expected SymbolConflict for duplicate name, got {result:?}"
+    );
+}

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -331,6 +331,46 @@ fn name_map_detects_conflict_via_define_api() {
 }
 
 #[test]
+fn name_map_rebuilds_after_mutable_item_rename() {
+    let mut module = Module::new(ModuleKind::Library, Path::new("mod"));
+    module
+        .define_constant(constant_with_name("old"))
+        .expect("first insertion should succeed");
+
+    for item in module.items_mut() {
+        let Export::Constant(constant) = item else {
+            continue;
+        };
+        constant.name = ident_with_name("dup");
+    }
+
+    let result = module.define_type(type_alias_with_name("dup"));
+    assert!(
+        matches!(result, Err(SemanticAnalysisError::SymbolConflict { .. })),
+        "expected SymbolConflict after renaming through items_mut(), got {result:?}"
+    );
+}
+
+#[test]
+fn name_map_drops_old_name_after_mutable_item_rename() {
+    let mut module = Module::new(ModuleKind::Library, Path::new("mod"));
+    module
+        .define_constant(constant_with_name("old"))
+        .expect("first insertion should succeed");
+
+    for item in module.items_mut() {
+        let Export::Constant(constant) = item else {
+            continue;
+        };
+        constant.name = ident_with_name("new");
+    }
+
+    module
+        .define_type(type_alias_with_name("old"))
+        .expect("old name should be available after the name map is rebuilt");
+}
+
+#[test]
 fn enum_variant_matching_enum_name_reports_symbol_conflict() {
     let context = SyntaxTestContext::default();
     let source = "\

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -329,3 +329,17 @@ fn name_map_detects_conflict_via_define_api() {
         "expected SymbolConflict for duplicate name, got {result:?}"
     );
 }
+
+#[test]
+fn enum_variant_matching_enum_name_reports_symbol_conflict() {
+    let context = SyntaxTestContext::default();
+    let source = "\
+enum DUP : u8 {
+    DUP,
+}
+";
+    let error = context
+        .parse_module(source)
+        .expect_err("expected symbol conflict when enum variant matches enum name");
+    assert_symbol_conflict(&error, "DUP");
+}

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -287,7 +287,8 @@ impl Linker {
 
         let module_index = self.next_module_id();
         let symbols = {
-            core::mem::take(module.items_mut())
+            module
+                .take_items()
                 .into_iter()
                 .enumerate()
                 .map(|(idx, item)| {


### PR DESCRIPTION
Fixes #3212

Name conflict detection in Module previously scanned all exports, resulting in O(n²) insertion time for large modules. This change adds a BTreeMap-based name index, reducing conflict checks to O(log n).

A new Module::take_items() helper keeps the index synchronized when module contents are consumed, and existing consumers in sema and linker were updated to use it.

This significantly improves performance for modules containing large numbers of items