### PR TITLE
chore(processor): Add an execution option to bound the memory size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [BREAKING] Changed semantics of `LoopNode` to unconditionally enter loops ([#3187](https://github.com/0xMiden/miden-vm/pull/3187)).
 - Removed the legacy LALRPOP parser backend
 - [BREAKING] Cleaned up `Processor` trait by moving methods into their corresponding sub-interface ([#3202](https://github.com/0xMiden/miden-vm/pull/3202)).
+- Bounded `FastProcessor` memory growth with a configurable `ExecutionOptions::max_memory_elements` limit, rejecting writes to arbitrarily many unique addresses that could otherwise exhaust host memory ([#3226](https://github.com/0xMiden/miden-vm/pull/3226)).
 
 #### Fixes
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -221,6 +221,13 @@ pub enum MemoryError {
     UnalignedWordAccess { addr: u32, ctx: ContextId },
     #[error("failed to read from memory: {0}")]
     MemoryReadFailed(String),
+    #[error(
+        "writing to memory address {addr} in context {ctx} would exceed the maximum number of memory elements {max}"
+    )]
+    #[diagnostic(help(
+        "increase the limit via `ExecutionOptions::with_max_memory_elements`, or reduce the number of distinct memory addresses the program writes to"
+    ))]
+    MemoryElementLimitExceeded { ctx: ContextId, addr: u32, max: usize },
 }
 
 // CRYPTO ERROR

--- a/processor/src/execution_options.rs
+++ b/processor/src/execution_options.rs
@@ -26,6 +26,9 @@ pub struct ExecutionOptions {
     /// Maximum number of field elements allowed on the operand stack in the active execution
     /// context.
     max_stack_depth: usize,
+    /// Maximum number of field elements allowed in the processor's memory at any point during
+    /// execution, rounded up to the nearest multiple of 4.
+    max_memory_elements: usize,
 }
 
 impl Default for ExecutionOptions {
@@ -39,6 +42,7 @@ impl Default for ExecutionOptions {
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
             max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
             max_stack_depth: Self::DEFAULT_MAX_STACK_DEPTH,
+            max_memory_elements: Self::DEFAULT_MAX_MEMORY_ELEMENTS,
         }
     }
 }
@@ -76,6 +80,15 @@ impl ExecutionOptions {
     /// This preserves the effective stack depth ceiling imposed by the previous fixed
     /// `FastProcessor` stack buffer.
     pub const DEFAULT_MAX_STACK_DEPTH: usize = 6615;
+
+    /// Default maximum number of field elements allowed in the processor's memory.
+    ///
+    /// Memory is element-addressable, so this bounds the total number of elements live across all
+    /// contexts. Internally memory is stored at word granularity (4 elements per word), so the
+    /// effective limit is rounded up to a whole number of words. Set to 2^28, which lets programs
+    /// use a large amount of memory while still providing a finite host-memory backstop against
+    /// unbounded growth from writes to arbitrarily many unique addresses.
+    pub const DEFAULT_MAX_MEMORY_ELEMENTS: usize = 1 << 28;
 
     // CONSTRUCTOR
     // --------------------------------------------------------------------------------------------
@@ -137,6 +150,7 @@ impl ExecutionOptions {
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
             max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
             max_stack_depth: Self::DEFAULT_MAX_STACK_DEPTH,
+            max_memory_elements: Self::DEFAULT_MAX_MEMORY_ELEMENTS,
         })
     }
 
@@ -227,6 +241,15 @@ impl ExecutionOptions {
         self.max_stack_depth
     }
 
+    /// Returns the configured maximum number of field elements allowed in the processor's memory.
+    ///
+    /// This is the raw value as set via [`Self::with_max_memory_elements`]; the effective cap is
+    /// rounded up to a whole number of words (a multiple of 4) when memory is initialized.
+    #[inline]
+    pub fn max_memory_elements(&self) -> usize {
+        self.max_memory_elements
+    }
+
     /// Sets the maximum number of continuations allowed on the continuation stack.
     pub fn with_max_num_continuations(mut self, max_num_continuations: usize) -> Self {
         self.max_num_continuations = max_num_continuations;
@@ -247,6 +270,12 @@ impl ExecutionOptions {
         }
         self.max_stack_depth = max_stack_depth;
         Ok(self)
+    }
+
+    /// Sets the maximum number of field elements allowed in the processor's memory.
+    pub fn with_max_memory_elements(mut self, max_memory_elements: usize) -> Self {
+        self.max_memory_elements = max_memory_elements;
+        self
     }
 }
 

--- a/processor/src/fast/memory.rs
+++ b/processor/src/fast/memory.rs
@@ -3,7 +3,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 use miden_air::trace::RowIndex;
 use miden_core::{EMPTY_WORD, Felt, WORD_SIZE, Word, ZERO};
 
