### PR TITLE
fix: Bound advice Merkle store growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Bound memory AIR word addresses to their range-checked decomposition limbs ([#3245](https://github.com/0xMiden/miden-vm/pull/3245)).
 - Rejected oversized AEAD decrypt outputs before reading ciphertext or running host-side decryption ([#3252](https://github.com/0xMiden/miden-vm/pull/3252)).
 - [BREAKING] Bounded deferred precompile request growth by request count and total calldata bytes in `AdviceProvider` ([#3260](https://github.com/0xMiden/miden-vm/pull/3260)).
+- [BREAKING] Bounded advice Merkle store growth by internal node count during setup and execution ([#3264](https://github.com/0xMiden/miden-vm/pull/3264)).
 - Fixed MASM tooling edge cases around atomic file writes, source URI paths, package loading, local registry state, diagnostics, generated MASM memory addresses, and CST `$...` special identifiers ([#3178](https://github.com/0xMiden/miden-vm/pull/3178)).
 - [BREAKING] Removed the public `eddsa_ed25519::verify_prehash` entrypoint and bound EdDSA precompile verification to the signed message ([#3254](https://github.com/0xMiden/miden-vm/pull/3254)).
 - Replaced `bincode` proof serialization with `wincode` and bounded verifier-side STARK proof deserialization to 64 MiB ([#3148](https://github.com/0xMiden/miden-vm/pull/3148)).

--- a/processor/src/execution_options.rs
+++ b/processor/src/execution_options.rs
@@ -23,6 +23,8 @@ pub struct ExecutionOptions {
     /// Maximum number of continuations allowed on the continuation stack at any point during
     /// execution.
     max_num_continuations: usize,
+    /// Maximum number of internal nodes allowed in the advice provider's Merkle store.
+    max_merkle_store_nodes: usize,
     /// Maximum number of deferred precompile requests allowed during execution.
     max_precompile_requests: usize,
     /// Maximum total number of calldata bytes allowed across deferred precompile requests.
@@ -51,6 +53,7 @@ impl Default for ExecutionOptions {
             max_adv_map_elements: Self::DEFAULT_MAX_ADV_MAP_ELEMENTS,
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
             max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
+            max_merkle_store_nodes: Self::DEFAULT_MAX_MERKLE_STORE_NODES,
             max_precompile_requests: Self::DEFAULT_MAX_PRECOMPILE_REQUESTS,
             max_precompile_request_calldata_bytes:
                 Self::DEFAULT_MAX_PRECOMPILE_REQUEST_CALLDATA_BYTES,
@@ -87,6 +90,12 @@ impl ExecutionOptions {
     /// Default maximum number of continuations allowed on the continuation stack.
     /// Set to 2^16 (65536).
     pub const DEFAULT_MAX_NUM_CONTINUATIONS: usize = 1 << 16;
+
+    /// Default maximum number of internal nodes allowed in the advice provider's Merkle store.
+    ///
+    /// Set to 2^20 so the default allows large Merkle inputs and repeated updates while still
+    /// providing a finite host-memory backstop.
+    pub const DEFAULT_MAX_MERKLE_STORE_NODES: usize = 1 << 20;
 
     /// Default maximum number of deferred precompile requests allowed during execution.
     /// Set to 2^16 (65536).
@@ -170,6 +179,7 @@ impl ExecutionOptions {
             max_adv_map_elements: Self::DEFAULT_MAX_ADV_MAP_ELEMENTS,
             max_hash_len_bytes: Self::DEFAULT_MAX_HASH_LEN_BYTES,
             max_num_continuations: Self::DEFAULT_MAX_NUM_CONTINUATIONS,
+            max_merkle_store_nodes: Self::DEFAULT_MAX_MERKLE_STORE_NODES,
             max_precompile_requests: Self::DEFAULT_MAX_PRECOMPILE_REQUESTS,
             max_precompile_request_calldata_bytes:
                 Self::DEFAULT_MAX_PRECOMPILE_REQUEST_CALLDATA_BYTES,
@@ -258,6 +268,12 @@ impl ExecutionOptions {
         self.max_num_continuations
     }
 
+    /// Returns the maximum number of internal nodes allowed in the advice provider's Merkle store.
+    #[inline]
+    pub fn max_merkle_store_nodes(&self) -> usize {
+        self.max_merkle_store_nodes
+    }
+
     /// Returns the maximum number of deferred precompile requests allowed during execution.
     #[inline]
     pub fn max_precompile_requests(&self) -> usize {
@@ -289,6 +305,12 @@ impl ExecutionOptions {
     /// Sets the maximum number of continuations allowed on the continuation stack.
     pub fn with_max_num_continuations(mut self, max_num_continuations: usize) -> Self {
         self.max_num_continuations = max_num_continuations;
+        self
+    }
+
+    /// Sets the maximum number of internal nodes allowed in the advice provider's Merkle store.
+    pub fn with_max_merkle_store_nodes(mut self, max_merkle_store_nodes: usize) -> Self {
+        self.max_merkle_store_nodes = max_merkle_store_nodes;
         self
     }
 

--- a/processor/src/host/advice/errors.rs
+++ b/processor/src/host/advice/errors.rs
@@ -33,6 +33,10 @@ pub enum AdviceError {
     )]
     AdvMapElementBudgetExceeded { current: usize, added: usize, max: usize },
     #[error(
+        "Merkle store node budget exceeded: adding {added} nodes to the current {current} would exceed the maximum of {max}"
+    )]
+    MerkleStoreNodeBudgetExceeded { current: usize, added: usize, max: usize },
+    #[error(
         "precompile request count budget exceeded: adding {added} requests to the current {current} would exceed the maximum of {max}"
     )]
     PrecompileRequestCountExceeded { current: usize, added: usize, max: usize },

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -1,4 +1,7 @@
-use alloc::{collections::VecDeque, vec::Vec};
+use alloc::{
+    collections::{BTreeSet, VecDeque},
+    vec::Vec,
+};
 
 use miden_core::{
     Felt, WORD_SIZE, Word,
@@ -47,15 +50,16 @@ impl MerkleStoreBudget for MerkleStore {
     where
         I: IntoIterator<Item = Word>,
     {
-        let mut new_roots = Vec::new();
+        let mut seen_roots = BTreeSet::new();
+        let mut count = 0;
 
         for root in roots {
-            if !self.contains_internal_node(root) && !new_roots.contains(&root) {
-                new_roots.push(root);
+            if seen_roots.insert(root) && !self.contains_internal_node(root) {
+                count += 1;
             }
         }
 
-        new_roots.len()
+        count
     }
 
     fn new_path_node_count(

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -3,7 +3,10 @@ use alloc::{collections::VecDeque, vec::Vec};
 use miden_core::{
     Felt, WORD_SIZE, Word,
     advice::{AdviceInputs, AdviceMap},
-    crypto::merkle::{InnerNodeInfo, MerklePath, MerkleStore, NodeIndex},
+    crypto::{
+        hash::Poseidon2,
+        merkle::{InnerNodeInfo, MerkleError, MerklePath, MerkleStore, NodeIndex},
+    },
     precompile::PrecompileRequest,
 };
 #[cfg(test)]
@@ -19,6 +22,52 @@ use crate::{ExecutionOptions, host::AdviceMutation, processor::AdviceProviderInt
 
 /// Maximum number of elements allowed on the advice stack. Set to 2^17.
 pub const MAX_ADVICE_STACK_SIZE: usize = 1 << 17;
+
+trait MerkleStoreBudget {
+    fn contains_internal_node(&self, root: Word) -> bool;
+
+    fn new_internal_node_count<I>(&self, roots: I) -> usize
+    where
+        I: IntoIterator<Item = Word>;
+
+    fn new_path_node_count(
+        &self,
+        index: u64,
+        node: Word,
+        path: &MerklePath,
+    ) -> Result<usize, MerkleError>;
+}
+
+impl MerkleStoreBudget for MerkleStore {
+    fn contains_internal_node(&self, root: Word) -> bool {
+        self.get_node(root, NodeIndex::root()).is_ok()
+    }
+
+    fn new_internal_node_count<I>(&self, roots: I) -> usize
+    where
+        I: IntoIterator<Item = Word>,
+    {
+        let mut new_roots = Vec::new();
+
+        for root in roots {
+            if !self.contains_internal_node(root) && !new_roots.contains(&root) {
+                new_roots.push(root);
+            }
+        }
+
+        new_roots.len()
+    }
+
+    fn new_path_node_count(
+        &self,
+        index: u64,
+        node: Word,
+        path: &MerklePath,
+    ) -> Result<usize, MerkleError> {
+        path.authenticated_nodes(index, node)
+            .map(|nodes| self.new_internal_node_count(nodes.map(|node| node.value)))
+    }
+}
 
 // ADVICE PROVIDER
 // ================================================================================================
@@ -457,9 +506,16 @@ impl AdviceProvider {
         Ok(())
     }
 
-    fn commit_merkle_store(&mut self, store: MerkleStore) {
-        self.merkle_store_node_count = store.num_internal_nodes();
-        self.store = store;
+    fn check_merkle_store_node_addition(&self, added: usize) -> Result<(), AdviceError> {
+        let Some(node_count) = self.merkle_store_node_count.checked_add(added) else {
+            return Err(AdviceError::MerkleStoreNodeBudgetExceeded {
+                current: self.merkle_store_node_count,
+                added,
+                max: self.max_merkle_store_nodes,
+            });
+        };
+
+        self.check_merkle_store_node_budget(node_count)
     }
 
     /// Inserts the provided value into the advice map under the specified key.
@@ -604,9 +660,6 @@ impl AdviceProvider {
     /// Updates a node at the specified depth and index in a Merkle tree with the specified root;
     /// returns the Merkle path from the updated node to the new root, together with the new root.
     ///
-    /// The tree is cloned prior to the update. Thus, the advice provider retains the original and
-    /// the updated tree.
-    ///
     /// # Errors
     /// Returns an error if:
     /// - A Merkle tree for the specified root cannot be found in this advice provider.
@@ -623,13 +676,28 @@ impl AdviceProvider {
     ) -> Result<(MerklePath, Word), AdviceError> {
         let node_index = NodeIndex::from_elements(&depth, &index)
             .map_err(|_| AdviceError::InvalidMerkleTreeNodeIndex { depth, index })?;
-        let mut store = self.store.clone();
-        let root_path = store
-            .set_node(root, node_index, value)
+        let proof = self
+            .store
+            .get_path(root, node_index)
             .map_err(AdviceError::MerkleStoreUpdateFailed)?;
-        self.check_merkle_store_node_budget(store.num_internal_nodes())?;
-        self.commit_merkle_store(store);
-        Ok((root_path.path, root_path.root))
+        let path = proof.path;
+
+        if proof.value == value {
+            return Ok((path, root));
+        }
+
+        let added = self
+            .store
+            .new_path_node_count(node_index.position(), value, &path)
+            .map_err(AdviceError::MerkleStoreUpdateFailed)?;
+        self.check_merkle_store_node_addition(added)?;
+
+        let new_root = self
+            .store
+            .add_merkle_path(node_index.position(), value, path.clone())
+            .map_err(AdviceError::MerkleStoreUpdateFailed)?;
+        self.merkle_store_node_count += added;
+        Ok((path, new_root))
     }
 
     /// Creates a new Merkle tree in the advice provider by combining Merkle trees with the
@@ -641,10 +709,12 @@ impl AdviceProvider {
     /// It is not checked whether a Merkle tree for either of the specified roots can be found in
     /// this advice provider.
     pub fn merge_roots(&mut self, lhs: Word, rhs: Word) -> Result<Word, AdviceError> {
-        let mut store = self.store.clone();
-        let root = store.merge_roots(lhs, rhs).map_err(AdviceError::MerkleStoreMergeFailed)?;
-        self.check_merkle_store_node_budget(store.num_internal_nodes())?;
-        self.commit_merkle_store(store);
+        let root = Poseidon2::merge(&[lhs, rhs]);
+        let added = self.store.new_internal_node_count([root]);
+        self.check_merkle_store_node_addition(added)?;
+
+        let root = self.store.merge_roots(lhs, rhs).map_err(AdviceError::MerkleStoreMergeFailed)?;
+        self.merkle_store_node_count += added;
         Ok(root)
     }
 
@@ -658,12 +728,12 @@ impl AdviceProvider {
     where
         I: IntoIterator<Item = InnerNodeInfo>,
     {
-        let mut store = self.store.clone();
-        for info in iter {
-            store.extend([info]);
-            self.check_merkle_store_node_budget(store.num_internal_nodes())?;
-        }
-        self.commit_merkle_store(store);
+        let nodes = iter.into_iter().collect::<Vec<_>>();
+        let added = self.store.new_internal_node_count(nodes.iter().map(|node| node.value));
+        self.check_merkle_store_node_addition(added)?;
+
+        self.store.extend(nodes);
+        self.merkle_store_node_count += added;
         Ok(())
     }
 
@@ -1020,6 +1090,23 @@ mod tests {
         let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
 
         provider.extend_merkle_store(tree.inner_nodes()).unwrap();
+
+        assert_eq!(provider.merkle_store_node_count, base_node_count + 1);
+        assert!(provider.has_merkle_root(tree.root()));
+    }
+
+    #[test]
+    fn merkle_store_extend_counts_only_new_unique_nodes() {
+        let base_node_count = MerkleStore::default().num_internal_nodes();
+        let tree = merkle_tree_from_leaves(0..2);
+        let options = ExecutionOptions::default().with_max_merkle_store_nodes(base_node_count + 1);
+        let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
+        let nodes = tree.inner_nodes().collect::<Vec<_>>();
+
+        provider
+            .extend_merkle_store(nodes.iter().cloned().chain(nodes.iter().cloned()))
+            .unwrap();
+        provider.extend_merkle_store(nodes).unwrap();
 
         assert_eq!(provider.merkle_store_node_count, base_node_count + 1);
         assert!(provider.has_merkle_root(tree.root()));

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -57,6 +57,8 @@ pub struct AdviceProvider {
     max_map_value_size: usize,
     max_map_elements: usize,
     store: MerkleStore,
+    merkle_store_node_count: usize,
+    max_merkle_store_nodes: usize,
     pc_requests: Vec<PrecompileRequest>,
     pc_request_calldata_bytes: usize,
     max_pc_requests: usize,
@@ -77,19 +79,23 @@ impl AdviceProvider {
         let AdviceInputs { stack, map, store } = inputs;
         let mut provider = Self::empty(options);
         provider.extend_stack(stack)?;
-        provider.extend_merkle_store(store.inner_nodes());
+        provider.extend_merkle_store(store.inner_nodes())?;
         provider.extend_map(&map)?;
         Ok(provider)
     }
 
     fn empty(options: &ExecutionOptions) -> Self {
+        let store = MerkleStore::default();
+        let merkle_store_node_count = store.num_internal_nodes();
         Self {
             stack: VecDeque::new(),
             map: AdviceMap::default(),
             map_element_count: 0,
             max_map_value_size: options.max_adv_map_value_size(),
             max_map_elements: options.max_adv_map_elements(),
-            store: MerkleStore::default(),
+            store,
+            merkle_store_node_count,
+            max_merkle_store_nodes: options.max_merkle_store_nodes(),
             pc_requests: Vec::new(),
             pc_request_calldata_bytes: 0,
             max_pc_requests: options.max_precompile_requests(),
@@ -112,6 +118,13 @@ impl AdviceProvider {
                 max: options.max_adv_map_elements(),
             });
         }
+        if self.merkle_store_node_count > options.max_merkle_store_nodes() {
+            return Err(AdviceError::MerkleStoreNodeBudgetExceeded {
+                current: 0,
+                added: self.merkle_store_node_count,
+                max: options.max_merkle_store_nodes(),
+            });
+        }
         if self.pc_requests.len() > options.max_precompile_requests() {
             return Err(AdviceError::PrecompileRequestCountExceeded {
                 current: 0,
@@ -130,6 +143,7 @@ impl AdviceProvider {
         self.map_element_count = map_element_count;
         self.max_map_value_size = options.max_adv_map_value_size();
         self.max_map_elements = options.max_adv_map_elements();
+        self.max_merkle_store_nodes = options.max_merkle_store_nodes();
         self.max_pc_requests = options.max_precompile_requests();
         self.max_pc_request_calldata_bytes = options.max_precompile_request_calldata_bytes();
         Ok(())
@@ -158,7 +172,7 @@ impl AdviceProvider {
                 self.extend_map(&other)?;
             },
             AdviceMutation::ExtendMerkleStore { infos } => {
-                self.extend_merkle_store(infos);
+                self.extend_merkle_store(infos)?;
             },
             AdviceMutation::ExtendPrecompileRequests { data } => {
                 self.extend_precompile_requests(data)?;
@@ -432,6 +446,22 @@ impl AdviceProvider {
         Ok(())
     }
 
+    fn check_merkle_store_node_budget(&self, node_count: usize) -> Result<(), AdviceError> {
+        if node_count > self.max_merkle_store_nodes {
+            return Err(AdviceError::MerkleStoreNodeBudgetExceeded {
+                current: self.merkle_store_node_count,
+                added: node_count.saturating_sub(self.merkle_store_node_count),
+                max: self.max_merkle_store_nodes,
+            });
+        }
+        Ok(())
+    }
+
+    fn commit_merkle_store(&mut self, store: MerkleStore) {
+        self.merkle_store_node_count = store.num_internal_nodes();
+        self.store = store;
+    }
+
     /// Inserts the provided value into the advice map under the specified key.
     ///
     /// The values in the advice map can be moved onto the advice stack by invoking
@@ -593,10 +623,13 @@ impl AdviceProvider {
     ) -> Result<(MerklePath, Word), AdviceError> {
         let node_index = NodeIndex::from_elements(&depth, &index)
             .map_err(|_| AdviceError::InvalidMerkleTreeNodeIndex { depth, index })?;
-        self.store
+        let mut store = self.store.clone();
+        let root_path = store
             .set_node(root, node_index, value)
-            .map(|root| (root.path, root.root))
-            .map_err(AdviceError::MerkleStoreUpdateFailed)
+            .map_err(AdviceError::MerkleStoreUpdateFailed)?;
+        self.check_merkle_store_node_budget(store.num_internal_nodes())?;
+        self.commit_merkle_store(store);
+        Ok((root_path.path, root_path.root))
     }
 
     /// Creates a new Merkle tree in the advice provider by combining Merkle trees with the
@@ -608,7 +641,11 @@ impl AdviceProvider {
     /// It is not checked whether a Merkle tree for either of the specified roots can be found in
     /// this advice provider.
     pub fn merge_roots(&mut self, lhs: Word, rhs: Word) -> Result<Word, AdviceError> {
-        self.store.merge_roots(lhs, rhs).map_err(AdviceError::MerkleStoreMergeFailed)
+        let mut store = self.store.clone();
+        let root = store.merge_roots(lhs, rhs).map_err(AdviceError::MerkleStoreMergeFailed)?;
+        self.check_merkle_store_node_budget(store.num_internal_nodes())?;
+        self.commit_merkle_store(store);
+        Ok(root)
     }
 
     /// Returns true if the Merkle root exists for the advice provider Merkle store.
@@ -617,11 +654,17 @@ impl AdviceProvider {
     }
 
     /// Extends the [MerkleStore] with the given nodes.
-    pub fn extend_merkle_store<I>(&mut self, iter: I)
+    pub fn extend_merkle_store<I>(&mut self, iter: I) -> Result<(), AdviceError>
     where
         I: IntoIterator<Item = InnerNodeInfo>,
     {
-        self.store.extend(iter);
+        let mut store = self.store.clone();
+        for info in iter {
+            store.extend([info]);
+            self.check_merkle_store_node_budget(store.num_internal_nodes())?;
+        }
+        self.commit_merkle_store(store);
+        Ok(())
     }
 
     // PRECOMPILE REQUESTS
@@ -702,7 +745,7 @@ impl AdviceProvider {
     /// Extends the contents of this instance with the contents of an `AdviceInputs`.
     pub fn extend_from_inputs(&mut self, inputs: &AdviceInputs) -> Result<(), AdviceError> {
         self.extend_stack(inputs.stack.iter().cloned())?;
-        self.extend_merkle_store(inputs.store.inner_nodes());
+        self.extend_merkle_store(inputs.store.inner_nodes())?;
         self.extend_map(&inputs.map)
     }
 
@@ -929,6 +972,130 @@ mod tests {
         assert_eq!(provider.precompile_requests(), &[precompile_request(1, 2)]);
     }
 
+    #[test]
+    fn initial_merkle_store_respects_node_budget() {
+        let tree = merkle_tree_from_leaves(0..4);
+        let store = merkle_store_from_tree(&tree);
+        let options =
+            ExecutionOptions::default().with_max_merkle_store_nodes(store.num_internal_nodes() - 1);
+        let inputs = AdviceInputs::default().with_merkle_store(store);
+
+        let err = AdviceProvider::new(inputs, &options).unwrap_err();
+        assert!(matches!(
+            err,
+            AdviceError::MerkleStoreNodeBudgetExceeded {
+                current: _,
+                added: _,
+                max
+            } if max == options.max_merkle_store_nodes()
+        ));
+    }
+
+    #[test]
+    fn merkle_store_extend_respects_node_budget_atomically() {
+        let base_node_count = MerkleStore::default().num_internal_nodes();
+        let options = ExecutionOptions::default().with_max_merkle_store_nodes(base_node_count + 1);
+        let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
+        let tree = merkle_tree_from_leaves(0..4);
+
+        let err = provider.extend_merkle_store(tree.inner_nodes()).unwrap_err();
+        assert!(matches!(
+            err,
+            AdviceError::MerkleStoreNodeBudgetExceeded {
+                current,
+                added: _,
+                max
+            } if current == base_node_count && max == base_node_count + 1
+        ));
+
+        assert_eq!(provider.merkle_store_node_count, base_node_count);
+        assert!(!provider.has_merkle_root(tree.root()));
+    }
+
+    #[test]
+    fn merkle_store_extend_allows_exact_node_budget() {
+        let base_node_count = MerkleStore::default().num_internal_nodes();
+        let tree = merkle_tree_from_leaves(0..2);
+        let options = ExecutionOptions::default().with_max_merkle_store_nodes(base_node_count + 1);
+        let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
+
+        provider.extend_merkle_store(tree.inner_nodes()).unwrap();
+
+        assert_eq!(provider.merkle_store_node_count, base_node_count + 1);
+        assert!(provider.has_merkle_root(tree.root()));
+    }
+
+    #[test]
+    fn merkle_store_merge_respects_node_budget_atomically() {
+        let base_node_count = MerkleStore::default().num_internal_nodes();
+        let options = ExecutionOptions::default().with_max_merkle_store_nodes(base_node_count);
+        let mut provider = AdviceProvider::new(AdviceInputs::default(), &options).unwrap();
+
+        let err = provider.merge_roots(make_leaf(0), make_leaf(4)).unwrap_err();
+        assert!(matches!(
+            err,
+            AdviceError::MerkleStoreNodeBudgetExceeded {
+                current,
+                added: 1,
+                max
+            } if current == base_node_count && max == base_node_count
+        ));
+
+        assert_eq!(provider.merkle_store_node_count, base_node_count);
+    }
+
+    #[test]
+    fn merkle_store_update_respects_node_budget_atomically() {
+        let tree = merkle_tree_from_leaves(0..4);
+        let store = merkle_store_from_tree(&tree);
+        let node_count = store.num_internal_nodes();
+        let options = ExecutionOptions::default().with_max_merkle_store_nodes(node_count);
+        let inputs = AdviceInputs::default().with_merkle_store(store);
+        let mut provider = AdviceProvider::new(inputs, &options).unwrap();
+
+        let err = provider
+            .update_merkle_node(tree.root(), Felt::new_unchecked(2), Felt::ZERO, make_leaf(100))
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            AdviceError::MerkleStoreNodeBudgetExceeded {
+                current,
+                added: _,
+                max
+            } if current == node_count && max == node_count
+        ));
+
+        assert_eq!(provider.merkle_store_node_count, node_count);
+        assert_eq!(
+            provider.get_tree_node(tree.root(), Felt::new_unchecked(2), Felt::ZERO).unwrap(),
+            make_leaf(0)
+        );
+    }
+
+    #[test]
+    fn merkle_store_update_allows_exact_node_budget() {
+        let tree = merkle_tree_from_leaves(0..4);
+        let store = merkle_store_from_tree(&tree);
+        let mut staged = store.clone();
+        staged
+            .set_node(
+                tree.root(),
+                miden_core::crypto::merkle::NodeIndex::new(2, 0).unwrap(),
+                make_leaf(100),
+            )
+            .unwrap();
+        let options =
+            ExecutionOptions::default().with_max_merkle_store_nodes(staged.num_internal_nodes());
+        let inputs = AdviceInputs::default().with_merkle_store(store);
+        let mut provider = AdviceProvider::new(inputs, &options).unwrap();
+
+        provider
+            .update_merkle_node(tree.root(), Felt::new_unchecked(2), Felt::ZERO, make_leaf(100))
+            .unwrap();
+
+        assert_eq!(provider.merkle_store_node_count, staged.num_internal_nodes());
+    }
+
     fn advice_map_from_entries(keys: impl Iterator<Item = u64>, value_len: usize) -> AdviceMap {
         keys.map(|key| {
             let values = (0..value_len)
@@ -943,5 +1110,15 @@ mod tests {
     fn precompile_request(seed: u64, calldata_len: usize) -> PrecompileRequest {
         let calldata = (0..calldata_len).map(|offset| seed as u8 + offset as u8).collect();
         PrecompileRequest::new(EventId::from_u64(seed), calldata)
+    }
+
+    fn merkle_tree_from_leaves(keys: impl Iterator<Item = u64>) -> MerkleTree {
+        MerkleTree::new(keys.map(make_leaf).collect::<Vec<_>>()).unwrap()
+    }
+
+    fn merkle_store_from_tree(tree: &MerkleTree) -> MerkleStore {
+        let mut store = MerkleStore::default();
+        store.extend(tree.inner_nodes());
+        store
     }
 }


### PR DESCRIPTION
`AdviceProvider` could keep adding internal Merkle store nodes without a runtime limit. A program could grow the store until the host ran out of memory.
This adds an execution option for the maximum Merkle store node count. AdviceProvider now rejects initial advice and live Merkle store mutations that would exceed that limit before it changes the stored nodes.

Closes 0xMiden/security-issues#12.