### PR TITLE
fix(debug): preserve struct names in debug types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.23.4 (TBD)
+
+#### Fixes
+
+- Preserved semantic struct and field names when emitting debug types, so debug dumps no longer fall back to anonymous struct metadata ([#3269](https://github.com/0xMiden/miden-vm/pull/3269)).
+
 ## v0.23.3 (2026-05-26)
 
 - Pure version bump to attach build artifacts to the release.

--- a/crates/assembly-syntax/src/ast/type.rs
+++ b/crates/assembly-syntax/src/ast/type.rs
@@ -363,7 +363,7 @@ impl TypeExpr {
                 for field in t.fields.iter() {
                     let field_ty = field.ty.resolve_type_with_depth(resolver, depth + 1)?;
                     if let Some(field_ty) = field_ty {
-                        fields.push(field_ty);
+                        fields.push((field.name.clone().into_inner(), field_ty));
                     } else {
                         return Ok(None);
                     }
@@ -1178,7 +1178,7 @@ impl crate::prettier::PrettyPrint for Variant {
 
 #[cfg(test)]
 mod tests {
-    use alloc::sync::Arc;
+    use alloc::{sync::Arc, vec::Vec};
     use core::str::FromStr;
 
     use miden_debug_types::DefaultSourceManager;
@@ -1262,5 +1262,37 @@ mod tests {
             matches!(err, SymbolResolutionError::TypeExpressionDepthExceeded { max_depth, .. }
                 if max_depth == MAX_TYPE_EXPR_NESTING)
         );
+    }
+
+    #[test]
+    fn struct_type_expr_resolution_preserves_field_names() {
+        let mut resolver = DummyResolver::new();
+        let expr = TypeExpr::Struct(StructType::new(
+            Some(Ident::from_str("Pair").expect("valid ident")),
+            [
+                StructField {
+                    span: SourceSpan::UNKNOWN,
+                    name: Ident::from_str("left").expect("valid ident"),
+                    ty: TypeExpr::Primitive(Span::unknown(Type::Felt)),
+                },
+                StructField {
+                    span: SourceSpan::UNKNOWN,
+                    name: Ident::from_str("right").expect("valid ident"),
+                    ty: TypeExpr::Primitive(Span::unknown(Type::Felt)),
+                },
+            ],
+        ));
+
+        let Type::Struct(ty) = expr
+            .resolve_type(&mut resolver)
+            .expect("type resolution should succeed")
+            .expect("type should resolve")
+        else {
+            panic!("expected struct type");
+        };
+
+        assert_eq!(ty.name().as_deref(), Some("Pair"));
+        let field_names = ty.fields().iter().map(|field| field.name.as_deref()).collect::<Vec<_>>();
+        assert_eq!(field_names, [Some("left"), Some("right")]);
     }
 }

--- a/crates/assembly/src/assembler/debuginfo.rs
+++ b/crates/assembly/src/assembler/debuginfo.rs
@@ -297,22 +297,25 @@ fn register_debug_type(
             let mut fields = vec![];
             for (i, field) in struct_ty.fields().iter().enumerate() {
                 let decl = declared_field_tys.and_then(|fields| fields.get(i));
-                let declared_name = decl.map(|decl| decl.name.clone().into_inner());
+                let field_name =
+                    decl.map(|decl| decl.name.clone().into_inner()).or_else(|| field.name.clone());
                 let declared_ty = decl.map(|decl| &decl.ty);
+                let field_type_name = declared_type_name(declared_ty);
                 let type_idx = register_debug_type(
                     debug_types_section,
-                    declared_name.clone(),
+                    field_type_name,
                     declared_ty,
                     &field.ty,
                 )?;
                 let name_idx = debug_types_section
-                    .add_string(declared_name.unwrap_or_else(|| format!("{i}").into()));
+                    .add_string(field_name.unwrap_or_else(|| format!("{i}").into()));
                 fields.push(DebugFieldInfo { name_idx, type_idx, offset: field.offset });
             }
+            let struct_name = declared_name.clone().or_else(|| struct_ty.name());
             let name_idx = debug_types_section
-                .add_string(declared_name.clone().unwrap_or_else(|| "<anon>".into()));
+                .add_string(struct_name.clone().unwrap_or_else(|| "<anon>".into()));
             let size = u32::try_from(struct_ty.size()).map_err(|_| {
-                if let Some(declared_name) = declared_name.as_ref() {
+                if let Some(declared_name) = struct_name.as_ref() {
                     Report::msg(format!(
                         "invalid struct type '{declared_name}': struct is too large"
                     ))
@@ -376,4 +379,90 @@ fn register_debug_type(
             })
         },
     })
+}
+
+fn declared_type_name(declared_ty: Option<&TypeExpr>) -> Option<Arc<str>> {
+    match declared_ty? {
+        TypeExpr::Ref(path) => Some(Arc::from(path.inner().as_str())),
+        TypeExpr::Struct(ty) => ty.name.as_ref().map(|name| name.clone().into_inner()),
+        TypeExpr::Primitive(_) | TypeExpr::Ptr(_) | TypeExpr::Array(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+
+    use super::*;
+    use crate::ast::types::{CallConv, FunctionType};
+
+    #[test]
+    fn function_debug_types_preserve_resolved_struct_metadata() {
+        let felt_wrapper = Type::Struct(Arc::new(StructType::named(
+            "felt-wrapper".into(),
+            [(Arc::from("inner"), Type::Felt)],
+        )));
+        let account_id = Type::Struct(Arc::new(StructType::named(
+            "account-id".into(),
+            [(Arc::from("prefix"), felt_wrapper.clone()), (Arc::from("suffix"), felt_wrapper)],
+        )));
+        let function = Type::Function(Arc::new(FunctionType::new(
+            CallConv::ComponentModel,
+            [account_id.clone()],
+            [account_id],
+        )));
+        let mut section = DebugTypesSection::new();
+
+        let function_idx =
+            register_debug_type(&mut section, Some(Arc::from("take-account-id")), None, &function)
+                .expect("function type should register");
+
+        let (return_type_idx, param_type_idx) = match section.get_type(function_idx).unwrap() {
+            DebugTypeInfo::Function {
+                return_type_idx: Some(return_type_idx),
+                param_type_indices,
+            } => {
+                assert_eq!(param_type_indices.len(), 1);
+                (*return_type_idx, param_type_indices[0])
+            },
+            other => panic!("expected function debug type, got {other:?}"),
+        };
+
+        assert_struct_debug_type(
+            &section,
+            param_type_idx,
+            "account-id",
+            &[("prefix", "felt-wrapper"), ("suffix", "felt-wrapper")],
+        );
+        assert_struct_debug_type(
+            &section,
+            return_type_idx,
+            "account-id",
+            &[("prefix", "felt-wrapper"), ("suffix", "felt-wrapper")],
+        );
+    }
+
+    fn assert_struct_debug_type(
+        section: &DebugTypesSection,
+        type_idx: DebugTypeIdx,
+        expected_name: &str,
+        expected_fields: &[(&str, &str)],
+    ) {
+        let DebugTypeInfo::Struct { name_idx, fields, .. } = section.get_type(type_idx).unwrap()
+        else {
+            panic!("expected struct debug type");
+        };
+
+        assert_eq!(section.get_string(*name_idx).as_deref(), Some(expected_name));
+        assert_eq!(fields.len(), expected_fields.len());
+        for (field, (expected_name, expected_type_name)) in fields.iter().zip(expected_fields) {
+            assert_eq!(section.get_string(field.name_idx).as_deref(), Some(*expected_name));
+
+            let DebugTypeInfo::Struct { name_idx, .. } = section.get_type(field.type_idx).unwrap()
+            else {
+                panic!("expected struct field type");
+            };
+            assert_eq!(section.get_string(*name_idx).as_deref(), Some(*expected_type_name));
+        }
+    }
 }


### PR DESCRIPTION
This preserves concrete struct metadata when emitting VM debug types. Previously, structs that reached debug info without a declared `TypeExpr` fell back to `<anon>` and numeric fields; now the emitter uses the resolved `StructType` name and `field` names when available. This fixes debug dumps for SDK/WIT record types, e.g. `miden:base/core-types@1.0.0/felt`, which now renders by name instead of as `<anon>`.

Useful for debugging tools.

Resolves this:  https://github.com/0xMiden/compiler/issues/1198