### PR TITLE
Clean up processor error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [BREAKING] `ProjectAssembler::assemble_with_sources` has been removed - projects require assembly from the filesystem going forward ([#3216](https://github.com/0xMiden/miden-vm/pull/3216))
 - [BREAKING] `miden-vm bundle` now treats the `--kernel` option as a flag; when set, it expects the file path given to `bundle` to be the path to the root module of the kernel, and the support library for the kernel is derived from explicit submodule declarations in that module.
 - [BREAKING] Moved debug info ownership out of `MastForest` and into package debug sections, adding source-node debug metadata that preserves distinct source occurrences after MAST node deduplication ([#3221](https://github.com/0xMiden/miden-vm/pull/3221)).
+- Cleaned up processor error handling for diagnostics, malformed MAST loading, and binary-value checks ([#3230](https://github.com/0xMiden/miden-vm/pull/3230)).
 
 #### Fixes
 

--- a/miden-vm/tests/integration/flow_control/mod.rs
+++ b/miden-vm/tests/integration/flow_control/mod.rs
@@ -2,7 +2,10 @@ use alloc::sync::Arc;
 
 use miden_assembly::{Assembler, DefaultSourceManager, PathBuf, Report, ast::ModuleKind};
 use miden_core_lib::CoreLibrary;
-use miden_processor::{ExecutionError, Word, operation::OperationError};
+use miden_processor::{
+    ExecutionError, Word,
+    operation::{BinaryValueErrorContext, OperationError},
+};
 use miden_utils_testing::{build_debug_test, build_test, expect_exec_error_matches, push_inputs};
 use miden_vm::Module;
 
@@ -69,7 +72,10 @@ fn faulty_condition_from_loop() {
     expect_exec_error_matches!(
         test,
         ExecutionError::OperationError {
-            err: OperationError::NotBinaryValueLoop { value: _ },
+            err: OperationError::NotBinaryValue {
+                context: BinaryValueErrorContext::Loop,
+                value: _,
+            },
             ..
         }
     );

--- a/miden-vm/tests/integration/flow_control/mod.rs
+++ b/miden-vm/tests/integration/flow_control/mod.rs
@@ -129,7 +129,7 @@ fn faulty_condition_from_tail_controlled_loop() {
     expect_exec_error_matches!(
         test,
         ExecutionError::OperationError {
-            err: OperationError::NotBinaryValueLoop { value: _ },
+            err: OperationError::NotBinaryValue { value: _, .. },
             ..
         }
     );

--- a/miden-vm/tests/integration/operations/field_ops.rs
+++ b/miden-vm/tests/integration/operations/field_ops.rs
@@ -544,7 +544,7 @@ fn not_fail() {
 
     expect_exec_error_matches!(
         test,
-        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value }, .. } if value == Felt::new_unchecked(2_u64)
+        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value, .. }, .. } if value == Felt::new_unchecked(2_u64)
     );
 }
 
@@ -572,19 +572,19 @@ fn and_fail() {
     let test = build_op_test!(asm_op, &[2, 3]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value }, .. } if value == Felt::new_unchecked(2_u64)
+        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value, .. }, .. } if value == Felt::new_unchecked(2_u64)
     );
 
     let test = build_op_test!(asm_op, &[0, 2]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value }, .. } if value == Felt::new_unchecked(2_u64)
+        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value, .. }, .. } if value == Felt::new_unchecked(2_u64)
     );
 
     let test = build_op_test!(asm_op, &[2, 0]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value }, .. } if value == Felt::new_unchecked(2_u64)
+        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value, .. }, .. } if value == Felt::new_unchecked(2_u64)
     );
 }
 
@@ -613,19 +613,19 @@ fn or_fail() {
     let test = build_op_test!(asm_op, &[2, 3]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value }, .. } if value == expected_value
+        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value, .. }, .. } if value == expected_value
     );
 
     let test = build_op_test!(asm_op, &[0, 2]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value }, .. } if value == expected_value
+        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value, .. }, .. } if value == expected_value
     );
 
     let test = build_op_test!(asm_op, &[2, 0]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value }, .. } if value == expected_value
+        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value, .. }, .. } if value == expected_value
     );
 }
 
@@ -656,21 +656,21 @@ fn xor_fail() {
     let test = build_op_test!(asm_op, &[3, 2]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value }, .. } if value == expected_value
