### PR TITLE
fix: Bound deferred precompile requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Preserved `LOGPRECOMPILE` tail stack slots in the AIR, preventing forged values in `stack[12..15]` ([#3244](https://github.com/0xMiden/miden-vm/pull/3244)).
 - Bound memory AIR word addresses to their range-checked decomposition limbs ([#3245](https://github.com/0xMiden/miden-vm/pull/3245)).
 - Rejected oversized AEAD decrypt outputs before reading ciphertext or running host-side decryption ([#3252](https://github.com/0xMiden/miden-vm/pull/3252)).
+- [BREAKING] Bounded deferred precompile request growth by request count and total calldata bytes in `AdviceProvider` ([#3260](https://github.com/0xMiden/miden-vm/pull/3260)).
 - Fixed MASM tooling edge cases around atomic file writes, source URI paths, package loading, local registry state, diagnostics, generated MASM memory addresses, and CST `$...` special identifiers ([#3178](https://github.com/0xMiden/miden-vm/pull/3178)).
 - [BREAKING] Removed the public `eddsa_ed25519::verify_prehash` entrypoint and bound EdDSA precompile verification to the signed message ([#3254](https://github.com/0xMiden/miden-vm/pull/3254)).
 - Replaced `bincode` proof serialization with `wincode` and bounded verifier-side STARK proof deserialization to 64 MiB ([#3148](https://github.com/0xMiden/miden-vm/pull/3148)).

--- a/processor/src/execution_options.rs
+++ b/processor/src/execution_options.rs
@@ -23,6 +23,10 @@ pub struct ExecutionOptions {
     /// Maximum number of continuations allowed on the continuation stack at any point during
     /// execution.
     max_num_continuations: usize,
+    /// Maximum number of deferred precompile requests allowed during execution.
+    max_precompile_requests: usize,
+    /// Maximum total number of calldata bytes allowed across deferred precompile requests.
+    max_precompile_request_calldata_bytes: usize,
     /// Maximum number of field elements allowed on the operand stack in the active execution
     /// context.
     max_stack_depth: usize,
@@ -41,6 +45,9 @@ impl Default for ExecutionOptions {
             max_adv_map_elements: Self::DEFAULT_MAX_ADV_MAP_ELEMENTS,
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
             max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
+            max_precompile_requests: Self::DEFAULT_MAX_PRECOMPILE_REQUESTS,
+            max_precompile_request_calldata_bytes:
+                Self::DEFAULT_MAX_PRECOMPILE_REQUEST_CALLDATA_BYTES,
             max_stack_depth: Self::DEFAULT_MAX_STACK_DEPTH,
             max_memory_elements: Self::DEFAULT_MAX_MEMORY_ELEMENTS,
         }
@@ -74,6 +81,14 @@ impl ExecutionOptions {
     /// Default maximum number of continuations allowed on the continuation stack.
     /// Set to 2^16 (65536).
     pub const DEFAULT_MAX_NUM_CONTINUATIONS: usize = 1 << 16;
+
+    /// Default maximum number of deferred precompile requests allowed during execution.
+    /// Set to 2^16 (65536).
+    pub const DEFAULT_MAX_PRECOMPILE_REQUESTS: usize = 1 << 16;
+
+    /// Default maximum total calldata bytes allowed across deferred precompile requests.
+    /// Set to 2^28 (256 MB).
+    pub const DEFAULT_MAX_PRECOMPILE_REQUEST_CALLDATA_BYTES: usize = 1 << 28;
 
     /// Default maximum number of field elements allowed on the operand stack.
     ///
@@ -149,6 +164,9 @@ impl ExecutionOptions {
             max_adv_map_elements: Self::DEFAULT_MAX_ADV_MAP_ELEMENTS,
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
             max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
+            max_precompile_requests: Self::DEFAULT_MAX_PRECOMPILE_REQUESTS,
+            max_precompile_request_calldata_bytes:
+                Self::DEFAULT_MAX_PRECOMPILE_REQUEST_CALLDATA_BYTES,
             max_stack_depth: Self::DEFAULT_MAX_STACK_DEPTH,
             max_memory_elements: Self::DEFAULT_MAX_MEMORY_ELEMENTS,
         })
@@ -234,6 +252,18 @@ impl ExecutionOptions {
         self.max_num_continuations
     }
 
+    /// Returns the maximum number of deferred precompile requests allowed during execution.
+    #[inline]
+    pub fn max_precompile_requests(&self) -> usize {
+        self.max_precompile_requests
+    }
+
+    /// Returns the maximum total calldata bytes allowed across deferred precompile requests.
+    #[inline]
+    pub fn max_precompile_request_calldata_bytes(&self) -> usize {
+        self.max_precompile_request_calldata_bytes
+    }
+
     /// Returns the maximum number of field elements allowed on the operand stack in the active
     /// execution context.
     #[inline]
@@ -253,6 +283,21 @@ impl ExecutionOptions {
     /// Sets the maximum number of continuations allowed on the continuation stack.
     pub fn with_max_num_continuations(mut self, max_num_continuations: usize) -> Self {
         self.max_num_continuations = max_num_continuations;
+        self
+    }
+
+    /// Sets the maximum number of deferred precompile requests allowed during execution.
+    pub fn with_max_precompile_requests(mut self, max_precompile_requests: usize) -> Self {
+        self.max_precompile_requests = max_precompile_requests;
+        self
+    }
+
+    /// Sets the maximum total calldata bytes allowed across deferred precompile requests.
+    pub fn with_max_precompile_request_calldata_bytes(
+        mut self,
+        max_precompile_request_calldata_bytes: usize,
+    ) -> Self {
+        self.max_precompile_request_calldata_bytes = max_precompile_request_calldata_bytes;
         self
     }
 

--- a/processor/src/host/advice/errors.rs
+++ b/processor/src/host/advice/errors.rs
@@ -33,6 +33,14 @@ pub enum AdviceError {
     )]
     AdvMapElementBudgetExceeded { current: usize, added: usize, max: usize },
     #[error(
+        "precompile request count budget exceeded: adding {added} requests to the current {current} would exceed the maximum of {max}"
+    )]
+    PrecompileRequestCountExceeded { current: usize, added: usize, max: usize },
+    #[error(
+        "precompile request calldata byte budget exceeded: adding {added} bytes to the current {current} would exceed the maximum of {max}"
+    )]
+    PrecompileRequestCalldataBudgetExceeded { current: usize, added: usize, max: usize },
+    #[error(
         "provided merkle tree {depth} is out of bounds and cannot be represented as an unsigned 8-bit integer"
     )]
     InvalidMerkleTreeDepth { depth: Felt },

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -58,6 +58,9 @@ pub struct AdviceProvider {
     max_map_elements: usize,
     store: MerkleStore,
     pc_requests: Vec<PrecompileRequest>,
+    pc_request_calldata_bytes: usize,
+    max_pc_requests: usize,
+    max_pc_request_calldata_bytes: usize,
 }
 
 impl Default for AdviceProvider {
@@ -88,6 +91,9 @@ impl AdviceProvider {
             max_map_elements: options.max_adv_map_elements(),
             store: MerkleStore::default(),
             pc_requests: Vec::new(),
+            pc_request_calldata_bytes: 0,
+            max_pc_requests: options.max_precompile_requests(),
+            max_pc_request_calldata_bytes: options.max_precompile_request_calldata_bytes(),
         }
     }
 
@@ -106,10 +112,26 @@ impl AdviceProvider {
                 max: options.max_adv_map_elements(),
             });
         }
+        if self.pc_requests.len() > options.max_precompile_requests() {
+            return Err(AdviceError::PrecompileRequestCountExceeded {
+                current: 0,
+                added: self.pc_requests.len(),
+                max: options.max_precompile_requests(),
+            });
+        }
+        if self.pc_request_calldata_bytes > options.max_precompile_request_calldata_bytes() {
+            return Err(AdviceError::PrecompileRequestCalldataBudgetExceeded {
+                current: 0,
+                added: self.pc_request_calldata_bytes,
+                max: options.max_precompile_request_calldata_bytes(),
+            });
+        }
 
         self.map_element_count = map_element_count;
         self.max_map_value_size = options.max_adv_map_value_size();
         self.max_map_elements = options.max_adv_map_elements();
+        self.max_pc_requests = options.max_precompile_requests();
+        self.max_pc_request_calldata_bytes = options.max_precompile_request_calldata_bytes();
         Ok(())
     }
 
@@ -139,7 +161,7 @@ impl AdviceProvider {
                 self.extend_merkle_store(infos);
             },
             AdviceMutation::ExtendPrecompileRequests { data } => {
-                self.extend_precompile_requests(data);
+                self.extend_precompile_requests(data)?;
             },
         }
         Ok(())
@@ -614,11 +636,55 @@ impl AdviceProvider {
     }
 
     /// Extends the precompile requests with the given entries.
-    pub fn extend_precompile_requests<I>(&mut self, iter: I)
+    pub fn extend_precompile_requests<I>(&mut self, iter: I) -> Result<(), AdviceError>
     where
         I: IntoIterator<Item = PrecompileRequest>,
     {
-        self.pc_requests.extend(iter);
+        let requests = Vec::from_iter(iter);
+        let added_calldata_bytes = requests
+            .iter()
+            .try_fold(0usize, |acc, request| acc.checked_add(request.calldata().len()));
+        let added_calldata_bytes =
+            added_calldata_bytes.ok_or(AdviceError::PrecompileRequestCalldataBudgetExceeded {
+                current: self.pc_request_calldata_bytes,
+                added: usize::MAX,
+                max: self.max_pc_request_calldata_bytes,
+            })?;
+
+        let request_count = self.pc_requests.len().checked_add(requests.len()).ok_or(
+            AdviceError::PrecompileRequestCountExceeded {
+                current: self.pc_requests.len(),
+                added: requests.len(),
+                max: self.max_pc_requests,
+            },
+        )?;
+        if request_count > self.max_pc_requests {
+            return Err(AdviceError::PrecompileRequestCountExceeded {
+                current: self.pc_requests.len(),
+                added: requests.len(),
+                max: self.max_pc_requests,
+            });
+        }
+
+        let calldata_bytes = self
+            .pc_request_calldata_bytes
+            .checked_add(added_calldata_bytes)
+            .ok_or(AdviceError::PrecompileRequestCalldataBudgetExceeded {
+                current: self.pc_request_calldata_bytes,
+                added: added_calldata_bytes,
+                max: self.max_pc_request_calldata_bytes,
+            })?;
+        if calldata_bytes > self.max_pc_request_calldata_bytes {
+            return Err(AdviceError::PrecompileRequestCalldataBudgetExceeded {
+                current: self.pc_request_calldata_bytes,
+                added: added_calldata_bytes,
+                max: self.max_pc_request_calldata_bytes,
+            });
+        }
+
+        self.pc_request_calldata_bytes = calldata_bytes;
+        self.pc_requests.extend(requests);
+        Ok(())
     }
 
     /// Moves all accumulated precompile requests out of this provider, leaving it empty.
@@ -626,6 +692,7 @@ impl AdviceProvider {
     /// Intended for proof packaging, where requests are serialized into the proof and no longer
     /// needed in the provider after consumption.
     pub fn take_precompile_requests(&mut self) -> Vec<PrecompileRequest> {
+        self.pc_request_calldata_bytes = 0;
         core::mem::take(&mut self.pc_requests)
     }
 
@@ -692,7 +759,7 @@ impl AdviceProviderInterface for AdviceProvider {
 mod tests {
     use alloc::{collections::BTreeMap, vec, vec::Vec};
 
-    use miden_core::WORD_SIZE;
+    use miden_core::{WORD_SIZE, events::EventId, precompile::PrecompileRequest};
 
     use super::AdviceProvider;
     use crate::{
@@ -816,6 +883,52 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn precompile_requests_extend_respects_count_budget_atomically() {
+        let options = ExecutionOptions::default().with_max_precompile_requests(2);
+        let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
+        provider.extend_precompile_requests([precompile_request(0, 1)]).unwrap();
+
+        let err = provider
+            .extend_precompile_requests([precompile_request(1, 1), precompile_request(2, 1)])
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            AdviceError::PrecompileRequestCountExceeded { current: 1, added: 2, max: 2 }
+        ));
+
+        assert_eq!(provider.precompile_requests().len(), 1);
+        assert_eq!(provider.precompile_requests()[0], precompile_request(0, 1));
+    }
+
+    #[test]
+    fn precompile_requests_extend_respects_calldata_budget_atomically() {
+        let options = ExecutionOptions::default().with_max_precompile_request_calldata_bytes(3);
+        let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
+        provider.extend_precompile_requests([precompile_request(0, 2)]).unwrap();
+
+        let err = provider.extend_precompile_requests([precompile_request(1, 2)]).unwrap_err();
+        assert!(matches!(
+            err,
+            AdviceError::PrecompileRequestCalldataBudgetExceeded { current: 2, added: 2, max: 3 }
+        ));
+
+        assert_eq!(provider.precompile_requests().len(), 1);
+        assert_eq!(provider.precompile_requests()[0], precompile_request(0, 2));
+    }
+
+    #[test]
+    fn take_precompile_requests_resets_calldata_budget() {
+        let options = ExecutionOptions::default().with_max_precompile_request_calldata_bytes(2);
+        let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
+        provider.extend_precompile_requests([precompile_request(0, 2)]).unwrap();
+
+        assert_eq!(provider.take_precompile_requests(), vec![precompile_request(0, 2)]);
+
+        provider.extend_precompile_requests([precompile_request(1, 2)]).unwrap();
+        assert_eq!(provider.precompile_requests(), &[precompile_request(1, 2)]);
+    }
+
     fn advice_map_from_entries(keys: impl Iterator<Item = u64>, value_len: usize) -> AdviceMap {
         keys.map(|key| {
             let values = (0..value_len)
@@ -825,5 +938,10 @@ mod tests {
         })
         .collect::<BTreeMap<_, _>>()
         .into()
+    }
+
+    fn precompile_request(seed: u64, calldata_len: usize) -> PrecompileRequest {
+        let calldata = (0..calldata_len).map(|offset| seed as u8 + offset as u8).collect();
+        PrecompileRequest::new(EventId::from_u64(seed), calldata)
     }
 }


### PR DESCRIPTION
`AdviceProvider` could keep adding deferred precompile requests without a count limit or calldata byte limit. A program could grow the request  list until the host ran out of memory.

This adds execution options for the maximum request count and total calldata bytes. `AdviceProvider` now rejects additions that would exceed either limit before it changes the stored requests.

Closes 0xMiden/security-issues#14.