-use crate::{ContextId, MemoryAddress, MemoryError, processor::MemoryInterface};
+use crate::{ContextId, ExecutionOptions, MemoryAddress, MemoryError, processor::MemoryInterface};
 
 /// The memory for the processor.
 ///
@@ -19,15 +19,43 @@ use crate::{ContextId, MemoryAddress, MemoryError, processor::MemoryInterface};
 /// processor operations (i.e. all variants of the [`miden_core::operations::Operation`] enum). This
 /// is a consequence of the design of the memory chiplet constraints, which allow for multiple reads
 /// but not multiple writes in the same clock cycle to the same address.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Memory {
     memory: BTreeMap<(ContextId, u32), Word>,
+    /// Maximum number of word entries allowed in `memory`. Memory is stored at word granularity
+    /// (each entry holds `WORD_SIZE` elements), so a write that would insert a new word entry
+    /// beyond this limit is rejected. This bounds host-memory growth from writes to
+    /// arbitrarily many unique addresses.
+    ///
+    /// The element-addressable limit exposed via [`ExecutionOptions`] is converted to this
+    /// word-granular limit once, at construction time, so the per-write check is a plain
+    /// comparison.
+    max_entries: usize,
+}
+
+impl Default for Memory {
+    fn default() -> Self {
+        Self::new(ExecutionOptions::DEFAULT_MAX_MEMORY_ELEMENTS)
+    }
 }
 
 impl Memory {
-    /// Creates a new memory instance.
-    pub fn new() -> Self {
-        Self::default()
+    /// Creates a new memory instance allowing at most `max_elements` field elements.
+    ///
+    /// Memory is stored at word granularity, so the limit is rounded up to a whole number of words.
+    pub fn new(max_elements: usize) -> Self {
+        Self {
+            memory: BTreeMap::new(),
+            max_entries: max_elements.div_ceil(WORD_SIZE),
+        }
+    }
+
+    /// Sets the maximum number of field elements allowed in memory.
+    ///
+    /// As with [`Self::new`], the limit is rounded up to a whole number of words. It governs future
+    /// growth only; entries already present are retained even if they exceed the new limit.
+    pub(crate) fn set_max_elements(&mut self, max_elements: usize) {
+        self.max_entries = max_elements.div_ceil(WORD_SIZE);
     }
 
     /// Reads an element from memory at the provided address in the provided context.
@@ -71,6 +99,16 @@ impl Memory {
     ) -> Result<(), MemoryError> {
         let (word_addr, idx) = split_addr(clean_addr(addr)?);
 
+        // Reject writes that would grow the map beyond the configured maximum. Modifying an
+        // existing entry never grows the map, so it is always allowed.
+        if !self.memory.contains_key(&(ctx, word_addr)) && self.memory.len() >= self.max_entries {
+            return Err(MemoryError::MemoryElementLimitExceeded {
+                ctx,
+                addr: word_addr,
+                max: self.max_element_limit(),
+            });
+        }
+
         self.memory
             .entry((ctx, word_addr))
             .and_modify(|word| {
@@ -101,6 +139,17 @@ impl Memory {
         word: Word,
     ) -> Result<(), MemoryError> {
         let addr = enforce_word_aligned_addr(ctx, clean_addr(addr)?)?;
+
+        // Reject writes that would grow the map beyond the configured maximum. Overwriting an
+        // existing entry never grows the map, so it is always allowed.
+        if !self.memory.contains_key(&(ctx, addr)) && self.memory.len() >= self.max_entries {
+            return Err(MemoryError::MemoryElementLimitExceeded {
+                ctx,
+                addr,
+                max: self.max_element_limit(),
+            });
+        }
+
         self.memory.insert((ctx, addr), word);
 
         Ok(())
@@ -128,6 +177,14 @@ impl Memory {
 
     // HELPERS
     // --------------------------------------------------------------------------------------------
+
+    /// Returns the configured entry limit expressed as an element count, for reporting in errors.
+    ///
+    /// This lives off the hot path: it is only evaluated when a write is being rejected.
+    #[inline]
+    fn max_element_limit(&self) -> usize {
+        self.max_entries.saturating_mul(WORD_SIZE)
+    }
 
     /// Reads an element from memory at the provided address in the provided context.
     ///

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -230,6 +230,7 @@ impl FastProcessor {
     /// [`Self::with_advice`] or use [`Self::new_with_options`].
     pub fn with_options(mut self, options: ExecutionOptions) -> Result<Self, AdviceError> {
         self.advice.set_options(&options)?;
+        self.memory.set_max_elements(options.max_memory_elements());
         self.options = options;
         Ok(self)
     }
@@ -264,7 +265,7 @@ impl FastProcessor {
             clk: 0_u32.into(),
             ctx: 0_u32.into(),
             caller_hash: EMPTY_WORD,
-            memory: Memory::new(),
+            memory: Memory::new(options.max_memory_elements()),
             system_call_state_stack: Vec::new(),
             stack_overflow_save_stack: Vec::new(),
             options,

--- a/processor/src/fast/tests/memory.rs
+++ b/processor/src/fast/tests/memory.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::{ExecutionError, MemoryError, fast::Memory};
 
 #[test]
 fn test_memory_word_access_alignment() {
@@ -196,5 +197,117 @@ fn test_mstream() {
             word_at_addr_44[2],
             word_at_addr_44[3]
         ]
+    );
+}
+
+#[test]
+fn test_memory_element_limit_enforced() {
+    let ctx = 0_u32.into();
+    let clk: RowIndex = 0_u32.into();
+    // The limit is element-wise; `2 * WORD_SIZE` elements allows 2 word entries.
+    let max_elements = 2 * WORD_SIZE;
+    let mut memory = Memory::new(max_elements);
+
+    // Two writes to distinct word addresses fit within the limit.
+    memory.write_word(ctx, Felt::from_u32(0), clk, [ONE; WORD_SIZE].into()).unwrap();
+    memory.write_word(ctx, Felt::from_u32(4), clk, [ONE; WORD_SIZE].into()).unwrap();
+
+    // Writes that don't insert a new entry are always allowed, even at the limit: overwriting an
+    // existing word, or modifying an element within an already-tracked word.
+    memory
+        .write_word(ctx, Felt::from_u32(0), clk, [ZERO; WORD_SIZE].into())
+        .unwrap();
+    memory.write_element(ctx, Felt::from_u32(5), ONE).unwrap();
+
+    // Writing a word to a new address beyond the limit is rejected.
+    let err = memory
+        .write_word(ctx, Felt::from_u32(8), clk, [ONE; WORD_SIZE].into())
+        .unwrap_err();
+    assert_matches!(
+        err,
+        MemoryError::MemoryElementLimitExceeded { max, addr: 8, .. } if max == max_elements
+    );
+
+    // Writing an element to a new address beyond the limit is rejected as well.
+    let err = memory.write_element(ctx, Felt::from_u32(9), ONE).unwrap_err();
+    assert_matches!(
+        err,
+        MemoryError::MemoryElementLimitExceeded { max, addr: 8, .. } if max == max_elements
+    );
+}
+
+#[test]
+fn test_memory_element_limit_enforced_during_execution() {
+    let mut host = DefaultHost::default();
+
+    // Store words to three distinct word addresses (0, 4, and 8). Together with the procedure frame
+    // word written on entry, the program touches 4 distinct word addresses, i.e. 4 * WORD_SIZE
+    // elements, in total.
+    let program_source = "
+    begin
+        mem_storew_be.0
+        mem_storew_be.4
+        mem_storew_be.8
+    end
+    ";
+    let source_manager = Arc::new(DefaultSourceManager::default());
+    let program = Assembler::new(source_manager)
+        .assemble_program("program", program_source)
+        .expect("program should assemble")
+        .unwrap_program();
+
+    // A limit of 3 words' worth of elements is exceeded by the 4th distinct word write.
+    let options = ExecutionOptions::default().with_max_memory_elements(3 * WORD_SIZE);
+    let processor =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .unwrap();
+    let err = processor.execute_sync(&program, &mut host).unwrap_err();
+    assert_matches!(
+        err,
+        ExecutionError::MemoryError {
+            err: MemoryError::MemoryElementLimitExceeded { .. },
+            ..
+        }
+    );
+
+    // A limit of 4 words' worth of elements accommodates every distinct word the program writes to.
+    let options = ExecutionOptions::default().with_max_memory_elements(4 * WORD_SIZE);
+    let mut processor =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .unwrap();
+    processor.execute_mut_sync(&program, &mut host).unwrap();
+    assert_eq!(processor.memory.num_accessed_words(), 4);
+}
+
+/// Regression test: the memory limit must also be applied when set via the `with_options` builder,
+/// not only via `new_with_options`.
+#[test]
+fn test_memory_element_limit_enforced_via_with_options() {
+    let mut host = DefaultHost::default();
+
+    // The program touches 4 distinct word addresses (see the test above).
+    let program_source = "
+    begin
+        mem_storew_be.0
+        mem_storew_be.4
+        mem_storew_be.8
+    end
+    ";
+    let source_manager = Arc::new(DefaultSourceManager::default());
+    let program = Assembler::new(source_manager)
+        .assemble_program("program", program_source)
+        .expect("program should assemble")
+        .unwrap_program();
+
+    // The limit is configured through the `new(...).with_options(...)` builder chain.
+    let options = ExecutionOptions::default().with_max_memory_elements(3 * WORD_SIZE);
+    let processor = FastProcessor::new(StackInputs::default()).with_options(options).unwrap();
+    let err = processor.execute_sync(&program, &mut host).unwrap_err();
+    assert_matches!(
+        err,
+        ExecutionError::MemoryError {
+            err: MemoryError::MemoryElementLimitExceeded { .. },
+            ..
+        }
     );
 }


### PR DESCRIPTION
Fixes a security vulnerability where the processor's memory was still unbounded.