+        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value, .. }, .. } if value == expected_value
     );
 
     // Stack [0, 2] - position 1 is 2, error for value 2
     let test = build_op_test!(asm_op, &[0, 2]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value }, .. } if value == expected_value
+        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value, .. }, .. } if value == expected_value
     );
 
     // Stack [2, 0] - position 1 is 0 (valid), position 0 is 2, error for value 2
     let test = build_op_test!(asm_op, &[2, 0]);
     expect_exec_error_matches!(
         test,
-        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value }, .. } if value == expected_value
+        ExecutionError::OperationError { err: OperationError::NotBinaryValue { value, .. }, .. } if value == expected_value
     );
 }
 

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -565,6 +565,19 @@ pub fn procedure_not_found_with_package_source_context(
     ExecutionError::ProcedureNotFound { label, source_file, root_digest }
 }
 
+/// Creates a `MalformedMastForestInHost` operation error with execution context.
+pub fn malformed_mast_forest_with_context(
+    root_digest: Word,
+    context: Option<PackageSourceDebugContext<'_>>,
+    host: &impl BaseHost,
+) -> ExecutionError {
+    let err = OperationError::MalformedMastForestInHost { root_digest };
+    match context {
+        Some(context) => err.with_package_source_context(context, host, None),
+        None => err.with_context(),
+    }
+}
+
 // CONSOLIDATED EXTENSION TRAITS (plafer's approach)
 // ================================================================================================
 //

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -214,10 +214,9 @@ pub enum MemoryError {
         "memory range start address cannot exceed end address, but was ({start_addr}, {end_addr})"
     )]
     InvalidMemoryRange { start_addr: u64, end_addr: u64 },
-    #[error("word access at memory address {addr} in context {ctx} is unaligned")]
-    #[diagnostic(help(
-        "ensure that the memory address accessed is aligned to a word boundary (it is a multiple of 4)"
-    ))]
+    #[error(
+        "word access at memory address {addr} in context {ctx} is unaligned: word accesses require addresses that are multiples of 4"
+    )]
     UnalignedWordAccess { addr: u32, ctx: ContextId },
     #[error("failed to read from memory: {0}")]
     MemoryReadFailed(String),
@@ -284,10 +283,7 @@ pub enum CryptoError {
 pub enum OperationError {
     #[error("external node with mast root {0} resolved to an external node")]
     CircularExternalNode(Word),
-    #[error("division by zero")]
-    #[diagnostic(help(
-        "ensure the divisor (second stack element) is non-zero before division or modulo operations"
-    ))]
+    #[error("division by zero: divisor must be non-zero for division or modulo operations")]
     DivideByZero,
     #[error(
         "assertion failed with error {}",
@@ -296,23 +292,17 @@ pub enum OperationError {
             None => format!("code: {err_code}"),
         }
     )]
-    #[diagnostic(help(
-        "assertions validate program invariants. Review the assertion condition and ensure all prerequisites are met"
-    ))]
     FailedAssertion {
         err_code: Felt,
         err_msg: Option<Arc<str>>,
     },
     #[error(
-        "u32 assertion failed with error {}: invalid values: {invalid_values:?}",
+        "u32 assertion failed: u32assert2 requires both stack values to be valid 32-bit unsigned integers; error {}; invalid values: {invalid_values:?}",
         match err_msg {
             Some(msg) => format!("message: {msg}"),
             None => format!("code: {err_code}"),
         }
     )]
