### PR TITLE
fix(debug): encode enum and u256 debug types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 #### Enhancements
 
 - Added a `RELEASE_PROCEDURE` file ([#3199](https://github.com/0xMiden/miden-vm/pull/3199)).
+- Added enum and `u256` records to `.debug_types` metadata so debuggers can preserve those type identities ([#3227](https://github.com/0xMiden/miden-vm/pull/3227)).
 - Exposed a new parser function for parsing inline MASM blocks as CST or AST. ([#3211](https://github.com/0xMiden/miden-vm/pull/3211))
 
 ## v0.23.3 (2026-05-26)

--- a/crates/assembly/src/assembler/debuginfo.rs
+++ b/crates/assembly/src/assembler/debuginfo.rs
@@ -9,7 +9,7 @@ use std::{
 use miden_assembly_syntax::debuginfo::{FileLineCol, Location, Uri};
 use miden_mast_package::debug_info::{
     DebugFieldInfo, DebugFunctionsSection, DebugPrimitiveType, DebugSourcesSection, DebugTypeIdx,
-    DebugTypeInfo, DebugTypesSection,
+    DebugTypeInfo, DebugTypesSection, DebugVariantInfo,
 };
 
 use crate::{
@@ -206,7 +206,10 @@ fn register_debug_type(
         Type::F64 => {
             debug_types_section.add_type(DebugTypeInfo::Primitive(DebugPrimitiveType::F64))
         },
-        Type::U256 | Type::Unknown => debug_types_section.add_type(DebugTypeInfo::Unknown),
+        Type::U256 => {
+            debug_types_section.add_type(DebugTypeInfo::Primitive(DebugPrimitiveType::U256))
+        },
+        Type::Unknown => debug_types_section.add_type(DebugTypeInfo::Unknown),
         Type::Never => {
             debug_types_section.add_type(DebugTypeInfo::Primitive(DebugPrimitiveType::Void))
         },
@@ -325,13 +328,30 @@ fn register_debug_type(
         Type::Enum(enum_ty) => {
             let discrim_ty =
                 register_debug_type(debug_types_section, None, None, enum_ty.discriminant())?;
-            if enum_ty.is_c_like() {
-                discrim_ty
-            } else {
-                // TODO(pauls): We need to figure out how best to represent this in terms of DWARF
-                // debug info
-                debug_types_section.add_type(DebugTypeInfo::Unknown)
-            }
+            let name_idx = debug_types_section.add_string(enum_ty.name().clone());
+            let size = u32::try_from(enum_ty.size_in_bytes()).map_err(|_| {
+                Report::msg(format!("invalid enum type '{}': enum is too large", enum_ty.name()))
+            })?;
+            let variants = enum_ty
+                .variants()
+                .iter()
+                .zip(enum_ty.discriminant_values())
+                .map(|(variant, discriminant)| {
+                    let name_idx = debug_types_section.add_string(variant.name.clone());
+                    let type_idx = variant
+                        .value
+                        .as_ref()
+                        .map(|ty| register_debug_type(debug_types_section, None, None, ty))
+                        .transpose()?;
+                    Ok(DebugVariantInfo { name_idx, type_idx, discriminant })
+                })
+                .collect::<Result<_, Report>>()?;
+            debug_types_section.add_type(DebugTypeInfo::Enum {
+                name_idx,
+                size,
+                discriminant_type_idx: discrim_ty,
+                variants,
+            })
         },
         Type::Function(fty) => {
             let return_type_index = match fty.results() {
@@ -376,4 +396,79 @@ fn register_debug_type(
             })
         },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::types::{EnumType, Variant};
+
+    #[test]
+    fn registers_c_like_enum_debug_type() {
+        let mut section = DebugTypesSection::new();
+        let enum_ty = EnumType::new(
+            Arc::from("Status"),
+            Type::U16,
+            [
+                Variant::c_like(Arc::from("Ok"), Some(200)),
+                Variant::c_like(Arc::from("NotFound"), Some(404)),
+            ],
+        )
+        .unwrap();
+        let ty = Type::Enum(Arc::new(enum_ty));
+
+        let type_idx = register_debug_type(&mut section, None, None, &ty).unwrap();
+
+        let DebugTypeInfo::Enum {
+            name_idx,
+            size,
+            discriminant_type_idx,
+            variants,
+        } = section.get_type(type_idx).unwrap()
+        else {
+            panic!("expected enum debug type");
+        };
+        assert_eq!(section.get_string(*name_idx).as_deref(), Some("Status"));
+        assert_eq!(*size, 2);
+        assert_eq!(
+            section.get_type(*discriminant_type_idx),
+            Some(&DebugTypeInfo::Primitive(DebugPrimitiveType::U16))
+        );
+        assert_eq!(variants.len(), 2);
+        assert_eq!(section.get_string(variants[0].name_idx).as_deref(), Some("Ok"));
+        assert_eq!(variants[0].type_idx, None);
+        assert_eq!(variants[0].discriminant, 200);
+        assert_eq!(section.get_string(variants[1].name_idx).as_deref(), Some("NotFound"));
+        assert_eq!(variants[1].type_idx, None);
+        assert_eq!(variants[1].discriminant, 404);
+    }
+
+    #[test]
+    fn registers_payload_enum_debug_type() {
+        let mut section = DebugTypesSection::new();
+        let enum_ty = EnumType::new(
+            Arc::from("OptionU32"),
+            Type::U8,
+            [
+                Variant::c_like(Arc::from("None"), Some(0)),
+                Variant::new(Arc::from("Some"), Type::U32, Some(1)),
+            ],
+        )
+        .unwrap();
+        let ty = Type::Enum(Arc::new(enum_ty));
+
+        let type_idx = register_debug_type(&mut section, None, None, &ty).unwrap();
+
+        let DebugTypeInfo::Enum { variants, .. } = section.get_type(type_idx).unwrap() else {
+            panic!("expected enum debug type");
+        };
+        assert_eq!(variants.len(), 2);
+        assert_eq!(variants[0].type_idx, None);
+        let payload_type_idx = variants[1].type_idx.expect("Some variant should have payload");
+        assert_eq!(
+            section.get_type(payload_type_idx),
+            Some(&DebugTypeInfo::Primitive(DebugPrimitiveType::U32))
+        );
+        assert_eq!(variants[1].discriminant, 1);
+    }
 }

--- a/crates/assembly/src/assembler/debuginfo.rs
+++ b/crates/assembly/src/assembler/debuginfo.rs
@@ -333,17 +333,22 @@ fn register_debug_type(
                 Report::msg(format!("invalid enum type '{}': enum is too large", enum_ty.name()))
             })?;
             let variants = enum_ty
-                .variants()
-                .iter()
+                .variant_offsets()
                 .zip(enum_ty.discriminant_values())
-                .map(|(variant, discriminant)| {
+                .map(|((payload_offset, variant), discriminant)| {
                     let name_idx = debug_types_section.add_string(variant.name.clone());
                     let type_idx = variant
                         .value
                         .as_ref()
                         .map(|ty| register_debug_type(debug_types_section, None, None, ty))
                         .transpose()?;
-                    Ok(DebugVariantInfo { name_idx, type_idx, discriminant })
+                    let payload_offset = variant.value.as_ref().map(|_| payload_offset);
+                    Ok(DebugVariantInfo {
+                        name_idx,
+                        type_idx,
+                        payload_offset,
+                        discriminant,
+                    })
                 })
                 .collect::<Result<_, Report>>()?;
             debug_types_section.add_type(DebugTypeInfo::Enum {
@@ -437,9 +442,11 @@ mod tests {
         assert_eq!(variants.len(), 2);
         assert_eq!(section.get_string(variants[0].name_idx).as_deref(), Some("Ok"));
         assert_eq!(variants[0].type_idx, None);
+        assert_eq!(variants[0].payload_offset, None);
         assert_eq!(variants[0].discriminant, 200);
         assert_eq!(section.get_string(variants[1].name_idx).as_deref(), Some("NotFound"));
         assert_eq!(variants[1].type_idx, None);
+        assert_eq!(variants[1].payload_offset, None);
         assert_eq!(variants[1].discriminant, 404);
     }
 
@@ -469,6 +476,7 @@ mod tests {
             section.get_type(payload_type_idx),
             Some(&DebugTypeInfo::Primitive(DebugPrimitiveType::U32))
         );
+        assert_eq!(variants[1].payload_offset, Some(4));
         assert_eq!(variants[1].discriminant, 1);
     }
 }

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -333,6 +333,10 @@ impl Serializable for DebugVariantInfo {
         if let Some(type_idx) = self.type_idx {
             target.write_u32(type_idx.as_u32());
         }
+        target.write_bool(self.payload_offset.is_some());
+        if let Some(payload_offset) = self.payload_offset {
+            target.write_u32(payload_offset);
+        }
         target.write_u64((self.discriminant >> 64) as u64);
         target.write_u64(self.discriminant as u64);
     }
@@ -346,11 +350,17 @@ impl Deserializable for DebugVariantInfo {
         } else {
             None
         };
+        let payload_offset = if source.read_bool()? {
+            Some(source.read_u32()?)
+        } else {
+            None
+        };
         let hi = source.read_u64()? as u128;
         let lo = source.read_u64()? as u128;
         Ok(Self {
             name_idx,
             type_idx,
+            payload_offset,
             discriminant: (hi << 64) | lo,
         })
     }
@@ -683,11 +693,13 @@ mod tests {
                 DebugVariantInfo {
                     name_idx: ok_idx,
                     type_idx: None,
+                    payload_offset: None,
                     discriminant: 0,
                 },
                 DebugVariantInfo {
                     name_idx: err_idx,
                     type_idx: Some(felt_type_idx),
+                    payload_offset: Some(8),
                     discriminant: 1,
                 },
             ],

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -12,7 +12,7 @@ use super::{
     DEBUG_FUNCTIONS_VERSION, DEBUG_SOURCES_VERSION, DEBUG_TYPES_VERSION, DebugFieldInfo,
     DebugFileInfo, DebugFunctionInfo, DebugFunctionsSection, DebugInlinedCallInfo,
     DebugPrimitiveType, DebugSourcesSection, DebugTypeIdx, DebugTypeInfo, DebugTypesSection,
-    DebugVariableInfo,
+    DebugVariableInfo, DebugVariantInfo,
 };
 
 // DEBUG TYPES SECTION SERIALIZATION
@@ -181,6 +181,7 @@ const TYPE_TAG_ARRAY: u8 = 2;
 const TYPE_TAG_STRUCT: u8 = 3;
 const TYPE_TAG_FUNCTION: u8 = 4;
 const TYPE_TAG_UNKNOWN: u8 = 5;
+const TYPE_TAG_ENUM: u8 = 6;
 
 impl Serializable for DebugTypeInfo {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
@@ -219,6 +220,21 @@ impl Serializable for DebugTypeInfo {
                 target.write_usize(param_type_indices.len());
                 for idx in param_type_indices {
                     target.write_u32(idx.as_u32());
+                }
+            },
+            Self::Enum {
+                name_idx,
+                size,
+                discriminant_type_idx,
+                variants,
+            } => {
+                target.write_u8(TYPE_TAG_ENUM);
+                target.write_u32(*name_idx);
+                target.write_u32(*size);
+                target.write_u32(discriminant_type_idx.as_u32());
+                target.write_usize(variants.len());
+                for variant in variants {
+                    variant.write_into(target);
                 }
             },
             Self::Unknown => {
@@ -268,6 +284,19 @@ impl Deserializable for DebugTypeInfo {
                 let param_type_indices = alloc::vec::Vec::<DebugTypeIdx>::read_from(source)?;
                 Ok(Self::Function { return_type_idx, param_type_indices })
             },
+            TYPE_TAG_ENUM => {
+                let name_idx = source.read_u32()?;
+                let size = source.read_u32()?;
+                let discriminant_type_idx = DebugTypeIdx::from(source.read_u32()?);
+                let variants_len = source.read_usize()?;
+                let variants = source.read_many_iter(variants_len)?.collect::<Result<_, _>>()?;
+                Ok(Self::Enum {
+                    name_idx,
+                    size,
+                    discriminant_type_idx,
+                    variants,
+                })
+            },
             TYPE_TAG_UNKNOWN => Ok(Self::Unknown),
             _ => Err(DeserializationError::InvalidValue(alloc::format!("invalid type tag: {tag}"))),
         }
@@ -291,6 +320,39 @@ impl Deserializable for DebugFieldInfo {
         let type_idx = DebugTypeIdx::from(source.read_u32()?);
         let offset = source.read_u32()?;
         Ok(Self { name_idx, type_idx, offset })
+    }
+}
+
+// DEBUG VARIANT INFO SERIALIZATION
+// ================================================================================================
+
+impl Serializable for DebugVariantInfo {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u32(self.name_idx);
+        target.write_bool(self.type_idx.is_some());
+        if let Some(type_idx) = self.type_idx {
+            target.write_u32(type_idx.as_u32());
+        }
+        target.write_u64((self.discriminant >> 64) as u64);
+        target.write_u64(self.discriminant as u64);
+    }
+}
+
+impl Deserializable for DebugVariantInfo {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let name_idx = source.read_u32()?;
+        let type_idx = if source.read_bool()? {
+            Some(DebugTypeIdx::from(source.read_u32()?))
+        } else {
+            None
+        };
+        let hi = source.read_u64()? as u128;
+        let lo = source.read_u64()? as u128;
+        Ok(Self {
+            name_idx,
+            type_idx,
+            discriminant: (hi << 64) | lo,
+        })
     }
 }
 
@@ -609,6 +671,28 @@ mod tests {
             ],
         });
 
+        // Add an enum type
+        let status_idx = section.add_string(Arc::from("Status"));
+        let ok_idx = section.add_string(Arc::from("Ok"));
+        let err_idx = section.add_string(Arc::from("Err"));
+        section.add_type(DebugTypeInfo::Enum {
+            name_idx: status_idx,
+            size: 8,
+            discriminant_type_idx: i32_type_idx,
+            variants: alloc::vec![
+                DebugVariantInfo {
+                    name_idx: ok_idx,
+                    type_idx: None,
+                    discriminant: 0,
+                },
+                DebugVariantInfo {
+                    name_idx: err_idx,
+                    type_idx: Some(felt_type_idx),
+                    discriminant: 1,
+                },
+            ],
+        });
+
         roundtrip(&section);
     }
 
@@ -674,6 +758,7 @@ mod tests {
             DebugPrimitiveType::F64,
             DebugPrimitiveType::Felt,
             DebugPrimitiveType::Word,
+            DebugPrimitiveType::U256,
         ] {
             section.add_type(DebugTypeInfo::Primitive(prim));
         }

--- a/crates/mast-package/src/debug_info/types.rs
+++ b/crates/mast-package/src/debug_info/types.rs
@@ -454,6 +454,8 @@ pub struct DebugVariantInfo {
     pub name_idx: u32,
     /// Payload type of this variant (index into type table), if present.
     pub type_idx: Option<DebugTypeIdx>,
+    /// Byte offset of the payload from the base of the enum value, if present.
+    pub payload_offset: Option<u32>,
     /// Discriminant value for this variant.
     pub discriminant: u128,
 }

--- a/crates/mast-package/src/debug_info/types.rs
+++ b/crates/mast-package/src/debug_info/types.rs
@@ -89,7 +89,7 @@ pub const DEBUG_TYPES_VERSION: u8 = 1;
 
 /// Debug types section containing type definitions for a MASP package.
 ///
-/// This section stores type information (primitives, structs, arrays, pointers,
+/// This section stores type information (primitives, structs, enums, arrays, pointers,
 /// function types) that enables debuggers to properly display values.
 ///
 /// String indices in sub-types (e.g., `name_idx` in `DebugFieldInfo`) are relative
@@ -319,6 +319,17 @@ pub enum DebugTypeInfo {
         /// Parameter types (indices into type table)
         param_type_indices: Vec<DebugTypeIdx>,
     },
+    /// An enum type.
+    Enum {
+        /// Name of the enum (index into string table).
+        name_idx: u32,
+        /// Size in bytes.
+        size: u32,
+        /// Type of the enum discriminant.
+        discriminant_type_idx: DebugTypeIdx,
+        /// Variants of the enum.
+        variants: Vec<DebugVariantInfo>,
+    },
     /// An unknown or opaque type
     Unknown,
 }
@@ -363,6 +374,8 @@ pub enum DebugPrimitiveType {
     Felt,
     /// Miden word (4 field elements)
     Word,
+    /// Unsigned 256-bit integer
+    U256,
 }
 
 impl DebugPrimitiveType {
@@ -375,7 +388,7 @@ impl DebugPrimitiveType {
             Self::I32 | Self::U32 | Self::F32 => 4,
             Self::I64 | Self::U64 | Self::F64 | Self::Felt => 8,
             Self::I128 | Self::U128 => 16,
-            Self::Word => 32,
+            Self::Word | Self::U256 => 32,
         }
     }
 
@@ -392,7 +405,7 @@ impl DebugPrimitiveType {
             | Self::U32
             | Self::Felt => 1,
             Self::I64 | Self::U64 | Self::F32 | Self::F64 => 2,
-            Self::I128 | Self::U128 | Self::Word => 4,
+            Self::I128 | Self::U128 | Self::Word | Self::U256 => 4,
         }
     }
 
@@ -415,6 +428,7 @@ impl DebugPrimitiveType {
             13 => Some(Self::F64),
             14 => Some(Self::Felt),
             15 => Some(Self::Word),
+            16 => Some(Self::U256),
             _ => None,
         }
     }
@@ -430,6 +444,18 @@ pub struct DebugFieldInfo {
     pub type_idx: DebugTypeIdx,
     /// Byte offset within the struct
     pub offset: u32,
+}
+
+/// Variant information within an enum type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DebugVariantInfo {
+    /// Name of the variant (index into string table).
+    pub name_idx: u32,
+    /// Payload type of this variant (index into type table), if present.
+    pub type_idx: Option<DebugTypeIdx>,
+    /// Discriminant value for this variant.
+    pub discriminant: u128,
 }
 
 // DEBUG FILE INFO
