### PR TITLE
fix: Reject empty FRI query regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 #### Fixes
 
+- Rejected empty query regions in the standalone FRI verifier ([#3237](https://github.com/0xMiden/miden-vm/pull/3237)).
 - Replaced `bincode` proof serialization with `wincode` and bounded verifier-side STARK proof deserialization to 64 MiB ([#3148](https://github.com/0xMiden/miden-vm/pull/3148)).
 - [BREAKING] Replaced the Poseidon2 sponge precompile transcript with a 2-to-1 hash folding scheme; the rolling state is itself a complete digest at every step, removing `finalize()` and `PrecompileTranscriptDigest`. The `log_precompile` opcode is reshaped accordingly (helper/stack rename, STMNT placed at stack[4..8]) and the MASM `log_precompile_request` wrapper now computes STMNT via `hmerge`. RELATION_DIGEST bumped ([#3100](https://github.com/0xMiden/miden-vm/pull/3100)).
 - Preserved `AssemblyOp` source mappings when merging `MastForest`s, preventing source-location loss after node deduplication ([#2958](https://github.com/0xMiden/miden-vm/pull/2958)).

--- a/crates/lib/core/asm/pcs/fri/frie2f4.masm
+++ b/crates/lib/core/asm/pcs/fri/frie2f4.masm
@@ -510,6 +510,7 @@ pub proc verify
     exec.constants::get_fri_queries_address
     # => [query_ptr, fri_layer_ptr, remainder_poly_ptr, g, ...]
 
+    dup dup.2 u32assert2 u32lt assert.err="fri query region must be non-empty"
 
     exec.constants::get_remainder_poly_size
     exec.helper::get_fri_remainder_poly_max_degree_plus_1_half

--- a/crates/lib/core/tests/pcs/fri/mod.rs
+++ b/crates/lib/core/tests/pcs/fri/mod.rs
@@ -9,6 +9,25 @@ use miden_core::Word;
 pub use verifier_fri_e2f4::*;
 
 #[test]
+fn fri_verify_rejects_empty_query_region() {
+    let source = "
+        use miden::core::pcs::fri::frie2f4
+        use miden::core::stark::constants
+
+        begin
+            push.1 exec.constants::set_lde_domain_generator
+            push.64 exec.constants::set_remainder_poly_size
+            push.4294912800 exec.constants::set_remainder_poly_address
+            push.4294912800 exec.constants::set_fri_queries_address
+            exec.frie2f4::verify
+        end
+        ";
+
+    let test = build_test!(source, &[]);
+    expect_assert_error_message!(test, contains "fri query region must be non-empty");
+}
+
+#[test]
 fn fri_fold4_ext2_remainder64() {
     let source = "
         use miden::core::pcs::fri::frie2f4


### PR DESCRIPTION
`frie2f4::verify` accepts an empty query region when the query pointer equals the first FRI layer pointer. In that case, the verifier can skip all query checks.

This rejects empty query regions before verifier dispatch by requiring `query_ptr < fri_layer_ptr`.

Closes https://github.com/0xMiden/security-issues/issues/27