-    #[diagnostic(help(
-        "u32assert2 requires both stack values to be valid 32-bit unsigned integers"
-    ))]
     U32AssertionFailed {
         err_code: Felt,
         err_msg: Option<Arc<str>>,
@@ -326,8 +316,7 @@ pub enum OperationError {
     InvalidMerklePathLength { path_len: usize, depth: Felt },
     #[error("when returning from a call, stack depth must be {MIN_STACK_DEPTH}, but was {depth}")]
     InvalidStackDepthOnReturn { depth: usize },
-    #[error("attempted to calculate integer logarithm with zero argument")]
-    #[diagnostic(help("ilog2 requires a non-zero argument"))]
+    #[error("ilog2 requires a non-zero argument")]
     LogArgumentZero,
     #[error(
         "MAST forest in host indexed by procedure root {root_digest} doesn't contain that root"
@@ -349,10 +338,9 @@ pub enum OperationError {
     NotBinaryValue { value: Felt },
     #[error("if statement expected a binary value on top of the stack, but got {value}")]
     NotBinaryValueIf { value: Felt },
-    #[error("loop condition must be a binary value, but got {value}")]
-    #[diagnostic(help(
-        "this could happen either when first entering the loop, or any subsequent iteration"
-    ))]
+    #[error(
+        "loop condition must be a binary value on entry and each subsequent iteration, but got {value}"
+    )]
     NotBinaryValueLoop { value: Felt },
     #[error("operation expected u32 values, but got values: {values:?}")]
     NotU32Values { values: Vec<Felt> },

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -334,20 +334,36 @@ pub enum OperationError {
     MerklePathVerificationFailed {
         inner: Box<MerklePathVerificationFailedInner>,
     },
-    #[error("operation expected a binary value, but got {value}")]
-    NotBinaryValue { value: Felt },
-    #[error("if statement expected a binary value on top of the stack, but got {value}")]
-    NotBinaryValueIf { value: Felt },
-    #[error(
-        "loop condition must be a binary value on entry and each subsequent iteration, but got {value}"
-    )]
-    NotBinaryValueLoop { value: Felt },
+    #[error("{message}, but got {value}", message = context.message())]
+    NotBinaryValue {
+        context: BinaryValueErrorContext,
+        value: Felt,
+    },
     #[error("operation expected u32 values, but got values: {values:?}")]
     NotU32Values { values: Vec<Felt> },
     #[error("syscall failed: procedure with root {proc_root} was not found in the kernel")]
     SyscallTargetNotInKernel { proc_root: Word },
     #[error("failed to execute the operation for internal reason: {0}")]
     Internal(&'static str),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryValueErrorContext {
+    Operation,
+    If,
+    Loop,
+}
+
+impl BinaryValueErrorContext {
+    const fn message(self) -> &'static str {
+        match self {
+            Self::Operation => "operation expected a binary value",
+            Self::If => "if statement expected a binary value on top of the stack",
+            Self::Loop => {
+                "loop condition must be a binary value on entry and each subsequent iteration"
+            },
+        }
+    }
 }
 
 impl OperationError {

--- a/processor/src/execution/loop.rs
+++ b/processor/src/execution/loop.rs
@@ -5,7 +5,7 @@ use crate::{
     continuation_stack::Continuation,
     execution::{ExecutionState, finalize_clock_cycle, finalize_clock_cycle_with_continuation},
     mast::{ExecutableMastForest, LoopNode, MastNodeId},
-    operation::OperationError,
+    operation::{BinaryValueErrorContext, OperationError},
     option_map_break_reason,
     processor::{Processor, StackInterface},
     tracer::Tracer,
@@ -193,7 +193,10 @@ where
             current_forest,
         )
     } else {
-        let err = OperationError::NotBinaryValueLoop { value: condition };
+        let err = OperationError::NotBinaryValue {
+            context: BinaryValueErrorContext::Loop,
+            value: condition,
+        };
         ControlFlow::Break(BreakReason::Err(state.operation_error_with_current_context(err)))
     }
 }
@@ -270,7 +273,10 @@ where
             current_forest,
         )
     } else {
-        let err = OperationError::NotBinaryValueLoop { value: condition };
+        let err = OperationError::NotBinaryValue {
+            context: BinaryValueErrorContext::Loop,
+            value: condition,
+        };
         ControlFlow::Break(BreakReason::Err(state.operation_error_with_current_context(err)))
     }
 }

--- a/processor/src/execution/operations/field_ops/mod.rs
+++ b/processor/src/execution/operations/field_ops/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     Felt, ONE, ZERO,
     field::Field,
-    operation::OperationError,
+    operation::{BinaryValueErrorContext, OperationError},
     processor::{Processor, StackInterface},
     tracer::OperationHelperRegisters,
 };
@@ -122,7 +122,10 @@ pub(super) fn op_not<P: Processor>(
     } else if *top == ONE {
         *top = ZERO;
     } else {
-        return Err(OperationError::NotBinaryValue { value: *top });
+        return Err(OperationError::NotBinaryValue {
+            context: BinaryValueErrorContext::Operation,
+            value: *top,
+        });
     }
     Ok(OperationHelperRegisters::Empty)
 }
