### PR TITLE
fix(processor): stack depth limits include all active contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - Made AEAD decrypt verify the input ciphertext as well as the tag ([#3147](https://github.com/0xMiden/miden-vm/pull/3147)).
 - Removed overly aggressive validation check that prevented defining virtual executable targets in Miden projects
 - Constrained Core AIR stack routes for control and stream operations, preventing unconstrained stack values across `SYSCALL`, `EVALCIRCUIT`, `CALLER`, `MSTREAM`, `PIPE`, `REPEAT`, `SWAPW2`, and `SWAPW3` ([#3249](https://github.com/0xMiden/miden-vm/pull/3249)).
+- Stack depth limits now properly include all active contexts' overflow stacks ([#3261](https://github.com/0xMiden/miden-vm/pull/3261)).
 
 #### Enhancements
 - Improved O(n²) to O(log n) name conflict checks in `Module::define_*` methods by introducing a `BTreeMap` name index; also narrowed `items_mut()` to return an iterator instead of `&mut Vec<Export>` to preserve the index invariant ([#3218](https://github.com/0xMiden/miden-vm/pull/3218)).

--- a/processor/src/execution_options.rs
+++ b/processor/src/execution_options.rs
@@ -27,8 +27,14 @@ pub struct ExecutionOptions {
     max_precompile_requests: usize,
     /// Maximum total number of calldata bytes allowed across deferred precompile requests.
     max_precompile_request_calldata_bytes: usize,
-    /// Maximum number of field elements allowed on the operand stack in the active execution
-    /// context.
+    /// Maximum number of field elements allowed on the operand stack across the active execution
+    /// context and all suspended contexts.
+    ///
+    /// A `call`, `dyncall`, or `syscall` context switch hides the caller's operand-stack overflow
+    /// (everything below the top 16 elements) until the callee returns. This limit bounds the
+    /// aggregate of the active context's depth plus all such suspended overflow, so nesting
+    /// context switches cannot accumulate hidden operand-stack memory beyond the configured
+    /// budget.
     max_stack_depth: usize,
     /// Maximum number of field elements allowed in the processor's memory at any point during
     /// execution, rounded up to the nearest multiple of 4.
@@ -264,8 +270,8 @@ impl ExecutionOptions {
         self.max_precompile_request_calldata_bytes
     }
 
-    /// Returns the maximum number of field elements allowed on the operand stack in the active
-    /// execution context.
+    /// Returns the maximum number of field elements allowed on the operand stack across the active
+    /// execution context and all suspended contexts.
     #[inline]
     pub fn max_stack_depth(&self) -> usize {
         self.max_stack_depth
@@ -301,8 +307,8 @@ impl ExecutionOptions {
         self
     }
 
-    /// Sets the maximum number of field elements allowed on the operand stack in the active
-    /// execution context.
+    /// Sets the maximum number of field elements allowed on the operand stack across the active
+    /// execution context and all suspended contexts.
     pub fn with_max_stack_depth(
         mut self,
         max_stack_depth: usize,

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -132,6 +132,13 @@ pub struct FastProcessor {
     /// `system_call_state_stack`.
     stack_overflow_save_stack: Vec<Vec<Felt>>,
 
+    /// Running total of the number of field elements currently held across all suspended overflow
+    /// segments in `stack_overflow_save_stack`. Maintained in lockstep with that stack so the
+    /// aggregate operand-stack depth (active context plus all suspended overflow) can be bounded
+    /// by `ExecutionOptions::max_stack_depth()` in O(1) without summing every saved segment on
+    /// each push. See [`Self::ensure_stack_capacity_for_push`].
+    saved_overflow_len: usize,
+
     /// Options for execution, including cycle limits, stack limits, advice map limits, and the
     /// size of core trace fragments during execution.
     options: ExecutionOptions,
@@ -268,6 +275,7 @@ impl FastProcessor {
             memory: Memory::new(options.max_memory_elements()),
             system_call_state_stack: Vec::new(),
             stack_overflow_save_stack: Vec::new(),
+            saved_overflow_len: 0,
             options,
             pc_transcript: PrecompileTranscript::new(),
         })
@@ -489,9 +497,20 @@ impl FastProcessor {
     /// `SmallVec` would put a useful inline buffer inside `FastProcessor`, and preallocating the
     /// full limit would penalize ordinary programs. This policy is performance-sensitive and should
     /// be benchmarked against the fixed-buffer baseline.
+    ///
+    /// The depth that is checked is the *aggregate* operand-stack depth: the active context's depth
+    /// plus every element held in suspended overflow segments (`saved_overflow_len`). A `call`,
+    /// `dyncall`, or `syscall` context switch hides the caller's overflow in
+    /// `stack_overflow_save_stack` rather than freeing it, so checking only the active context
+    /// would let a program nest context switches to accumulate `O(call_depth *
+    /// max_stack_depth)` hidden operand-stack memory while every live frame stayed within the
+    /// limit. Because a context switch merely moves elements between the active stack and the
+    /// saved overflow (it never creates elements), the aggregate is conserved across switches
+    /// and only grows on a push, so enforcing the bound here is sufficient to cap total
+    /// operand-stack memory.
     #[inline(always)]
     fn ensure_stack_capacity_for_push(&mut self) -> Result<(), ExecutionError> {
-        let depth = self.stack_size() + 1;
+        let depth = self.stack_size() + self.saved_overflow_len + 1;
         let max = self.options.max_stack_depth();
         if depth > max {
             return Err(ExecutionError::StackDepthLimitExceeded { depth, max });

--- a/processor/src/fast/operation.rs
+++ b/processor/src/fast/operation.rs
@@ -295,6 +295,11 @@ impl StackInterface for FastProcessor {
 
         self.stack_bot_idx = self.stack_top_idx - MIN_STACK_DEPTH;
 
+        // Charge the suspended overflow against the aggregate operand-stack budget. The elements
+        // are merely moved from the active stack into the saved overflow, so the aggregate depth is
+        // unchanged here; tracking it lets `ensure_stack_capacity_for_push` cap the total across
+        // all nested contexts rather than only the active one.
+        self.saved_overflow_len += overflow_stack.len();
         self.stack_overflow_save_stack.push(overflow_stack);
     }
 
@@ -315,6 +320,10 @@ impl StackInterface for FastProcessor {
             MIN_STACK_DEPTH.saturating_add(target_overflow_len) <= self.options.max_stack_depth(),
             "suspended caller stacks are checked against the operand stack depth limit before being saved"
         );
+
+        // Release this segment from the aggregate operand-stack budget; the elements are about to
+        // be moved back into the active context below.
+        self.saved_overflow_len -= target_overflow_len;
 
         // Check if there's enough room to restore the overflow stack in the current stack buffer.
         // If not, move the stack within the buffer so that after restoring the overflow stack, the

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -1709,6 +1709,9 @@ fn issue_2818_restore_context_grows_stack_buffer_for_suspended_caller() {
     processor
         .stack_overflow_save_stack
         .push(vec![Felt::from_u32(42); caller_overflow_len]);
+    // Keep the aggregate-overflow accounting consistent with the manually injected suspended
+    // caller, mirroring what `start_context` would have done.
+    processor.saved_overflow_len += caller_overflow_len;
     processor.system_call_state_stack.push(SystemCallState {
         ctx: processor.ctx,
         caller_hash: processor.caller_hash,
@@ -1974,6 +1977,153 @@ fn stack_depth_limit_exceeded() {
             max: MIN_STACK_DEPTH,
         } if depth == MIN_STACK_DEPTH + 1
     );
+}
+
+/// Nested `call` context switches park the caller's operand-stack overflow (everything below the
+/// top 16 elements) in `stack_overflow_save_stack` rather than freeing it. Before the fix, only the
+/// active context was charged against `max_stack_depth`, so a program could keep every live frame
+/// within the limit while accumulating `O(call_depth * (max_stack_depth - 16))` hidden overflow in
+/// heap memory. This test drives such a nested-call chain and asserts that the aggregate operand
+/// stack (active context plus all suspended overflow) is now bounded: execution fails with
+/// `StackDepthLimitExceeded`, and the aggregate never exceeds the configured limit at any step.
+#[test]
+fn nested_calls_enforce_aggregate_stack_depth_limit() {
+    let max_stack_depth = MIN_STACK_DEPTH + 2;
+
+    // Each frame pushes 2 elements (filling the active context to `max_stack_depth`) and then calls
+    // the next frame, which parks those 2 elements as hidden overflow. Without an aggregate bound
+    // the saved overflow would grow without limit as the chain deepens.
+    let source = "
+        proc leaf
+            push.0
+            drop
+        end
+
+        proc mid_3
+            push.0 push.0
+            call.leaf
+            drop drop
+        end
+
+        proc mid_2
+            push.0 push.0
+            call.mid_3
+            drop drop
+        end
+
+        proc mid_1
+            push.0 push.0
+            call.mid_2
+            drop drop
+        end
+
+        begin
+            push.0 push.0
+            call.mid_1
+            drop drop
+        end
+        ";
+
+    let source_manager = Arc::new(DefaultSourceManager::default());
+    let program = Assembler::new(source_manager)
+        .assemble_program("program", source)
+        .expect("program should assemble")
+        .unwrap_program();
+
+    let options = ExecutionOptions::default().with_max_stack_depth(max_stack_depth).unwrap();
+    let mut processor =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits");
+    let mut host = DefaultHost::default();
+    let mut resume_ctx = processor
+        .get_initial_resume_context(&program)
+        .expect("initial resume context should be created");
+
+    // Step until execution halts. At every step the aggregate operand-stack depth (active context
+    // plus all suspended overflow) must stay within the configured limit, and execution must
+    // eventually fail with `StackDepthLimitExceeded` rather than silently accumulating overflow.
+    let err = loop {
+        let saved_hidden_values: usize =
+            processor.stack_overflow_save_stack.iter().map(Vec::len).sum();
+        assert!(
+            processor.stack_size() + saved_hidden_values <= max_stack_depth,
+            "aggregate operand-stack depth must never exceed the configured limit"
+        );
+
+        match processor.step_sync(&mut host, resume_ctx) {
+            Ok(Some(next_ctx)) => resume_ctx = next_ctx,
+            Ok(None) => panic!("nested-call chain should not complete within the aggregate limit"),
+            Err(err) => break err,
+        }
+    };
+
+    assert_matches!(
+        err,
+        ExecutionError::StackDepthLimitExceeded { depth, max }
+            if depth == max_stack_depth + 1 && max == max_stack_depth
+    );
+}
+
+/// Companion to [`nested_calls_enforce_aggregate_stack_depth_limit`]: the aggregate operand-stack
+/// budget must be *released* when a context returns. A nested-call chain whose peak aggregate
+/// (active context plus all suspended overflow) stays within the limit executes to completion, and
+/// the saved overflow is fully unwound by the end.
+#[test]
+fn nested_calls_within_aggregate_budget_succeed() {
+    // Four frames each park 2 elements of hidden overflow. The peak aggregate occurs in the deepest
+    // callee: 16 (active) + 4 * 2 (suspended) + 1 (its first push) = 25. Give exactly that budget.
+    let max_stack_depth = MIN_STACK_DEPTH + 9;
+
+    let source = "
+        proc leaf
+            push.0
+            drop
+        end
+
+        proc mid_3
+            push.0 push.0
+            call.leaf
+            drop drop
+        end
+
+        proc mid_2
+            push.0 push.0
+            call.mid_3
+            drop drop
+        end
+
+        proc mid_1
+            push.0 push.0
+            call.mid_2
+            drop drop
+        end
+
+        begin
+            push.0 push.0
+            call.mid_1
+            drop drop
+        end
+        ";
+
+    let source_manager = Arc::new(DefaultSourceManager::default());
+    let program = Assembler::new(source_manager)
+        .assemble_program("program", source)
+        .expect("program should assemble")
+        .unwrap_program();
+
+    let options = ExecutionOptions::default().with_max_stack_depth(max_stack_depth).unwrap();
+    let mut processor =
+        FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+            .expect("processor advice inputs should fit advice map limits");
+    let mut host = DefaultHost::default();
+
+    processor
+        .execute_mut_sync(&program, &mut host)
+        .expect("a nested-call chain within the aggregate budget should succeed");
+
+    // Every context returned, so the suspended-overflow budget is fully released.
+    assert!(processor.stack_overflow_save_stack.is_empty());
+    assert_eq!(processor.saved_overflow_len, 0);
 }
 
 /// Tests that `ExecutionError::Internal` is correctly emitted when the continuation stack grows


### PR DESCRIPTION
Fixes a vulnerability where stack depth limits computation didn't include all active contexts.