### PR TITLE
Remove stripped MastForest serialization mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [BREAKING] Moved debug info ownership out of `MastForest` and into package debug sections, adding source-node debug metadata that preserves distinct source occurrences after MAST node deduplication ([#3221](https://github.com/0xMiden/miden-vm/pull/3221)).
 - Cleaned up processor error handling for diagnostics, malformed MAST loading, and binary-value checks ([#3230](https://github.com/0xMiden/miden-vm/pull/3230)).
 - [BREAKING] Bump Plonky3 related dependencies to fix NEON arithmetic bug ([#3272](https://github.com/0xMiden/miden-vm/pull/3272)).
+- [BREAKING] Removed the stripped `MastForest` serialization mode. Normal forest bytes now describe execution data only ([#3268](https://github.com/0xMiden/miden-vm/pull/3268)).
 
 #### Fixes
 

--- a/core/benches/mast_serialization_size.rs
+++ b/core/benches/mast_serialization_size.rs
@@ -1,4 +1,4 @@
-//! Benchmark MastForest serialization and report byte sizes for full/stripped/hashless.
+//! Benchmark MastForest serialization and report byte sizes for normal and hashless modes.
 
 use std::hint::black_box;
 
@@ -20,15 +20,15 @@ fn sample_forest(params: MastForestParams, runner: &mut TestRunner) -> MastFores
 }
 
 fn serialize_sizes(forest: &MastForest) -> (usize, usize, usize) {
-    let full_bytes = forest.to_bytes();
+    let to_bytes = forest.to_bytes();
 
-    let mut stripped_bytes = Vec::new();
-    forest.write_stripped(&mut stripped_bytes);
+    let mut write_into_bytes = Vec::new();
+    forest.write_into(&mut write_into_bytes);
 
     let mut hashless_bytes = Vec::new();
     forest.write_hashless(&mut hashless_bytes);
 
-    (full_bytes.len(), stripped_bytes.len(), hashless_bytes.len())
+    (to_bytes.len(), write_into_bytes.len(), hashless_bytes.len())
 }
 
 fn bench_serialization_sizes(c: &mut Criterion) {
@@ -54,26 +54,28 @@ fn bench_serialization_sizes(c: &mut Criterion) {
         };
 
         let forest = sample_forest(gen_params, &mut runner);
-        let (full, stripped, hashless) = serialize_sizes(&forest);
-        eprintln!("blocks={blocks_per_forest} full={full} stripped={stripped} hashless={hashless}");
+        let (to_bytes, write_into, hashless) = serialize_sizes(&forest);
+        eprintln!(
+            "blocks={blocks_per_forest} to_bytes={to_bytes} write_into={write_into} hashless={hashless}"
+        );
 
-        group.throughput(Throughput::Bytes(full as u64));
+        group.throughput(Throughput::Bytes(to_bytes as u64));
         group.bench_with_input(
-            BenchmarkId::new("full", blocks_per_forest),
+            BenchmarkId::new("to_bytes", blocks_per_forest),
             &forest,
             |b, forest| {
                 b.iter(|| black_box(forest.to_bytes()));
             },
         );
 
-        group.throughput(Throughput::Bytes(stripped as u64));
+        group.throughput(Throughput::Bytes(write_into as u64));
         group.bench_with_input(
-            BenchmarkId::new("stripped", blocks_per_forest),
+            BenchmarkId::new("write_into", blocks_per_forest),
             &forest,
             |b, forest| {
                 b.iter(|| {
                     let mut bytes = Vec::new();
-                    forest.write_stripped(&mut bytes);
+                    forest.write_into(&mut bytes);
                     black_box(bytes);
                 });
             },

--- a/core/src/advice/map.rs
+++ b/core/src/advice/map.rs
@@ -75,19 +75,6 @@ impl AdviceMap {
         self.0.is_empty()
     }
 
-    /// Returns the exact serialized size of this AdviceMap in bytes.
-    pub(crate) fn serialized_size_hint(&self) -> usize {
-        let mut size = self.0.len().get_size_hint();
-        for (key, values) in self.0.iter() {
-            size += key.get_size_hint();
-            size += values.len().get_size_hint();
-            for value in values.iter() {
-                size += value.get_size_hint();
-            }
-        }
-        size
-    }
-
     /// Returns the total number of field elements stored in this advice map's keys and values.
     ///
     /// Each key is a word, so every entry contributes [`WORD_SIZE`] key elements plus the number

--- a/core/src/mast/mod.rs
+++ b/core/src/mast/mod.rs
@@ -16,8 +16,7 @@
 //! from the input size. Use [`UntrustedMastForest::read_from_bytes_with_options`] with
 //! [`UntrustedMastForestReadOptions`] to tune the wire byte budget. This limits allocations driven
 //! directly by wire counts while reading the payload. A separate validation helper budget is
-//! derived from it for later allocations needed to materialize and check stripped or hashless
-//! payloads.
+//! derived from it for later allocations needed to materialize and check hashless payloads.
 //!
 //! ```ignore
 //! use miden_core::mast::{UntrustedMastForest, UntrustedMastForestReadOptions};
@@ -568,45 +567,15 @@ impl MastForest {
     // SERIALIZATION
     // --------------------------------------------------------------------------------------------
 
-    /// Serializes this MastForest without debug information.
-    ///
-    /// `MastForest` is an execution artifact, so current writers always omit legacy debug payloads.
-    /// The resulting bytes can be deserialized with the standard [`Deserializable`] impl.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use miden_core::{mast::MastForest, serde::Serializable};
-    ///
-    /// let forest = MastForest::new();
-    ///
-    /// // Full serialization (with debug info)
-    /// let full_bytes = forest.to_bytes();
-    ///
-    /// // Stripped serialization (without debug info)
-    /// let mut stripped_bytes = Vec::new();
-    /// forest.write_stripped(&mut stripped_bytes);
-    ///
-    /// // Both can be deserialized the same way
-    /// // let restored = MastForest::read_from_bytes(&stripped_bytes).unwrap();
-    /// ```
-    pub fn write_stripped<W: ByteWriter>(&self, target: &mut W) {
-        serialization::write_stripped_into(self, target);
-    }
-
     /// Serializes this MastForest with the HASHLESS flag set.
     ///
-    /// Hashless implies stripped: debug info is omitted, and digests must be recomputed during
-    /// validation. Trusted deserialization rejects this flag.
+    /// Hashless forest bytes omit rebuildable internal node hashes. External node digests stay on
+    /// the wire because they cannot be rebuilt from local structure. Trusted deserialization
+    /// rejects this flag.
     ///
     /// Use this when producing data for untrusted validation.
     pub fn write_hashless<W: ByteWriter>(&self, target: &mut W) {
         serialization::write_hashless_into(self, target);
-    }
-
-    /// Returns the exact size of stripped serialization in bytes.
-    pub fn stripped_size_hint(&self) -> usize {
-        serialization::stripped_size_hint(self)
     }
 }
 

--- a/core/src/mast/serialization/basic_blocks.rs
+++ b/core/src/mast/serialization/basic_blocks.rs
@@ -12,8 +12,8 @@
 //! The total encoded size is:
 //! `encoded_operations_len + size_of::<u32>() + (5 * num_batches)`.
 //!
-//! This matches [`basic_block_data_len`], which is used for size accounting in stripped and
-//! hashless serialization.
+//! This matches [`basic_block_data_len`], which is used for size accounting in normal and hashless
+//! serialization.
 
 use alloc::vec::Vec;
 

--- a/core/src/mast/serialization/layout.rs
+++ b/core/src/mast/serialization/layout.rs
@@ -1,8 +1,6 @@
 use alloc::{format, string::ToString, vec::Vec};
 
-use super::{
-    FLAG_HASHLESS, FLAG_STRIPPED, FLAGS_RESERVED_MASK, MAGIC, MastForest, MastNodeEntry, VERSION,
-};
+use super::{FLAG_HASHLESS, FLAGS_RESERVED_MASK, MAGIC, MastForest, MastNodeEntry, VERSION};
 use crate::{
     mast::MastNodeId,
     serde::{ByteReader, Deserializable, DeserializationError, SliceReader},
@@ -148,23 +146,12 @@ impl ForestLayout {
 // ================================================================================================
 
 impl WireFlags {
-    pub(super) fn new(bits: u8) -> Result<Self, DeserializationError> {
-        let flags = Self(bits);
-        if flags.is_hashless() && !flags.is_stripped() {
-            return Err(DeserializationError::InvalidValue(
-                "HASHLESS flag requires STRIPPED flag to be set".to_string(),
-            ));
-        }
-
-        Ok(flags)
+    pub(super) fn new(bits: u8) -> Self {
+        Self(bits)
     }
 
     pub(super) fn bits(self) -> u8 {
         self.0
-    }
-
-    pub(super) fn is_stripped(self) -> bool {
-        self.0 & FLAG_STRIPPED != 0
     }
 
     pub(super) fn is_hashless(self) -> bool {
@@ -183,7 +170,7 @@ pub(super) fn read_header_and_scan_layout<R: OffsetTrackingReader>(
     // policy for counts: e.g. `SliceReader` for trusted inspection versus `BudgetedReader` for the
     // untrusted deserialization path.
     let (raw_flags, _version) = read_and_validate_header(source)?;
-    let flags = WireFlags::new(raw_flags)?;
+    let flags = WireFlags::new(raw_flags);
     if flags.is_hashless() && !allow_hashless {
         return Err(DeserializationError::InvalidValue(
             "HASHLESS flag is set; use UntrustedMastForest for untrusted input".to_string(),

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -1,7 +1,6 @@
-//! MAST forest serialization keeps one fixed structural layout for full, stripped, and hashless
-//! payloads.
+//! MAST forest serialization keeps one fixed structural layout for normal and hashless payloads.
 //!
-//! The main goal is to keep random access cheap in stripped and hashless modes. Node structure
+//! The main goal is to keep random access cheap in both modes. Node structure
 //! stays in one fixed-width section. Variable-size data lives in separate sections. Internal node
 //! digests also live in a separate section so hashless payloads can omit them without changing the
 //! structural layout.
@@ -12,7 +11,7 @@
 //! validation recomputes those digests and requires them to match the serialized values.
 //! Budgeted untrusted reads always bound wire counts during layout scanning via
 //! [`ByteReader::max_alloc`]. Validation also gets a second check:
-//! - later stripped/hashless helper allocations are charged against a validation budget before the
+//! - later hashless helper allocations are charged against a validation budget before the
 //!   corresponding `Vec` or CSR scaffolding is created
 //! - that budget is derived from the wire budget by a coarse multiplier; this is intentionally a
 //!   simple bound for common callers, not an exact peak-memory formula
@@ -62,25 +61,22 @@
 //! (Advice map section)
 //! - Advice map (`AdviceMap`)
 //!
-//! (Legacy DebugInfo section - rejected if present; omitted by current writers)
+//! (No trailing debug section)
 //!
-//! Current writers always omit the legacy `DebugInfo` section. Readers reject legacy wire debug
-//! payloads because package-owned debug sections are now the only supported debug serialization
-//! path.
+//! Readers reject any trailing payload after the advice map. Package-owned debug sections are now
+//! the only supported debug serialization path.
 //!
-//! In hashless format, the internal node-hash section is omitted and `HASHLESS` also implies
-//! `STRIPPED`. External node digests still stay on the wire because they cannot be rebuilt from
-//! local structure. This keeps hashless focused on the untrusted-validation use case: trusted
-//! reads reject `HASHLESS`, and the untrusted path rebuilds the data it actually trusts before
-//! use, so supporting a separate "hashless but with debug info" mode would add another wire mode
-//! without changing the validation semantics.
+//! In hashless format, the internal node-hash section is omitted. External node digests still stay
+//! on the wire because they cannot be rebuilt from local structure. This keeps hashless focused on
+//! the untrusted-validation use case: trusted reads reject `HASHLESS`, and the untrusted path
+//! rebuilds the data it actually trusts before use.
 //!
 //! Readers recover per-node digest lookup by scanning node entries once and building a compact
 //! "slot by node index" table. This preserves random access without forcing all digests into the
 //! same contiguous array on the wire.
 //!
 //! Public entry points adopt these policies:
-//! - [`MastForest::read_from_bytes`]: trusted stripped execution payload, no hashless support.
+//! - [`MastForest::read_from_bytes`]: trusted execution payload, no hashless support.
 //! - [`MastForestWireView::new`]: trusted wire-backed cache access; rejects hashless and legacy
 //!   debug-bearing payloads.
 //! - [`crate::mast::UntrustedMastForest::read_from_bytes`] /
@@ -136,8 +132,8 @@ type NodeDataOffset = u32;
 
 /// Default multiplier for the untrusted validation allocation budget.
 ///
-/// The budgeted byte reader limits wire-driven parsing. Hashless and stripped validation also
-/// needs transient per-node allocations for the slot table and rebuilt digest data.
+/// The budgeted byte reader limits wire-driven parsing. Hashless validation also needs transient
+/// per-node allocations for the slot table and rebuilt digest data.
 /// The generic untrusted path also retains a recorded copy of the consumed
 /// serialized payload for deferred validation.
 ///
@@ -166,27 +162,19 @@ const TRUSTED_BYTE_READ_BUDGET_MULTIPLIER: usize = 64;
 ///
 /// The header is `b"MAST"` + flags byte + version bytes.
 ///
-/// This repurposes the old `b"MAST\0"` terminator as the flags byte, so legacy payloads still
-/// decode as "debug info present".
+/// This repurposes the old `b"MAST\0"` terminator as the flags byte.
 const MAGIC: &[u8; 4] = b"MAST";
-
-/// Flag indicating that the `DebugInfo` section is omitted from the wire payload.
-///
-/// Readers treat this as serializer intent about the wire layout, not as a trust decision.
-const FLAG_STRIPPED: u8 = 0x01;
 
 /// Flag indicating that the internal node-hash section is omitted from the wire payload.
 ///
 /// External digests still remain serialized in their own section because they cannot be rebuilt
-/// from local structure. This flag implies [`FLAG_STRIPPED`] because no supported consumer treats
-/// wire `DebugInfo` as trusted in hashless mode: [`crate::mast::MastForest`] rejects `HASHLESS`,
-/// and the untrusted path rebuilds the data it actually trusts before use.
+/// from local structure.
 pub(super) const FLAG_HASHLESS: u8 = 0x02;
 
 /// Mask for reserved flag bits that must be zero.
 ///
-/// Bits 2-7 are reserved for future use. If any are set, deserialization fails.
-const FLAGS_RESERVED_MASK: u8 = 0xfc;
+/// Bit 0 and bits 2-7 are reserved for future use. If any are set, deserialization fails.
+const FLAGS_RESERVED_MASK: u8 = 0xfd;
 
 /// The format version.
 ///
@@ -203,15 +191,16 @@ const FLAGS_RESERVED_MASK: u8 = 0xfc;
 /// - [0, 0, 2]: AssemblyOps moved out of inline metadata into a dedicated DebugInfo section.
 ///   Removed `should_break` field from AssemblyOp serialization (#2646). Removed `breakpoint`
 ///   instruction (#2655).
-/// - [0, 0, 3]: Added HASHLESS flag (bit 1). HASHLESS implies STRIPPED. Trusted deserialization
-///   rejects HASHLESS. Split fixed-width node entries from digest storage. External digests moved
-///   to a dedicated section. Hashless serialization omits the general node-hash section entirely.
-///   Removed the unused metadata-count field from the wire header. Before any public release on
-///   this branch, the same unreleased wire version also grew explicit internal/external node counts
-///   in the header.
+/// - [0, 0, 3]: Added HASHLESS flag (bit 1). Trusted deserialization rejects HASHLESS. Split
+///   fixed-width node entries from digest storage. External digests moved to a dedicated section.
+///   Hashless serialization omits the general node-hash section entirely. Removed the unused
+///   metadata-count field from the wire header. Before any public release on this branch, the same
+///   unreleased wire version also grew explicit internal/external node counts in the header.
 /// - [0, 0, 4]: Removed the legacy inline metadata wire slots entirely. All assembly op metadata
 ///   and debug variable metadata are now stored in the DebugInfo section as separate indexed
-///   records. MAST nodes are metadata-free identifiers.
+///   records. MAST nodes are metadata-free identifiers. Before any public release on this branch,
+///   the same unreleased wire version also reserved bit 0 and stopped using it as a forest-level
+///   debug-presence flag.
 ///
 /// Legacy wire versions (pre-#3192 decorator terminology):
 ///   [0,0,1] stored metadata as serialized decorator variants in CSR per-node slots.
@@ -232,13 +221,13 @@ impl Serializable for MastForest {
 impl MastForest {
     /// Internal serialization with options.
     ///
-    /// Current writers always omit the legacy DebugInfo section and set the STRIPPED flag.
+    /// Current writers encode normal execution payloads or hashless validation payloads.
     fn write_into_with_options<W: ByteWriter>(&self, target: &mut W, hashless: bool) {
         let mut basic_block_data_builder = BasicBlockDataBuilder::new();
 
         // magic & flags
         target.write_bytes(MAGIC);
-        let flags = FLAG_STRIPPED | if hashless { FLAG_HASHLESS } else { 0 };
+        let flags = if hashless { FLAG_HASHLESS } else { 0 };
         target.write_u8(flags);
 
         // version
@@ -295,47 +284,8 @@ impl MastForest {
     }
 }
 
-pub(super) fn write_stripped_into<W: ByteWriter>(forest: &MastForest, target: &mut W) {
-    forest.write_into_with_options(target, false);
-}
-
 pub(super) fn write_hashless_into<W: ByteWriter>(forest: &MastForest, target: &mut W) {
     forest.write_into_with_options(target, true);
-}
-
-pub(super) fn stripped_size_hint(forest: &MastForest) -> usize {
-    serialized_size_hint(forest, false)
-}
-
-fn serialized_size_hint(forest: &MastForest, hashless: bool) -> usize {
-    let node_count = forest.nodes.len();
-    let external_count = forest.nodes.iter().filter(|node| node.is_external()).count();
-    let non_external_count = node_count - external_count;
-
-    let mut size = MAGIC.len() + 1 + VERSION.len();
-    size += non_external_count.get_size_hint();
-    size += external_count.get_size_hint();
-
-    let roots_len = forest.roots.len();
-    size += roots_len.get_size_hint();
-    size += roots_len * size_of::<u32>();
-
-    let mut basic_block_len = 0usize;
-    for node in forest.nodes.iter() {
-        if let MastNode::Block(block) = node {
-            basic_block_len += basic_block_data_len(block);
-        }
-    }
-    size += basic_block_len.get_size_hint() + basic_block_len;
-
-    size += node_count * MastNodeEntry::SERIALIZED_SIZE;
-    size += external_count * Word::min_serialized_size();
-    if !hashless {
-        size += non_external_count * Word::min_serialized_size();
-    }
-    size += forest.advice_map.serialized_size_hint();
-
-    size
 }
 
 /// Trusted read backing mode for read-only MAST forest access.
@@ -358,11 +308,10 @@ pub enum MastForestReadView<'a> {
 
 /// A trusted wire-backed view over serialized MAST forest bytes.
 ///
-/// This view accepts complete stripped payloads with hashes. It validates the header and the
-/// fixed-width structural sections needed for random access, but it does not fully materialize the
-/// forest. Hashless payloads are rejected because trusted cache bytes must be complete. Legacy
-/// debug-bearing forest payloads are rejected because debug metadata now belongs to package-owned
-/// debug sections.
+/// This view accepts complete payloads with hashes. It validates the header and the fixed-width
+/// structural sections needed for random access, but it does not fully materialize the forest.
+/// Hashless payloads are rejected because trusted cache bytes must be complete. Trailing payloads
+/// are rejected because debug metadata now belongs to package-owned debug sections.
 ///
 /// Use this when callers need random access to roots or node metadata without deserializing the
 /// full forest. For strict trusted deserialization, use
@@ -383,7 +332,7 @@ pub enum MastForestReadView<'a> {
 /// forest.make_root(block_id);
 ///
 /// let mut bytes = Vec::new();
-/// forest.write_stripped(&mut bytes);
+/// forest.write_into(&mut bytes);
 ///
 /// let view = MastForestWireView::new(&bytes).unwrap();
 /// assert_eq!(view.node_count(), forest.nodes().len());
@@ -392,7 +341,6 @@ pub enum MastForestReadView<'a> {
 #[derive(Debug)]
 pub struct MastForestWireView<'a> {
     bytes: &'a [u8],
-    flags: WireFlags,
     layout: ForestLayout,
     advice_map: WireAdviceMapView<'a>,
     resolved: OnceLockCompat<Result<ResolvedSerializedForest<'a>, DeserializationError>>,
@@ -401,12 +349,11 @@ pub struct MastForestWireView<'a> {
 impl<'a> MastForestWireView<'a> {
     /// Creates a new view from serialized bytes.
     ///
-    /// The input must be stripped format and include all node hashes. Structural parsing is
+    /// The input must include all node hashes. Structural parsing is
     /// delegated to the same single-pass scanner used by reader-based deserialization paths.
     ///
     /// This constructor validates the header and sections needed for node/roots/random-access
-    /// metadata, indexes `AdviceMap` keys for on-demand lookup, and rejects legacy forest
-    /// `DebugInfo` payloads.
+    /// metadata, indexes `AdviceMap` keys for on-demand lookup, and rejects trailing payloads.
     ///
     /// Treat this as a trusted cache API, not as an untrusted-validation entry point. It is
     /// appropriate for local tools that need random access over serialized structure, but callers
@@ -441,7 +388,7 @@ impl<'a> MastForestWireView<'a> {
     /// forest.make_root(block_id);
     ///
     /// let mut bytes = Vec::new();
-    /// forest.write_stripped(&mut bytes);
+    /// forest.write_into(&mut bytes);
     ///
     /// let view = MastForestWireView::new(&bytes).unwrap();
     /// assert_eq!(view.node_count(), 1);
@@ -449,13 +396,12 @@ impl<'a> MastForestWireView<'a> {
     pub fn new(bytes: &'a [u8]) -> Result<Self, DeserializationError> {
         let mut reader = SliceReader::new(bytes);
         let mut scanner = TrackingReader::new(&mut reader);
-        let (flags, layout) = read_header_and_scan_layout(&mut scanner, false)?;
+        let (_flags, layout) = read_header_and_scan_layout(&mut scanner, false)?;
         let advice_map = WireAdviceMapView::new(bytes, layout.advice_map_offset())?;
-        check_no_legacy_debug_payload(bytes, flags, advice_map.end_offset())?;
+        check_no_trailing_payload(bytes, advice_map.end_offset())?;
 
         Ok(Self {
             bytes,
-            flags,
             layout,
             advice_map,
             resolved: OnceLockCompat::new(),
@@ -465,11 +411,6 @@ impl<'a> MastForestWireView<'a> {
     /// Returns the number of nodes in the serialized forest.
     pub fn node_count(&self) -> usize {
         self.layout.node_count
-    }
-
-    /// Returns `true` when the wire header says that the `DebugInfo` section is omitted.
-    pub fn is_stripped(&self) -> bool {
-        self.flags.is_stripped()
     }
 
     /// Returns the number of procedure roots in the serialized forest.
@@ -503,7 +444,7 @@ impl<'a> MastForestWireView<'a> {
     /// forest.make_root(block_id);
     ///
     /// let mut bytes = Vec::new();
-    /// forest.write_stripped(&mut bytes);
+    /// forest.write_into(&mut bytes);
     ///
     /// let view = MastForestWireView::new(&bytes).unwrap();
     /// assert!(view.node_info_at(0).is_ok());
@@ -542,30 +483,19 @@ impl<'a> MastForestWireView<'a> {
     }
 }
 
-fn check_no_legacy_debug_payload(
+fn check_no_trailing_payload(
     bytes: &[u8],
-    flags: WireFlags,
     debug_info_offset: usize,
 ) -> Result<(), DeserializationError> {
-    if !flags.is_stripped() {
-        return Err(legacy_debug_info_error());
-    }
-
     let payload = bytes.get(debug_info_offset..).ok_or(DeserializationError::UnexpectedEOF)?;
     if payload.is_empty() {
         return Ok(());
     }
-    Err(extra_bytes_after_stripped_payload_error())
+    Err(extra_bytes_after_mast_forest_payload_error())
 }
 
-fn legacy_debug_info_error() -> DeserializationError {
-    DeserializationError::InvalidValue(
-        "MastForest payloads with legacy DebugInfo are no longer supported; debug metadata belongs in Package debug sections".into(),
-    )
-}
-
-fn extra_bytes_after_stripped_payload_error() -> DeserializationError {
-    DeserializationError::InvalidValue("extra bytes after stripped MastForest payload".into())
+fn extra_bytes_after_mast_forest_payload_error() -> DeserializationError {
+    DeserializationError::InvalidValue("extra bytes after MastForest payload".into())
 }
 
 impl MastForest {
@@ -573,8 +503,8 @@ impl MastForest {
     ///
     /// [`MastForestReadMode::Materialized`] is equivalent to [`Self::read_from_bytes`].
     /// [`MastForestReadMode::WireBacked`] returns a trusted random-access cache view and rejects
-    /// hashless and legacy debug-bearing payloads because trusted cache bytes must be complete
-    /// stripped execution payloads.
+    /// hashless and trailing payloads because trusted cache bytes must be complete execution
+    /// payloads.
     pub fn read_view_from_bytes(
         bytes: &[u8],
         mode: MastForestReadMode,
@@ -814,7 +744,7 @@ impl Deserializable for MastForest {
         let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
         let forest = Self::read_from(&mut reader)?;
         if reader.has_more_bytes() {
-            return Err(extra_bytes_after_stripped_payload_error());
+            return Err(extra_bytes_after_mast_forest_payload_error());
         }
         Ok(forest)
     }
@@ -878,9 +808,6 @@ fn decode_from_reader_inner<R: ByteReader>(
     debug_assert_eq!(recording.offset(), layout.advice_map_offset());
 
     let advice_map = AdviceMap::read_from(&mut recording)?;
-    if !flags.is_stripped() {
-        return Err(legacy_debug_info_error());
-    }
     Ok((
         flags,
         super::UntrustedMastForest {

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -323,6 +323,7 @@ pub enum MastForestReadView<'a> {
 /// use miden_core::{
 ///     mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, MastForestWireView},
 ///     operations::Operation,
+///     serde::Serializable,
 /// };
 ///
 /// let mut forest = MastForest::new();
@@ -379,6 +380,7 @@ impl<'a> MastForestWireView<'a> {
     /// use miden_core::{
     ///     mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, MastForestWireView},
     ///     operations::Operation,
+    ///     serde::Serializable,
     /// };
     ///
     /// let mut forest = MastForest::new();
@@ -435,6 +437,7 @@ impl<'a> MastForestWireView<'a> {
     /// use miden_core::{
     ///     mast::{BasicBlockNodeBuilder, MastForest, MastForestContributor, MastForestWireView},
     ///     operations::Operation,
+    ///     serde::Serializable,
     /// };
     ///
     /// let mut forest = MastForest::new();

--- a/core/src/mast/serialization/seed_gen.rs
+++ b/core/src/mast/serialization/seed_gen.rs
@@ -85,7 +85,7 @@ fn generate_fuzz_seeds() {
         );
     }
 
-    // Seed 3: Stripped forest (no debug info)
+    // Seed 3: Normal forest
     {
         let mut forest = MastForest::new();
         let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add])
@@ -94,7 +94,7 @@ fn generate_fuzz_seeds() {
         forest.make_root(block_id);
 
         let mut bytes = Vec::new();
-        forest.write_stripped(&mut bytes);
+        forest.write_into(&mut bytes);
         write_mast_seed(
             &[
                 "mast_forest_deserialize",
@@ -103,7 +103,7 @@ fn generate_fuzz_seeds() {
                 "mast_forest_wire_view_new",
                 "basic_block_data",
             ],
-            "stripped.bin",
+            "normal.bin",
             &bytes,
         );
     }

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -5,7 +5,7 @@ use std::{
 
 use super::*;
 use crate::{
-    Felt, ONE, Word,
+    Felt, Word,
     chiplets::hasher,
     mast::{
         BasicBlockNodeBuilder, CallNodeBuilder, DynNodeBuilder, ExternalNodeBuilder,
@@ -355,7 +355,7 @@ fn test_operation_encoded_size_push_varint_boundaries() {
 
 fn assert_serialized_view_matches_forest(forest: &MastForest) {
     let mut bytes = Vec::new();
-    forest.write_stripped(&mut bytes);
+    forest.write_into(&mut bytes);
 
     let view = MastForestWireView::new(&bytes).unwrap();
     assert_eq!(view.node_count(), forest.nodes().len());
@@ -399,7 +399,7 @@ fn test_mast_forest_view_trait_matches_serialized_view() {
     forest.advice_map_mut().insert(advice_key, advice_values.clone());
 
     let mut bytes = Vec::new();
-    forest.write_stripped(&mut bytes);
+    forest.write_into(&mut bytes);
     let serialized = MastForestWireView::new(&bytes).unwrap();
 
     let in_memory: &dyn MastForestView = &forest;
@@ -465,7 +465,7 @@ fn test_mast_forest_read_view_modes_match() {
     forest.advice_map_mut().insert(advice_key, advice_values.clone());
 
     let mut bytes = Vec::new();
-    forest.write_stripped(&mut bytes);
+    forest.write_into(&mut bytes);
 
     let materialized =
         MastForest::read_view_from_bytes(&bytes, MastForestReadMode::Materialized).unwrap();
@@ -825,12 +825,11 @@ fn mast_forest_serialize_deserialize_omits_legacy_debug_info() {
     forest.make_root(block3_id);
 
     let serialized = forest.to_bytes();
-    let mut stripped = Vec::new();
-    forest.write_stripped(&mut stripped);
-    assert_eq!(serialized, stripped);
+    let mut explicit = Vec::new();
+    forest.write_into(&mut explicit);
+    assert_eq!(serialized, explicit);
 
     let view = MastForestWireView::new(&serialized).unwrap();
-    assert!(view.is_stripped());
     assert_eq!(view.debug_info_offset(), serialized.len());
 
     let deserialized = MastForest::read_from_bytes(&serialized).unwrap();
@@ -847,22 +846,16 @@ fn serialized_single_block_forest() -> Vec<u8> {
     forest.to_bytes()
 }
 
-fn clear_stripped_flag(bytes: &mut [u8]) {
-    let flags_offset = MAGIC.len();
-    bytes[flags_offset] &= !FLAG_STRIPPED;
-}
-
 #[test]
-fn mast_forest_deserializers_reject_legacy_debug_bearing_payloads() {
+fn mast_forest_deserializers_reject_reserved_bit_zero() {
     let mut bytes = serialized_single_block_forest();
-    clear_stripped_flag(&mut bytes);
-    bytes.extend_from_slice(&[0, 0, 0, 0]);
+    bytes[MAGIC.len()] = 0x01;
 
     let trusted = MastForest::read_from_bytes(&bytes);
     assert_matches!(
         trusted,
         Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("legacy DebugInfo") && msg.contains("Package debug sections")
+            if msg.contains("Unknown flags") && msg.contains("0x01")
     );
 
     let materialized_view =
@@ -870,33 +863,33 @@ fn mast_forest_deserializers_reject_legacy_debug_bearing_payloads() {
     assert_matches!(
         materialized_view,
         Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("legacy DebugInfo") && msg.contains("Package debug sections")
+            if msg.contains("Unknown flags") && msg.contains("0x01")
     );
 
     let wire_backed_view = MastForest::read_view_from_bytes(&bytes, MastForestReadMode::WireBacked);
     assert_matches!(
         wire_backed_view,
         Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("legacy DebugInfo") && msg.contains("Package debug sections")
+            if msg.contains("Unknown flags") && msg.contains("0x01")
     );
 
     let wire_view = MastForestWireView::new(&bytes);
     assert_matches!(
         wire_view,
         Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("legacy DebugInfo") && msg.contains("Package debug sections")
+            if msg.contains("Unknown flags") && msg.contains("0x01")
     );
 
     let untrusted = UntrustedMastForest::read_from_bytes(&bytes);
     assert_matches!(
         untrusted,
         Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("legacy DebugInfo") && msg.contains("Package debug sections")
+            if msg.contains("Unknown flags") && msg.contains("0x01")
     );
 }
 
 #[test]
-fn mast_forest_wire_view_rejects_trailing_bytes_after_stripped_payload() {
+fn mast_forest_wire_view_rejects_trailing_bytes_after_payload() {
     let mut bytes = serialized_single_block_forest();
     bytes.extend_from_slice(&[1, 2, 3]);
 
@@ -904,12 +897,12 @@ fn mast_forest_wire_view_rejects_trailing_bytes_after_stripped_payload() {
     assert_matches!(
         result,
         Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("extra bytes after stripped MastForest payload")
+            if msg.contains("extra bytes after MastForest payload")
     );
 }
 
 #[test]
-fn mast_forest_byte_readers_reject_trailing_bytes_after_stripped_payload() {
+fn mast_forest_byte_readers_reject_trailing_bytes_after_payload() {
     let mut bytes = serialized_single_block_forest();
     bytes.extend_from_slice(&[1, 2, 3]);
 
@@ -917,7 +910,7 @@ fn mast_forest_byte_readers_reject_trailing_bytes_after_stripped_payload() {
     assert_matches!(
         trusted,
         Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("extra bytes after stripped MastForest payload")
+            if msg.contains("extra bytes after MastForest payload")
     );
 
     let materialized_view =
@@ -925,14 +918,14 @@ fn mast_forest_byte_readers_reject_trailing_bytes_after_stripped_payload() {
     assert_matches!(
         materialized_view,
         Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("extra bytes after stripped MastForest payload")
+            if msg.contains("extra bytes after MastForest payload")
     );
 
     let untrusted = UntrustedMastForest::read_from_bytes(&bytes);
     assert_matches!(
         untrusted,
         Err(DeserializationError::InvalidValue(msg))
-            if msg.contains("extra bytes after stripped MastForest payload")
+            if msg.contains("extra bytes after MastForest payload")
     );
 }
 
@@ -1055,22 +1048,22 @@ fn read_header_counts(bytes: &[u8]) -> (usize, usize) {
 }
 
 #[test]
-fn test_header_flags_for_all_serialization_modes() {
+fn test_header_flags_for_serialization_modes() {
     let mut forest = MastForest::new();
     let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add])
         .add_to_forest(&mut forest)
         .unwrap();
     forest.make_root(block_id);
 
-    assert_header_flags(&forest.to_bytes(), 0x01);
+    assert_header_flags(&forest.to_bytes(), 0x00);
 
-    let mut stripped_bytes = Vec::new();
-    forest.write_stripped(&mut stripped_bytes);
-    assert_header_flags(&stripped_bytes, 0x01);
+    let mut normal_bytes = Vec::new();
+    forest.write_into(&mut normal_bytes);
+    assert_header_flags(&normal_bytes, 0x00);
 
     let mut hashless_bytes = Vec::new();
     forest.write_hashless(&mut hashless_bytes);
-    assert_header_flags(&hashless_bytes, 0x03);
+    assert_header_flags(&hashless_bytes, 0x02);
 }
 
 #[test]
@@ -1143,7 +1136,7 @@ fn test_deserialization_rejects_mismatched_header_counts() {
     );
 }
 
-/// Test that default and stripped serialization match, and hashless is smaller.
+/// Test that normal serialization includes hashes, and hashless is smaller.
 #[test]
 fn test_serialization_sizes_shrink_from_digestful_to_hashless() {
     let mut forest = MastForest::new();
@@ -1154,92 +1147,27 @@ fn test_serialization_sizes_shrink_from_digestful_to_hashless() {
 
     let full_bytes = forest.to_bytes();
 
-    let mut stripped_bytes = Vec::new();
-    forest.write_stripped(&mut stripped_bytes);
+    let mut normal_bytes = Vec::new();
+    forest.write_into(&mut normal_bytes);
 
     let mut hashless_bytes = Vec::new();
     forest.write_hashless(&mut hashless_bytes);
 
     let full_view = MastForestWireView::new(&full_bytes).unwrap();
-    assert!(full_view.is_stripped());
     assert_eq!(full_view.node_count(), forest.num_nodes() as usize);
     assert_eq!(full_view.procedure_root_count(), 1);
     assert!(full_view.node_info_at(0).is_ok());
 
-    assert_eq!(stripped_bytes, full_bytes);
-    assert!(hashless_bytes.len() < stripped_bytes.len());
+    assert_eq!(normal_bytes, full_bytes);
+    assert!(hashless_bytes.len() < normal_bytes.len());
 
-    let stripped_view = MastForestWireView::new(&stripped_bytes).unwrap();
+    let normal_view = MastForestWireView::new(&normal_bytes).unwrap();
     let hashless_view = MastForestWireView::new(&hashless_bytes);
-    assert!(stripped_view.node_hash_offset().is_some());
+    assert!(normal_view.node_hash_offset().is_some());
     assert_matches!(hashless_view, Err(DeserializationError::InvalidValue(msg)) if msg.contains("HASHLESS flag is set"));
 }
 
-fn assert_stripped_size_hint_matches_serialized_len(forest: &MastForest) {
-    let mut bytes = Vec::new();
-    forest.write_stripped(&mut bytes);
-    assert_eq!(forest.stripped_size_hint(), bytes.len());
-}
-
-/// Test that stripped size hints stay exact for both compact and large forests.
-#[test]
-fn test_stripped_size_hint_matches_serialized_len() {
-    let mut small_forest = MastForest::new();
-
-    let block1 =
-        BasicBlockNodeBuilder::new(vec![Operation::Add, Operation::Push(Felt::new_unchecked(3))])
-            .add_to_forest(&mut small_forest)
-            .unwrap();
-    let block2 = BasicBlockNodeBuilder::new(vec![
-        Operation::U32div,
-        Operation::Assert(Felt::new_unchecked(1)),
-    ])
-    .add_to_forest(&mut small_forest)
-    .unwrap();
-    let join = JoinNodeBuilder::new([block1, block2]).add_to_forest(&mut small_forest).unwrap();
-    small_forest.make_root(join);
-    small_forest
-        .advice_map_mut()
-        .insert(Word::default(), vec![ONE, Felt::new_unchecked(2)]);
-    assert_stripped_size_hint_matches_serialized_len(&small_forest);
-
-    let mut forest = MastForest::new();
-
-    let mut operations = Vec::with_capacity(304);
-    for _ in 0..300 {
-        operations.push(Operation::Add);
-    }
-    operations.push(Operation::Push(Felt::new_unchecked(7)));
-    operations.push(Operation::Assert(Felt::new_unchecked(9)));
-    operations.push(Operation::U32assert2(Felt::new_unchecked(11)));
-    operations.push(Operation::MpVerify(Felt::new_unchecked(13)));
-
-    let block_id = BasicBlockNodeBuilder::new(operations).add_to_forest(&mut forest).unwrap();
-    forest.make_root(block_id);
-
-    let key_a = Word::new([
-        Felt::new_unchecked(1),
-        Felt::new_unchecked(2),
-        Felt::new_unchecked(3),
-        Felt::new_unchecked(4),
-    ]);
-    let key_b = Word::new([
-        Felt::new_unchecked(5),
-        Felt::new_unchecked(6),
-        Felt::new_unchecked(7),
-        Felt::new_unchecked(8),
-    ]);
-
-    let values_a: Vec<Felt> = (0u64..200).map(Felt::new_unchecked).collect();
-    let values_b: Vec<Felt> = (10u64..15).map(Felt::new_unchecked).collect();
-
-    forest.advice_map_mut().insert(key_a, values_a);
-    forest.advice_map_mut().insert(key_b, values_b);
-
-    assert_stripped_size_hint_matches_serialized_len(&forest);
-}
-
-/// Test that node digests are preserved in stripped serialization.
+/// Test that unknown header flags are rejected.
 #[test]
 fn test_deserialize_rejects_unknown_flags() {
     let mut forest = MastForest::new();
@@ -1248,16 +1176,19 @@ fn test_deserialize_rejects_unknown_flags() {
         .unwrap();
     forest.make_root(block_id);
 
-    let mut bytes = forest.to_bytes();
+    let bytes = forest.to_bytes();
 
-    // Set an unknown flag (bit 2)
-    bytes[4] = 0x04;
+    for flag in [0x01, 0x04] {
+        let mut bytes = bytes.clone();
+        bytes[4] = flag;
 
-    let result = MastForest::read_from_bytes(&bytes);
-    assert_matches!(
-        result,
-        Err(DeserializationError::InvalidValue(msg)) if msg.contains("reserved") || msg.contains("flags")
-    );
+        let result = MastForest::read_from_bytes(&bytes);
+        assert_matches!(
+            result,
+            Err(DeserializationError::InvalidValue(msg))
+                if msg.contains("Unknown flags") && msg.contains("Reserved bits")
+        );
+    }
 }
 
 /// Test that trusted deserialization rejects hashless inputs.
@@ -1314,26 +1245,6 @@ fn test_materialized_deserialization_preserves_duplicate_roots() {
     assert_eq!(restored.commitment(), forest.commitment());
 }
 
-/// Test that hashless without stripped is rejected.
-#[test]
-fn test_hashless_requires_stripped() {
-    let mut forest = MastForest::new();
-    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add])
-        .add_to_forest(&mut forest)
-        .unwrap();
-    forest.make_root(block_id);
-
-    let mut bytes = forest.to_bytes();
-    // Set HASHLESS without STRIPPED
-    bytes[4] = 0x02;
-
-    let result = UntrustedMastForest::read_from_bytes(&bytes);
-    assert_matches!(
-        result,
-        Err(DeserializationError::InvalidValue(msg)) if msg.contains("HASHLESS") && msg.contains("STRIPPED")
-    );
-}
-
 fn assert_untrusted_overspec_logging(
     bytes: &[u8],
     expected_nodes: u32,
@@ -1368,9 +1279,9 @@ fn test_untrusted_overspecification_logging_matches_wire_mode() {
     forest.write_hashless(&mut hashless_bytes);
     assert_untrusted_overspec_logging(&hashless_bytes, forest.num_nodes(), &[]);
 
-    let mut stripped_bytes = Vec::new();
-    forest.write_stripped(&mut stripped_bytes);
-    assert_untrusted_overspec_logging(&stripped_bytes, forest.num_nodes(), &["wire node hashes"]);
+    let mut normal_bytes = Vec::new();
+    forest.write_into(&mut normal_bytes);
+    assert_untrusted_overspec_logging(&normal_bytes, forest.num_nodes(), &["wire node hashes"]);
 
     let bytes = forest.to_bytes();
     assert_untrusted_overspec_logging(&bytes, forest.num_nodes(), &["wire node hashes"]);
@@ -1906,7 +1817,7 @@ fn test_untrusted_forest_validates_all_node_types() {
     assert_eq!(forest, validated);
 }
 
-/// Test that UntrustedMastForest::validate works with stripped serialization.
+/// Test that UntrustedMastForest::validate rejects excessive node counts before validation.
 #[test]
 fn test_deserialization_rejects_excessive_node_count() {
     // Craft a malicious payload with node_count exceeding MAX_NODES
@@ -1939,7 +1850,7 @@ fn test_untrusted_deserialization_rejects_node_count_above_budget_bound() {
     let mut bytes = Vec::new();
 
     MAGIC.write_into(&mut bytes);
-    bytes.write_u8(FLAG_STRIPPED | FLAG_HASHLESS);
+    bytes.write_u8(FLAG_HASHLESS);
     VERSION.write_into(&mut bytes);
 
     2usize.write_into(&mut bytes);
@@ -1989,10 +1900,10 @@ fn test_untrusted_hashless_validation_respects_custom_allocation_budget() {
     );
 }
 
-/// Test that stripped payloads do not charge legacy debug-info scaffolding.
+/// Test that MastForest payloads do not charge legacy debug-info scaffolding.
 #[cfg(target_pointer_width = "64")]
 #[test]
-fn test_untrusted_stripped_payload_does_not_allocate_debug_info_scaffolding() {
+fn test_untrusted_payload_does_not_allocate_debug_info_scaffolding() {
     let mut forest = MastForest::new();
     let left = BasicBlockNodeBuilder::new(vec![Operation::Add])
         .add_to_forest(&mut forest)
@@ -2004,7 +1915,7 @@ fn test_untrusted_stripped_payload_does_not_allocate_debug_info_scaffolding() {
     forest.make_root(root);
 
     let mut bytes = Vec::new();
-    forest.write_stripped(&mut bytes);
+    forest.write_into(&mut bytes);
 
     let validation_budget =
         (usize::try_from(forest.num_nodes()).unwrap() + 1) * size_of::<usize>() - 1;
@@ -2014,7 +1925,7 @@ fn test_untrusted_stripped_payload_does_not_allocate_debug_info_scaffolding() {
             .with_wire_byte_budget(bytes.len())
             .with_validation_allocation_budget(validation_budget),
     )
-    .expect("stripped reads should not allocate debug-info scaffolding");
+    .expect("normal reads should not allocate debug-info scaffolding");
     untrusted
         .validate()
         .expect("validation should fit the budget previously consumed by debug scaffolding");

--- a/core/src/mast/untrusted.rs
+++ b/core/src/mast/untrusted.rs
@@ -126,7 +126,7 @@ impl UntrustedMastForest {
     /// This method uses a [`BudgetedReader`] plus a bounded validation-allocation budget derived
     /// from the input size to protect against denial-of-service attacks from malicious input.
     /// The default validation budget includes room for the retained serialized copy used by the
-    /// deferred-validation path, in addition to stripped/hashless helper allocations. Concretely,
+    /// deferred-validation path, in addition to hashless helper allocations. Concretely,
     /// the default is `bytes.len()` for parsing and `bytes.len() * 7` for validation allocations.
     /// That `* 7` factor is a coarse convenience bound, not an exact peak-memory formula.
     ///
@@ -149,8 +149,8 @@ impl UntrustedMastForest {
     /// Deserializes an [`UntrustedMastForest`] from bytes with explicit options.
     ///
     /// The wire byte budget limits wire-driven parsing and collection pre-sizing. The validation
-    /// helper-allocation budget is derived from that wire budget and caps tracked stripped/hashless
-    /// helper allocations such as digest slot tables and rebuilt digest tables.
+    /// helper-allocation budget is derived from that wire budget and caps tracked hashless helper
+    /// allocations such as digest slot tables and rebuilt digest tables.
     pub fn read_from_bytes_with_options(
         bytes: &[u8],
         options: UntrustedMastForestReadOptions,
@@ -163,7 +163,7 @@ impl UntrustedMastForest {
         )?;
         if reader.has_more_bytes() {
             return Err(DeserializationError::InvalidValue(
-                "extra bytes after stripped MastForest payload".into(),
+                "extra bytes after MastForest payload".into(),
             ));
         }
         Ok(forest)

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -4555,29 +4555,28 @@ fn issue_3035_compact_after_clear_debug_info_does_not_grow_mast() -> TestResult 
         "test input must create at least one padded basic block"
     );
 
-    let stripped_size = forest.to_bytes().len();
-    let stripped_without_debug_info_size = {
+    let original_size = forest.to_bytes().len();
+    let explicit_size = {
         let mut bytes = Vec::new();
-        forest.write_stripped(&mut bytes);
+        forest.write_into(&mut bytes);
         bytes.len()
     };
-    let stripped_nodes = forest.nodes().len();
+    let original_nodes = forest.nodes().len();
     let (compacted, _) = forest.compact();
     let compacted_size = compacted.to_bytes().len();
-    let compacted_without_debug_info_size = {
+    let compacted_explicit_size = {
         let mut bytes = Vec::new();
-        compacted.write_stripped(&mut bytes);
+        compacted.write_into(&mut bytes);
         bytes.len()
     };
     let compacted_nodes = compacted.nodes().len();
 
     assert!(
-        compacted_size <= stripped_size,
-        "MastForest::compact increased serialized size after stripping debug info: \
-         stripped={stripped_size}, compacted={compacted_size}, \
-         stripped_without_debug_info={stripped_without_debug_info_size}, \
-         compacted_without_debug_info={compacted_without_debug_info_size}, \
-         stripped_nodes={stripped_nodes}, compacted_nodes={compacted_nodes}"
+        compacted_size <= original_size,
+        "MastForest::compact increased serialized execution size: \
+         original={original_size}, compacted={compacted_size}, \
+         explicit={explicit_size}, compacted_explicit={compacted_explicit_size}, \
+         original_nodes={original_nodes}, compacted_nodes={compacted_nodes}"
     );
 
     Ok(())

--- a/crates/lib/core/tests/mast_forest_merge.rs
+++ b/crates/lib/core/tests/mast_forest_merge.rs
@@ -89,14 +89,14 @@ fn test_core_lib_serialization_roundtrip() {
     }
 }
 
-/// Tests that stripped size hint matches the serialized length for the core library.
+/// Tests that explicit serialization matches `to_bytes` for the core library.
 #[test]
-fn test_core_lib_stripped_size_hint() {
+fn test_core_lib_write_into_matches_to_bytes() {
     let std_lib = miden_core_lib::CoreLibrary::default();
     let forest = std_lib.mast_forest().as_ref();
 
-    let mut stripped_bytes = Vec::new();
-    forest.write_stripped(&mut stripped_bytes);
+    let mut explicit_bytes = Vec::new();
+    forest.write_into(&mut explicit_bytes);
 
-    assert_eq!(forest.stripped_size_hint(), stripped_bytes.len());
+    assert_eq!(forest.to_bytes(), explicit_bytes);
 }

--- a/crates/mast-package/src/package/serialization.rs
+++ b/crates/mast-package/src/package/serialization.rs
@@ -1793,13 +1793,13 @@ mod tests {
     ) -> (Vec<u8>, Word) {
         use miden_core::serde::Serializable;
 
-        // Serialize the MastForest in stripped form so the byte layout is minimal and stable.
+        // Serialize the MastForest normally so the byte layout is stable.
         let forest = lib.mast_forest().as_ref();
         let original_digest = forest[MastNodeId::new_unchecked(0)].digest();
         let mut output_bytes = Vec::new();
         lib.write_header_into(&mut output_bytes);
         let forest_offset = output_bytes.len();
-        forest.write_stripped(&mut output_bytes);
+        forest.write_into(&mut output_bytes);
 
         let (node_hashes_start, node_count) =
             locate_first_node_hash(&output_bytes[forest_offset..]);

--- a/miden-core-fuzz/fuzz_targets/mast_forest_wire_view_new.rs
+++ b/miden-core-fuzz/fuzz_targets/mast_forest_wire_view_new.rs
@@ -16,7 +16,6 @@ fuzz_target!(|data: &[u8]| {
         return;
     };
 
-    let _ = view.is_stripped();
     let root_count = view.procedure_root_count();
     let node_count = view.node_count();
 


### PR DESCRIPTION
Closes #3263.

PR #3221 moved debug info out of `MastForest` and into package debug sections. After that change, the forest level `STRIPPED` flag and APIs still made `MastForest` look like it could carry debug info. It cannot. A `MastForest` now stores execution data only.

This PR removes the stripped forest mode. Normal forest serialization now uses `Serializable::write_into` and `to_bytes` with flag `0x00`. Hashless serialization keeps flag `0x02`. Bit 0 is now reserved.

This also removes `MastForest::write_stripped`, `MastForest::stripped_size_hint`, `MastForestWireView::is_stripped`, and the old size hint code. Tests and callers now use normal serialization or hashless serialization directly.