@@ -288,7 +291,10 @@ where
 #[inline(always)]
 fn assert_binary(value: Felt) -> Result<(), OperationError> {
     if value != ZERO && value != ONE {
-        Err(OperationError::NotBinaryValue { value })
+        Err(OperationError::NotBinaryValue {
+            context: BinaryValueErrorContext::Operation,
+            value,
+        })
     } else {
         Ok(())
     }

--- a/processor/src/execution/operations/stack_ops/mod.rs
+++ b/processor/src/execution/operations/stack_ops/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     ExecutionError, Felt, ZERO,
-    operation::OperationError,
+    operation::{BinaryValueErrorContext, OperationError},
     processor::{Processor, StackInterface},
     tracer::OperationHelperRegisters,
 };
@@ -96,7 +96,10 @@ where
             processor.stack_mut().swap(0, 1);
         },
         _ => {
-            return Err(OperationError::NotBinaryValue { value: condition });
+            return Err(OperationError::NotBinaryValue {
+                context: BinaryValueErrorContext::Operation,
+                value: condition,
+            });
         },
     }
 
@@ -127,7 +130,10 @@ where
             processor.stack_mut().swap(3, 7);
         },
         _ => {
-            return Err(OperationError::NotBinaryValue { value: condition });
+            return Err(OperationError::NotBinaryValue {
+                context: BinaryValueErrorContext::Operation,
+                value: condition,
+            });
         },
     }
 

--- a/processor/src/execution/split.rs
+++ b/processor/src/execution/split.rs
@@ -5,7 +5,7 @@ use crate::{
     continuation_stack::Continuation,
     execution::{ExecutionState, finalize_clock_cycle, finalize_clock_cycle_with_continuation},
     mast::{ExecutableMastForest, MastNodeId, SplitNode},
-    operation::OperationError,
+    operation::{BinaryValueErrorContext, OperationError},
     processor::{Processor, StackInterface},
     tracer::Tracer,
 };
