### PR TITLE
chore: gate proptest rand dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Removed the legacy LALRPOP parser backend
 - [BREAKING] Cleaned up `Processor` trait by moving methods into their corresponding sub-interface ([#3202](https://github.com/0xMiden/miden-vm/pull/3202)).
 - [BREAKING] Update `miden-crypto` and `miden-lifted-stark` dependencies to v0.26 ([#3228](https://github.com/0xMiden/miden-vm/pull/3228)).
+- Moved `proptest` test support behind optional features so `rand` 0.9 is not in the default dependency tree ([#3241](https://github.com/0xMiden/miden-vm/pull/3241)).
 - Bounded `FastProcessor` memory growth with a configurable `ExecutionOptions::max_memory_elements` limit, rejecting writes to arbitrarily many unique addresses that could otherwise exhaust host memory ([#3226](https://github.com/0xMiden/miden-vm/pull/3226)).
 - [BREAKING] Simplified `MastForestBuilder` around builder-local refs and immutable finalized `MastForest`s ([#3139](https://github.com/0xMiden/miden-vm/pull/3139)).
 - Added `do <block> while <cond> end` syntax ([#3232](https://github.com/0xMiden/miden-vm/pull/3232)).

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,13 @@ FEATURES_air             := testing
 FEATURES_assembly        := testing
 FEATURES_assembly-syntax := testing,serde
 FEATURES_core            :=
-FEATURES_vm              := concurrent,executable,internal
+FEATURES_vm              := concurrent,executable,internal,testing
 FEATURES_mast-package    := serde
 FEATURES_processor       := concurrent,testing,bus-debugger
 FEATURES_project         := resolver,serde
 FEATURES_package-registry:= resolver
 FEATURES_prover          := concurrent
-FEATURES_core-lib        :=
+FEATURES_core-lib        := testing
 FEATURES_verifier        :=
 
 # -- linting --------------------------------------------------------------------------------------

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -22,7 +22,7 @@ std = [
     "miden-debug-types/std",
     "miden-utils-diagnostics/std",
     "thiserror/std",
-    "proptest/std",
+    "proptest?/std",
 ]
 serde = [
     "dep:serde",

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -27,7 +27,9 @@ path = "tests/main.rs"
 
 [features]
 default = ["std"]
+arbitrary = ["std", "miden-assembly/testing", "miden-utils-testing/arbitrary"]
 std = ["miden-assembly/std", "miden-processor/std", "miden-utils-sync/std"]
+testing = ["arbitrary"]
 constraints-tools = ["std", "dep:miden-air", "dep:miden-ace-codegen"]
 
 [dependencies]

--- a/crates/lib/core/tests/crypto/falcon.rs
+++ b/crates/lib/core/tests/crypto/falcon.rs
@@ -10,12 +10,14 @@ use miden_core::{
 };
 use miden_core_lib::{CoreLibrary, dsa::falcon512_poseidon2};
 use miden_processor::{
-    DefaultHost, ExecutionError, FastProcessor, ProcessorState, Program, StackInputs,
+    DefaultHost, ExecutionError, FastProcessor, ProcessorState, Program,
     advice::{AdviceInputs, AdviceMutation},
     crypto::random::RandomCoin,
     event::EventError,
     operation::OperationError,
 };
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::proptest::proptest;
 use miden_utils_testing::{
     AdviceStackBuilder, Word,
     crypto::{
@@ -23,8 +25,8 @@ use miden_utils_testing::{
         falcon512_poseidon2::{Polynomial, SecretKey},
     },
     expect_exec_error_matches,
-    proptest::proptest,
     rand::random_word,
+    stack_inputs_from_ints,
 };
 use rand::{Rng, RngExt, SeedableRng, rng};
 use rand_chacha::ChaCha20Rng;
@@ -163,6 +165,7 @@ fn test_falcon512_diff_mod_m() {
     test2.expect_stack(&[simplified_answer as u64]);
 }
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn diff_mod_m_proptest(v in 0..Felt::ORDER_U64, w in 0..J, u in 0..J) {
@@ -508,7 +511,7 @@ fn falcon_prove_verify() {
         .expect("failed to compile test source")
         .unwrap_program();
 
-    let stack_inputs = StackInputs::try_from_ints(op_stack).expect("failed to create stack inputs");
+    let stack_inputs = stack_inputs_from_ints(op_stack);
     let advice_inputs = AdviceInputs::default().with_map(advice_map);
     let mut host = DefaultHost::default();
     host.load_library(&CoreLibrary::default()).expect("failed to load mast forest");

--- a/crates/lib/core/tests/crypto/mod.rs
+++ b/crates/lib/core/tests/crypto/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "std")]
 mod falcon;
 
 mod aead;

--- a/crates/lib/core/tests/math/u128_mod.rs
+++ b/crates/lib/core/tests/math/u128_mod.rs
@@ -1,4 +1,5 @@
 use miden_core::Felt;
+#[cfg(feature = "arbitrary")]
 use miden_utils_testing::proptest::prelude::*;
 
 // =================================================================================================
@@ -212,6 +213,7 @@ fn edge_case_stack_preservation() {
 // PROPERTY-BASED TESTS
 // =================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn overflowing_add(a in any::<u128>(), b in any::<u128>()) {
@@ -371,6 +373,7 @@ fn split_u128(value: u128) -> (u64, u64, u64, u64) {
 // COMPARISON TESTS
 // =================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn test_eq(a in any::<u128>(), b in any::<u128>()) {
@@ -495,6 +498,7 @@ proptest! {
 // BITWISE TESTS
 // =================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn test_and(a in any::<u128>(), b in any::<u128>()) {
@@ -572,6 +576,7 @@ proptest! {
 // SHIFT TESTS
 // =================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn test_shl(a in any::<u128>(), n in 0u32..128u32) {
@@ -642,6 +647,7 @@ proptest! {
 // MIN/MAX TESTS
 // =================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn test_min(a in any::<u128>(), b in any::<u128>()) {
@@ -684,6 +690,7 @@ proptest! {
 // BIT-COUNTING TESTS
 // =================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn test_clz(a in any::<u128>()) {
@@ -1328,6 +1335,7 @@ fn mod_simple() {
 
 /// Strategy that generates u128 values biased toward limb boundaries.
 /// Mixes uniform random with values near 0, u32::MAX, u64::MAX, u96::MAX, and u128::MAX.
+#[cfg(feature = "arbitrary")]
 fn u128_with_limb_boundaries() -> impl Strategy<Value = u128> {
     prop_oneof![
         3 => any::<u128>(),                                   // uniform random
@@ -1339,6 +1347,7 @@ fn u128_with_limb_boundaries() -> impl Strategy<Value = u128> {
     ]
 }
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(512))]
 

--- a/crates/lib/core/tests/math/u256_mod.rs
+++ b/crates/lib/core/tests/math/u256_mod.rs
@@ -1,5 +1,6 @@
 use core::ops::{BitAnd, BitOr, BitXor, Not};
 
+#[cfg(feature = "arbitrary")]
 use miden_utils_testing::proptest::prelude::*;
 
 // MULTIPLICATION
@@ -645,6 +646,7 @@ fn shift_panics_on_non_u32_amount() {
     }
 }
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn wrapping_mul_proptest(
@@ -1504,6 +1506,7 @@ fn regression_pairs() -> Vec<(U256, U256)> {
 /// Strategy that mixes 32-bit boundary values with uniformly random ones. Each variant has equal
 /// probability of being sampled; the boundary cases stress carry/borrow handling and the sign-bit
 /// position within a limb.
+#[cfg(feature = "arbitrary")]
 fn boundary_biased_u32() -> impl Strategy<Value = u32> {
     prop_oneof![
         Just(0u32),
@@ -1577,6 +1580,7 @@ fn assert_divmod(a: U256, b: U256) {
     build_test!(&source, &operands).execute().unwrap();
 }
 
+#[cfg(feature = "arbitrary")]
 fn assert_div(a: U256, b: U256) {
     let (q, _) = a.divmod(b);
     let q_limbs = q.to_le_limbs();
@@ -1593,6 +1597,7 @@ fn assert_div(a: U256, b: U256) {
     build_test!(&source, &operands).execute().unwrap();
 }
 
+#[cfg(feature = "arbitrary")]
 fn assert_mod(a: U256, b: U256) {
     let (_, r) = a.divmod(b);
     let r_limbs = r.to_le_limbs();

--- a/crates/lib/core/tests/math/u64_mod.rs
+++ b/crates/lib/core/tests/math/u64_mod.rs
@@ -1,11 +1,13 @@
+#[cfg(feature = "arbitrary")]
 use core::cmp;
 
 use miden_core::assert_matches;
 use miden_core_lib::handlers::u64_div::{U64_DIV_EVENT_NAME, U64DivError};
 use miden_processor::{ExecutionError, operation::OperationError};
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::proptest::prelude::*;
 use miden_utils_testing::{
-    Felt, PrimeField64, U32_BOUND, expect_exec_error_matches, proptest::prelude::*,
-    rand::rand_value, stack,
+    Felt, PrimeField64, U32_BOUND, expect_exec_error_matches, rand::rand_value, stack,
 };
 
 #[test]
@@ -1410,6 +1412,7 @@ fn u32clz_nonzero_boundary_regression() {
     build_test!(source, &stack![1], &[32]).expect_stack(&[31]);
 }
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn u32clz_matches_rust_leading_zeros(n in any::<u32>()) {
@@ -1499,6 +1502,7 @@ fn cto() {
 // RANDOMIZED TESTS
 // ================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn unchecked_lt_proptest(a in any::<u64>(), b in any::<u64>()) {
@@ -1768,6 +1772,7 @@ proptest! {
 /// Strategy that mixes boundary u64 values with uniformly random ones. Each variant has equal
 /// probability of being sampled; the boundary cases stress 32-bit limb edges where carry handling
 /// is most likely to fail.
+#[cfg(feature = "arbitrary")]
 fn boundary_biased_u64() -> impl Strategy<Value = u64> {
     prop_oneof![
         Just(0u64),
@@ -1786,6 +1791,7 @@ fn boundary_biased_u64() -> impl Strategy<Value = u64> {
 
 /// Strategy for shift amounts in [0, 64) biased toward the values that exercise control-flow
 /// boundaries in shr/rotl/rotr (32-bit limb edge, the no-op case, and the maximum).
+#[cfg(feature = "arbitrary")]
 fn boundary_biased_shift() -> impl Strategy<Value = u32> {
     prop_oneof![
         Just(0u32),

--- a/crates/lib/core/tests/stark/mod.rs
+++ b/crates/lib/core/tests/stark/mod.rs
@@ -1,7 +1,7 @@
 use std::{array, sync::Arc};
 
 use miden_air::PublicInputs;
-use miden_assembly::Assembler;
+use miden_assembly::{Assembler, DefaultSourceManager};
 use miden_core::{
     Felt, WORD_SIZE,
     field::{BasedVectorSpace, Field, PrimeCharacteristicRing, QuadFelt},
@@ -11,8 +11,9 @@ use miden_core::{
 use miden_mast_package::Package;
 use miden_processor::{DefaultHost, ExecutionOptions, Program, ProgramInfo};
 use miden_utils_testing::{
-    AdviceInputs, ProvingOptions, StackInputs, prove_sync,
+    AdviceInputs, ProvingOptions, prove_sync,
     recursive_verifier::{VerifierData, generate_advice_inputs},
+    stack_inputs_from_ints,
 };
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
@@ -78,22 +79,21 @@ pub fn generate_recursive_verifier_data(
     stack_inputs: Vec<u64>,
     kernel: Option<&str>,
 ) -> VerifierData {
+    let source_manager = Arc::new(DefaultSourceManager::default());
     let (program, kernel_lib) = {
         match kernel {
             Some(kernel) => {
-                let context = miden_assembly::testing::TestContext::new();
-                let kernel_lib = Assembler::new(context.source_manager())
+                let kernel_lib = Assembler::new(source_manager.clone())
                     .assemble_kernel("kernel", kernel)
                     .map(Arc::<Package>::from)
                     .unwrap();
-                let assembler =
-                    Assembler::with_kernel(context.source_manager(), kernel_lib.clone()).unwrap();
+                let assembler = Assembler::with_kernel(source_manager, kernel_lib.clone()).unwrap();
                 let program: Program =
                     assembler.assemble_program("program", source).unwrap().unwrap_program();
                 (program, Some(kernel_lib))
             },
             None => {
-                let program: Program = Assembler::default()
+                let program: Program = Assembler::new(source_manager)
                     .assemble_program("program", source)
                     .unwrap()
                     .unwrap_program();
@@ -101,7 +101,7 @@ pub fn generate_recursive_verifier_data(
             },
         }
     };
-    let stack_inputs = StackInputs::try_from_ints(stack_inputs).unwrap();
+    let stack_inputs = stack_inputs_from_ints(stack_inputs);
     let advice_inputs = AdviceInputs::default();
     let mut host = DefaultHost::default();
     if let Some(ref kernel_lib) = kernel_lib {

--- a/crates/lib/core/tests/sys/mod.rs
+++ b/crates/lib/core/tests/sys/mod.rs
@@ -18,6 +18,7 @@ use miden_processor::{
     event::{EventError, EventHandler},
 };
 use miden_prover::ProvingOptions;
+#[cfg(feature = "arbitrary")]
 use miden_utils_testing::{MIN_STACK_DEPTH, proptest::prelude::*, rand::rand_vector};
 
 #[test]
@@ -75,6 +76,7 @@ fn reduce_kernel_digests_upper_bound() {
     expect_assert_error_message!(test);
 }
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn truncate_stack_proptest(test_values in prop::collection::vec(any::<u64>(), MIN_STACK_DEPTH), n in 1_usize..100) {

--- a/crates/test-serde-macros/Cargo.toml
+++ b/crates/test-serde-macros/Cargo.toml
@@ -20,9 +20,8 @@ proc-macro = true
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["derive", "extra-traits", "full"] }
-proptest.workspace = true
-proptest-derive.workspace = true
 
 [dev-dependencies]
 proptest = { workspace = true }
+proptest-derive = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -15,23 +15,27 @@ publish = false
 
 [features]
 default = ["std"]
+arbitrary = ["dep:proptest", "miden-assembly/testing", "miden-core/testing"]
 std = [
     "miden-assembly/std",
     "miden-core/std",
     "miden-processor/std",
     "miden-prover/std",
     "miden-verifier/std",
+    "proptest?/std",
 ]
+testing = ["arbitrary"]
 
 [dependencies]
 miden-air.workspace = true
-miden-assembly = { workspace = true, features = ["testing"] }
-miden-core = { workspace = true, features = ["testing"] }
+miden-assembly.workspace = true
+miden-core.workspace = true
 miden-crypto.workspace = true
 miden-mast-package.workspace = true
 miden-processor = { workspace = true, features = ["testing"] }
 miden-prover.workspace = true
 miden-verifier.workspace = true
+proptest = { workspace = true, optional = true }
 serde-wincode.workspace = true
 test-case = "3.2"
 thiserror.workspace = true
@@ -45,4 +49,3 @@ pretty_assertions = { workspace = true, default-features = false, features = [
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 env_logger.workspace = true
 pretty_assertions = { workspace = true, features = ["std"] }
-proptest.workspace = true

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -49,7 +49,7 @@ pub use miden_prover::prove_sync;
 pub use miden_prover::{ProvingOptions, prove};
 pub use miden_verifier::verify;
 pub use pretty_assertions::{assert_eq, assert_ne, assert_str_eq};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(feature = "arbitrary", not(target_family = "wasm")))]
 use proptest::prelude::{Arbitrary, Strategy};
 pub use test_case::test_case;
 
@@ -71,7 +71,7 @@ pub mod recursive_verifier;
 
 mod test_builders;
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(feature = "arbitrary", not(target_family = "wasm")))]
 pub use proptest;
 // CONSTANTS
 // ================================================================================================
@@ -270,7 +270,7 @@ impl Test {
     /// Sets the stack inputs for this test using stack-ordered values.
     #[track_caller]
     pub fn with_stack_inputs(mut self, stack_inputs: impl AsRef<[u64]>) -> Self {
-        self.stack_inputs = StackInputs::try_from_ints(stack_inputs.as_ref().to_vec()).unwrap();
+        self.stack_inputs = stack_inputs_from_ints(stack_inputs.as_ref().iter().copied());
         self
     }
 
@@ -334,7 +334,7 @@ impl Test {
     #[cfg(not(target_family = "wasm"))]
     #[track_caller]
     pub fn expect_stack(&self, final_stack: &[u64]) {
-        let result = self.get_last_stack_state().as_int_vec();
+        let result = stack_outputs_as_int_vec(&self.get_last_stack_state());
         let expected = resize_to_min_stack_depth(final_stack);
         assert_eq!(expected, result, "Expected stack to be {:?}, found {:?}", expected, result);
     }
@@ -386,12 +386,12 @@ impl Test {
     /// Asserts that executing the test inside a proptest results in the expected final stack state.
     /// The proptest will return a test failure instead of panicking if the assertion condition
     /// fails.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(all(feature = "arbitrary", not(target_family = "wasm")))]
     pub fn prop_expect_stack(
         &self,
         final_stack: &[u64],
     ) -> Result<(), proptest::prelude::TestCaseError> {
-        let result = self.get_last_stack_state().as_int_vec();
+        let result = stack_outputs_as_int_vec(&self.get_last_stack_state());
         proptest::prop_assert_eq!(resize_to_min_stack_depth(final_stack), result);
 
         Ok(())
@@ -412,7 +412,7 @@ impl Test {
             })
             .expect("failed to execute");
 
-        let result = trace.last_stack_state().as_int_vec();
+        let result = stack_outputs_as_int_vec(&trace.last_stack_state());
         let expected = resize_to_min_stack_depth(final_stack);
         assert_eq!(expected, result, "Expected stack to be {:?}, found {:?}", expected, result);
     }
@@ -512,7 +512,7 @@ impl Test {
         &self,
         stack_inputs: &[u64],
     ) -> Result<ExecutionTrace, ExecutionError> {
-        let stack_inputs = StackInputs::try_from_ints(stack_inputs.to_vec()).unwrap();
+        let stack_inputs = stack_inputs_from_ints(stack_inputs.iter().copied());
         self.execute_with_stack_inputs_inner(stack_inputs)
     }
 
@@ -578,8 +578,8 @@ impl Test {
     #[cfg(not(target_family = "wasm"))]
     pub fn prove_and_verify(&self, pub_inputs: Vec<u64>, test_fail: bool) {
         let (program, mut host) = self.get_program_and_host();
-        let stack_inputs = StackInputs::try_from_ints(pub_inputs).unwrap();
-        let (mut stack_outputs, proof) = prove_sync(
+        let stack_inputs = stack_inputs_from_ints(pub_inputs);
+        let (stack_outputs, proof) = prove_sync(
             &program,
             stack_inputs,
             self.advice_inputs.clone(),
@@ -591,7 +591,11 @@ impl Test {
 
         let program_info = ProgramInfo::from(program);
         if test_fail {
-            stack_outputs.as_mut()[0] += ONE;
+            let mut elements = [ZERO; MIN_STACK_DEPTH];
+            elements.copy_from_slice(&*stack_outputs);
+            elements[0] += ONE;
+            let stack_outputs =
+                StackOutputs::new(&elements).expect("stack outputs should fit the VM stack");
             assert!(verify(program_info, stack_inputs, stack_outputs, proof).is_err());
         } else {
             let result = verify(program_info, stack_inputs, stack_outputs, proof);
@@ -766,6 +770,20 @@ pub fn felt_slice_to_ints(values: &[Felt]) -> Vec<u64> {
     values.iter().map(|e| (*e).as_canonical_u64()).collect()
 }
 
+#[doc(hidden)]
+#[track_caller]
+pub fn stack_inputs_from_ints(values: impl IntoIterator<Item = u64>) -> StackInputs {
+    let values = values
+        .into_iter()
+        .map(|value| Felt::new(value).expect("stack input should be a valid field element"))
+        .collect::<Vec<_>>();
+    StackInputs::new(&values).expect("stack inputs should fit the VM stack")
+}
+
+fn stack_outputs_as_int_vec(outputs: &StackOutputs) -> Vec<u64> {
+    outputs.iter().map(Felt::as_canonical_u64).collect()
+}
+
 pub fn resize_to_min_stack_depth(values: &[u64]) -> Vec<u64> {
     let mut result: Vec<u64> = values.to_vec();
     result.resize(MIN_STACK_DEPTH, 0);
@@ -773,7 +791,7 @@ pub fn resize_to_min_stack_depth(values: &[u64]) -> Vec<u64> {
 }
 
 /// A proptest strategy for generating a random word with 4 values of type T.
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(feature = "arbitrary", not(target_family = "wasm")))]
 pub fn prop_randw<T: Arbitrary>() -> impl Strategy<Value = Vec<T>> {
     use proptest::prelude::{any, prop};
     prop::collection::vec(any::<T>(), 4)

--- a/crates/test-utils/src/test_builders.rs
+++ b/crates/test-utils/src/test_builders.rs
@@ -3,7 +3,7 @@
 
 /// Creates a `Vec<u64>` for stack inputs where the first element will be on top of the stack.
 ///
-/// This macro handles the reversal required by `StackInputs::try_from_ints`, which reverses
+/// This macro handles the reversal required by `StackInputs`, which reverses
 /// its input internally. With this macro, you can specify stack inputs in intuitive order.
 ///
 /// # Example
@@ -143,7 +143,7 @@ macro_rules! build_test_by_mode {
         use $crate::SourceManager;
 
         let stack_inputs: ::alloc::vec::Vec<u64> = $stack_inputs.to_vec();
-        let stack_inputs = $crate::StackInputs::try_from_ints(stack_inputs).unwrap();
+        let stack_inputs = $crate::stack_inputs_from_ints(stack_inputs);
         let advice_inputs = $crate::AdviceInputs::default();
         let name = format!("test{}", line!());
         let source_manager = ::alloc::sync::Arc::new($crate::DefaultSourceManager::default());
@@ -169,7 +169,7 @@ macro_rules! build_test_by_mode {
         use $crate::SourceManager;
 
         let stack_inputs: ::alloc::vec::Vec<u64> = $stack_inputs.to_vec();
-        let stack_inputs = $crate::StackInputs::try_from_ints(stack_inputs).unwrap();
+        let stack_inputs = $crate::stack_inputs_from_ints(stack_inputs);
         let stack_values: ::alloc::vec::Vec<u64> = $advice_stack.to_vec();
         let store = $crate::crypto::MerkleStore::new();
         let advice_inputs = $crate::AdviceInputs::default()
@@ -206,7 +206,7 @@ macro_rules! build_test_by_mode {
         use $crate::SourceManager;
 
         let stack_inputs: Vec<u64> = $stack_inputs.to_vec();
-        let stack_inputs = $crate::StackInputs::try_from_ints(stack_inputs).unwrap();
+        let stack_inputs = $crate::stack_inputs_from_ints(stack_inputs);
         let stack_values: Vec<u64> = $advice_stack.to_vec();
         let advice_inputs = $crate::AdviceInputs::default()
             .with_stack_values(stack_values)
@@ -243,7 +243,7 @@ macro_rules! build_test_by_mode {
         use $crate::SourceManager;
 
         let stack_inputs: Vec<u64> = $stack_inputs.to_vec();
-        let stack_inputs = $crate::StackInputs::try_from_ints(stack_inputs).unwrap();
+        let stack_inputs = $crate::stack_inputs_from_ints(stack_inputs);
         let stack_values: Vec<u64> = $advice_stack.to_vec();
         let advice_inputs = $crate::AdviceInputs::default()
             .with_stack_values(stack_values)

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -49,7 +49,7 @@ name = "miden-cli"
 path = "tests/integration/main.rs"
 
 [features]
-arbitrary = ["std", "dep:proptest"]
+arbitrary = ["std", "dep:proptest", "miden-assembly/testing", "miden-utils-testing/arbitrary"]
 concurrent = ["miden-prover/concurrent", "std"]
 default = ["std"]
 executable = ["dep:hex", "dep:clap", "dep:tracing-subscriber", "internal", "serde", "std"]
@@ -64,6 +64,7 @@ std = [
     "serde?/std",
     "serde_json?/std",
 ]
+testing = ["arbitrary"]
 # For internal use, not meant to be used by users
 internal = ["dep:hex", "serde", "std"]
 
@@ -95,6 +96,5 @@ miden-processor = { workspace = true, features = ["testing"] }
 miden-test-serde-macros.workspace = true
 miden-utils-testing.workspace = true
 predicates = { version = "3.1" }
-proptest.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 walkdir.workspace = true

--- a/miden-vm/tests/integration/flow_control/mod.rs
+++ b/miden-vm/tests/integration/flow_control/mod.rs
@@ -1,6 +1,6 @@
 use alloc::sync::Arc;
 
-use miden_assembly::{Assembler, PathBuf, Report, ast::ModuleKind};
+use miden_assembly::{Assembler, DefaultSourceManager, PathBuf, Report, ast::ModuleKind};
 use miden_core_lib::CoreLibrary;
 use miden_processor::{ExecutionError, Word, operation::OperationError};
 use miden_utils_testing::{build_debug_test, build_test, expect_exec_error_matches, push_inputs};
@@ -456,8 +456,11 @@ fn simple_dyn_exec() {
         end";
 
     // Compute the hash of foo by assembling the program
-    let context = miden_assembly::testing::TestContext::new();
-    let program = context.assemble(program_source).unwrap();
+    let source_manager = Arc::new(DefaultSourceManager::default());
+    let program = Assembler::new(source_manager)
+        .assemble_program("program", program_source)
+        .unwrap()
+        .unwrap_program();
     let procedure_digests: Vec<Word> = program.mast_forest().procedure_digests().collect();
     let foo_digest = procedure_digests[0];
 
@@ -550,8 +553,11 @@ fn simple_dyncall() {
         end";
 
     // Compute the hash of foo by assembling the program
-    let context = miden_assembly::testing::TestContext::new();
-    let program = context.assemble(program_source).unwrap();
+    let source_manager = Arc::new(DefaultSourceManager::default());
+    let program = Assembler::new(source_manager)
+        .assemble_program("program", program_source)
+        .unwrap()
+        .unwrap_program();
     let procedure_digests: Vec<Word> = program.mast_forest().procedure_digests().collect();
     let foo_digest = procedure_digests[0];
 
@@ -648,7 +654,7 @@ fn procref() -> Result<(), Report> {
 
     // obtain procedures' MAST roots by compiling them as module
     let mast_roots: Vec<Word> = {
-        let source_manager = Arc::new(miden_assembly::DefaultSourceManager::default());
+        let source_manager = Arc::new(DefaultSourceManager::default());
         let module_path = PathBuf::new("test::foo").unwrap();
         let mut parser = Module::parser(ModuleKind::Library);
         let module = parser.parse_str(module_path, module_source, source_manager.clone())?;

--- a/miden-vm/tests/integration/operations/crypto_ops.rs
+++ b/miden-vm/tests/integration/operations/crypto_ops.rs
@@ -1,14 +1,19 @@
+#[cfg(feature = "arbitrary")]
 use miden_core::field::{BasedVectorSpace, QuadFelt};
 use miden_processor::{ExecutionError, MemoryError};
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::build_test;
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::proptest::prelude::*;
 use miden_utils_testing::{
-    Felt, build_expected_hash, build_expected_perm, build_op_test, build_test,
+    Felt, build_expected_hash, build_expected_perm, build_op_test,
     crypto::{MerkleTree, NodeIndex, init_merkle_leaf, init_merkle_store},
-    proptest::prelude::*,
 };
 
 // TESTS
 // ================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn hash_proptest(
@@ -30,6 +35,7 @@ proptest! {
     }
 }
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn hperm_proptest(
@@ -118,6 +124,7 @@ fn hmerge() {
     assert_eq!(expected_stack_slice, &last_state[4..8]);
 }
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn hmerge_proptest(
@@ -584,10 +591,14 @@ fn crypto_stream_allows_adjacent_before() {
 // ================================================================================================
 
 // Constants for stack positions (low coefficient closer to top / lower index)
+#[cfg(feature = "arbitrary")]
 const ALPHA_ADDR_INDEX: usize = 13;
+#[cfg(feature = "arbitrary")]
 const ACC_LOW_INDEX: usize = 14;
+#[cfg(feature = "arbitrary")]
 const ACC_HIGH_INDEX: usize = 15;
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(5))]
     #[test]

--- a/miden-vm/tests/integration/operations/field_ops.rs
+++ b/miden-vm/tests/integration/operations/field_ops.rs
@@ -1,11 +1,15 @@
+#[cfg(feature = "testing")]
 use miden_assembly::testing::regex;
 use miden_core::field::Field;
 use miden_processor::{ExecutionError, operation::OperationError};
 use miden_utils_testing::{
-    Felt, ONE, PrimeField64, WORD_SIZE, ZERO, assert_assembler_diagnostic, assert_diagnostic_lines,
-    build_op_test, build_test, expect_exec_error_matches, prop_randw, proptest::prelude::*,
+    Felt, ONE, PrimeField64, ZERO, build_op_test, build_test, expect_exec_error_matches,
     rand::rand_value,
 };
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::{WORD_SIZE, prop_randw, proptest::prelude::*};
+#[cfg(feature = "testing")]
+use miden_utils_testing::{assert_assembler_diagnostic, assert_diagnostic_lines};
 
 // FIELD OPS ARITHMETIC - MANUAL TESTS
 // ================================================================================================
@@ -183,17 +187,20 @@ fn div_b() {
     let test = build_op_test!(build_asm_op(1), &[77]);
     test.expect_stack(&[77]);
 
-    let test = build_op_test!(build_asm_op(0), &[14]);
+    #[cfg(feature = "testing")]
+    {
+        let test = build_op_test!(build_asm_op(0), &[14]);
 
-    assert_assembler_diagnostic!(
-        test,
-        "invalid constant expression: division by zero",
-        regex!(r#",-\[test[\d]+:[\d]+:[\d]+\]"#),
-        "12 |",
-        "13 | begin div.0 exec.truncate_stack end",
-        "   :           ^",
-        "   `----"
-    );
+        assert_assembler_diagnostic!(
+            test,
+            "invalid constant expression: division by zero",
+            regex!(r#",-\[test[\d]+:[\d]+:[\d]+\]"#),
+            "12 |",
+            "13 | begin div.0 exec.truncate_stack end",
+            "   :           ^",
+            "   `----"
+        );
+    }
 
     let test = build_op_test!(build_asm_op(2), &[4]);
     test.expect_stack(&[2]);
@@ -243,6 +250,7 @@ fn neg() {
 }
 
 #[test]
+#[cfg(feature = "testing")]
 fn neg_fail() {
     let asm_op = "neg.1";
 
@@ -279,6 +287,7 @@ fn inv() {
 }
 
 #[test]
+#[cfg(feature = "testing")]
 fn inv_fail() {
     let asm_op = "inv";
 
@@ -360,23 +369,25 @@ fn exp_bits_length_fail() {
         if err_code == ZERO && err_msg.is_none()
     );
 
-    //---------------------- exp containing more than 64 bits -------------------------------------
+    #[cfg(feature = "testing")]
+    {
+        //---------------------- exp containing more than 64 bits -------------------------------------
 
-    let base = 9;
-    let pow = 1021; // pow is a 10 bit number
+        let base = 9;
+        let pow = 1021; // pow is a 10 bit number
+        let test = build_op_test!(build_asm_op(65), &[pow, base]);
 
-    let test = build_op_test!(build_asm_op(65), &[pow, base]);
-
-    assert_assembler_diagnostic!(
-        test,
-        "invalid literal: expected value to be a valid bit size, e.g. 0..63",
-        regex!(r#",-\[test[\d]+:[\d]+:[\d]+\]"#),
-        "12 |",
-        "13 | begin exp.u65 exec.truncate_stack end",
-        "   :            ^^",
-        "   `----",
-        r#" help: expected primitive opcode (e.g. "add"), or "end", or control flow opcode (e.g. "if.true")"#
-    );
+        assert_assembler_diagnostic!(
+            test,
+            "invalid literal: expected value to be a valid bit size, e.g. 0..63",
+            regex!(r#",-\[test[\d]+:[\d]+:[\d]+\]"#),
+            "12 |",
+            "13 | begin exp.u65 exec.truncate_stack end",
+            "   :            ^^",
+            "   `----",
+            r#" help: expected primitive opcode (e.g. "add"), or "end", or control flow opcode (e.g. "if.true")"#
+        );
+    }
 }
 
 #[test]
@@ -739,6 +750,7 @@ fn gte() {
 // FIELD OPS ARITHMETIC - RANDOMIZED TESTS
 // ================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(100))]
     #[test]
@@ -891,6 +903,7 @@ proptest! {
 // FIELD OPS COMPARISON - RANDOMIZED TESTS
 // ================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn eq_proptest(a in any::<u64>(), b in any::<u64>()) {

--- a/miden-vm/tests/integration/operations/io_ops/constant_ops.rs
+++ b/miden-vm/tests/integration/operations/io_ops/constant_ops.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "arbitrary")]
 use miden_utils_testing::proptest::prelude::*;
 
 use super::build_op_test;
@@ -89,6 +90,7 @@ fn push_odd_hex_length_original_issue() {
     test.expect_stack(&[256]); // 0x100 = 256 (now works with padding)
 }
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn proptest_push_all_hex_lengths(

--- a/miden-vm/tests/integration/operations/stack_ops.rs
+++ b/miden-vm/tests/integration/operations/stack_ops.rs
@@ -1,8 +1,12 @@
+#[cfg(feature = "testing")]
 use miden_assembly::testing::regex;
-use miden_utils_testing::{
-    MIN_STACK_DEPTH, WORD_SIZE, assert_assembler_diagnostic, assert_diagnostic_lines,
-    build_op_test, proptest::prelude::*,
-};
+use miden_utils_testing::build_op_test;
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::proptest::prelude::*;
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::{MIN_STACK_DEPTH, WORD_SIZE};
+#[cfg(feature = "testing")]
+use miden_utils_testing::{assert_assembler_diagnostic, assert_diagnostic_lines};
 
 // STACK OPERATIONS TESTS
 // ================================================================================================
@@ -53,6 +57,7 @@ fn dupn() {
 }
 
 #[test]
+#[cfg(feature = "testing")]
 fn dupn_fail() {
     let asm_op = "dup.16";
 
@@ -89,6 +94,7 @@ fn dupwn() {
 }
 
 #[test]
+#[cfg(feature = "testing")]
 fn dupwn_fail() {
     let asm_op = "dupw.4";
 
@@ -125,6 +131,7 @@ fn swapn() {
 }
 
 #[test]
+#[cfg(feature = "testing")]
 fn swapn_fail() {
     let asm_op = "swap.16";
 
@@ -161,6 +168,7 @@ fn swapwn() {
 }
 
 #[test]
+#[cfg(feature = "testing")]
 fn swapwn_fail() {
     let asm_op = "swapw.4";
 
@@ -196,6 +204,7 @@ fn movup() {
 }
 
 #[test]
+#[cfg(feature = "testing")]
 fn movup_fail() {
     let asm_op = "movup.0";
     let test = build_op_test!(asm_op, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
@@ -246,6 +255,7 @@ fn movupw() {
 }
 
 #[test]
+#[cfg(feature = "testing")]
 fn movupw_fail() {
     let asm_op = "movupw.0";
     let test = build_op_test!(asm_op, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
@@ -296,6 +306,7 @@ fn movdn() {
 }
 
 #[test]
+#[cfg(feature = "testing")]
 fn movdn_fail() {
     let asm_op = "movdn.0";
     let test = build_op_test!(asm_op, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
@@ -346,6 +357,7 @@ fn movdnw() {
 }
 
 #[test]
+#[cfg(feature = "testing")]
 fn movdnw_fail() {
     let asm_op = "movdnw.0";
     let test = build_op_test!(asm_op, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
@@ -432,6 +444,7 @@ fn cdropw() {
     test.expect_stack(&[1, 2, 3, 4, 9, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0]);
 }
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(100))]
 

--- a/miden-vm/tests/integration/operations/u32_ops/arithmetic_ops.rs
+++ b/miden-vm/tests/integration/operations/u32_ops/arithmetic_ops.rs
@@ -1,7 +1,7 @@
 use miden_processor::{ExecutionError, operation::OperationError};
-use miden_utils_testing::{
-    U32_BOUND, build_op_test, expect_exec_error_matches, proptest::prelude::*, rand::rand_value,
-};
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::proptest::prelude::*;
+use miden_utils_testing::{U32_BOUND, build_op_test, expect_exec_error_matches, rand::rand_value};
 
 // U32 OPERATIONS TESTS - MANUAL - ARITHMETIC OPERATIONS
 // ================================================================================================
@@ -684,6 +684,7 @@ fn u32divmod_fail() {
 
 // U32 OPERATIONS TESTS - RANDOMIZED - ARITHMETIC OPERATIONS
 // ================================================================================================
+#[cfg(feature = "arbitrary")]
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(100))]
     #[test]

--- a/miden-vm/tests/integration/operations/u32_ops/bitwise_ops.rs
+++ b/miden-vm/tests/integration/operations/u32_ops/bitwise_ops.rs
@@ -1,7 +1,7 @@
 use miden_processor::{ExecutionError, Felt, operation::OperationError};
-use miden_utils_testing::{
-    U32_BOUND, build_op_test, expect_exec_error_matches, proptest::prelude::*, rand::rand_value,
-};
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::proptest::prelude::*;
+use miden_utils_testing::{U32_BOUND, build_op_test, expect_exec_error_matches, rand::rand_value};
 
 use super::test_input_out_of_bounds;
 
@@ -585,6 +585,7 @@ fn u32cto() {
 // U32 OPERATIONS TESTS - RANDOMIZED - BITWISE OPERATIONS
 // ================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn u32and_proptest(a in any::<u32>(), b in any::<u32>()) {

--- a/miden-vm/tests/integration/operations/u32_ops/comparison_ops.rs
+++ b/miden-vm/tests/integration/operations/u32_ops/comparison_ops.rs
@@ -1,6 +1,8 @@
 use core::cmp::Ordering;
 
-use miden_utils_testing::{build_op_test, proptest::prelude::*, rand::rand_value};
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::proptest::prelude::*;
+use miden_utils_testing::{build_op_test, rand::rand_value};
 
 // U32 OPERATIONS TESTS - MANUAL - COMPARISON OPERATIONS
 // ================================================================================================
@@ -56,6 +58,7 @@ fn u32max() {
 // U32 OPERATIONS TESTS - RANDOMIZED - COMPARISON OPERATIONS
 // ================================================================================================
 
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn u32lt_proptest(a in any::<u32>(), b in any::<u32>()) {

--- a/miden-vm/tests/integration/operations/u32_ops/conversion_ops.rs
+++ b/miden-vm/tests/integration/operations/u32_ops/conversion_ops.rs
@@ -1,10 +1,15 @@
-use miden_processor::{ExecutionError, field::PrimeField64, operation::OperationError};
+use miden_processor::{ExecutionError, operation::OperationError};
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::PrimeField64;
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::proptest::prelude::*;
 use miden_utils_testing::{
-    Felt, U32_BOUND, WORD_SIZE, build_op_test, expect_exec_error_matches, proptest::prelude::*,
-    rand::rand_value,
+    Felt, U32_BOUND, WORD_SIZE, build_op_test, expect_exec_error_matches, rand::rand_value,
 };
 
-use super::{prop_randw, test_inputs_out_of_bounds};
+#[cfg(feature = "arbitrary")]
+use super::prop_randw;
+use super::test_inputs_out_of_bounds;
 
 // U32 OPERATIONS TESTS - MANUAL - CONVERSIONS AND TESTS
 // ================================================================================================
@@ -256,6 +261,7 @@ fn u32split() {
 
 // U32 OPERATIONS TESTS - RANDOMIZED - CONVERSIONS AND TESTS
 // ================================================================================================
+#[cfg(feature = "arbitrary")]
 proptest! {
     #[test]
     fn u32test_proptest(value in any::<u64>()) {

--- a/miden-vm/tests/integration/operations/u32_ops/mod.rs
+++ b/miden-vm/tests/integration/operations/u32_ops/mod.rs
@@ -1,5 +1,7 @@
 use miden_processor::{ExecutionError, operation::OperationError};
-use miden_utils_testing::{Felt, U32_BOUND, build_op_test, expect_exec_error_matches, prop_randw};
+#[cfg(feature = "arbitrary")]
+use miden_utils_testing::prop_randw;
+use miden_utils_testing::{Felt, U32_BOUND, build_op_test, expect_exec_error_matches};
 
 mod arithmetic_ops;
 mod bitwise_ops;

--- a/miden-vm/tests/integration/prove_verify.rs
+++ b/miden-vm/tests/integration/prove_verify.rs
@@ -9,6 +9,7 @@ use miden_processor::ExecutionOptions;
 use miden_prover::{
     AdviceInputs, ProgramInfo, ProvingOptions, PublicInputs, StackInputs, StackOutputs, prove_sync,
 };
+use miden_utils_testing::stack_inputs_from_ints;
 use miden_verifier::verify;
 use miden_vm::{DefaultHost, HashFunction};
 
@@ -23,7 +24,7 @@ fn assert_prove_verify(
         .assemble_program("program", source)
         .unwrap()
         .unwrap_program();
-    let stack_inputs = StackInputs::try_from_ints([0, 1]).unwrap();
+    let stack_inputs = stack_inputs_from_ints([0, 1]);
     let advice_inputs = AdviceInputs::default();
     let mut host =
         DefaultHost::default().with_source_manager(Arc::new(DefaultSourceManager::default()));
@@ -287,7 +288,7 @@ mod fast_parallel {
             .assemble_program("program", source)
             .unwrap()
             .unwrap_program();
-        let stack_inputs = StackInputs::try_from_ints([0, 1]).unwrap();
+        let stack_inputs = miden_utils_testing::stack_inputs_from_ints([0, 1]);
         let advice_inputs = AdviceInputs::default();
         let mut host = default_source_manager_host();
         let trace_inputs =
@@ -338,7 +339,7 @@ mod fast_parallel {
             .assemble_program("program", source)
             .unwrap()
             .unwrap_program();
-        let stack_inputs = StackInputs::try_from_ints([0, 1]).unwrap();
+        let stack_inputs = miden_utils_testing::stack_inputs_from_ints([0, 1]);
         let advice_inputs = AdviceInputs::default();
         let mut host = default_source_manager_host();
         let trace_inputs =

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -9,7 +9,7 @@ use miden_core::{
     operations::Operation,
     program::StackInputs,
 };
-use miden_utils_testing::build_test;
+use miden_utils_testing::{build_test, stack_inputs_from_ints};
 use rstest::rstest;
 
 use super::*;
@@ -60,7 +60,7 @@ fn stack_get_word_out_of_bounds_read() {
 
 #[test]
 fn stack_get_safe_boundary() {
-    let inputs = StackInputs::try_from_ints(1..=16_u64).unwrap();
+    let inputs = stack_inputs_from_ints(1..=16_u64);
     let processor = FastProcessor::new(inputs);
 
     // idx == stack_top_idx: out of bounds, should return ZERO.
@@ -78,7 +78,7 @@ fn stack_get_safe_boundary() {
 
 #[test]
 fn stack_get_word_safe_partial_read() {
-    let inputs = StackInputs::try_from_ints(1..=16_u64).unwrap();
+    let inputs = stack_inputs_from_ints(1..=16_u64);
     let processor = FastProcessor::new(inputs);
 
     // The stack has 16 elements (indices 0..=15). Reading a word at start_idx=15 means we want

--- a/processor/src/trace/tests/chiplets/hasher.rs
+++ b/processor/src/trace/tests/chiplets/hasher.rs
@@ -32,14 +32,14 @@ use miden_core::{
     operations::{Operation, opcodes},
     program::Program,
 };
-use miden_utils_testing::stack;
+use miden_utils_testing::{stack, stack_inputs_from_ints};
 use rstest::rstest;
 
 use super::super::{
     build_trace_from_ops_with_inputs, build_trace_from_program,
     lookup_harness::{Expectations, InteractionLog},
 };
-use crate::{AdviceInputs, RowIndex, StackInputs, trace::utils::build_span_with_respan_ops};
+use crate::{AdviceInputs, RowIndex, trace::utils::build_span_with_respan_ops};
 
 // RESPONSE-SIDE DISPATCH
 // ================================================================================================
@@ -402,7 +402,7 @@ fn mpverify_hasher_bus() {
     runtime_stack.push(tree.depth() as u64);
     runtime_stack.push(index as u64);
     runtime_stack.extend_from_slice(&word_to_ints(tree.root()));
-    let stack_inputs = StackInputs::try_from_ints(runtime_stack).unwrap();
+    let stack_inputs = stack_inputs_from_ints(runtime_stack);
     let store = MerkleStore::from(&tree);
     let advice_inputs = AdviceInputs::default().with_merkle_store(store);
 
@@ -484,7 +484,7 @@ fn mrupdate_hasher_bus() {
     runtime_stack.push(index as u64);
     runtime_stack.extend_from_slice(&word_to_ints(tree.root()));
     runtime_stack.extend_from_slice(&word_to_ints(new_leaf_value));
-    let stack_inputs = StackInputs::try_from_ints(runtime_stack).unwrap();
+    let stack_inputs = stack_inputs_from_ints(runtime_stack);
     let store = MerkleStore::from(&tree);
     let advice_inputs = AdviceInputs::default().with_merkle_store(store);
 
@@ -639,7 +639,7 @@ fn mrupdate_emits_sibling_add_and_remove_per_level(#[case] index: u64) {
     init_stack.extend_from_slice(&[3, index]);
     init_stack.extend_from_slice(&word_to_ints(tree.root()));
     init_stack.extend_from_slice(&word_to_ints(new_node));
-    let stack_inputs = StackInputs::try_from_ints(init_stack).unwrap();
+    let stack_inputs = stack_inputs_from_ints(init_stack);
     let store = MerkleStore::from(&tree);
     let advice_inputs = AdviceInputs::default().with_merkle_store(store);
 


### PR DESCRIPTION
This fixes #2875 by keeping proptest, and its rand 0.9 dependency, behind arbitrary/testing. Most of the heavy lifting done prior to that in #3228 by @Nashtare 

Deterministic tests still run without arbitrary. Targeted test presets for VM and core-lib now enable testing, so their property and diagnostic tests still run.