@@ -707,19 +733,21 @@ mod tests {
         assert_eq!(DebugPrimitiveType::I64.size_in_bytes(), 8);
         assert_eq!(DebugPrimitiveType::Felt.size_in_bytes(), 8);
         assert_eq!(DebugPrimitiveType::Word.size_in_bytes(), 32);
+        assert_eq!(DebugPrimitiveType::U256.size_in_bytes(), 32);
 
         assert_eq!(DebugPrimitiveType::Void.size_in_felts(), 0);
         assert_eq!(DebugPrimitiveType::I32.size_in_felts(), 1);
         assert_eq!(DebugPrimitiveType::I64.size_in_felts(), 2);
         assert_eq!(DebugPrimitiveType::Word.size_in_felts(), 4);
+        assert_eq!(DebugPrimitiveType::U256.size_in_felts(), 4);
     }
 
     #[test]
     fn test_primitive_type_roundtrip() {
-        for discriminant in 0..=15 {
+        for discriminant in 0..=16 {
             let ty = DebugPrimitiveType::from_discriminant(discriminant).unwrap();
             assert_eq!(ty as u8, discriminant);
         }
-        assert!(DebugPrimitiveType::from_discriminant(16).is_none());
+        assert!(DebugPrimitiveType::from_discriminant(17).is_none());
     }
 }


### PR DESCRIPTION
In assembler, we did not support `U256` and `Enums` in `.debug_types`. This patch adds that.

This will need handling in debugger.