### PR TITLE
fix: bump p3 dependencies to fix NEON bug on p3-goldilocks Poseidon2 arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [BREAKING] `miden-vm bundle` now treats the `--kernel` option as a flag; when set, it expects the file path given to `bundle` to be the path to the root module of the kernel, and the support library for the kernel is derived from explicit submodule declarations in that module.
 - [BREAKING] Moved debug info ownership out of `MastForest` and into package debug sections, adding source-node debug metadata that preserves distinct source occurrences after MAST node deduplication ([#3221](https://github.com/0xMiden/miden-vm/pull/3221)).
 - Cleaned up processor error handling for diagnostics, malformed MAST loading, and binary-value checks ([#3230](https://github.com/0xMiden/miden-vm/pull/3230)).
+- [BREAKING] Bump Plonky3 related dependencies to fix NEON arithmetic bug ([#3272](https://github.com/0xMiden/miden-vm/pull/3272)).
 
 #### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,9 +2038,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "p3-air"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2ec9cbfc642fc5173817287c3f8b789d07743b5f7e812d058b7a03e344f9ab"
+checksum = "c824e8d7c7ddf208b742eac8d48e0b2d52d22fa013578a7762bf6931dbab1f46"
 dependencies = [
  "p3-field",
  "p3-matrix",
@@ -2049,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "p3-blake3"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b667f43b19499dd939c9e2553aa95688936a88360d50117dae3c8848d07dbc70"
+checksum = "2733229a713bd83ccf5eb749e8f8e7380c1052674394a25c0422a772204a20af"
 dependencies = [
  "blake3",
  "p3-symmetric",
@@ -2060,9 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0b490c745a7d2adeeafff06411814c8078c432740162332b3cd71be0158a76"
+checksum = "8972ccd1d5dc90e46cdb1f2ab4ee2bae49b3917e5e98aa533f0c2b779c010445"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -2074,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55301e91544440254977108b85c32c09d7ea05f2f0dd61092a2825339906a4a7"
+checksum = "17771aca44632f9cc11f2718d7ea7ec06794946c4190ef3a985bfc893f14c18a"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -2089,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85affca7fc983889f260655c4cf74163eebb94605f702e4b6809ead707cba54f"
+checksum = "6f3eb24d0591fd4d282d89cbe4e4efba5571c699375006f80b2cbf53ce83461c"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -2105,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "p3-goldilocks"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca1081f5c47b940f2d75a11c04f62ea1cc58a5d480dd465fef3861c045c63cd"
+checksum = "5751c6591a0d2397d726620c2c29a7436ec6c5e19d2ed74ca5d078d4fbb18eb5"
 dependencies = [
  "num-bigint",
  "p3-challenger",
@@ -2125,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "p3-keccak"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcf27615ece1995e4fcf4c69740f1cf515d1481367a20b4b3ce7f4f1b8d70f7"
+checksum = "77a7df174ff0c19a8742eb4698eaa1667c5f858d018e2faf09c55f1f24a6f9c3"
 dependencies = [
  "p3-symmetric",
  "p3-util",
@@ -2136,9 +2136,9 @@ dependencies = [
 
 [[package]]
 name = "p3-matrix"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53428126b009071563d1d07305a9de8be0d21de00b57d2475289ee32ffca6577"
+checksum = "ea9c94c0714944e7b8a9a62e6340b1e3e1d3f8ecfd3e35c08798360200e73eff"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -2151,18 +2151,18 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082bf467011c06c768c579ec6eb9accb5e1e62108891634cc770396e917f978a"
+checksum = "eebc233a34b1ab0273f35b4052fa2eeb3114b22ba4575bd7da00716e878ffb77"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "p3-mds"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35209e6214102ea6ec6b8cb1b9c15a9b8e597a39f9173597c957f123bced81b3"
+checksum = "6b5441fa8116246ec9e6c835f15273cb27777ca572960ec87476b67fef13e01e"
 dependencies = [
  "p3-dft",
  "p3-field",
@@ -2173,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "p3-monty-31"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa8c99ec50c035020bbf5457c6a729ba6a975719c1a8dd3f16421081e4f650c"
+checksum = "8724f330ea6d19dd4f2436aa0f88b5fcbf88f0f55ca7fccd3fea8b736dbcddad"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -2197,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon1"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a018b618e3fa0aec8be933b1d8e404edd23f46991f6bf3f5c2f3f95e9413fe9"
+checksum = "04e2a562fea210baae390a32f9ecf0dd8724ae3f4352d1c8e413077b6f00a162"
 dependencies = [
  "p3-field",
  "p3-symmetric",
@@ -2208,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256a668a9ba916f8767552f13d0ba50d18968bc74a623bfdafa41e2970c944d0"
+checksum = "06394851c161d17e4aa4ad2aad5557d32f14cadd1dc838f965d8e1821a63b8c5"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -2221,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c60a71a1507c13611b0f2b0b6e83669fd5b76f8e3115bcbced5ccfdf3ca7807"
+checksum = "9ac1a276d421f8ef3361bb7d8c39a02c93c6b3f10eeaa559cc4c50222f9a5b82"
 dependencies = [
  "itertools 0.14.0",
  "p3-field",
@@ -2233,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b766b9e9254bf3fa98d76e42cf8a5b30628c182dfd5272d270076ee12f0fc0"
+checksum = "d08a58162a4c264269ef454f0b28dcda89939490eecacb2b2cf5b00f719b80f6"
 dependencies = [
  "rayon",
  "serde",
@@ -3032,7 +3032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",


### PR DESCRIPTION
## Describe your changes

A bug in `p3-goldilocks` NEON arithmetic was discovered in v0.5.2, which was fixed in the follow-up patch release v0.5.3 but dependencies in `miden-vm` had never been updated, even after faulty versions had been yanked.

This fixes the bug highlighted in #3270.
closes #3270 

Output on my machine (M4 pro) post dependencies update: (note that the program hash matches x86 targets)

<details><summary>blake3_1to1</summary>
<p>

```bash
===============================================================================
Prove program: ./miden-vm/masm-examples/hashing/blake3_1to1/blake3_1to1.masm
-------------------------------------------------------------------------------
INFO     read_library_files [ 208ns | 100.00% ]
INFO     read_input_file [ 613µs | 100.00% ]
ERROR    🚨 [error]: UntrustedMastForest expected HASHLESS input; supplied artifact includes wire node hashes, and validation will recompute them and require them to match | log.target: "miden_core::mast::serialization" | log.module_path: "miden_core::mast::serialization" | log.file: "core/src/mast/serialization/mod.rs" | log.line: 858
WARN     🚧 [warn]: Package read ignored debug sections from an untrusted artifact; use Package::read_from_trusted for local cache/debug reads | log.target: "miden_mast_package::package::serialization" | log.module_path: "miden_mast_package::package::serialization" | log.file: "crates/mast-package/src/package/serialization.rs" | log.line: 266
INFO     read_program_file [ 714µs | 100.00% ] path: ./miden-vm/masm-examples/hashing/blake3_1to1/blake3_1to1.masm
INFO     compile_package [ 1.53ms | 100.00% ]
Proving program with hash 6a3fcc14e38dc61659ee5554be11a44c0824e9344b494dc9d68764d051fabcde...
INFO     execute_trace_inputs_with_package_debug_info_at_source_node_sync [ 14.0ms | 100.00% ]
INFO     prove_trace_sync [ 7.39s | 0.00% / 100.00% ]
INFO     ┝━ build_trace [ 44.5ms | 0.60% ]
INFO     ┝━ ｉ [info]: Generated execution trace of 73 columns and 1048576 steps (padded from 647388)
INFO     ┝━ to_core_chiplets_matrices [ 16.0µs | 0.00% ]
INFO     ┕━ prove [ 7.35s | 0.62% / 99.40% ]
INFO        ┝━ commit to main traces [ 2.10s | 0.00% / 28.40% ]
INFO        │  ┝━ LDE [ 150ms | 2.02% ] trace: 0 | log_height: 19 | width: 22
INFO        │  ┝━ LDE [ 776ms | 10.50% ] trace: 1 | log_height: 20 | width: 51
INFO        │  ┝━ hash leaves [ 1.04s | 4.02% / 14.10% ]
INFO        │  │  ┝━ absorb matrix [ 177ms | 2.39% ] height: 4194304 | width: 22
INFO        │  │  ┕━ absorb matrix [ 568ms | 7.68% ] height: 8388608 | width: 51
INFO        │  ┕━ compress tree layers [ 132ms | 1.78% ]
INFO        ┝━ build aux traces [ 121ms | 0.00% / 1.64% ]
INFO        │  ┝━ build_aux_trace_logup [ 94.6ms | 1.28% ]
INFO        │  ┕━ build_aux_trace_logup [ 26.4ms | 0.36% ]
INFO        ┝━ commit to aux traces [ 556ms | 0.00% / 7.51% ]
INFO        │  ┝━ LDE [ 40.6ms | 0.55% ] trace: 0 | log_height: 19 | width: 6
INFO        │  ┝━ LDE [ 123ms | 1.66% ] trace: 1 | log_height: 20 | width: 8
INFO        │  ┝━ hash leaves [ 296ms | 1.13% / 4.01% ]
INFO        │  │  ┝━ absorb matrix [ 69.8ms | 0.94% ] height: 4194304 | width: 6
INFO        │  │  ┕━ absorb matrix [ 143ms | 1.93% ] height: 8388608 | width: 8
INFO        │  ┕━ compress tree layers [ 96.1ms | 1.30% ]
INFO        ┝━ evaluate constraints [ 3.40s | 45.96% / 45.96% ]
INFO        │  ┕━ divide_by_height [ 117µs | 0.00% ] dims: 18x16
INFO        ┝━ commit to quotient poly chunks [ 701ms | 1.29% / 9.47% ]
INFO        │  ┝━ quotient iDFT [ 27.0ms | 0.35% / 0.36% ] dims: 1048576x8
INFO        │  │  ┕━ divide_by_height [ 1.05ms | 0.01% ] dims: 16x1048576
INFO        │  ┝━ quotient scaling [ 1.97ms | 0.03% ] n: 1048576
INFO        │  ┝━ quotient DFT [ 213ms | 2.87% ] dims: 8388608x16
INFO        │  ┝━ hash leaves [ 282ms | 0.83% / 3.82% ]
INFO        │  │  ┕━ absorb matrix [ 220ms | 2.98% ] height: 8388608 | width: 16
INFO        │  ┕━ compress tree layers [ 81.2ms | 1.10% ]
INFO        ┕━ open [ 429ms | 0.00% / 5.80% ]
INFO           ┕━ PCS opening [ 429ms | 0.00% / 5.80% ]
INFO              ┝━ DEEP quotient [ 316ms | 0.11% / 4.27% ]
INFO              │  ┝━ PointQuotients::new [ 73.3ms | 0.99% ] n: 8388608
INFO              │  ┝━ evaluate at OOD points [ 26.9ms | 0.00% / 0.36% ]
INFO              │  │  ┕━ batch_eval_lifted [ 26.9ms | 0.36% ] n_groups: 3
INFO              │  ┝━ DEEP grind [ 1.01ms | 0.00% / 0.01% ] bits: 12
INFO              │  │  ┕━ grind for proof-of-work witness [ 1.01ms | 0.01% ]
INFO              │  ┕━ DEEP reduce + assemble [ 207ms | 2.79% ]
INFO              ┝━ FRI commit phase [ 108ms | 0.06% / 1.46% ]
INFO              │  ┝━ FRI round commit [ 66.4ms | 0.00% / 0.90% ] round: 0 | domain_size: 8388608
INFO              │  │  ┝━ hash leaves [ 42.6ms | 0.04% / 0.58% ]
INFO              │  │  │  ┕━ absorb matrix [ 39.4ms | 0.53% ] height: 2097152 | width: 8
INFO              │  │  ┕━ compress tree layers [ 23.8ms | 0.32% ]
INFO              │  ┝━ FRI folding grind [ 47.5µs | 0.00% / 0.00% ] round: 0 | bits: 4
INFO              │  │  ┕━ grind for proof-of-work witness [ 46.8µs | 0.00% ]
INFO              │  ┝━ FRI fold [ 4.65ms | 0.06% ] round: 0 | domain_size: 8388608
INFO              │  ┝━ FRI round commit [ 18.7ms | 0.00% / 0.25% ] round: 1 | domain_size: 2097152
INFO              │  │  ┝━ hash leaves [ 11.8ms | 0.02% / 0.16% ]
INFO              │  │  │  ┕━ absorb matrix [ 10.2ms | 0.14% ] height: 524288 | width: 8
INFO              │  │  ┕━ compress tree layers [ 6.93ms | 0.09% ]
INFO              │  ┝━ FRI folding grind [ 67.0µs | 0.00% / 0.00% ] round: 1 | bits: 4
INFO              │  │  ┕━ grind for proof-of-work witness [ 66.2µs | 0.00% ]
INFO              │  ┝━ FRI fold [ 1.41ms | 0.02% ] round: 1 | domain_size: 2097152
INFO              │  ┝━ FRI round commit [ 6.20ms | 0.00% / 0.08% ] round: 2 | domain_size: 524288
INFO              │  │  ┝━ hash leaves [ 3.29ms | 0.01% / 0.04% ]
INFO              │  │  │  ┕━ absorb matrix [ 2.76ms | 0.04% ] height: 131072 | width: 8
INFO              │  │  ┕━ compress tree layers [ 2.91ms | 0.04% ]
INFO              │  ┝━ FRI folding grind [ 73.4µs | 0.00% / 0.00% ] round: 2 | bits: 4
INFO              │  │  ┕━ grind for proof-of-work witness [ 72.8µs | 0.00% ]
INFO              │  ┝━ FRI fold [ 473µs | 0.01% ] round: 2 | domain_size: 524288
INFO              │  ┝━ FRI round commit [ 2.29ms | 0.00% / 0.03% ] round: 3 | domain_size: 131072
INFO              │  │  ┝━ hash leaves [ 1.03ms | 0.00% / 0.01% ]
INFO              │  │  │  ┕━ absorb matrix [ 797µs | 0.01% ] height: 32768 | width: 8
INFO              │  │  ┕━ compress tree layers [ 1.25ms | 0.02% ]
INFO              │  ┝━ FRI folding grind [ 56.7µs | 0.00% / 0.00% ] round: 3 | bits: 4
INFO              │  │  ┕━ grind for proof-of-work witness [ 56.0µs | 0.00% ]
INFO              │  ┝━ FRI fold [ 241µs | 0.00% ] round: 3 | domain_size: 131072
INFO              │  ┝━ FRI round commit [ 1.34ms | 0.00% / 0.02% ] round: 4 | domain_size: 32768
INFO              │  │  ┝━ hash leaves [ 445µs | 0.00% / 0.01% ]
INFO              │  │  │  ┕━ absorb matrix [ 320µs | 0.00% ] height: 8192 | width: 8
INFO              │  │  ┕━ compress tree layers [ 889µs | 0.01% ]
INFO              │  ┝━ FRI folding grind [ 35.7µs | 0.00% / 0.00% ] round: 4 | bits: 4
INFO              │  │  ┕━ grind for proof-of-work witness [ 35.2µs | 0.00% ]
INFO              │  ┝━ FRI fold [ 136µs | 0.00% ] round: 4 | domain_size: 32768
INFO              │  ┝━ FRI round commit [ 773µs | 0.00% / 0.01% ] round: 5 | domain_size: 8192
INFO              │  │  ┝━ hash leaves [ 178µs | 0.00% / 0.00% ]
INFO              │  │  │  ┕━ absorb matrix [ 104µs | 0.00% ] height: 2048 | width: 8
INFO              │  │  ┕━ compress tree layers [ 594µs | 0.01% ]
INFO              │  ┝━ FRI folding grind [ 32.5µs | 0.00% / 0.00% ] round: 5 | bits: 4
INFO              │  │  ┕━ grind for proof-of-work witness [ 32.0µs | 0.00% ]
INFO              │  ┝━ FRI fold [ 119µs | 0.00% ] round: 5 | domain_size: 8192
INFO              │  ┝━ FRI round commit [ 525µs | 0.00% / 0.01% ] round: 6 | domain_size: 2048
INFO              │  │  ┝━ hash leaves [ 173µs | 0.00% / 0.00% ]
INFO              │  │  │  ┕━ absorb matrix [ 93.8µs | 0.00% ] height: 512 | width: 8
INFO              │  │  ┕━ compress tree layers [ 351µs | 0.00% ]
INFO              │  ┝━ FRI folding grind [ 146µs | 0.00% / 0.00% ] round: 6 | bits: 4
INFO              │  │  ┕━ grind for proof-of-work witness [ 146µs | 0.00% ]
INFO              │  ┕━ FRI fold [ 77.5µs | 0.00% ] round: 6 | domain_size: 2048
INFO              ┝━ query grind [ 3.95ms | 0.00% / 0.05% ] bits: 16
INFO              │  ┕━ grind for proof-of-work witness [ 3.95ms | 0.05% ]
INFO              ┕━ query phase [ 936µs | 0.00% / 0.01% ]
INFO                 ┝━ open input trees [ 769µs | 0.01% ] n_trees: 3
INFO                 ┕━ open FRI trees [ 165µs | 0.00% ]
Program proved in 7408 ms
INFO     write_data_to_proof_file [ 1.24ms | 100.00% ] path: ./miden-vm/masm-examples/hashing/blake3_1to1/blake3_1to1.proof | size: "137 KB"
INFO     write_data_to_output_file [ 472µs | 100.00% ] path: ./miden-vm/masm-examples/hashing/blake3_1to1/blake3_1to1.outputs
Output: [4210649924, 4239425932, 2583891669, 2278324621, 1697424527, 1323302812, 3062448259, 2695025053, 0, 0, 0, 0, 0, 0, 0, 0]
```

</p>
</details> 

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md'