@@ -70,7 +70,10 @@ where
             source_node_id,
         );
     } else {
-        let err = OperationError::NotBinaryValueIf { value: condition };
+        let err = OperationError::NotBinaryValue {
+            context: BinaryValueErrorContext::If,
+            value: condition,
+        };
         return ControlFlow::Break(BreakReason::Err(
             state.operation_error_with_current_context(err),
         ));
@@ -123,7 +126,10 @@ where
         state.continuation_stack.push_finish_split(node_id);
         state.continuation_stack.push_start_node(split_node.on_false());
     } else {
-        let err = OperationError::NotBinaryValueIf { value: condition };
+        let err = OperationError::NotBinaryValue {
+            context: BinaryValueErrorContext::If,
+            value: condition,
+        };
         return ControlFlow::Break(BreakReason::Err(
             state.operation_error_with_current_context(err),
         ));

--- a/processor/src/fast/execution_api.rs
+++ b/processor/src/fast/execution_api.rs
@@ -19,7 +19,9 @@ use super::{
 use crate::{
     ExecutionError, ExecutionOutput, Host, LoadedMastForest, Stopper, SyncHost, TraceBuildInputs,
     continuation_stack::ContinuationStack,
-    errors::{MapExecErr, MapExecErrNoCtx, OperationError, PackageSourceDebugContext},
+    errors::{
+        MapExecErr, MapExecErrNoCtx, PackageSourceDebugContext, malformed_mast_forest_with_context,
+    },
     execution::{
         InternalBreakReason, execute_impl, finish_emit_op_execution,
         finish_load_mast_forest_from_dyn_start, finish_load_mast_forest_from_external,
@@ -1004,15 +1006,13 @@ impl FastProcessor {
         let mast_forest = loaded_mast_forest.mast_forest().clone();
 
         let root_id = mast_forest.find_procedure_root(node_digest).ok_or_else(|| {
-            let err = OperationError::MalformedMastForestInHost { root_digest: node_digest };
-            match (package_debug_info, source_node_id) {
-                (Some(debug_info), Some(source_node_id)) => err.with_package_source_context(
-                    PackageSourceDebugContext::new(debug_info, source_node_id),
-                    host,
-                    None,
-                ),
-                _ => Err::<(), _>(err).map_exec_err().unwrap_err(),
-            }
+            let context = match (package_debug_info, source_node_id) {
+                (Some(debug_info), Some(source_node_id)) => {
+                    Some(PackageSourceDebugContext::new(debug_info, source_node_id))
+                },
+                _ => None,
+            };
+            malformed_mast_forest_with_context(node_digest, context, host)
         })?;
 
         self.advice.extend_map(mast_forest.advice_map()).map_exec_err()?;
@@ -1060,15 +1060,13 @@ impl FastProcessor {
         let mast_forest = loaded_mast_forest.mast_forest().clone();
 
         let root_id = mast_forest.find_procedure_root(node_digest).ok_or_else(|| {
-            let err = OperationError::MalformedMastForestInHost { root_digest: node_digest };
-            match (package_debug_info, source_node_id) {
-                (Some(debug_info), Some(source_node_id)) => err.with_package_source_context(
-                    PackageSourceDebugContext::new(debug_info, source_node_id),
-                    host,
-                    None,
-                ),
-                _ => Err::<(), _>(err).map_exec_err().unwrap_err(),
-            }
+            let context = match (package_debug_info, source_node_id) {
+                (Some(debug_info), Some(source_node_id)) => {
+                    Some(PackageSourceDebugContext::new(debug_info, source_node_id))
+                },
+                _ => None,
+            };
+            malformed_mast_forest_with_context(node_digest, context, host)
         })?;
 
         self.advice.extend_map(mast_forest.advice_map()).map_exec_err()?;

--- a/processor/src/fast/tests/memory.rs
+++ b/processor/src/fast/tests/memory.rs
@@ -18,7 +18,10 @@ fn test_memory_word_access_alignment() {
         let err = FastProcessor::new(StackInputs::new(&[Felt::from_u32(43)]).unwrap())
             .execute_sync(&program, &mut host)
             .unwrap_err();
-        assert_eq!(err.to_string(), "word access at memory address 43 in context 0 is unaligned");
+        assert_eq!(
+            err.to_string(),
+            "word access at memory address 43 in context 0 is unaligned: word accesses require addresses that are multiples of 4"
+        );
     }
 
     // mstorew
@@ -34,7 +37,10 @@ fn test_memory_word_access_alignment() {
         let err = FastProcessor::new(StackInputs::new(&[Felt::from_u32(43)]).unwrap())
             .execute_sync(&program, &mut host)
             .unwrap_err();
-        assert_eq!(err.to_string(), "word access at memory address 43 in context 0 is unaligned");
+        assert_eq!(
+            err.to_string(),
+            "word access at memory address 43 in context 0 is unaligned: word accesses require addresses that are multiples of 4"
+        );
     }
 }
 

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_03_vec__Felt__from_u32_1__Felt__from_u32_2____operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_03_vec__Felt__from_u32_1__Felt__from_u32_2____operations_09_vec__Operation__And_.snap
@@ -18,6 +18,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_03_vec__Felt__from_u32_1__Felt__from_u32_2____operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_03_vec__Felt__from_u32_1__Felt__from_u32_2____operations_10_vec__Operation__Or_.snap
@@ -18,6 +18,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_04_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3____operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_04_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3____operations_09_vec__Operation__And_.snap
@@ -18,6 +18,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_04_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3____operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_04_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3____operations_10_vec__Operation__Or_.snap
@@ -18,6 +18,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_05_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_05_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -18,6 +18,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_05_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_05_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_06_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_06_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_06_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_06_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_07_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_07_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_07_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_07_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_08_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_08_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_08_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_08_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_09_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_09_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_09_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_09_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_10_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_10_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_10_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_10_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_11_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_11_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_11_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_11_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_12_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_12_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_12_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_12_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_13_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_13_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_13_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_13_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_14_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_14_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_14_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_14_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_15_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_15_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_15_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_15_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_16_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_16_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_16_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_16_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_17_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_17_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_09_vec__Operation__And_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_17_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__all_ops__fast__tests__all_ops__test_basic_block__stack_inputs_17_vec__Felt__from_u32_1__Felt__from_u32_2__Felt__from_u32_3__Felt___operations_10_vec__Operation__Or_.snap
@@ -17,6 +17,7 @@ Err(
         },
         source_file: None,
         err: NotBinaryValue {
+            context: Operation,
             value: 2,
         },
     },

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__masm_consistency__fast__tests__masm_consistency__test_masm_errors_consistency__case_1.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__masm_consistency__fast__tests__masm_consistency__test_masm_errors_consistency__case_1.snap
@@ -15,7 +15,8 @@ OperationError {
         ),
     },
     source_file: None,
-    err: NotBinaryValueIf {
+    err: NotBinaryValue {
+        context: If,
         value: 2,
     },
 }

--- a/processor/src/fast/tests/snapshots/miden_processor__fast__tests__masm_consistency__fast__tests__masm_consistency__test_masm_errors_consistency__case_2.snap
+++ b/processor/src/fast/tests/snapshots/miden_processor__fast__tests__masm_consistency__fast__tests__masm_consistency__test_masm_errors_consistency__case_2.snap
@@ -16,7 +16,8 @@ OperationError {
         ),
     },
     source_file: None,
-    err: NotBinaryValueLoop {
+    err: NotBinaryValue {
+        context: Loop,
         value: 100,
     },
 }

--- a/processor/src/host/advice/errors.rs
+++ b/processor/src/host/advice/errors.rs
@@ -9,10 +9,10 @@ use crate::{Felt, Word, crypto::merkle::MerkleError};
 
 #[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum AdviceError {
-    #[error("value for key {} already present in the advice map", key.to_hex())]
-    #[diagnostic(help(
-        "previous values at key were '{prev_values:?}'. Operation would have replaced them with '{new_values:?}'",
-    ))]
+    #[error(
+        "value for key {} already present in the advice map: previous values were '{prev_values:?}', attempted replacement values were '{new_values:?}'",
+        key.to_hex()
+    )]
     MapKeyAlreadyPresent {
         key: Word,
         prev_values: Vec<Felt>,

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -90,7 +90,7 @@ pub mod event {
 pub mod operation {
     pub use miden_core::operations::*;
 
-    pub use crate::errors::OperationError;
+    pub use crate::errors::{BinaryValueErrorContext, OperationError};
 }
 
 pub mod trace;

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -154,8 +154,7 @@ fn test_diagnostic_advice_map_key_already_present() {
     assert_diagnostic_lines!(
         err,
         "advice provider error at clock cycle",
-        "x value for key 0x0000000000000000000000000000000000000000000000000000000000000000 already present in the advice map",
-        "help: previous values at key were '[0]'. Operation would have replaced them with '[1]'"
+        "x value for key 0x0000000000000000000000000000000000000000000000000000000000000000 already present in the advice map: previous values were '[0]', attempted replacement values were '[1]'"
     );
 }
 
@@ -272,14 +271,13 @@ fn test_diagnostic_host_event_advice_error_uses_emit_location() {
     #[rustfmt::skip]
     assert_diagnostic_lines!(
         err,
-        "  x value for key 0x0000000000000000000000000000000000000000000000000000000000000000 already present in the advice map",
+        "  x value for key 0x0000000000000000000000000000000000000000000000000000000000000000 already present in the advice map: previous values were '[0]', attempted replacement values were '[1]'",
         regex!(r#",-\[.*:3:20\]"#),
         " 2 |         begin",
       r#" 3 |             push.1 emit.event("test::host_event_advice_error")"#,
         "   :                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
         " 4 |         end",
-        "   `----",
-        "help: previous values at key were '[0]'. Operation would have replaced them with '[1]'"
+        "   `----"
     );
 }
 
@@ -321,14 +319,13 @@ fn test_diagnostic_divide_by_zero_1() {
     let err = build_test.execute().expect_err("expected error");
     assert_diagnostic_lines!(
         err,
-        "  x division by zero",
+        "  x division by zero: divisor must be non-zero for division or modulo operations",
         regex!(r#",-\[test[\d]+:3:13\]"#),
         " 2 |         begin",
         " 3 |             div",
         "   :             ^^^",
         " 4 |         end",
-        "   `----",
-        "  help: ensure the divisor (second stack element) is non-zero before division or modulo operations"
+        "   `----"
     );
 }
 
@@ -343,14 +340,13 @@ fn test_diagnostic_divide_by_zero_2() {
     let err = build_test.execute().expect_err("expected error");
     assert_diagnostic_lines!(
         err,
-        "  x division by zero",
+        "  x division by zero: divisor must be non-zero for division or modulo operations",
         regex!(r#",-\[test[\d]+:3:13\]"#),
         " 2 |         begin",
         " 3 |             u32div",
         "   :             ^^^^^^",
         " 4 |         end",
-        "   `----",
-        "  help: ensure the divisor (second stack element) is non-zero before division or modulo operations"
+        "   `----"
     );
 }
 
@@ -422,8 +418,7 @@ fn test_diagnostic_failed_assertion() {
         " 4 |             assertz",
         "   :             ^^^^^^^",
         " 5 |             push.3.4",
-        "   `----",
-        "  help: assertions validate program invariants. Review the assertion condition and ensure all prerequisites are met"
+        "   `----"
     );
 
     // With error message
@@ -452,8 +447,7 @@ fn test_diagnostic_failed_assertion() {
         r#" 4 |             assertz.err="some error message""#,
         "   :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
         " 5 |             push.3.4",
-        "   `----",
-        "  help: assertions validate program invariants. Review the assertion condition and ensure all prerequisites are met"
+        "   `----"
     );
 
     // With error message as constant
@@ -475,8 +469,7 @@ fn test_diagnostic_failed_assertion() {
         " 5 |             assertz.err=ERR_MSG",
         "   :             ^^^^^^^^^^^^^^^^^^^",
         " 6 |             push.3.4",
-        "   `----",
-        "  help: assertions validate program invariants. Review the assertion condition and ensure all prerequisites are met"
+        "   `----"
     );
 }
 
@@ -698,14 +691,13 @@ fn test_diagnostic_log_argument_zero() {
     let err = build_test.execute().expect_err("expected error");
     assert_diagnostic_lines!(
         err,
-        "  x attempted to calculate integer logarithm with zero argument",
+        "  x ilog2 requires a non-zero argument",
         regex!(r#",-\[test[\d]+:3:13\]"#),
         " 2 |         begin",
         " 3 |             ilog2",
         "   :             ^^^^^",
         " 4 |         end",
-        "   `----",
-        "  help: ilog2 requires a non-zero argument"
+        "   `----"
     );
 }
 
@@ -726,14 +718,13 @@ fn test_diagnostic_unaligned_word_access() {
 
     assert_diagnostic_lines!(
         err,
-        "word access at memory address 3 in context 0 is unaligned",
+        "word access at memory address 3 in context 0 is unaligned: word accesses require addresses that are multiples of 4",
         regex!(r#",-\[test[\d]+:4:22\]"#),
         " 3 |         begin",
         " 4 |             exec.foo mem_storew_be.3",
         "   :                      ^^^^^^^^^^^^^^^",
         " 5 |         end",
-        "   `----",
-        "help: ensure that the memory address accessed is aligned to a word boundary (it is a multiple of 4)"
+        "   `----"
     );
 
     // mem_loadw_be
@@ -747,14 +738,13 @@ fn test_diagnostic_unaligned_word_access() {
 
     assert_diagnostic_lines!(
         err,
-        "word access at memory address 3 in context 0 is unaligned",
+        "word access at memory address 3 in context 0 is unaligned: word accesses require addresses that are multiples of 4",
         regex!(r#",-\[test[\d]+:3:13\]"#),
         " 2 |         begin",
         " 3 |             mem_loadw_be.3",
         "   :             ^^^^^^^^^^^^^^",
         " 4 |         end",
-        "   `----",
-        "help: ensure that the memory address accessed is aligned to a word boundary (it is a multiple of 4)"
+        "   `----"
     );
 }
 
@@ -1379,8 +1369,7 @@ fn test_assert_message_without_debug_info_reports_error_code() {
         format!(
             "  x assertion failed with error code: {}",
             error_code_from_msg("Value is not zero")
-        ),
-        "  help: assertions validate program invariants. Review the assertion condition and ensure all prerequisites are met"
+        )
     );
 
     let diagnostic = format!(

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -1216,8 +1216,8 @@ fn test_diagnostic_not_binary_value_loop_node() {
     // The entry-check error originates from the SPLIT that the assembler wraps around the LOOP
     // when desugaring `while.true`, so the message reads "if statement". The source pointer is
     // still the `while.true` token because the SPLIT carries that asm_op. The iteration-check
-    // (REPEAT/END) still produces a `NotBinaryValueLoop` error — see masm_errors_consistency
-    // case_2 for that path.
+    // (REPEAT/END) still produces a loop-context `NotBinaryValue` error — see
+    // masm_errors_consistency case_2 for that path.
     assert_diagnostic_lines!(
         err,
         "  x if statement expected a binary value on top of the stack, but got 2",

--- a/processor/src/tests/mod.rs
+++ b/processor/src/tests/mod.rs
@@ -9,12 +9,13 @@ use miden_core::{
     crypto::merkle::{MerkleStore, MerkleTree},
     mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, error_code_from_msg},
 };
-use miden_debug_types::SourceManager;
+use miden_debug_types::{Location, SourceFile, SourceManager, SourceSpan};
 use miden_utils_testing::crypto::{init_merkle_leaves, init_merkle_store};
 
 /// Tests in this file make sure that diagnostics presented to the user are as expected.
 use crate::{
-    DefaultHost, FastProcessor, Kernel, ONE, ProcessorState, Program, StackInputs, Word, ZERO,
+    BaseHost, DefaultHost, FastProcessor, Kernel, LoadedMastForest, ONE, ProcessorState, Program,
+    StackInputs, SyncHost, Word, ZERO,
     advice::{AdviceInputs, AdviceMap, AdviceMutation},
     event::{EventError, EventHandler, EventName},
     operation::Operation,
@@ -88,6 +89,32 @@ macro_rules! build_test_by_mode {
     ($mode:expr, $source:expr, $($tail:tt)+) => {{
         miden_utils_testing::build_test_by_mode!($mode, $source, $($tail)+)
     }};
+}
+
+struct MalformedMastForestHost {
+    source_manager: Arc<DefaultSourceManager>,
+    mast_forest: Arc<MastForest>,
+}
+
+impl BaseHost for MalformedMastForestHost {
+    fn get_label_and_source_file(
+        &self,
+        location: &Location,
+    ) -> (SourceSpan, Option<Arc<SourceFile>>) {
+        let maybe_file = self.source_manager.get_by_uri(location.uri());
+        let span = self.source_manager.location_to_span(location.clone()).unwrap_or_default();
+        (span, maybe_file)
+    }
+}
+
+impl SyncHost for MalformedMastForestHost {
+    fn get_mast_forest(&self, _node_digest: &Word) -> Option<LoadedMastForest> {
+        Some(LoadedMastForest::new(self.mast_forest.clone()))
+    }
+
+    fn on_event(&mut self, _process: &ProcessorState) -> Result<Vec<AdviceMutation>, EventError> {
+        Ok(Vec::new())
+    }
 }
 
 // AdviceMap inlined in the script
@@ -1107,6 +1134,49 @@ fn test_diagnostic_procedure_not_found_split() {
         " 10 | `->             end",
         " 11 |             end",
         "    `----"
+    );
+}
+
+#[test]
+fn test_diagnostic_malformed_mast_forest_in_host() {
+    let source_manager = Arc::new(DefaultSourceManager::default());
+    let package = Assembler::new(source_manager.clone())
+        .assemble_program(
+            "program",
+            "
+            begin
+                dyncall
+            end",
+        )
+        .unwrap();
+    let debug_info = package.debug_info().unwrap().unwrap();
+    let program = package.unwrap_program();
+
+    let mut malformed_forest = MastForest::new();
+    let unexpected_root = BasicBlockNodeBuilder::new(vec![Operation::Noop])
+        .add_to_forest(&mut malformed_forest)
+        .unwrap();
+    malformed_forest.make_root(unexpected_root);
+
+    let mut host = MalformedMastForestHost {
+        source_manager,
+        mast_forest: malformed_forest.into(),
+    };
+
+    let processor = FastProcessor::new(StackInputs::default());
+    let err = processor
+        .execute_with_package_debug_info_sync(&program, &debug_info, &mut host)
+        .unwrap_err();
+
+    assert_diagnostic_lines!(
+        err,
+        "  x MAST forest in host indexed by procedure root 0x0000000000000000000000000000000000000000000000000000000000000000 doesn't contain that root",
+        regex!(r#",-\[.*:3:17\]"#),
+        " 2 |             begin",
+        " 3 |                 dyncall",
+        "   :                 ^^^^^^^",
+        " 4 |             end",
+        "   `----"
     );
 }
 


### PR DESCRIPTION
This cleans up the remaining error handling follow-ups from #2575.

- The diagnostic help item is fixed by moving the useful help text into the main error messages.

- The malformed MAST item is fixed by giving the `load_mast_forest` error path a named helper and adding diagnostic coverage for the missing-root case.

- The binary-value item is fixed by replacing `NotBinaryValue`, `NotBinaryValueIf`, and `NotBinaryValueLoop` with one `NotBinaryValue` error that carries its context.

Closes #2575 