### PR TITLE
Add Keccak-256 and SHA-512 precompiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Removed the legacy LALRPOP parser backend
 - Added the content-addressed deferred-DAG framework (`miden_core::deferred`): data model with a structured `Tag { id, args }`, wire format, the `Precompile` trait + `PrecompileRegistry`, the `adv.*_deferred` system events and MASM grammar, plus reference test precompiles. Purely additive substrate with no behavioral change; the precompile proof-model migrates onto it in a follow-up ([#3170](https://github.com/0xMiden/miden-vm/pull/3170)).
 - Added the `miden-precompiles` crate as the home for concrete deferred precompile implementations, built on top of the deferred framework in `miden_core::deferred`.
+- Added the `keccak256` and `sha512` deferred precompiles to `miden-precompiles`, built on a shared `HashPrecompile<H>` base, with MASM wrappers under `miden::precompiles::crypto::hashes`.
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [BREAKING] Changed semantics of `LoopNode` to unconditionally enter loops ([#3187](https://github.com/0xMiden/miden-vm/pull/3187)).
 - Removed the legacy LALRPOP parser backend
 - Added the content-addressed deferred-DAG framework (`miden_core::deferred`): data model with a structured `Tag { id, args }`, wire format, the `Precompile` trait + `PrecompileRegistry`, the `adv.*_deferred` system events and MASM grammar, plus reference test precompiles. Purely additive substrate with no behavioral change; the precompile proof-model migrates onto it in a follow-up ([#3170](https://github.com/0xMiden/miden-vm/pull/3170)).
+- Added the `miden-precompiles` crate as the home for concrete deferred precompile implementations, built on top of the deferred framework in `miden_core::deferred`.
 
 #### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ version = "0.24.0"
 dependencies = [
  "miden-assembly",
  "miden-core",
+ "miden-crypto",
  "miden-mast-package",
  "miden-package-registry",
  "miden-processor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,6 +1649,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-precompiles"
+version = "0.24.0"
+dependencies = [
+ "miden-core",
+]
+
+[[package]]
 name = "miden-processor"
 version = "0.24.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,7 +1652,12 @@ dependencies = [
 name = "miden-precompiles"
 version = "0.24.0"
 dependencies = [
+ "miden-assembly",
  "miden-core",
+ "miden-mast-package",
+ "miden-package-registry",
+ "miden-processor",
+ "miden-utils-sync",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "crates/utils-indexing",
     "crates/utils-sync",
     "miden-vm",
+    "precompiles",
     "processor",
     "prover",
     "verifier",

--- a/precompiles/CHANGELOG.md
+++ b/precompiles/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## v0.24.0 (TBD)
+
+#### Changes
+
+- Added the `miden-precompiles` crate as the home for concrete deferred precompile implementations,
+  built on top of the deferred framework in `miden_core::deferred`
+  ([#3170](https://github.com/0xMiden/miden-vm/pull/3170)).
+- Added the `miden-precompiles` MASM package (namespace `miden::precompiles`) and the
+  `PrecompilesLibrary` wrapper that embeds and loads it, with a duplicated copy of the deferred-DAG
+  helpers under `miden::precompiles::sys`.

--- a/precompiles/CHANGELOG.md
+++ b/precompiles/CHANGELOG.md
@@ -10,3 +10,7 @@
 - Added the `miden-precompiles` MASM package (namespace `miden::precompiles`) and the
   `PrecompilesLibrary` wrapper that embeds and loads it, with a duplicated copy of the deferred-DAG
   helpers under `miden::precompiles::sys`.
+- Added a reusable hash-precompile base (the `HashFunction` trait + `HashPrecompile<H>`) and the
+  `keccak256` and `sha512` deferred precompiles built on it, with MASM wrappers under
+  `miden::precompiles::crypto::hashes::{keccak256,sha512}` (`hash`, `hash_bytes`, `merge`) sharing a
+  `register_preimage` helper; `registry()` installs both.

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -19,8 +19,18 @@ doctest = false
 
 [features]
 default = ["std"]
-std = ["miden-core/std"]
+std = ["miden-core/std", "miden-processor/std", "miden-utils-sync/std"]
 
 [dependencies]
 # Miden dependencies
 miden-core.workspace = true
+miden-mast-package.workspace = true
+miden-processor.workspace = true
+miden-utils-sync.workspace = true
+
+[dev-dependencies]
+miden-assembly.workspace = true
+
+[build-dependencies]
+miden-assembly = { workspace = true, features = ["std"] }
+miden-package-registry = { workspace = true, features = ["resolver"] }

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -19,11 +19,12 @@ doctest = false
 
 [features]
 default = ["std"]
-std = ["miden-core/std", "miden-processor/std", "miden-utils-sync/std"]
+std = ["miden-core/std", "miden-crypto/std", "miden-processor/std", "miden-utils-sync/std"]
 
 [dependencies]
 # Miden dependencies
 miden-core.workspace = true
+miden-crypto.workspace = true
 miden-mast-package.workspace = true
 miden-processor.workspace = true
 miden-utils-sync.workspace = true

--- a/precompiles/Cargo.toml
+++ b/precompiles/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "miden-precompiles"
+version.workspace = true
+description = "Concrete deferred precompile implementations for the Miden VM"
+documentation = "https://docs.rs/miden-precompiles"
+readme = "README.md"
+categories = ["cryptography", "no-std"]
+keywords = ["miden", "precompile", "deferred", "zkp"]
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+
+[lib]
+bench = false
+doctest = false
+
+[features]
+default = ["std"]
+std = ["miden-core/std"]
+
+[dependencies]
+# Miden dependencies
+miden-core.workspace = true

--- a/precompiles/PLAN.md
+++ b/precompiles/PLAN.md
@@ -1,0 +1,246 @@
+# Miden Precompiles Plan
+
+This document tracks the `miden-precompiles` work across the stacked branches built on top of
+#3170 (`adr1anh/deferred/framework`). It records the design context, decisions already made, and
+the intended sequencing so each branch can stay reviewable.
+
+## Context
+
+The deferred framework work started with two related branches:
+
+- #3170 (`adr1anh/deferred/framework`) adds the generic deferred-DAG framework in
+  `miden_core::deferred` and aligns the existing `LOGPRECOMPILE` transcript fold with the
+  framework `AND` domain.
+- #3172 (`adr1anh/deferred/migrate`) migrates production precompiles to the deferred-DAG proof
+  model, but it does so by moving concrete production semantics into `miden-core-lib`.
+
+Issue #2282 points in a different long-term direction: concrete precompile and PVM work should
+have a first-class top-level crate. The generic framework belongs in `miden-core`, while concrete
+precompile semantics, MASM wrappers, registries, and later PVM proving work should live in
+`miden-precompiles`.
+
+The current plan is therefore to treat #3172 (`adr1anh/deferred/migrate`) as source material, not
+as the final branch shape. We are rebuilding that migration in smaller branches on top of
+#3170 (`adr1anh/deferred/framework`) and the `precompiles/crate` scaffold.
+
+We considered moving the legacy request-list production precompiles into `precompiles/` before
+adopting the deferred framework. We rejected that sequence because it would create a throwaway
+crate boundary around the old `PrecompileRequest` / `PrecompileVerifier` architecture, add
+unnecessary dependency pressure, and then immediately rewrite the same code into deferred-DAG
+semantics.
+
+## Resolved Decisions
+
+- Use a top-level `precompiles/` crate, not `crates/precompiles/`.
+- Cargo package name: `miden-precompiles`.
+- MASM package name: `miden-precompiles`.
+- MASM namespace: `miden::precompiles`.
+- Use the current package abstraction, not the removed MASM `Library` abstraction:
+  `miden-project.toml`, `Package`, `Package::write_masp_file`, embedded `.masp`,
+  `package() -> Arc<Package>`, and `mast_forest()`.
+- `miden-core` owns the generic deferred framework:
+  `Tag`, `Node`, `Payload`, `DeferredState`, `DeferredStateWire`, `Precompile`,
+  `PrecompileRegistry`, and generic processor/system-event machinery.
+- `miden-precompiles` owns concrete deferred precompile semantics, MASM wrappers, registries, and
+  future PVM work.
+- The processor remains generic. It should carry installed registries and update deferred state,
+  but it should not know which concrete precompiles exist.
+- It is acceptable on this tracking branch to duplicate the generic deferred MASM helpers under
+  `miden::precompiles::sys` instead of introducing a MASM package dependency on
+  `miden::core::sys` or moving helpers immediately.
+- Keccak is the first concrete vertical slice. It exercises chunks, deferred evaluation/logging,
+  registry installation, and MASM package loading without the extra complexity of signature
+  precompile layouts.
+- Processor/prover/verifier proof-wire support comes after the first concrete precompile package
+  slice. That gives the proof plumbing a small real vertical test instead of abstract-only
+  coverage.
+- #3176 (`al/ecdsa-k256-on-vm`) stays independent for now. It is later source material for K1,
+  SZ-modmul, and ECDSA work.
+- PVM AIR/trace/proving work from `precompile-experiments` is deferred until the crate/package and
+  proof-wire boundaries are stable.
+
+## Current Scaffold: `precompiles/crate`
+
+This branch establishes the crate and package boundary without migrating any production
+precompile.
+
+Completed:
+
+- Added the `miden-precompiles` Rust crate under top-level `precompiles/`.
+- Added a buildable MASM package `miden-precompiles` under `precompiles/asm`.
+- Exported the namespace `miden::precompiles`.
+- Added `PrecompilesLibrary`, which embeds and loads `miden-precompiles.masp`.
+- Added `package()`, `mast_forest()`, `Default`, `AsRef<Package>`, and
+  `From<&PrecompilesLibrary> for HostLibrary`.
+- Added an empty `registry() -> PrecompileRegistry`.
+- Duplicated deferred MASM helpers under `miden::precompiles::sys`:
+  `register_expr`, `register_chunk`, `log_node_digest`, and `log_precompile_request`.
+- Added focused package smoke tests for deserialization, exported paths, dynamic linking, and host
+  loading.
+
+Explicitly not done here:
+
+- No concrete precompile migration.
+- No `ExecutionProof` changes.
+- No `verify_with_precompiles`.
+- No proof-wire plumbing.
+- No legacy request-list deletion.
+- No #3176 (`al/ecdsa-k256-on-vm`) material.
+- No PVM AIR/proving import.
+
+## Planned Stack
+
+```text
+#3170 (`adr1anh/deferred/framework`)
+└── precompiles/crate
+    └── precompiles/keccak
+        └── precompiles/proof-wire
+            └── precompiles/sha512
+                └── precompiles/signatures
+                    └── precompiles/remove-legacy
+```
+
+This stack can be adjusted as the work unfolds, but each branch should remain a coherent review
+unit.
+
+## Branch Scopes
+
+### `precompiles/keccak`
+
+Port only the Keccak deferred precompile vertical slice from #3172
+(`adr1anh/deferred/migrate`) into `miden-precompiles`.
+
+In scope:
+
+- Shared byte/chunk codec needed by Keccak.
+- `Keccak256Precompile`.
+- `registry()` installs only Keccak.
+- MASM wrapper under `::miden::precompiles::crypto::hashes::keccak256`.
+- Focused tests for Rust semantics, registry installation, package exports, dynamic linking, and
+  execution/deferred-state behavior where feasible.
+
+Out of scope:
+
+- SHA-512.
+- ECDSA or EdDSA.
+- Proof-wire support.
+- Legacy request-list deletion.
+- #3176 (`al/ecdsa-k256-on-vm`) material.
+
+### `precompiles/proof-wire`
+
+Add the generic proof-model cutover using the Keccak package slice as the real vertical test.
+
+In scope:
+
+- `ExecutionProof` carries `DeferredStateWire`.
+- Trace/prover serializes final deferred state under the registry used during execution.
+- Verifier rehydrates the wire under a supplied `PrecompileRegistry`.
+- `miden-vm` API/CLI support for loading `PrecompilesLibrary` where needed.
+- End-to-end prove/verify coverage for a program using the Keccak precompile package.
+
+Out of scope:
+
+- Adding new concrete precompiles beyond Keccak.
+- #3176 (`al/ecdsa-k256-on-vm`) material.
+- PVM proof import.
+
+### `precompiles/sha512`
+
+Port SHA-512 from #3172 (`adr1anh/deferred/migrate`) into `miden-precompiles`.
+
+In scope:
+
+- SHA-512 Rust deferred semantics.
+- SHA-512 MASM wrapper under `::miden::precompiles`.
+- Registry update and focused tests.
+
+Out of scope:
+
+- Signature precompiles.
+- Legacy request-list deletion unless all replacements are ready.
+
+### `precompiles/signatures`
+
+Port the migrated ECDSA-k256-keccak and EdDSA-Ed25519 deferred precompiles from
+#3172 (`adr1anh/deferred/migrate`).
+
+In scope:
+
+- Signature precompile Rust semantics.
+- MASM wrappers under `::miden::precompiles`.
+- Registry update and focused tests.
+
+Out of scope:
+
+- #3176 (`al/ecdsa-k256-on-vm`) K1/SZ optimizations.
+- PVM proof work.
+
+### `precompiles/remove-legacy`
+
+Remove the old production request-list precompile path after replacement branches are working.
+
+In scope:
+
+- Remove legacy production `PrecompileRequest` proof witness plumbing.
+- Remove old production request handlers for Keccak, SHA-512, ECDSA, and EdDSA.
+- Remove stale request-list fuzz targets and docs.
+- Update examples/docs to point at `miden-precompiles`.
+
+Out of scope:
+
+- New concrete precompile implementations.
+- PVM proof work.
+
+### Later: #3176 (`al/ecdsa-k256-on-vm`)
+
+Use #3176 (`al/ecdsa-k256-on-vm`) as source material after the migrated production precompile
+stack is stable.
+
+Likely work:
+
+- K1 field/scalar/group MASM helpers.
+- SZ-modmul codegen.
+- Native secp256k1 ECDSA support.
+- Deciding which pieces belong as reusable MASM helpers versus concrete PVM-backed precompile
+  logic.
+
+### Later: PVM Proof Work
+
+Port PVM AIR/trace/proving work from `precompile-experiments` after the crate/package/proof-wire
+boundary is stable.
+
+Likely work:
+
+- PVM chiplets and relation registry.
+- Trace and witness generation.
+- PVM proof production and verification.
+- Integration between final deferred state/wire commitments and PVM proofs.
+
+## Testing Policy
+
+Tests should match the branch layer.
+
+- `precompiles/crate`: package deserialization, export lookup, dynamic linking, host loading, and
+  empty-registry smoke tests.
+- Concrete precompile branches: focused Rust semantics, registry installation, MASM package export,
+  dynamic linking, and execution/deferred-state tests.
+- `precompiles/proof-wire`: prove/verify tests using one concrete precompile, initially Keccak.
+- Later branches should add tests for their own concrete precompile only.
+
+Avoid:
+
+- Exhaustive duplicate vector suites in every layer.
+- Vacuous error tests that only assert an obvious rejection round-trips.
+- Proof tests before the proof-wire branch.
+- Broad workspace churn in narrow precompile slices.
+
+## Open Questions
+
+- Where should duplicated MASM deferred helpers eventually live?
+- Should `::miden::core` retain compatibility aliases for moved precompile wrappers?
+- What is the final `miden-vm` API/CLI shape for loading `PrecompilesLibrary`?
+- When should `verify_with_precompiles` become public versus hidden behind higher-level package
+  loading?
+- How should PVM proof APIs attach once `precompile-experiments` is ported?
+- When, if ever, should `miden-precompiles` split into smaller crates?

--- a/precompiles/PLAN.md
+++ b/precompiles/PLAN.md
@@ -48,9 +48,17 @@ semantics.
 - It is acceptable on this tracking branch to duplicate the generic deferred MASM helpers under
   `miden::precompiles::sys` instead of introducing a MASM package dependency on
   `miden::core::sys` or moving helpers immediately.
-- Keccak is the first concrete vertical slice. It exercises chunks, deferred evaluation/logging,
-  registry installation, and MASM package loading without the extra complexity of signature
-  precompile layouts.
+- The keccak256 + sha512 hash family is the first concrete vertical slice, landing together so the
+  shared base has two real consumers. It exercises chunks, deferred evaluation/logging, registry
+  installation, and MASM package loading without the extra complexity of signature precompile
+  layouts.
+- The hash precompiles share a generic base (a `HashFunction` trait + `HashPrecompile<H>`); each
+  hash is a thin spec (name, digest width, byte-level hash) plus a MASM wrapper.
+- The canonical digest node uses a uniform `ceil(DIGEST_FELTS / 8)`-chunk encoding for every width
+  (256-bit → one chunk, 512-bit → two), so there is no `Value`-vs-`Chunks` special case.
+- MASM hash wrappers write the digest to a caller-provided memory pointer
+  (`[out_ptr, ...] -> [...]`), keeping the operand stack net-neutral, and share a `register_preimage`
+  helper under `miden::precompiles::crypto::hashes`.
 - Processor/prover/verifier proof-wire support comes after the first concrete precompile package
   slice. That gives the proof plumbing a small real vertical test instead of abstract-only
   coverage.
@@ -93,11 +101,10 @@ Explicitly not done here:
 ```text
 #3170 (`adr1anh/deferred/framework`)
 └── precompiles/crate
-    └── precompiles/keccak
+    └── precompiles/hash
         └── precompiles/proof-wire
-            └── precompiles/sha512
-                └── precompiles/signatures
-                    └── precompiles/remove-legacy
+            └── precompiles/signatures
+                └── precompiles/remove-legacy
 ```
 
 This stack can be adjusted as the work unfolds, but each branch should remain a coherent review
@@ -105,23 +112,24 @@ unit.
 
 ## Branch Scopes
 
-### `precompiles/keccak`
+### `precompiles/hash`
 
-Port only the Keccak deferred precompile vertical slice from #3172
-(`adr1anh/deferred/migrate`) into `miden-precompiles`.
+Port the Keccak-256 and SHA-512 deferred precompiles from #3172
+(`adr1anh/deferred/migrate`) into `miden-precompiles`, on a shared hash-precompile base.
 
 In scope:
 
-- Shared byte/chunk codec needed by Keccak.
-- `Keccak256Precompile`.
-- `registry()` installs only Keccak.
-- MASM wrapper under `::miden::precompiles::crypto::hashes::keccak256`.
+- Shared byte/chunk codec and a generic hash-precompile base (a `HashFunction` trait +
+  `HashPrecompile<H>`); each hash is a thin spec.
+- `Keccak256Precompile` and `Sha512Precompile`; `registry()` installs both.
+- MASM wrappers under `::miden::precompiles::crypto::hashes::{keccak256,sha512}`, sharing a
+  `register_preimage` helper and writing the digest to a caller-provided memory pointer.
+- Uniform `ceil(DIGEST_FELTS / 8)`-chunk digest encoding.
 - Focused tests for Rust semantics, registry installation, package exports, dynamic linking, and
-  execution/deferred-state behavior where feasible.
+  execution/deferred-state behavior.
 
 Out of scope:
 
-- SHA-512.
 - ECDSA or EdDSA.
 - Proof-wire support.
 - Legacy request-list deletion.
@@ -129,7 +137,7 @@ Out of scope:
 
 ### `precompiles/proof-wire`
 
-Add the generic proof-model cutover using the Keccak package slice as the real vertical test.
+Add the generic proof-model cutover using the hash package slice as the real vertical test.
 
 In scope:
 
@@ -137,28 +145,13 @@ In scope:
 - Trace/prover serializes final deferred state under the registry used during execution.
 - Verifier rehydrates the wire under a supplied `PrecompileRegistry`.
 - `miden-vm` API/CLI support for loading `PrecompilesLibrary` where needed.
-- End-to-end prove/verify coverage for a program using the Keccak precompile package.
+- End-to-end prove/verify coverage for a program using a hash precompile (keccak256 or sha512).
 
 Out of scope:
 
-- Adding new concrete precompiles beyond Keccak.
+- Adding concrete precompiles beyond the hash family.
 - #3176 (`al/ecdsa-k256-on-vm`) material.
 - PVM proof import.
-
-### `precompiles/sha512`
-
-Port SHA-512 from #3172 (`adr1anh/deferred/migrate`) into `miden-precompiles`.
-
-In scope:
-
-- SHA-512 Rust deferred semantics.
-- SHA-512 MASM wrapper under `::miden::precompiles`.
-- Registry update and focused tests.
-
-Out of scope:
-
-- Signature precompiles.
-- Legacy request-list deletion unless all replacements are ready.
 
 ### `precompiles/signatures`
 

--- a/precompiles/README.md
+++ b/precompiles/README.md
@@ -1,0 +1,19 @@
+# Miden precompiles
+This crate is the home for concrete deferred precompile implementations used by Miden VM.
+
+The generic deferred-computation framework stays in [`miden-core`](../core), under `miden_core::deferred`: the node/DAG data model, the `Precompile` trait, the `PrecompileRegistry`, deferred state, and wire validation. This crate builds on that framework and provides the concrete precompiles that programs can defer their semantic checks to, exposing them through a single `registry()` constructor.
+
+## Usage
+This crate exposes a `registry()` function that returns a `miden_core::deferred::PrecompileRegistry` — the registry that routes deferred tags to their owning precompile — populated with the precompiles this crate provides.
+
+## Crate features
+Miden precompiles can be compiled with the following features:
+
+* `std` - enabled by default and relies on the Rust standard library.
+* `no_std` does not rely on the Rust standard library and enables compilation to WebAssembly.
+    * Only the `wasm32-unknown-unknown` and `wasm32-wasip1` targets are officially supported.
+
+To compile with `no_std`, disable default features via `--no-default-features` flag.
+
+## License
+This project is dual-licensed under the [MIT](http://opensource.org/licenses/MIT) and [Apache 2.0](https://opensource.org/license/apache-2-0) licenses.

--- a/precompiles/asm/crypto/hashes/keccak256.masm
+++ b/precompiles/asm/crypto/hashes/keccak256.masm
@@ -1,0 +1,140 @@
+use miden::precompiles::sys
+use miden::precompiles::crypto::hashes
+
+# ENCODING CONVENTIONS
+# ================================================================================================
+#
+# This module uses the following notation for data representation:
+# - VALUE_U32[n] = arrays of n u32 values, denoted as [v_0, ..., v_{n-1}]
+# - VALUE_U8[n] = arrays of n u8 values, denoted as [b_0, ..., b_{n-1}]
+# - Conversion: v_i = u32::from_le_bytes([b_{4i}, b_{4i+1}, b_{4i+2}, b_{4i+3}])
+# - Fixed-size examples: DIGEST_U32[8] = [d_0, ..., d_7], INPUT_U8[32] = [b_0, ..., b_31]
+# - DIGEST_U32[8] = [d_0, ..., d_7] = Keccak256(INPUT_U8[..])
+
+# CONSTANTS — Keccak256Precompile precompile tag fields
+# ================================================================================================
+# Pinned to the Rust-side Keccak256Precompile constants. PRECOMPILE_ID is the Blake3-derived
+# `precompile_id(&Keccak256Precompile)` over NAME ("keccak256"); changing the NAME in Rust must
+# update this literal in lockstep. The Rust-side `masm_pinned_ids_match_derived_ids` test asserts
+# this value.
+
+const PRECOMPILE_ID = 1416710563871706399
+const DIGEST_TAG_ID = 1
+const EQ_TAG_ID = 2
+
+# PROCEDURES
+# ================================================================================================
+
+#! Computes the Keccak256 hash of data in memory, writing the digest to a caller-provided pointer.
+#!
+#! Input:  [out_ptr, in_ptr, len_bytes, ...]
+#! Output: [...]  (operand stack reduced by the three inputs; nothing left on top)
+#!
+#! Where:
+#! - out_ptr: word-aligned destination; on return holds DIGEST_U32[8] = Keccak256(INPUT_U8[len_bytes])
+#! - in_ptr:  word-aligned address holding INPUT_U32[⌈len_bytes/4⌉] (unused bytes in the final u32
+#!            must be 0)
+#! - len_bytes: number of bytes to hash
+#!
+#! Local memory layout (element addresses):
+#!   loc[0..4]  PREIMAGE_DIGEST
+#!   loc[4..8]  LEAF_DIGEST
+#!   loc[8]     out_ptr
+#!
+#! Flow:
+#!   1. `register_preimage` derives PREIMAGE_DIGEST in-circuit (a linear hash of the preimage chunks
+#!      at `in_ptr`), binding it to the caller's memory.
+#!   2. `adv.evaluate_deferred` runs Keccak256::hash host-side, registers the canonical Digest leaf,
+#!      and pushes its `LEAF_TAG || DIGEST` onto the advice stack (TAG first). The advice is
+#!      untrusted; it is bound by step 4.
+#!   3. Write the digest from advice straight to `out_ptr` (the caller's result and the buffer
+#!      step 4 binds).
+#!   4. Register the Digest leaf in-circuit as a one-chunk node over `out_ptr`, yielding LEAF_DIGEST.
+#!   5. Build & register an Eq predicate `(PREIMAGE_DIGEST, LEAF_DIGEST)` and fold its digest into
+#!      the transcript via `log_node_digest`. The verifier's rehydrate recomputes Keccak256(preimage)
+#!      and rejects a forged digest, so the eq is logged, not eagerly evaluated.
+@locals(9)
+pub proc hash_bytes
+    # ---- Step 0: Stash out_ptr ----
+    loc_store.8
+    # => [in_ptr, len_bytes, ...]
+
+    # ---- Step 1: Register preimage chunk → PREIMAGE_DIGEST ----
+    push.PRECOMPILE_ID
+    exec.hashes::register_preimage
+    # => [PREIMAGE_DIGEST, ...]
+
+    # ---- Step 2: Save PREIMAGE_DIGEST, evaluate (canonical body → advice stack, TAG first) ----
+    dupw loc_storew_le.0 dropw
+    # => [PREIMAGE_DIGEST, ...]  (loc[0..4] = PREIMAGE_DIGEST)
+    adv.evaluate_deferred
+    dropw
+    # => [...]
+
+    # ---- Step 3: Write the canonical digest from advice to out_ptr ----
+    adv_pushw dropw                                   # drop LEAF_TAG
+    adv_pushw loc_load.8 mem_storew_le dropw          # out_ptr[0..4] = DIGEST_LO
+    adv_pushw loc_load.8 add.4 mem_storew_le dropw    # out_ptr[4..8] = DIGEST_HI
+
+    # ---- Step 4: Register the digest chunk leaf (1 chunk at out_ptr) → LEAF_DIGEST ----
+    push.1
+    loc_load.8
+    push.0.0
+    push.DIGEST_TAG_ID
+    push.PRECOMPILE_ID
+    # => [DIGEST_TAG, out_ptr, 1, ...]
+    exec.sys::register_chunk
+    # => [LEAF_DIGEST, ...]
+    loc_storew_le.4 dropw                             # loc[4..8] = LEAF_DIGEST
+
+    # ---- Step 5: Build & register eq(PREIMAGE_DIGEST, LEAF_DIGEST), fold into the transcript ----
+    push.0.0
+    push.EQ_TAG_ID
+    push.PRECOMPILE_ID
+    # => [EQ_TAG, ...]
+    padw loc_loadw_le.4
+    # => [LEAF_DIGEST, EQ_TAG, ...]
+    padw loc_loadw_le.0
+    # => [PREIMAGE_DIGEST, LEAF_DIGEST, EQ_TAG, ...]
+    exec.sys::register_expr
+    # => [EQ_DIGEST, ...]
+    exec.sys::log_node_digest
+    # => [...]
+end
+
+#! Computes the Keccak256 hash of a single 256-bit input, writing the digest to `out_ptr`.
+#!
+#! Input:  [out_ptr, INPUT_U32[8], ...]
+#! Output: [...]  (DIGEST_U32[8] = Keccak256(INPUT_U8[32]) written to out_ptr)
+@locals(9)
+pub proc hash
+    # Stash out_ptr, then store INPUT_U32[8] in local memory.
+    loc_store.8
+    loc_storew_le.0 dropw
+    loc_storew_le.4 dropw
+
+    push.32 locaddr.0 loc_load.8
+    # => [out_ptr, in_ptr, 32, ...]
+
+    exec.hash_bytes
+end
+
+#! Merges two 256-bit inputs via Keccak256 over their 512-bit concatenation, writing the digest to
+#! `out_ptr`.
+#!
+#! Input:  [out_ptr, INPUT_L_U32[8], INPUT_R_U32[8], ...]
+#! Output: [...]  (DIGEST_U32[8] = Keccak256(INPUT_L_U8[32] || INPUT_R_U8[32]) written to out_ptr)
+@locals(17)
+pub proc merge
+    # Stash out_ptr, then store the two inputs contiguously in local memory.
+    loc_store.16
+    loc_storew_le.0 dropw
+    loc_storew_le.4 dropw
+    loc_storew_le.8 dropw
+    loc_storew_le.12 dropw
+
+    push.64 locaddr.0 loc_load.16
+    # => [out_ptr, in_ptr, 64, ...]
+
+    exec.hash_bytes
+end

--- a/precompiles/asm/crypto/hashes/mod.masm
+++ b/precompiles/asm/crypto/hashes/mod.masm
@@ -1,0 +1,43 @@
+use miden::precompiles::sys
+
+# Shared helpers for the deferred hash precompiles (keccak256, sha512, ...).
+# ================================================================================================
+# The per-hash wrappers differ only in their digest width; the preimage-registration step is
+# identical, so it lives here and is parameterized by the caller's PRECOMPILE_ID.
+
+# `preimage` tag discriminant, shared by every hash precompile (pinned to the Rust-side
+# `HashPrecompile::PREIMAGE_TAG_ID`).
+const PREIMAGE_TAG_ID = 0
+
+#! Registers the `preimage` chunk node for a hash precompile and returns its content-addressed
+#! digest.
+#!
+#! Input:  [PRECOMPILE_ID, ptr, len_bytes, ...]
+#! Output: [PREIMAGE_DIGEST, ...]
+#!
+#! Stages the preimage tag `[PRECOMPILE_ID, PREIMAGE_TAG_ID, len_bytes, 0]` over the
+#! `n_chunks = max(1, ceil(len_bytes/32))` rate-sized blocks at `ptr` and calls
+#! `sys::register_chunk`, which derives the digest in-circuit (a linear hash over the `8*n_chunks`
+#! felts), binding it to the caller's memory. Empty input is one zero chunk (empty chunk bodies are
+#! banned).
+pub proc register_preimage
+    # => [PRECOMPILE_ID, ptr, len_bytes, ...]
+    movdn.2
+    # => [ptr, len_bytes, PRECOMPILE_ID, ...]
+    dup.1
+    # => [len_bytes, ptr, len_bytes, PRECOMPILE_ID, ...]
+    add.31 u32div.32
+    # => [ceil(len_bytes/32), ptr, len_bytes, PRECOMPILE_ID, ...]
+    dup eq.0 add
+    # => [n_chunks, ptr, len_bytes, PRECOMPILE_ID, ...]  (clamp to >= 1)
+    movdn.2
+    # => [ptr, len_bytes, n_chunks, PRECOMPILE_ID, ...]
+    swap push.0 swap
+    # => [len_bytes, 0, ptr, n_chunks, PRECOMPILE_ID, ...]
+    push.PREIMAGE_TAG_ID
+    # => [PREIMAGE_TAG_ID, len_bytes, 0, ptr, n_chunks, PRECOMPILE_ID, ...]
+    movup.5
+    # => [PRECOMPILE_ID, PREIMAGE_TAG_ID, len_bytes, 0, ptr, n_chunks, ...]
+    exec.sys::register_chunk
+    # => [PREIMAGE_DIGEST, ...]
+end

--- a/precompiles/asm/crypto/hashes/sha512.masm
+++ b/precompiles/asm/crypto/hashes/sha512.masm
@@ -1,0 +1,131 @@
+use miden::precompiles::sys
+use miden::precompiles::crypto::hashes
+
+# ENCODING CONVENTIONS
+# ================================================================================================
+#
+# This module uses the following notation for data representation:
+# - VALUE_U32[n] = arrays of n u32 values, denoted as [v_0, ..., v_{n-1}]
+# - VALUE_U8[n] = arrays of n u8 values, denoted as [b_0, ..., b_{n-1}]
+# - Conversion: v_i = u32::from_le_bytes([b_{4i}, b_{4i+1}, b_{4i+2}, b_{4i+3}])
+# - DIGEST_U32[16] = [d_0, ..., d_15] = SHA-512(INPUT_U8[..]) (64 bytes packed as 16 u32 limbs)
+
+# CONSTANTS — Sha512Precompile precompile tag fields
+# ================================================================================================
+# Pinned to the Rust-side Sha512Precompile constants. PRECOMPILE_ID is the Blake3-derived
+# `precompile_id(&Sha512Precompile)` over NAME ("sha512"); changing the NAME in Rust must update
+# this literal in lockstep. The Rust-side `masm_pinned_ids_match_derived_ids` test asserts it.
+
+const PRECOMPILE_ID = 17153122752013038770
+const DIGEST_TAG_ID = 1
+const EQ_TAG_ID = 2
+
+# PROCEDURES
+# ================================================================================================
+
+#! Computes the SHA-512 hash of data in memory, writing the digest to a caller-provided pointer.
+#!
+#! Input:  [out_ptr, in_ptr, len_bytes, ...]
+#! Output: [...]  (operand stack reduced by the three inputs; nothing left on top)
+#!
+#! Where:
+#! - out_ptr: word-aligned destination; on return holds DIGEST_U32[16] = SHA-512(INPUT_U8[len_bytes])
+#! - in_ptr:  word-aligned address holding INPUT_U32[⌈len_bytes/4⌉] (unused bytes in the final u32
+#!            must be 0)
+#! - len_bytes: number of bytes to hash
+#!
+#! Local memory layout (element addresses):
+#!   loc[0..4]  PREIMAGE_DIGEST
+#!   loc[4..8]  LEAF_DIGEST
+#!   loc[8]     out_ptr
+#!
+#! Identical in shape to `keccak256::hash_bytes`; the only difference is the digest width — SHA-512's
+#! canonical leaf is a two-chunk node (16 felts), so step 3 writes four words and step 4 registers
+#! two chunks.
+@locals(9)
+pub proc hash_bytes
+    # ---- Step 0: Stash out_ptr ----
+    loc_store.8
+    # => [in_ptr, len_bytes, ...]
+
+    # ---- Step 1: Register preimage chunk → PREIMAGE_DIGEST ----
+    push.PRECOMPILE_ID
+    exec.hashes::register_preimage
+    # => [PREIMAGE_DIGEST, ...]
+
+    # ---- Step 2: Save PREIMAGE_DIGEST, evaluate (canonical body → advice stack, TAG first) ----
+    dupw loc_storew_le.0 dropw
+    # => [PREIMAGE_DIGEST, ...]  (loc[0..4] = PREIMAGE_DIGEST)
+    adv.evaluate_deferred
+    dropw
+    # => [...]
+
+    # ---- Step 3: Write the canonical digest (16 felts) from advice to out_ptr ----
+    adv_pushw dropw                                    # drop LEAF_TAG
+    adv_pushw loc_load.8 mem_storew_le dropw           # out_ptr[0..4]
+    adv_pushw loc_load.8 add.4 mem_storew_le dropw     # out_ptr[4..8]
+    adv_pushw loc_load.8 add.8 mem_storew_le dropw     # out_ptr[8..12]
+    adv_pushw loc_load.8 add.12 mem_storew_le dropw    # out_ptr[12..16]
+
+    # ---- Step 4: Register the digest chunk leaf (2 chunks at out_ptr) → LEAF_DIGEST ----
+    push.2
+    loc_load.8
+    push.0.0
+    push.DIGEST_TAG_ID
+    push.PRECOMPILE_ID
+    # => [DIGEST_TAG, out_ptr, 2, ...]
+    exec.sys::register_chunk
+    # => [LEAF_DIGEST, ...]
+    loc_storew_le.4 dropw                              # loc[4..8] = LEAF_DIGEST
+
+    # ---- Step 5: Build & register eq(PREIMAGE_DIGEST, LEAF_DIGEST), fold into the transcript ----
+    push.0.0
+    push.EQ_TAG_ID
+    push.PRECOMPILE_ID
+    # => [EQ_TAG, ...]
+    padw loc_loadw_le.4
+    # => [LEAF_DIGEST, EQ_TAG, ...]
+    padw loc_loadw_le.0
+    # => [PREIMAGE_DIGEST, LEAF_DIGEST, EQ_TAG, ...]
+    exec.sys::register_expr
+    # => [EQ_DIGEST, ...]
+    exec.sys::log_node_digest
+    # => [...]
+end
+
+#! Computes the SHA-512 hash of a single 256-bit input, writing the digest to `out_ptr`.
+#!
+#! Input:  [out_ptr, INPUT_U32[8], ...]
+#! Output: [...]  (DIGEST_U32[16] = SHA-512(INPUT_U8[32]) written to out_ptr)
+@locals(9)
+pub proc hash
+    # Stash out_ptr, then store INPUT_U32[8] in local memory.
+    loc_store.8
+    loc_storew_le.0 dropw
+    loc_storew_le.4 dropw
+
+    push.32 locaddr.0 loc_load.8
+    # => [out_ptr, in_ptr, 32, ...]
+
+    exec.hash_bytes
+end
+
+#! Merges two 256-bit inputs via SHA-512 over their 512-bit concatenation, writing the digest to
+#! `out_ptr`.
+#!
+#! Input:  [out_ptr, INPUT_L_U32[8], INPUT_R_U32[8], ...]
+#! Output: [...]  (DIGEST_U32[16] = SHA-512(INPUT_L_U8[32] || INPUT_R_U8[32]) written to out_ptr)
+@locals(17)
+pub proc merge
+    # Stash out_ptr, then store the two inputs contiguously in local memory.
+    loc_store.16
+    loc_storew_le.0 dropw
+    loc_storew_le.4 dropw
+    loc_storew_le.8 dropw
+    loc_storew_le.12 dropw
+
+    push.64 locaddr.0 loc_load.16
+    # => [out_ptr, in_ptr, 64, ...]
+
+    exec.hash_bytes
+end

--- a/precompiles/asm/miden-project.toml
+++ b/precompiles/asm/miden-project.toml
@@ -1,0 +1,13 @@
+[package]
+name = "miden-precompiles"
+version = "0.24.0"
+
+[lib]
+namespace = "miden::precompiles"
+path = "mod.masm"
+
+[profile.release]
+# Always produce debug information, as it can be stripped later by the VM
+debug = true
+# Use workspace-relative file paths in debug info for portability
+trim_paths = true

--- a/precompiles/asm/mod.masm
+++ b/precompiles/asm/mod.masm
@@ -1,0 +1,10 @@
+#! Top-level module of the `miden::precompiles` namespace.
+#!
+#! Concrete deferred precompiles will be exported from here and its submodules. For now it carries a
+#! single smoke procedure so the package exports at least one procedure during scaffolding.
+
+#! Smoke procedure used to verify that the `miden-precompiles` package assembles, links, and loads.
+#! It is a no-op with no operand-stack preconditions.
+pub proc smoke
+    nop
+end

--- a/precompiles/asm/sys/mod.masm
+++ b/precompiles/asm/sys/mod.masm
@@ -1,0 +1,113 @@
+# ===== DEFERRED-DAG HELPERS =======================================================================
+#
+# NOTE: these procedures are duplicated verbatim from `miden::core::sys`
+# (crates/lib/core/asm/sys/mod.masm) so the `miden-precompiles` package is self-contained while the
+# crate is being stood up on this tracking branch. They should be deduplicated against a single
+# shared source once the precompile proof-model migration settles.
+#
+# `register_expr` / `register_chunk` are safe by default: they derive the node digest in-circuit,
+# so the worst a misuse can do is make the verifier reject. There is intentionally no `evaluate`
+# proc here — `adv.evaluate_deferred` returns an *unbound* host hint (the canonical `tag || payload`
+# on the advice stack), and using it soundly requires re-hashing in-circuit and logging a predicate
+# the verifier re-checks. That discipline is precompile-specific, so each precompile wraps the raw
+# event itself rather than calling a deceptively "safe" shared helper.
+
+#! Folds a precompile commitment into the rolling transcript via `log_precompile` and removes
+#! the helper words produced by the instruction.
+#!
+#! Computes the per-call statement word `STMNT = Poseidon2::merge(COMM, TAG)` from the supplied
+#! commitment halves, seats it at stack[4..8] (the HPERM rate1 lanes), and lets the underlying
+#! `log_precompile` opcode fold it into the transcript state using framework AND capacity
+#! `[1, 0, 0, 0]`. Pads stack[0..4] and stack[8..12] with zero words so the opcode's writes there
+#! don't clobber data deeper in the stack.
+#!
+#! Input: `[COMM, TAG, ...]`
+#! Output: Stack with `COMM` and `TAG` consumed and the three helper words produced by
+#!         `log_precompile` dropped.
+pub proc log_precompile_request
+    hmerge
+    # => [STMNT, ...]
+    padw padw movdnw.2
+    # => [_, STMNT, _, ...]
+    log_precompile
+    # => [STATE_NEW, OUT_RATE1, OUT_CAP, ...]
+    dropw dropw dropw
+end
+
+#! Registers an expression-bodied node `(tag, payload)` in the deferred-computation DAG and
+#! returns its content-addressed digest on top of the operand stack.
+#!
+#! `adv.register_deferred` interns the node host-side (no stack or advice output); the digest is
+#! then derived *in-circuit* so it is constrained to the operand-stack payload rather than supplied
+#! by advice. The input is already in Poseidon2 sponge layout — `[R0=PAYLOAD_LO, R1=PAYLOAD_HI,
+#! C=TAG]` — so one `hperm` produces the permuted state and the digest is its rate0 word
+#! (`state[0..4]`), matching `Node::digest`.
+#!
+#! Input:  `[PAYLOAD_LO, PAYLOAD_HI, TAG, ...]`
+#! Output: `[NODE_DIGEST, ...]`
+pub proc register_expr
+    adv.register_deferred
+    # => [PAYLOAD_LO, PAYLOAD_HI, TAG, ...]  (rate = payload, capacity = tag)
+    hperm
+    # => [R0', R1', C', ...]
+    swapw.2 dropw dropw
+    # => [NODE_DIGEST, ...]  (digest = rate0 = state[0..4])
+end
+
+#! Registers a chunk-bodied node (`n` rate-sized blocks of bulk data at `ptr`) in the
+#! deferred-computation DAG and returns its content-addressed digest on top of the operand stack.
+#!
+#! `adv.register_deferred_chunk` interns the node host-side (reading `8n` felts from memory at
+#! `ptr`; `n` derived from the tag); it produces no stack or advice output. The digest is then
+#! derived *in-circuit* by a Poseidon2 linear hash over the same `8n` felts — capacity = `TAG`,
+#! one `hperm` per 8-felt block via `mem_stream` — so it is constrained to memory rather than
+#! supplied by advice, and the rate0 word matches `Node::digest`. The chunk count `n` is taken as
+#! an operand (the caller knows it); the event ignores it. Empty chunk bodies are forbidden, so
+#! `n ≥ 1` and the linear-hash loop always runs at least one permutation.
+#!
+#! Input:  `[TAG, ptr, n_chunks, ...]`
+#! Output: `[NODE_DIGEST, ...]`
+pub proc register_chunk
+    adv.register_deferred_chunk
+    # => [TAG, ptr, n_chunks, ...]
+
+    # Replace n_chunks with end_addr = ptr + 8 * n_chunks, leaving [TAG, ptr, end_addr, ...].
+    movup.5 mul.8 dup.5 add movdn.5
+    # => [TAG, ptr, end_addr, ...]
+
+    # Build the sponge state: rate = 0, capacity = TAG, with [start_addr, end_addr] beneath it.
+    padw padw
+    # => [R0=0w, R1=0w, C=TAG, start_addr=ptr, end_addr, ...]
+
+    # Linear hash: absorb one 8-felt block per iteration until start_addr reaches end_addr.
+    # (Mirrors poseidon2::absorb_double_words_from_memory, inlined to keep `sys` dependency-free.)
+    dup.13 dup.13 neq
+    while.true
+        mem_stream hperm
+        dup.13 dup.13 neq
+    end
+    # => [R0', R1', C', end_addr, end_addr, ...]
+
+    swapw.2 dropw dropw
+    # => [NODE_DIGEST, end_addr, end_addr, ...]  (digest = rate0)
+    movup.4 drop movup.4 drop
+    # => [NODE_DIGEST, ...]
+end
+
+#! Folds a deferred node digest into the rolling deferred commitment using the existing
+#! `log_precompile` commitment state. The digest must reference a node that will reduce to TRUE
+#! under the installed precompiles.
+#!
+#! Pads the operand stack so `log_precompile`'s implicit `[_, STMNT, _, ...]` shape sees
+#! NODE_DIGEST at stack[4..8] (the HPERM rate1 lanes). The opcode folds with framework AND
+#! capacity `[1, 0, 0, 0]`, then this helper drops the three words it writes to stack[0..12].
+#!
+#! Input:  `[NODE_DIGEST, ...]`
+#! Output: `[...]` (the deferred commitment root advances; node is folded in)
+pub proc log_node_digest
+    padw padw movdnw.2
+    # => [_, NODE_DIGEST, _, ...]
+    log_precompile
+    # => [STATE_NEW, OUT_RATE1, OUT_CAP, ...]
+    dropw dropw dropw
+end

--- a/precompiles/build.rs
+++ b/precompiles/build.rs
@@ -1,0 +1,46 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+use miden_assembly::{Assembler, ProjectTargetSelector, Report, diagnostics::IntoDiagnostic};
+
+// CONSTANTS
+// ================================================================================================
+
+const ASM_DIR_PATH: &str = "asm";
+const ASSETS_DIR_PATH: &str = "assets";
+
+// PRE-PROCESSING
+// ================================================================================================
+
+/// Assembles the `./asm` MASM project into `[OUT_DIR]/assets/miden-precompiles.masp`.
+fn main() -> Result<(), Report> {
+    use miden_assembly::diagnostics::reporting::ReportHandlerOpts;
+
+    // Re-assemble the package whenever the MASM sources or the assembler change. The assembler path
+    // is relative to the package root (precompiles/), so `../crates/assembly/src` reaches it.
+    println!("cargo:rerun-if-changed=asm");
+    println!("cargo:rerun-if-changed=../crates/assembly/src");
+
+    miden_assembly::diagnostics::reporting::set_hook(Box::new(|_| {
+        Box::new(ReportHandlerOpts::new().build())
+    }))
+    .unwrap();
+    miden_assembly::diagnostics::reporting::set_panic_hook();
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let asm_dir = Path::new(manifest_dir).join(ASM_DIR_PATH);
+
+    let assembler = Assembler::default();
+    let mut registry = miden_package_registry::InMemoryPackageRegistry::default();
+    let mut project_assembler =
+        assembler.for_project_at_path(asm_dir.join("miden-project.toml"), &mut registry)?;
+
+    let package = project_assembler.assemble(ProjectTargetSelector::Library, "release")?;
+
+    let build_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    package.write_masp_file(build_dir.join(ASSETS_DIR_PATH)).into_diagnostic()?;
+
+    Ok(())
+}

--- a/precompiles/src/codec.rs
+++ b/precompiles/src/codec.rs
@@ -1,0 +1,47 @@
+//! Shared chunk ↔ byte codec for the core precompiles. Each precompile's `evaluate` consumes its
+//! chunk body as a flat byte buffer; the framework guarantees the chunk count via `decode`,
+//! and this codec strips the trailing zero pad back down to the declared `n_bytes` after
+//! validating that the discarded pad bytes are zero.
+
+use alloc::vec::Vec;
+use core::num::NonZeroU32;
+
+use miden_core::{Felt, deferred::PrecompileError};
+
+/// Bytes packed per 8-felt chunk: each felt carries a u32 (4 bytes) little-endian limb.
+pub const BYTES_PER_CHUNK: u32 = 32;
+
+/// Number of 8-felt chunks needed to encode `n_bytes` of u32-packed input.
+///
+/// Empty input still needs one chunk: the framework bans empty chunk bodies
+/// ([`NodeType::Chunks`](miden_core::deferred::NodeType) holds a [`NonZeroU32`]), so a 0-byte hash
+/// preimage is encoded as a single zero chunk. The count is therefore clamped to at least 1.
+pub fn n_chunks(n_bytes: u32) -> NonZeroU32 {
+    NonZeroU32::new(n_bytes.div_ceil(BYTES_PER_CHUNK).max(1)).expect("clamped to at least 1")
+}
+
+/// Unpack a slice of u32-packed-LE chunks back to a `n_bytes`-length byte vector, returning
+/// `PrecompileError::InvalidNode` if any felt holds a value larger than `u32::MAX`.
+///
+/// The caller-supplied `n_bytes` may be shorter than `chunks.len() * BYTES_PER_CHUNK as usize`;
+/// the trailing bytes are zero-pad and are stripped from the output after validating they are
+/// zero.
+pub fn chunks_to_bytes(chunks: &[[Felt; 8]], n_bytes: usize) -> Result<Vec<u8>, PrecompileError> {
+    let chunk_bytes = BYTES_PER_CHUNK as usize;
+    if n_bytes > chunks.len() * chunk_bytes {
+        return Err(PrecompileError::InvalidNode);
+    }
+    let mut bytes = Vec::with_capacity(chunks.len() * chunk_bytes);
+    for chunk in chunks {
+        for felt in chunk {
+            let limb =
+                u32::try_from(felt.as_canonical_u64()).map_err(|_| PrecompileError::InvalidNode)?;
+            bytes.extend_from_slice(&limb.to_le_bytes());
+        }
+    }
+    if bytes[n_bytes..].iter().any(|&b| b != 0) {
+        return Err(PrecompileError::InvalidNode);
+    }
+    bytes.truncate(n_bytes);
+    Ok(bytes)
+}

--- a/precompiles/src/hash/keccak256.rs
+++ b/precompiles/src/hash/keccak256.rs
@@ -1,0 +1,52 @@
+//! Keccak-256 deferred precompile.
+
+use alloc::vec::Vec;
+
+use miden_crypto::hash::keccak::Keccak256;
+
+use super::{HashFunction, HashPrecompile};
+
+/// [`HashFunction`] spec for Keccak-256: a 256-bit digest (one 8-felt chunk).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Keccak256Hash;
+
+impl HashFunction for Keccak256Hash {
+    const NAME: &'static str = "keccak256";
+    const DIGEST_FELTS: usize = 8;
+
+    fn hash(input: &[u8]) -> Vec<u8> {
+        <[u8; 32]>::from(Keccak256::hash(input)).to_vec()
+    }
+}
+
+/// The Keccak-256 deferred precompile, installed by [`registry`](crate::registry) and wrapped in
+/// MASM under `miden::precompiles::crypto::hashes::keccak256`.
+pub type Keccak256Precompile = HashPrecompile<Keccak256Hash>;
+
+#[cfg(test)]
+mod tests {
+    use super::Keccak256Hash;
+    use crate::hash::{HashPrecompile, assert_hash_precompile, masm_const};
+
+    #[test]
+    fn suite() {
+        assert_hash_precompile::<Keccak256Hash>();
+    }
+
+    #[test]
+    fn masm_pinned_ids_match_derived_ids() {
+        const MASM: &str = include_str!("../../asm/crypto/hashes/keccak256.masm");
+        assert_eq!(
+            masm_const(MASM, "PRECOMPILE_ID"),
+            HashPrecompile::<Keccak256Hash>::id().as_canonical_u64(),
+        );
+        assert_eq!(
+            masm_const(MASM, "DIGEST_TAG_ID"),
+            HashPrecompile::<Keccak256Hash>::DIGEST_TAG_ID as u64,
+        );
+        assert_eq!(
+            masm_const(MASM, "EQ_TAG_ID"),
+            HashPrecompile::<Keccak256Hash>::EQ_TAG_ID as u64,
+        );
+    }
+}

--- a/precompiles/src/hash/mod.rs
+++ b/precompiles/src/hash/mod.rs
@@ -217,7 +217,7 @@ pub(crate) fn masm_const(source: &str, name: &str) -> u64 {
 /// integration tests.
 #[cfg(test)]
 pub(crate) fn assert_hash_precompile<H: HashFunction>() {
-    use alloc::{vec, vec::Vec};
+    use alloc::{sync::Arc, vec, vec::Vec};
 
     use miden_core::deferred::{DeferredState, PrecompileRegistry};
 
@@ -229,17 +229,15 @@ pub(crate) fn assert_hash_precompile<H: HashFunction>() {
     }
 
     let fresh = || {
-        (
-            PrecompileRegistry::new().with_precompile(HashPrecompile::<H>::default()),
-            DeferredState::new(usize::MAX),
+        DeferredState::new(
+            Arc::new(PrecompileRegistry::new().with_precompile(HashPrecompile::<H>::default())),
+            usize::MAX,
         )
+        .expect("hash precompile initialization should fit the test budget")
     };
-    let evaluate = |state: &mut DeferredState,
-                    reg: &PrecompileRegistry,
-                    node: Node|
-     -> Result<Node, PrecompileError> {
-        let digest = state.register(reg, node)?;
-        state.evaluate(reg, digest)
+    let evaluate = |state: &mut DeferredState, node: Node| -> Result<Node, PrecompileError> {
+        let digest = state.register(node)?;
+        state.evaluate(digest)
     };
 
     // -- decode routes each tag to its node shape and rejects malformed tags --
@@ -271,10 +269,10 @@ pub(crate) fn assert_hash_precompile<H: HashFunction>() {
 
     // -- preimage evaluates to the digest of the hashed bytes, across chunk boundaries --
     for &n in &[0usize, 11, 70] {
-        let (reg, mut state) = fresh();
+        let mut state = fresh();
         let input: Vec<u8> = (0..n).map(|i| i as u8).collect();
         let node = HashPrecompile::<H>::preimage_node(n as u32, pack_chunks(&input));
-        let got = evaluate(&mut state, &reg, node).unwrap();
+        let got = evaluate(&mut state, node).unwrap();
         let want =
             HashPrecompile::<H>::digest_node(&bytes_to_packed_u32_elements(&H::hash(&input)));
         assert_eq!(got, want, "preimage of {n} bytes");
@@ -282,52 +280,48 @@ pub(crate) fn assert_hash_precompile<H: HashFunction>() {
 
     // -- eq accepts a matching (preimage, digest) and rejects a forged digest --
     {
-        let (reg, mut state) = fresh();
+        let mut state = fresh();
         let input = b"hash precompile eq";
         let preimage = state
-            .register(
-                &reg,
-                HashPrecompile::<H>::preimage_node(input.len() as u32, pack_chunks(input)),
-            )
+            .register(HashPrecompile::<H>::preimage_node(input.len() as u32, pack_chunks(input)))
             .unwrap();
         let leaf = state
-            .register(
-                &reg,
-                HashPrecompile::<H>::digest_node(&bytes_to_packed_u32_elements(&H::hash(input))),
-            )
+            .register(HashPrecompile::<H>::digest_node(&bytes_to_packed_u32_elements(&H::hash(
+                input,
+            ))))
             .unwrap();
         assert!(
-            evaluate(&mut state, &reg, HashPrecompile::<H>::eq_node(preimage, leaf))
+            evaluate(&mut state, HashPrecompile::<H>::eq_node(preimage, leaf))
                 .unwrap()
                 .is_true_node()
         );
 
         let forged = state
-            .register(
-                &reg,
-                HashPrecompile::<H>::digest_node(&vec![Felt::from_u32(0xdead); H::DIGEST_FELTS]),
-            )
+            .register(HashPrecompile::<H>::digest_node(&vec![
+                Felt::from_u32(0xdead);
+                H::DIGEST_FELTS
+            ]))
             .unwrap();
-        let err = evaluate(&mut state, &reg, HashPrecompile::<H>::eq_node(preimage, forged));
+        let err = evaluate(&mut state, HashPrecompile::<H>::eq_node(preimage, forged));
         assert!(matches!(err.unwrap_err().root(), PrecompileError::AssertionFailed));
     }
 
     // -- preimage rejects an oversized n_bytes for the chunk count, and nonzero trailing pad --
     {
-        let (reg, mut state) = fresh();
+        let mut state = fresh();
         let node = HashPrecompile::<H>::preimage_node(100, vec![[ZERO; 8]]);
         assert!(matches!(
-            evaluate(&mut state, &reg, node).unwrap_err().root(),
+            evaluate(&mut state, node).unwrap_err().root(),
             PrecompileError::InvalidNode
         ));
     }
     {
-        let (reg, mut state) = fresh();
+        let mut state = fresh();
         let mut chunks = pack_chunks(&[1, 2, 3]);
         chunks[0][0] = Felt::from_u32(u32::from_le_bytes([1, 2, 3, 0xaa]));
         let node = HashPrecompile::<H>::preimage_node(3, chunks);
         assert!(matches!(
-            evaluate(&mut state, &reg, node).unwrap_err().root(),
+            evaluate(&mut state, node).unwrap_err().root(),
             PrecompileError::InvalidNode
         ));
     }

--- a/precompiles/src/hash/mod.rs
+++ b/precompiles/src/hash/mod.rs
@@ -1,0 +1,334 @@
+//! Shared base for deferred hash precompiles (keccak256, sha512, ...).
+//!
+//! Every hash precompile shares the same tag layout `Tag { id, args: [disc, arg1, ZERO] }`, the
+//! same three nodes — `preimage` (chunk-bodied, hashes to a digest), `digest` (self-evaluating
+//! leaf), `eq` (binary predicate asserting two digests match) — and the same deferred-DAG protocol.
+//! A concrete hash supplies only its [`HashFunction`]: the name, the digest width, and the
+//! byte-level hash. [`HashPrecompile<H>`] turns that into a full [`Precompile`].
+
+use alloc::{sync::Arc, vec::Vec};
+use core::{marker::PhantomData, num::NonZeroU32};
+
+use miden_core::{
+    Felt, ZERO,
+    deferred::{
+        DeferredContext, Digest, Node, NodeType, Payload, Precompile, PrecompileError, Tag,
+        precompile_id,
+    },
+    utils::bytes_to_packed_u32_elements,
+};
+
+use crate::codec::{chunks_to_bytes, n_chunks};
+
+pub mod keccak256;
+pub mod sha512;
+
+// HASH FUNCTION
+// ================================================================================================
+
+/// The byte-level hash backing a [`HashPrecompile`].
+pub trait HashFunction: Default + Send + Sync + 'static {
+    /// Stable name hashed into the precompile id; renaming changes every tag it owns.
+    const NAME: &'static str;
+    /// u32-packed-LE felts in the digest (8 for a 256-bit hash, 16 for 512-bit).
+    const DIGEST_FELTS: usize;
+    /// Hashes `input`, returning the digest as `DIGEST_FELTS * 4` bytes.
+    fn hash(input: &[u8]) -> Vec<u8>;
+}
+
+// TAG DISCRIMINANTS
+// ================================================================================================
+
+const PREIMAGE_DISC: u32 = 0;
+const DIGEST_DISC: u32 = 1;
+const EQ_DISC: u32 = 2;
+
+// HASH PRECOMPILE
+// ================================================================================================
+
+/// A deferred hash precompile parameterized by its [`HashFunction`].
+pub struct HashPrecompile<H>(PhantomData<H>);
+
+impl<H> Default for HashPrecompile<H> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<H: HashFunction> HashPrecompile<H> {
+    /// Local discriminant of the `preimage` tag.
+    pub const PREIMAGE_TAG_ID: u32 = PREIMAGE_DISC;
+    /// Local discriminant of the `digest` tag.
+    pub const DIGEST_TAG_ID: u32 = DIGEST_DISC;
+    /// Local discriminant of the `eq` tag.
+    pub const EQ_TAG_ID: u32 = EQ_DISC;
+
+    /// Derives this precompile's id from its [`HashFunction::NAME`].
+    pub fn id() -> Felt {
+        precompile_id(&Self::default())
+    }
+
+    /// Tag for a `preimage` chunk node carrying `n_bytes` of input.
+    pub fn preimage_tag(n_bytes: u32) -> Tag {
+        Tag::new(Self::id(), [Felt::from_u32(PREIMAGE_DISC), Felt::from_u32(n_bytes), ZERO])
+    }
+
+    /// Tag for the canonical `digest` leaf.
+    pub fn digest_tag() -> Tag {
+        Tag::new(Self::id(), [Felt::from_u32(DIGEST_DISC), ZERO, ZERO])
+    }
+
+    /// Tag for an `eq` predicate node.
+    pub fn eq_tag() -> Tag {
+        Tag::new(Self::id(), [Felt::from_u32(EQ_DISC), ZERO, ZERO])
+    }
+
+    /// Builds a `preimage` chunk node from caller-supplied 8-felt chunks (the input u32-packed-LE,
+    /// zero-padded to a chunk boundary).
+    pub fn preimage_node(n_bytes: u32, chunks: impl Into<Arc<[[Felt; 8]]>>) -> Node {
+        Node::chunk(Self::preimage_tag(n_bytes), chunks)
+    }
+
+    /// Builds the canonical `digest` node: the `DIGEST_FELTS` u32-packed felts encoded as
+    /// `ceil(DIGEST_FELTS / 8)` eight-felt chunks, zero-padded to the chunk boundary — a single,
+    /// width-agnostic encoding. (A one-chunk digest hashes identically to an 8-felt expression
+    /// leaf, so the chunk encoding loses nothing versus a `Value` leaf.)
+    pub fn digest_node(felts: &[Felt]) -> Node {
+        debug_assert_eq!(felts.len(), H::DIGEST_FELTS, "digest must be DIGEST_FELTS felts");
+        let mut padded = felts.to_vec();
+        padded.resize(Self::digest_chunks() * 8, ZERO);
+        let chunks: Vec<[Felt; 8]> = padded
+            .chunks_exact(8)
+            .map(|c| c.try_into().expect("chunk is 8 felts"))
+            .collect();
+        Node::chunk(Self::digest_tag(), chunks)
+    }
+
+    /// Builds an `eq` predicate over two child digests.
+    pub fn eq_node(lhs: Digest, rhs: Digest) -> Node {
+        Node::join(Self::eq_tag(), lhs, rhs)
+    }
+
+    /// Number of eight-felt chunks in the canonical digest node.
+    fn digest_chunks() -> usize {
+        H::DIGEST_FELTS.div_ceil(8)
+    }
+
+    /// Body shape of the `digest` node — `ceil(DIGEST_FELTS / 8)` chunks for every width.
+    fn digest_node_type() -> NodeType {
+        NodeType::Chunks(
+            NonZeroU32::new(Self::digest_chunks() as u32).expect("digest spans >= 1 chunk"),
+        )
+    }
+}
+
+impl<H: HashFunction> Precompile for HashPrecompile<H> {
+    fn name(&self) -> &'static str {
+        H::NAME
+    }
+
+    fn id(&self) -> Felt {
+        Self::id()
+    }
+
+    fn decode(&self, args: [Felt; 3]) -> Option<NodeType> {
+        let disc = u32::try_from(args[0].as_canonical_u64()).ok()?;
+        match disc {
+            PREIMAGE_DISC if args[2] == ZERO => {
+                let n_bytes = u32::try_from(args[1].as_canonical_u64()).ok()?;
+                Some(NodeType::Chunks(n_chunks(n_bytes)))
+            },
+            DIGEST_DISC if args[1] == ZERO && args[2] == ZERO => Some(Self::digest_node_type()),
+            EQ_DISC if args[1] == ZERO && args[2] == ZERO => Some(NodeType::Join),
+            _ => None,
+        }
+    }
+
+    fn evaluate(
+        &self,
+        args: [Felt; 3],
+        payload: &Payload,
+        context: &mut DeferredContext<'_>,
+    ) -> Result<Node, PrecompileError> {
+        let disc =
+            u32::try_from(args[0].as_canonical_u64()).map_err(|_| PrecompileError::InvalidNode)?;
+        match disc {
+            PREIMAGE_DISC => evaluate_preimage::<H>(args, payload),
+            DIGEST_DISC => Ok(Node::new(Tag::new(Self::id(), args), payload.clone())),
+            EQ_DISC => evaluate_eq::<H>(payload, context),
+            _ => Err(PrecompileError::InvalidNode),
+        }
+    }
+}
+
+/// Evaluates a `preimage` chunk node: unpack chunks to bytes (stripping zero-pad down to the
+/// `n_bytes` carried in `args[1]`), hash, and emit the canonical `digest` node.
+fn evaluate_preimage<H: HashFunction>(
+    args: [Felt; 3],
+    payload: &Payload,
+) -> Result<Node, PrecompileError> {
+    let n_bytes = u32::try_from(args[1].as_canonical_u64())
+        .map_err(|_| PrecompileError::InvalidNode)? as usize;
+    let bytes = chunks_to_bytes(payload.as_chunks()?, n_bytes)?;
+    let felts = bytes_to_packed_u32_elements(&H::hash(&bytes));
+    debug_assert_eq!(felts.len(), H::DIGEST_FELTS, "hash packs to DIGEST_FELTS felts");
+    Ok(HashPrecompile::<H>::digest_node(&felts))
+}
+
+/// Evaluates an `eq` predicate: resolve both children, require both are this hash's `digest`
+/// leaves, and assert their payloads match.
+fn evaluate_eq<H: HashFunction>(
+    payload: &Payload,
+    context: &mut DeferredContext<'_>,
+) -> Result<Node, PrecompileError> {
+    let (lhs_digest, rhs_digest) = payload.join_children()?;
+    let lhs = context.resolve(lhs_digest)?;
+    let rhs = context.resolve(rhs_digest)?;
+    let digest_tag = HashPrecompile::<H>::digest_tag();
+    if lhs.tag != digest_tag || rhs.tag != digest_tag {
+        return Err(PrecompileError::InvalidNode);
+    }
+    if lhs.payload != rhs.payload {
+        return Err(PrecompileError::AssertionFailed);
+    }
+    Ok(Node::TRUE)
+}
+
+// TEST SUPPORT
+// ================================================================================================
+
+/// Parses a `const NAME = VALUE` line out of a MASM source as a `u64`. Shared by the per-hash
+/// `masm_pinned_ids_match_derived_ids` tests.
+#[cfg(test)]
+pub(crate) fn masm_const(source: &str, name: &str) -> u64 {
+    source
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("const "))
+        .find_map(|assignment| {
+            let (const_name, value) = assignment.split_once(" = ")?;
+            (const_name == name).then(|| value.parse().ok()).flatten()
+        })
+        .expect("MASM const must be present and parse as u64")
+}
+
+/// Exercises the shared hash-precompile behavior for `H`: tag decoding, preimage evaluation across
+/// chunk boundaries, the `eq` predicate, and the malformed-input rejections. Each concrete hash
+/// calls this from its own test module; end-to-end hash correctness is pinned by the package
+/// integration tests.
+#[cfg(test)]
+pub(crate) fn assert_hash_precompile<H: HashFunction>() {
+    use alloc::{vec, vec::Vec};
+
+    use miden_core::deferred::{DeferredState, PrecompileRegistry};
+
+    fn pack_chunks(bytes: &[u8]) -> Vec<[Felt; 8]> {
+        let mut felts = bytes_to_packed_u32_elements(bytes);
+        let n = felts.len().div_ceil(8).max(1);
+        felts.resize(n * 8, ZERO);
+        felts.chunks_exact(8).map(|c| core::array::from_fn(|i| c[i])).collect()
+    }
+
+    let fresh = || {
+        (
+            PrecompileRegistry::new().with_precompile(HashPrecompile::<H>::default()),
+            DeferredState::new(usize::MAX),
+        )
+    };
+    let evaluate = |state: &mut DeferredState,
+                    reg: &PrecompileRegistry,
+                    node: Node|
+     -> Result<Node, PrecompileError> {
+        let digest = state.register(reg, node)?;
+        state.evaluate(reg, digest)
+    };
+
+    // -- decode routes each tag to its node shape and rejects malformed tags --
+    let pc = HashPrecompile::<H>::default();
+    assert!(matches!(
+        pc.decode([Felt::from_u32(HashPrecompile::<H>::PREIMAGE_TAG_ID), Felt::from_u32(65), ZERO]),
+        Some(NodeType::Chunks(n)) if n.get() == 3
+    ));
+    assert_eq!(
+        pc.decode([Felt::from_u32(HashPrecompile::<H>::DIGEST_TAG_ID), ZERO, ZERO]),
+        Some(HashPrecompile::<H>::digest_node_type()),
+    );
+    assert_eq!(
+        pc.decode([Felt::from_u32(HashPrecompile::<H>::EQ_TAG_ID), ZERO, ZERO]),
+        Some(NodeType::Join),
+    );
+    assert!(pc.decode([Felt::from_u32(99), ZERO, ZERO]).is_none());
+    // unused tag args must be zero
+    let one = Felt::from_u32(1);
+    assert!(
+        pc.decode([Felt::from_u32(HashPrecompile::<H>::PREIMAGE_TAG_ID), Felt::from_u32(1), one])
+            .is_none()
+    );
+    assert!(
+        pc.decode([Felt::from_u32(HashPrecompile::<H>::DIGEST_TAG_ID), one, ZERO])
+            .is_none()
+    );
+    assert!(pc.decode([Felt::from_u32(HashPrecompile::<H>::EQ_TAG_ID), ZERO, one]).is_none());
+
+    // -- preimage evaluates to the digest of the hashed bytes, across chunk boundaries --
+    for &n in &[0usize, 11, 70] {
+        let (reg, mut state) = fresh();
+        let input: Vec<u8> = (0..n).map(|i| i as u8).collect();
+        let node = HashPrecompile::<H>::preimage_node(n as u32, pack_chunks(&input));
+        let got = evaluate(&mut state, &reg, node).unwrap();
+        let want =
+            HashPrecompile::<H>::digest_node(&bytes_to_packed_u32_elements(&H::hash(&input)));
+        assert_eq!(got, want, "preimage of {n} bytes");
+    }
+
+    // -- eq accepts a matching (preimage, digest) and rejects a forged digest --
+    {
+        let (reg, mut state) = fresh();
+        let input = b"hash precompile eq";
+        let preimage = state
+            .register(
+                &reg,
+                HashPrecompile::<H>::preimage_node(input.len() as u32, pack_chunks(input)),
+            )
+            .unwrap();
+        let leaf = state
+            .register(
+                &reg,
+                HashPrecompile::<H>::digest_node(&bytes_to_packed_u32_elements(&H::hash(input))),
+            )
+            .unwrap();
+        assert!(
+            evaluate(&mut state, &reg, HashPrecompile::<H>::eq_node(preimage, leaf))
+                .unwrap()
+                .is_true_node()
+        );
+
+        let forged = state
+            .register(
+                &reg,
+                HashPrecompile::<H>::digest_node(&vec![Felt::from_u32(0xdead); H::DIGEST_FELTS]),
+            )
+            .unwrap();
+        let err = evaluate(&mut state, &reg, HashPrecompile::<H>::eq_node(preimage, forged));
+        assert!(matches!(err.unwrap_err().root(), PrecompileError::AssertionFailed));
+    }
+
+    // -- preimage rejects an oversized n_bytes for the chunk count, and nonzero trailing pad --
+    {
+        let (reg, mut state) = fresh();
+        let node = HashPrecompile::<H>::preimage_node(100, vec![[ZERO; 8]]);
+        assert!(matches!(
+            evaluate(&mut state, &reg, node).unwrap_err().root(),
+            PrecompileError::InvalidNode
+        ));
+    }
+    {
+        let (reg, mut state) = fresh();
+        let mut chunks = pack_chunks(&[1, 2, 3]);
+        chunks[0][0] = Felt::from_u32(u32::from_le_bytes([1, 2, 3, 0xaa]));
+        let node = HashPrecompile::<H>::preimage_node(3, chunks);
+        assert!(matches!(
+            evaluate(&mut state, &reg, node).unwrap_err().root(),
+            PrecompileError::InvalidNode
+        ));
+    }
+}

--- a/precompiles/src/hash/sha512.rs
+++ b/precompiles/src/hash/sha512.rs
@@ -1,0 +1,49 @@
+//! SHA-512 deferred precompile.
+
+use alloc::vec::Vec;
+
+use miden_crypto::hash::sha2::Sha512;
+
+use super::{HashFunction, HashPrecompile};
+
+/// [`HashFunction`] spec for SHA-512: a 512-bit digest carried as a 16-felt `Chunks(2)` node.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Sha512Hash;
+
+impl HashFunction for Sha512Hash {
+    const NAME: &'static str = "sha512";
+    const DIGEST_FELTS: usize = 16;
+
+    fn hash(input: &[u8]) -> Vec<u8> {
+        <[u8; 64]>::from(Sha512::hash(input)).to_vec()
+    }
+}
+
+/// The SHA-512 deferred precompile, installed by [`registry`](crate::registry) and wrapped in MASM
+/// under `miden::precompiles::crypto::hashes::sha512`.
+pub type Sha512Precompile = HashPrecompile<Sha512Hash>;
+
+#[cfg(test)]
+mod tests {
+    use super::Sha512Hash;
+    use crate::hash::{HashPrecompile, assert_hash_precompile, masm_const};
+
+    #[test]
+    fn suite() {
+        assert_hash_precompile::<Sha512Hash>();
+    }
+
+    #[test]
+    fn masm_pinned_ids_match_derived_ids() {
+        const MASM: &str = include_str!("../../asm/crypto/hashes/sha512.masm");
+        assert_eq!(
+            masm_const(MASM, "PRECOMPILE_ID"),
+            HashPrecompile::<Sha512Hash>::id().as_canonical_u64(),
+        );
+        assert_eq!(
+            masm_const(MASM, "DIGEST_TAG_ID"),
+            HashPrecompile::<Sha512Hash>::DIGEST_TAG_ID as u64,
+        );
+        assert_eq!(masm_const(MASM, "EQ_TAG_ID"), HashPrecompile::<Sha512Hash>::EQ_TAG_ID as u64,);
+    }
+}

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
+
+use miden_core::deferred::PrecompileRegistry;
+
+/// Returns a [`PrecompileRegistry`] containing the deferred precompiles provided by this crate.
+pub fn registry() -> PrecompileRegistry {
+    PrecompileRegistry::new()
+}

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -57,7 +57,6 @@ impl From<&PrecompilesLibrary> for HostLibrary {
         Self {
             mast_forest: precompiles_lib.mast_forest().clone(),
             handlers: vec![],
-            precompiles: registry(),
         }
     }
 }

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -5,7 +5,76 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-use miden_core::deferred::PrecompileRegistry;
+use alloc::{sync::Arc, vec};
+
+use miden_core::{deferred::PrecompileRegistry, mast::MastForest, serde::Deserializable};
+use miden_mast_package::Package;
+use miden_processor::HostLibrary;
+use miden_utils_sync::LazyLock;
+
+// PRECOMPILES LIBRARY
+// ================================================================================================
+
+/// The Miden precompiles library, wrapping the compiled `miden-precompiles` [`Package`].
+///
+/// The package bundles the MASM procedures exported under the `miden::precompiles` namespace.
+/// During scaffolding this is the deferred-DAG helper procedures under `miden::precompiles::sys`
+/// plus a smoke procedure; concrete precompiles are added as they are migrated onto the deferred
+/// framework. When the package is dynamically linked during assembly, these procedures can be
+/// called from any Miden program and are serialized as 32 bytes.
+///
+/// The crate's deferred [`PrecompileRegistry`] is exposed separately via [`registry`]; it is
+/// currently empty and grows alongside the concrete precompiles.
+///
+/// [`Package`]: miden_mast_package::Package
+#[derive(Clone)]
+pub struct PrecompilesLibrary(Arc<Package>);
+
+impl PrecompilesLibrary {
+    /// Serialized representation of the `miden-precompiles` package.
+    pub const SERIALIZED: &'static [u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/assets/miden-precompiles.masp"));
+
+    /// Returns a reference to the [`MastForest`] underlying the precompiles library.
+    pub fn mast_forest(&self) -> &Arc<MastForest> {
+        self.0.mast_forest()
+    }
+
+    /// Returns a reference to the underlying [`Arc<Package>`].
+    pub fn package(&self) -> Arc<Package> {
+        self.0.clone()
+    }
+}
+
+impl AsRef<Package> for PrecompilesLibrary {
+    fn as_ref(&self) -> &Package {
+        &self.0
+    }
+}
+
+impl From<&PrecompilesLibrary> for HostLibrary {
+    fn from(precompiles_lib: &PrecompilesLibrary) -> Self {
+        Self {
+            mast_forest: precompiles_lib.mast_forest().clone(),
+            handlers: vec![],
+            precompiles: registry(),
+        }
+    }
+}
+
+impl Default for PrecompilesLibrary {
+    fn default() -> Self {
+        static PRECOMPILES: LazyLock<PrecompilesLibrary> = LazyLock::new(|| {
+            let contents = Package::read_from_bytes(PrecompilesLibrary::SERIALIZED)
+                .expect("failed to read miden-precompiles package!");
+            PrecompilesLibrary(Arc::new(contents))
+        });
+        PRECOMPILES.clone()
+    }
+}
+
+// REGISTRY
+// ================================================================================================
 
 /// Returns a [`PrecompileRegistry`] containing the deferred precompiles provided by this crate.
 pub fn registry() -> PrecompileRegistry {

--- a/precompiles/src/lib.rs
+++ b/precompiles/src/lib.rs
@@ -12,19 +12,24 @@ use miden_mast_package::Package;
 use miden_processor::HostLibrary;
 use miden_utils_sync::LazyLock;
 
+mod codec;
+mod hash;
+
+pub use hash::{
+    HashFunction, HashPrecompile, keccak256::Keccak256Precompile, sha512::Sha512Precompile,
+};
+
 // PRECOMPILES LIBRARY
 // ================================================================================================
 
 /// The Miden precompiles library, wrapping the compiled `miden-precompiles` [`Package`].
 ///
-/// The package bundles the MASM procedures exported under the `miden::precompiles` namespace.
-/// During scaffolding this is the deferred-DAG helper procedures under `miden::precompiles::sys`
-/// plus a smoke procedure; concrete precompiles are added as they are migrated onto the deferred
-/// framework. When the package is dynamically linked during assembly, these procedures can be
-/// called from any Miden program and are serialized as 32 bytes.
+/// The package bundles the MASM procedures exported under the `miden::precompiles` namespace: the
+/// `keccak256` wrappers under `miden::precompiles::crypto::hashes::keccak256` and the deferred-DAG
+/// helper procedures under `miden::precompiles::sys`. When the package is dynamically linked during
+/// assembly, these procedures can be called from any Miden program and are serialized as 32 bytes.
 ///
-/// The crate's deferred [`PrecompileRegistry`] is exposed separately via [`registry`]; it is
-/// currently empty and grows alongside the concrete precompiles.
+/// The crate's deferred [`PrecompileRegistry`] is exposed separately via [`registry`].
 ///
 /// [`Package`]: miden_mast_package::Package
 #[derive(Clone)]
@@ -78,4 +83,6 @@ impl Default for PrecompilesLibrary {
 /// Returns a [`PrecompileRegistry`] containing the deferred precompiles provided by this crate.
 pub fn registry() -> PrecompileRegistry {
     PrecompileRegistry::new()
+        .with_precompile(Keccak256Precompile::default())
+        .with_precompile(Sha512Precompile::default())
 }

--- a/precompiles/tests/package.rs
+++ b/precompiles/tests/package.rs
@@ -1,10 +1,17 @@
 //! Focused smoke tests for the `miden-precompiles` package and its `PrecompilesLibrary` wrapper.
 
 use miden_assembly::{Assembler, Linkage};
-use miden_core::serde::Deserializable;
+use miden_core::{Felt, serde::Deserializable, utils::bytes_to_packed_u32_elements};
+use miden_crypto::hash::{keccak::Keccak256, sha2::Sha512};
 use miden_mast_package::Package;
 use miden_precompiles::PrecompilesLibrary;
-use miden_processor::DefaultHost;
+use miden_processor::{
+    DefaultHost, ExecutionOptions, ExecutionOutput, FastProcessor, StackInputs,
+    advice::AdviceInputs,
+};
+
+/// Memory address the e2e tests pass as the digest output pointer.
+const OUT_PTR: u32 = 0;
 
 /// The embedded `.masp` is a valid, deserializable package.
 #[test]
@@ -30,6 +37,38 @@ fn exports_expected_paths() {
     );
 }
 
+/// The keccak256 wrappers are exported under `miden::precompiles::crypto::hashes::keccak256`.
+#[test]
+fn exports_keccak_paths() {
+    let package = PrecompilesLibrary::default().package();
+    for path in [
+        "::miden::precompiles::crypto::hashes::keccak256::hash",
+        "::miden::precompiles::crypto::hashes::keccak256::hash_bytes",
+        "::miden::precompiles::crypto::hashes::keccak256::merge",
+    ] {
+        assert!(
+            package.get_procedure_root_by_path(path).is_some(),
+            "keccak256 procedure should be exported: {path}",
+        );
+    }
+}
+
+/// The sha512 wrappers are exported under `miden::precompiles::crypto::hashes::sha512`.
+#[test]
+fn exports_sha512_paths() {
+    let package = PrecompilesLibrary::default().package();
+    for path in [
+        "::miden::precompiles::crypto::hashes::sha512::hash",
+        "::miden::precompiles::crypto::hashes::sha512::hash_bytes",
+        "::miden::precompiles::crypto::hashes::sha512::merge",
+    ] {
+        assert!(
+            package.get_procedure_root_by_path(path).is_some(),
+            "sha512 procedure should be exported: {path}",
+        );
+    }
+}
+
 /// A program can be dynamically linked and assembled against the package.
 #[test]
 fn links_against_program() {
@@ -48,4 +87,120 @@ fn host_loads_library() {
     DefaultHost::default()
         .with_library(&PrecompilesLibrary::default())
         .expect("failed to load PrecompilesLibrary into the host");
+}
+
+/// End-to-end: a program calling `keccak256::hash` runs on a real processor with the precompile
+/// registry installed (via `with_library`) and returns the expected digest.
+#[test]
+fn keccak_hash_executes_end_to_end() {
+    let library = PrecompilesLibrary::default();
+
+    // 256-bit input, u32-packed-LE into 8 felts. The `hash` contract is `[out_ptr, INPUT_U32[8]]`,
+    // so seed the stack with `out_ptr` on top followed by the input felts.
+    let input: Vec<u8> = (0u8..32).collect();
+    let mut stack = vec![Felt::from_u32(OUT_PTR)];
+    stack.extend(bytes_to_packed_u32_elements(&input));
+
+    let source = "begin exec.::miden::precompiles::crypto::hashes::keccak256::hash end";
+    let program = Assembler::default()
+        .with_package(library.package(), Linkage::Dynamic)
+        .expect("failed to link miden-precompiles")
+        .assemble_program("keccak", source)
+        .expect("failed to assemble keccak program")
+        .unwrap_program();
+
+    let mut host = DefaultHost::default()
+        .with_library(&library)
+        .expect("failed to load PrecompilesLibrary into the host");
+
+    let output = FastProcessor::new_with_options(
+        StackInputs::new(&stack).expect("stack inputs"),
+        AdviceInputs::default(),
+        ExecutionOptions::default(),
+    )
+    .expect("processor construction")
+    .execute_sync(&program, &mut host)
+    .expect("keccak execution must succeed");
+
+    let expected = keccak_digest_felts(&input);
+    assert_eq!(
+        read_digest(&output, OUT_PTR, 8),
+        expected.to_vec(),
+        "digest at out_ptr must match Keccak256(input)",
+    );
+}
+
+/// Compute Keccak256 of `input`, unpacked into 8 u32-packed-LE felts — the layout the MASM wrapper
+/// writes to `out_ptr`.
+fn keccak_digest_felts(input: &[u8]) -> [Felt; 8] {
+    let hash: [u8; 32] = Keccak256::hash(input).into();
+    core::array::from_fn(|i| {
+        let mut limb = [0u8; 4];
+        limb.copy_from_slice(&hash[i * 4..(i + 1) * 4]);
+        Felt::from_u32(u32::from_le_bytes(limb))
+    })
+}
+
+/// End-to-end: `sha512::hash` runs on a real processor and writes the 512-bit digest (16 felts) to
+/// the caller-provided `out_ptr`.
+#[test]
+fn sha512_hash_executes_end_to_end() {
+    let library = PrecompilesLibrary::default();
+
+    // 256-bit input; `hash` contract is `[out_ptr, INPUT_U32[8]]`.
+    let input: Vec<u8> = (0u8..32).collect();
+    let mut stack = vec![Felt::from_u32(OUT_PTR)];
+    stack.extend(bytes_to_packed_u32_elements(&input));
+
+    let source = "begin exec.::miden::precompiles::crypto::hashes::sha512::hash end";
+    let program = Assembler::default()
+        .with_package(library.package(), Linkage::Dynamic)
+        .expect("failed to link miden-precompiles")
+        .assemble_program("sha512", source)
+        .expect("failed to assemble sha512 program")
+        .unwrap_program();
+
+    let mut host = DefaultHost::default()
+        .with_library(&library)
+        .expect("failed to load PrecompilesLibrary into the host");
+
+    let output = FastProcessor::new_with_options(
+        StackInputs::new(&stack).expect("stack inputs"),
+        AdviceInputs::default(),
+        ExecutionOptions::default(),
+    )
+    .expect("processor construction")
+    .execute_sync(&program, &mut host)
+    .expect("sha512 execution must succeed");
+
+    let expected = sha512_digest_felts(&input);
+    assert_eq!(
+        read_digest(&output, OUT_PTR, 16),
+        expected.to_vec(),
+        "digest at out_ptr must match Sha512(input)",
+    );
+}
+
+/// Compute SHA-512 of `input`, unpacked into 16 u32-packed-LE felts — the layout the MASM wrapper
+/// writes to `out_ptr`.
+fn sha512_digest_felts(input: &[u8]) -> [Felt; 16] {
+    let hash: [u8; 64] = Sha512::hash(input).into();
+    core::array::from_fn(|i| {
+        let mut limb = [0u8; 4];
+        limb.copy_from_slice(&hash[i * 4..(i + 1) * 4]);
+        Felt::from_u32(u32::from_le_bytes(limb))
+    })
+}
+
+/// Reads `n_felts` consecutive memory elements at `ptr` (context 0) — the digest a wrapper wrote.
+fn read_digest(output: &ExecutionOutput, ptr: u32, n_felts: u32) -> Vec<Felt> {
+    let ctx = 0u32.into();
+    (0..n_felts)
+        .map(|i| {
+            output
+                .memory
+                .read_element(ctx, Felt::from_u32(ptr + i))
+                .expect("digest element")
+        })
+        .collect()
 }

--- a/precompiles/tests/package.rs
+++ b/precompiles/tests/package.rs
@@ -1,0 +1,51 @@
+//! Focused smoke tests for the `miden-precompiles` package and its `PrecompilesLibrary` wrapper.
+
+use miden_assembly::{Assembler, Linkage};
+use miden_core::serde::Deserializable;
+use miden_mast_package::Package;
+use miden_precompiles::PrecompilesLibrary;
+use miden_processor::DefaultHost;
+
+/// The embedded `.masp` is a valid, deserializable package.
+#[test]
+fn package_deserializes() {
+    assert!(!PrecompilesLibrary::SERIALIZED.is_empty());
+    Package::read_from_bytes(PrecompilesLibrary::SERIALIZED)
+        .expect("embedded miden-precompiles.masp should deserialize");
+}
+
+/// The expected procedures are exported under the `miden::precompiles` namespace.
+#[test]
+fn exports_expected_paths() {
+    let package = PrecompilesLibrary::default().package();
+    assert!(
+        package.get_procedure_root_by_path("::miden::precompiles::smoke").is_some(),
+        "smoke procedure should be exported",
+    );
+    assert!(
+        package
+            .get_procedure_root_by_path("::miden::precompiles::sys::register_expr")
+            .is_some(),
+        "duplicated deferred sys helper should be exported",
+    );
+}
+
+/// A program can be dynamically linked and assembled against the package.
+#[test]
+fn links_against_program() {
+    let library = PrecompilesLibrary::default();
+    let source = "begin exec.::miden::precompiles::smoke end";
+    Assembler::default()
+        .with_package(library.package(), Linkage::Dynamic)
+        .expect("failed to link miden-precompiles")
+        .assemble_program("smoke", source)
+        .expect("failed to assemble a program against miden-precompiles");
+}
+
+/// A host can load the library via `DefaultHost::with_library`.
+#[test]
+fn host_loads_library() {
+    DefaultHost::default()
+        .with_library(&PrecompilesLibrary::default())
+        .expect("failed to load PrecompilesLibrary into the host");
+}

--- a/precompiles/tests/package.rs
+++ b/precompiles/tests/package.rs
@@ -4,7 +4,7 @@ use miden_assembly::{Assembler, Linkage};
 use miden_core::{Felt, serde::Deserializable, utils::bytes_to_packed_u32_elements};
 use miden_crypto::hash::{keccak::Keccak256, sha2::Sha512};
 use miden_mast_package::Package;
-use miden_precompiles::PrecompilesLibrary;
+use miden_precompiles::{PrecompilesLibrary, registry};
 use miden_processor::{
     DefaultHost, ExecutionOptions, ExecutionOutput, FastProcessor, StackInputs,
     advice::AdviceInputs,
@@ -90,7 +90,7 @@ fn host_loads_library() {
 }
 
 /// End-to-end: a program calling `keccak256::hash` runs on a real processor with the precompile
-/// registry installed (via `with_library`) and returns the expected digest.
+/// registry installed on the processor and returns the expected digest.
 #[test]
 fn keccak_hash_executes_end_to_end() {
     let library = PrecompilesLibrary::default();
@@ -119,6 +119,8 @@ fn keccak_hash_executes_end_to_end() {
         ExecutionOptions::default(),
     )
     .expect("processor construction")
+    .with_deferred_precompiles(registry())
+    .expect("failed to register miden-precompiles")
     .execute_sync(&program, &mut host)
     .expect("keccak execution must succeed");
 
@@ -170,6 +172,8 @@ fn sha512_hash_executes_end_to_end() {
         ExecutionOptions::default(),
     )
     .expect("processor construction")
+    .with_deferred_precompiles(registry())
+    .expect("failed to register miden-precompiles")
     .execute_sync(&program, &mut host)
     .expect("sha512 execution must succeed");
 


### PR DESCRIPTION
## Summary

Ports Keccak-256 and SHA-512 deferred precompiles into `miden-precompiles`.

Keccak and SHA-512 are handled together because they share the same MASM wrapper shape, Rust precompile structure, byte/chunk codec logic, and package tests.

## Changes

- Adds hash precompile registry entries for Keccak-256 and SHA-512.
- Adds MASM wrappers under `miden::precompiles::crypto::hashes`.
- Adds shared hash codec/precompile logic.
- Adds package export and end-to-end execution coverage.

## Design Notes

- Hash precompiles live outside the core library namespace.
- Programs link the MASM package via `PrecompilesLibrary`.
- Processor execution explicitly installs the Rust deferred registry.

## Tests

- `cargo test -p miden-precompiles`