### PR TITLE
perf(verifier): override constraint_degree() for Miden AIRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bounded `FastProcessor` memory growth with a configurable `ExecutionOptions::max_memory_elements` limit, rejecting writes to arbitrarily many unique addresses that could otherwise exhaust host memory ([#3226](https://github.com/0xMiden/miden-vm/pull/3226)).
 - [BREAKING] Simplified `MastForestBuilder` around builder-local refs and immutable finalized `MastForest`s ([#3139](https://github.com/0xMiden/miden-vm/pull/3139)).
 - Added `do <block> while <cond> end` syntax ([#3232](https://github.com/0xMiden/miden-vm/pull/3232)).
+- Speed-up native verifier by skipping symbolic recomputation of constraint degree ([#3242](https://github.com/0xMiden/miden-vm/pull/3242)).
 
 #### Fixes
 

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -718,3 +718,24 @@ impl<'a, EF: ExtensionField<Felt>> BoundaryBuilder for ReduceBoundaryBuilder<'a,
         }
     }
 }
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use miden_core::field::QuadFelt;
+
+    use super::*;
+
+    /// Guards the static `constraint_degree` override: if an AIR change moves the symbolic
+    /// degree away from the declared value, the override must be updated.
+    #[test]
+    fn constraint_degree_override_matches_symbolic() {
+        for air in [MidenAir::CORE, MidenAir::CHIPLETS] {
+            let symbolic = ConstraintDegrees::from_air::<Felt, QuadFelt, _>(&air);
+            let declared = <MidenAir as LiftedAir<Felt, QuadFelt>>::constraint_degree(&air);
+            assert_eq!(declared, symbolic, "static constraint_degree override is stale");
+        }
+    }
+}

--- a/air/src/lib.rs
+++ b/air/src/lib.rs
@@ -72,8 +72,8 @@ mod export {
     pub use miden_crypto::stark::{
         StarkConfig,
         air::{
-            AirBuilder, BaseAir, ExtensionBuilder, LiftedAir, LiftedAirBuilder, MultiAir,
-            PermutationAirBuilder, ProverStatement, Statement,
+            AirBuilder, BaseAir, ConstraintDegrees, ExtensionBuilder, LiftedAir, LiftedAirBuilder,
+            MultiAir, PermutationAirBuilder, ProverStatement, Statement,
         },
         debug,
     };
@@ -521,6 +521,11 @@ impl<EF: ExtensionField<Felt>> LiftedAir<Felt, EF> for MidenAir {
             "build_logup_aux_trace returns one committed final per AIR (col 0's terminal sum)"
         );
         (aux_trace, committed)
+    }
+
+    fn constraint_degree(&self) -> ConstraintDegrees {
+        // All AIRs peak at degree 9 over base-field and extension-field constraints.
+        ConstraintDegrees { base: 9, ext: 9 }
     }
 
     fn eval<AB: LiftedAirBuilder<F = Felt>>(&self, builder: &mut AB) {


### PR DESCRIPTION
## Describe your changes

Make constraint degrees explicit to skip symbolic recomputation on the verifier side.
Shaves off ~14% of `verify()` time on my machine (M4 pro).


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'