### PR TITLE
Reject private types in exported MASM surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
 - Fixed `FastProcessor` stack growth so operand stack depth is bounded by `ExecutionOptions::max_stack_depth` instead of the internal buffer size ([#3086](https://github.com/0xMiden/miden-vm/pull/3086)).
 - Hardened MAST forest and package byte-slice deserialization against fuzzed length fields ([#3088](https://github.com/0xMiden/miden-vm/pull/3088)).
 - [BREAKING] Fixed project artifact reuse to ignore unrelated manifest fields, rejected private cross-module imports, and kept signature-only type imports live ([#3091](https://github.com/0xMiden/miden-vm/pull/3091)).
+- Rejected private type references in exported procedure signatures, including transitive aliases and same-module absolute paths ([#3092](https://github.com/0xMiden/miden-vm/issues/3092)).
 - Fixed stale `ReplayProcessor` doc comment links to `ExecutionTracer` after module-structure refactors.
 
 #### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,7 @@
 - Fixed `FastProcessor` stack growth so operand stack depth is bounded by `ExecutionOptions::max_stack_depth` instead of the internal buffer size ([#3086](https://github.com/0xMiden/miden-vm/pull/3086)).
 - Hardened MAST forest and package byte-slice deserialization against fuzzed length fields ([#3088](https://github.com/0xMiden/miden-vm/pull/3088)).
 - [BREAKING] Fixed project artifact reuse to ignore unrelated manifest fields, rejected private cross-module imports, and kept signature-only type imports live ([#3091](https://github.com/0xMiden/miden-vm/pull/3091)).
-- Rejected private type references in exported procedure signatures, including transitive aliases and same-module absolute paths ([#3092](https://github.com/0xMiden/miden-vm/issues/3092)).
+- Rejected private type references in exported procedure signatures, including transitive aliases and same-module absolute paths ([#3273](https://github.com/0xMiden/miden-vm/pull/3273)).
 - Fixed stale `ReplayProcessor` doc comment links to `ExecutionTracer` after module-structure refactors.
 
 #### Changes

--- a/crates/assembly-syntax/src/lib.rs
+++ b/crates/assembly-syntax/src/lib.rs
@@ -30,7 +30,10 @@ pub use self::{
     ast::{Path, PathBuf, PathComponent, PathError},
     parser::{ModuleParser, ParsingError},
 };
-pub use self::{parse::Parse, sema::SemanticAnalysisError};
+pub use self::{
+    parse::Parse,
+    sema::{ExportedTypeUse, SemanticAnalysisError},
+};
 
 /// Maximum allowed iteration count for `repeat.<count>` blocks.
 pub const MAX_REPEAT_COUNT: u32 = 1_000_000;

--- a/crates/assembly-syntax/src/sema/errors.rs
+++ b/crates/assembly-syntax/src/sema/errors.rs
@@ -140,6 +140,16 @@ pub enum SemanticAnalysisError {
         #[label("previously defined here")]
         prev_span: SourceSpan,
     },
+    #[error("private type in exported procedure signature")]
+    #[diagnostic(help(
+        "exported procedure signatures may only reference public types, including nested type dependencies"
+    ))]
+    PrivateTypeInExportedSignature {
+        #[label("this exported procedure signature references a private type")]
+        span: SourceSpan,
+        #[label("this type is private")]
+        defined: SourceSpan,
+    },
     #[error("unused import")]
     #[diagnostic(severity(Warning), help("this import is never used and can be safely removed"))]
     UnusedImport {

--- a/crates/assembly-syntax/src/sema/errors.rs
+++ b/crates/assembly-syntax/src/sema/errors.rs
@@ -150,6 +150,16 @@ pub enum SemanticAnalysisError {
         #[label("this type is private")]
         defined: SourceSpan,
     },
+    #[error("private type in exported type declaration")]
+    #[diagnostic(help(
+        "exported type declarations may only reference public types, including nested type dependencies"
+    ))]
+    PrivateTypeInExportedType {
+        #[label("this exported type declaration references a private type")]
+        span: SourceSpan,
+        #[label("this type is private")]
+        defined: SourceSpan,
+    },
     #[error("unused import")]
     #[diagnostic(severity(Warning), help("this import is never used and can be safely removed"))]
     UnusedImport {

--- a/crates/assembly-syntax/src/sema/errors.rs
+++ b/crates/assembly-syntax/src/sema/errors.rs
@@ -48,6 +48,30 @@ pub struct SyntaxWarning {
     pub errors: Vec<SemanticAnalysisError>,
 }
 
+/// Identifies the exported surface where a private type was found.
+#[derive(Clone, Copy)]
+pub enum ExportedTypeUse {
+    ProcedureSignature,
+    TypeDeclaration,
+}
+
+impl ExportedTypeUse {
+    pub fn private_type_error(
+        self,
+        span: SourceSpan,
+        defined: SourceSpan,
+    ) -> SemanticAnalysisError {
+        match self {
+            Self::ProcedureSignature => {
+                SemanticAnalysisError::PrivateTypeInExportedSignature { span, defined }
+            },
+            Self::TypeDeclaration => {
+                SemanticAnalysisError::PrivateTypeInExportedType { span, defined }
+            },
+        }
+    }
+}
+
 /// Represents an error that occurs during semantic analysis
 #[derive(Debug, thiserror::Error, Diagnostic)]
 pub enum SemanticAnalysisError {

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -329,12 +329,7 @@ fn verify_exported_signature_type_expr(
         },
         TypeExpr::Struct(ty) => {
             for field in ty.fields.iter() {
-                verify_exported_signature_type_expr(
-                    module,
-                    analyzer,
-                    &field.ty,
-                    visiting_types,
-                );
+                verify_exported_signature_type_expr(module, analyzer, &field.ty, visiting_types);
             }
         },
         TypeExpr::Ref(path) => {
@@ -380,12 +375,9 @@ fn verify_exported_signature_type_expr(
             }
 
             match type_decl {
-                TypeDecl::Alias(alias) => verify_exported_signature_type_expr(
-                    module,
-                    analyzer,
-                    &alias.ty,
-                    visiting_types,
-                ),
+                TypeDecl::Alias(alias) => {
+                    verify_exported_signature_type_expr(module, analyzer, &alias.ty, visiting_types)
+                },
                 TypeDecl::Enum(ty) => {
                     for variant in ty.variants() {
                         if let Some(payload_ty) = variant.value_ty.as_ref() {

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -308,32 +308,101 @@ fn verify_exported_signature_type_visibility(module: &Module, analyzer: &mut Ana
 
         for ty in signature.args.iter().chain(signature.results.iter()) {
             let mut visiting_types = BTreeSet::default();
-            verify_exported_signature_type_expr(module, analyzer, ty, &mut visiting_types);
+            verify_exported_type_expr(
+                module,
+                analyzer,
+                ty,
+                &mut visiting_types,
+                ExportedTypeUse::ProcedureSignature,
+            );
+        }
+    }
+
+    for item in module.items() {
+        let Item::Type(type_decl) = item else {
+            continue;
+        };
+        if !type_decl.visibility().is_public() {
+            continue;
+        }
+
+        let mut visiting_types = BTreeSet::default();
+        verify_exported_type_decl(
+            module,
+            analyzer,
+            type_decl,
+            &mut visiting_types,
+            ExportedTypeUse::TypeDeclaration,
+        );
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ExportedTypeUse {
+    ProcedureSignature,
+    TypeDeclaration,
+}
+
+impl ExportedTypeUse {
+    fn private_type_error(self, span: SourceSpan, defined: SourceSpan) -> SemanticAnalysisError {
+        match self {
+            Self::ProcedureSignature => {
+                SemanticAnalysisError::PrivateTypeInExportedSignature { span, defined }
+            },
+            Self::TypeDeclaration => {
+                SemanticAnalysisError::PrivateTypeInExportedType { span, defined }
+            },
         }
     }
 }
 
-fn verify_exported_signature_type_expr(
+fn verify_exported_type_decl(
+    module: &Module,
+    analyzer: &mut AnalysisContext,
+    type_decl: &TypeDecl,
+    visiting_types: &mut BTreeSet<ItemIndex>,
+    usage: ExportedTypeUse,
+) {
+    match type_decl {
+        TypeDecl::Alias(alias) => {
+            verify_exported_type_expr(module, analyzer, &alias.ty, visiting_types, usage);
+        },
+        TypeDecl::Enum(ty) => {
+            for variant in ty.variants() {
+                if let Some(payload_ty) = variant.value_ty.as_ref() {
+                    verify_exported_type_expr(module, analyzer, payload_ty, visiting_types, usage);
+                }
+            }
+        },
+    }
+}
+
+fn verify_exported_type_expr(
     module: &Module,
     analyzer: &mut AnalysisContext,
     ty: &TypeExpr,
     visiting_types: &mut BTreeSet<ItemIndex>,
+    usage: ExportedTypeUse,
 ) {
     match ty {
         TypeExpr::Primitive(_) => (),
         TypeExpr::Ptr(ty) => {
-            verify_exported_signature_type_expr(module, analyzer, &ty.pointee, visiting_types);
+            verify_exported_type_expr(module, analyzer, &ty.pointee, visiting_types, usage);
         },
         TypeExpr::Array(ty) => {
-            verify_exported_signature_type_expr(module, analyzer, &ty.elem, visiting_types);
+            verify_exported_type_expr(module, analyzer, &ty.elem, visiting_types, usage);
         },
         TypeExpr::Struct(ty) => {
             for field in ty.fields.iter() {
-                verify_exported_signature_type_expr(module, analyzer, &field.ty, visiting_types);
+                verify_exported_type_expr(module, analyzer, &field.ty, visiting_types, usage);
             }
         },
         TypeExpr::Ref(path) => {
-            let resolution = match module.resolve_path(path.as_deref(), analyzer.source_manager()) {
+            let resolver = match LocalSymbolResolver::new(module, analyzer.source_manager()) {
+                Ok(resolver) => resolver,
+                Err(_) => return,
+            };
+            let resolution = match resolver.resolve_path(path.as_deref()) {
                 Ok(resolution) => resolution,
                 Err(_) => return,
             };
@@ -363,10 +432,7 @@ fn verify_exported_signature_type_expr(
             };
 
             if !type_decl.visibility().is_public() {
-                analyzer.error(SemanticAnalysisError::PrivateTypeInExportedSignature {
-                    span: path.span(),
-                    defined: type_decl.name().span(),
-                });
+                analyzer.error(usage.private_type_error(path.span(), type_decl.name().span()));
                 return;
             }
 
@@ -374,23 +440,7 @@ fn verify_exported_signature_type_expr(
                 return;
             }
 
-            match type_decl {
-                TypeDecl::Alias(alias) => {
-                    verify_exported_signature_type_expr(module, analyzer, &alias.ty, visiting_types)
-                },
-                TypeDecl::Enum(ty) => {
-                    for variant in ty.variants() {
-                        if let Some(payload_ty) = variant.value_ty.as_ref() {
-                            verify_exported_signature_type_expr(
-                                module,
-                                analyzer,
-                                payload_ty,
-                                visiting_types,
-                            );
-                        }
-                    }
-                },
-            }
+            verify_exported_type_decl(module, analyzer, type_decl, visiting_types, usage);
 
             visiting_types.remove(&item);
         },

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -19,7 +19,7 @@ use smallvec::SmallVec;
 use self::passes::{LocalInvokeTarget, VerifyInvokeTargets};
 pub use self::{
     context::AnalysisContext,
-    errors::{LimitKind, SemanticAnalysisError, SyntaxError},
+    errors::{ExportedTypeUse, LimitKind, SemanticAnalysisError, SyntaxError},
     passes::{ConstEvalVisitor, VerifyRepeatCounts},
 };
 use crate::{ast::*, parser::WordValue};
@@ -334,25 +334,6 @@ fn verify_exported_signature_type_visibility(module: &Module, analyzer: &mut Ana
             &mut visiting_types,
             ExportedTypeUse::TypeDeclaration,
         );
-    }
-}
-
-#[derive(Clone, Copy)]
-enum ExportedTypeUse {
-    ProcedureSignature,
-    TypeDeclaration,
-}
-
-impl ExportedTypeUse {
-    fn private_type_error(self, span: SourceSpan, defined: SourceSpan) -> SemanticAnalysisError {
-        match self {
-            Self::ProcedureSignature => {
-                SemanticAnalysisError::PrivateTypeInExportedSignature { span, defined }
-            },
-            Self::TypeDeclaration => {
-                SemanticAnalysisError::PrivateTypeInExportedType { span, defined }
-            },
-        }
     }
 }
 

--- a/crates/assembly-syntax/src/sema/mod.rs
+++ b/crates/assembly-syntax/src/sema/mod.rs
@@ -272,6 +272,8 @@ pub fn analyze(
         analyzer.error(SemanticAnalysisError::MissingEntrypoint);
     }
 
+    verify_exported_signature_type_visibility(&module, &mut analyzer);
+
     analyzer.has_failed()?;
 
     // Run item checks
@@ -292,6 +294,115 @@ fn normalize_namespace_path(path: &Path) -> Result<Arc<Path>, PathError> {
     path.canonicalize()
         .and_then(|path| path.to_absolute().map(Cow::into_owned))
         .map(Arc::<Path>::from)
+}
+
+fn verify_exported_signature_type_visibility(module: &Module, analyzer: &mut AnalysisContext) {
+    for procedure in module.procedures() {
+        if !procedure.visibility().is_public() {
+            continue;
+        }
+
+        let Some(signature) = procedure.signature() else {
+            continue;
+        };
+
+        for ty in signature.args.iter().chain(signature.results.iter()) {
+            let mut visiting_types = BTreeSet::default();
+            verify_exported_signature_type_expr(module, analyzer, ty, &mut visiting_types);
+        }
+    }
+}
+
+fn verify_exported_signature_type_expr(
+    module: &Module,
+    analyzer: &mut AnalysisContext,
+    ty: &TypeExpr,
+    visiting_types: &mut BTreeSet<ItemIndex>,
+) {
+    match ty {
+        TypeExpr::Primitive(_) => (),
+        TypeExpr::Ptr(ty) => {
+            verify_exported_signature_type_expr(module, analyzer, &ty.pointee, visiting_types);
+        },
+        TypeExpr::Array(ty) => {
+            verify_exported_signature_type_expr(module, analyzer, &ty.elem, visiting_types);
+        },
+        TypeExpr::Struct(ty) => {
+            for field in ty.fields.iter() {
+                verify_exported_signature_type_expr(
+                    module,
+                    analyzer,
+                    &field.ty,
+                    visiting_types,
+                );
+            }
+        },
+        TypeExpr::Ref(path) => {
+            let resolution = match module.resolve_path(path.as_deref(), analyzer.source_manager()) {
+                Ok(resolution) => resolution,
+                Err(_) => return,
+            };
+            let item = match resolution {
+                SymbolResolution::Local(item) => Some(item.into_inner()),
+                SymbolResolution::External(path)
+                    if path.parent().is_some_and(|parent| parent == module.path()) =>
+                {
+                    let Some(local_name) = path.last() else {
+                        return;
+                    };
+                    module.index_of(|item| item.name().as_str() == local_name)
+                },
+                SymbolResolution::External(_)
+                | SymbolResolution::MastRoot(_)
+                | SymbolResolution::Exact { .. }
+                | SymbolResolution::Module { .. } => None,
+            };
+            let Some(item) = item else {
+                return;
+            };
+            let Some(export) = module.get(item) else {
+                return;
+            };
+            let Item::Type(type_decl) = export else {
+                return;
+            };
+
+            if !type_decl.visibility().is_public() {
+                analyzer.error(SemanticAnalysisError::PrivateTypeInExportedSignature {
+                    span: path.span(),
+                    defined: type_decl.name().span(),
+                });
+                return;
+            }
+
+            if !visiting_types.insert(item) {
+                return;
+            }
+
+            match type_decl {
+                TypeDecl::Alias(alias) => verify_exported_signature_type_expr(
+                    module,
+                    analyzer,
+                    &alias.ty,
+                    visiting_types,
+                ),
+                TypeDecl::Enum(ty) => {
+                    for variant in ty.variants() {
+                        if let Some(payload_ty) = variant.value_ty.as_ref() {
+                            verify_exported_signature_type_expr(
+                                module,
+                                analyzer,
+                                payload_ty,
+                                visiting_types,
+                            );
+                        }
+                    }
+                },
+            }
+
+            visiting_types.remove(&item);
+        },
+    }
 }
 
 /// Visit all of the items of the current analysis context, and apply various transformation and

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -386,6 +386,8 @@ fn exported_proc_signature_rejects_private_local_type() {
     let error = context
         .parse_module(
             "
+namespace test
+
 type PrivateType = felt
 
 pub proc check(value: PrivateType)
@@ -399,30 +401,29 @@ end
 }
 
 #[test]
-fn exported_proc_signature_rejects_private_type_via_public_alias() {
+fn exported_type_alias_rejects_private_type() {
     let context = SyntaxTestContext::default();
     let error = context
         .parse_module(
             "
+namespace test
+
 type PrivateType = felt
 pub type PublicAlias = PrivateType
-
-pub proc check(value: PublicAlias)
-    nop
-end
 ",
         )
-        .expect_err("expected exported procedure signature to reject transitive private type");
+        .expect_err("expected exported type alias to reject private type");
     let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
-    assert!(rendered.contains("private type in exported procedure signature"));
+    assert!(rendered.contains("private type in exported type declaration"));
 }
 
 #[test]
 fn exported_proc_signature_rejects_private_local_type_via_absolute_path() {
     let context = SyntaxTestContext::default();
-    let error = context
-        .parse_module_with_path(
-            "wallet::memory",
+    let mut parser = Module::parser(None);
+    let error = parser
+        .parse_str(
+            Some(Path::new("wallet::memory")),
             "
 type PrivateType = felt
 
@@ -430,6 +431,7 @@ pub proc check(value: ::wallet::memory::PrivateType)
     nop
 end
 ",
+            context.source_manager(),
         )
         .expect_err(
             "expected exported procedure signature to reject private local type via absolute path",
@@ -444,6 +446,8 @@ fn private_proc_signature_allows_private_local_type() {
     context
         .parse_module(
             "
+namespace test
+
 type PrivateType = felt
 
 proc check(value: PrivateType)

--- a/crates/assembly-syntax/src/sema/tests.rs
+++ b/crates/assembly-syntax/src/sema/tests.rs
@@ -381,6 +381,80 @@ pub const ACCOUNT_ID_SUFFIX_OFFSET = ACCOUNT_ID_AND_NONCE_OFFSET + 2
 }
 
 #[test]
+fn exported_proc_signature_rejects_private_local_type() {
+    let context = SyntaxTestContext::default();
+    let error = context
+        .parse_module(
+            "
+type PrivateType = felt
+
+pub proc check(value: PrivateType)
+    nop
+end
+",
+        )
+        .expect_err("expected exported procedure signature to reject private local type");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("private type in exported procedure signature"));
+}
+
+#[test]
+fn exported_proc_signature_rejects_private_type_via_public_alias() {
+    let context = SyntaxTestContext::default();
+    let error = context
+        .parse_module(
+            "
+type PrivateType = felt
+pub type PublicAlias = PrivateType
+
+pub proc check(value: PublicAlias)
+    nop
+end
+",
+        )
+        .expect_err("expected exported procedure signature to reject transitive private type");
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("private type in exported procedure signature"));
+}
+
+#[test]
+fn exported_proc_signature_rejects_private_local_type_via_absolute_path() {
+    let context = SyntaxTestContext::default();
+    let error = context
+        .parse_module_with_path(
+            "wallet::memory",
+            "
+type PrivateType = felt
+
+pub proc check(value: ::wallet::memory::PrivateType)
+    nop
+end
+",
+        )
+        .expect_err(
+            "expected exported procedure signature to reject private local type via absolute path",
+        );
+    let rendered = format!("{}", PrintDiagnostic::new_without_color(&error));
+    assert!(rendered.contains("private type in exported procedure signature"));
+}
+
+#[test]
+fn private_proc_signature_allows_private_local_type() {
+    let context = SyntaxTestContext::default();
+    context
+        .parse_module(
+            "
+type PrivateType = felt
+
+proc check(value: PrivateType)
+    nop
+end
+",
+        )
+        .expect("expected private procedure signature to allow private local type");
+}
+
+#[test]
 fn sema_import_define_items_detect_cross_kind_duplicates_for_all_pairs_and_orders() {
     let kinds = [
         DefinitionKind::ModuleImport,

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -57,6 +57,25 @@ use crate::{
 /// remaining far above typical program structure depth.
 pub(crate) const MAX_CONTROL_FLOW_NESTING: usize = 256;
 
+#[derive(Clone, Copy)]
+enum ExportedTypeUse {
+    ProcedureSignature,
+    TypeDeclaration,
+}
+
+impl ExportedTypeUse {
+    fn private_type_error(self, span: SourceSpan, defined: SourceSpan) -> SemanticAnalysisError {
+        match self {
+            Self::ProcedureSignature => {
+                SemanticAnalysisError::PrivateTypeInExportedSignature { span, defined }
+            },
+            Self::TypeDeclaration => {
+                SemanticAnalysisError::PrivateTypeInExportedType { span, defined }
+            },
+        }
+    }
+}
+
 #[derive(Debug)]
 enum PendingPackageExport {
     Procedure(PendingProcedureExport),
@@ -820,64 +839,66 @@ impl Assembler {
                     continue;
                 }
 
-                match symbol.item() {
-                    SymbolItem::Procedure(proc) => {
-                        let proc = proc.borrow();
-                        self.verify_exported_signature(&resolver, module_index, proc.signature())?;
-                    },
-                    SymbolItem::Compiled(ItemInfo::Procedure(proc)) => {
-                        self.verify_exported_signature(
-                            &resolver,
-                            module_index,
-                            proc.signature.as_deref(),
-                        )?;
-                    },
-                    SymbolItem::Constant(_)
-                    | SymbolItem::Type(_)
-                    | SymbolItem::Compiled(ItemInfo::Constant(_))
-                    | SymbolItem::Compiled(ItemInfo::Type(_)) => (),
-                };
+                self.verify_exported_item(&resolver, module_index, symbol, None)?;
             }
 
             for import in module.imports() {
-                if !import.visibility().is_public() || !matches!(import.kind(), ast::ImportKind::Item)
+                if !import.visibility().is_public()
+                    || !matches!(import.kind(), ast::ImportKind::Item)
                 {
                     continue;
                 }
 
-                let target = import.target_path();
-                let context = SymbolResolutionContext {
-                    span: target.span(),
-                    module: module_index,
-                    kind: Some(InvokeKind::ProcRef),
-                };
-                let resolution =
-                    resolver.resolve_path(&context, target.as_deref()).map_err(Report::from)?;
-                let Some(gid) = resolution.into_global_id() else {
+                let Some(gid) = import.resolved() else {
                     continue;
                 };
 
-                match self.linker[gid].item() {
-                    SymbolItem::Procedure(proc) => {
-                        let proc = proc.borrow();
-                        self.verify_exported_signature(&resolver, gid.module, proc.signature())?;
-                    },
-                    SymbolItem::Compiled(ItemInfo::Procedure(proc)) => {
-                        self.verify_exported_signature(
-                            &resolver,
-                            gid.module,
-                            proc.signature.as_deref(),
-                        )?;
-                    },
-                    SymbolItem::Constant(_)
-                    | SymbolItem::Type(_)
-                    | SymbolItem::Compiled(ItemInfo::Constant(_))
-                    | SymbolItem::Compiled(ItemInfo::Type(_)) => (),
-                }
+                self.verify_exported_item(
+                    &resolver,
+                    gid.module,
+                    &self.linker[gid],
+                    Some(import.span()),
+                )?;
             }
         }
 
         Ok(())
+    }
+
+    fn verify_exported_item(
+        &self,
+        resolver: &SymbolResolver<'_>,
+        module_index: ModuleIndex,
+        symbol: &crate::linker::Symbol,
+        export_span: Option<SourceSpan>,
+    ) -> Result<(), Report> {
+        match symbol.item() {
+            SymbolItem::Procedure(proc) => {
+                let proc = proc.borrow();
+                self.verify_exported_signature(resolver, module_index, proc.signature())
+            },
+            SymbolItem::Type(type_decl) => {
+                if !symbol.visibility().is_public() {
+                    return Err(Report::new(SemanticAnalysisError::PrivateTypeInExportedType {
+                        span: export_span.unwrap_or_else(|| type_decl.name().span()),
+                        defined: type_decl.name().span(),
+                    }));
+                }
+
+                let mut visiting_types = BTreeSet::default();
+                self.verify_exported_type_decl(
+                    resolver,
+                    module_index,
+                    type_decl,
+                    &mut visiting_types,
+                    ExportedTypeUse::TypeDeclaration,
+                )
+            },
+            SymbolItem::Constant(_)
+            | SymbolItem::Compiled(
+                ItemInfo::Procedure(_) | ItemInfo::Constant(_) | ItemInfo::Type(_),
+            ) => Ok(()),
+        }
     }
 
     fn verify_exported_signature(
@@ -892,45 +913,86 @@ impl Assembler {
 
         for ty in signature.args.iter().chain(signature.results.iter()) {
             let mut visiting_types = BTreeSet::default();
-            self.verify_exported_signature_type_expr(
+            self.verify_exported_type_expr(
                 resolver,
                 current_module,
                 ty,
                 &mut visiting_types,
+                ExportedTypeUse::ProcedureSignature,
             )?;
         }
 
         Ok(())
     }
 
-    fn verify_exported_signature_type_expr(
+    fn verify_exported_type_decl(
+        &self,
+        resolver: &SymbolResolver<'_>,
+        current_module: ModuleIndex,
+        type_decl: &ast::TypeDecl,
+        visiting_types: &mut BTreeSet<GlobalItemIndex>,
+        usage: ExportedTypeUse,
+    ) -> Result<(), Report> {
+        match type_decl {
+            ast::TypeDecl::Alias(alias) => {
+                self.verify_exported_type_expr(
+                    resolver,
+                    current_module,
+                    &alias.ty,
+                    visiting_types,
+                    usage,
+                )?;
+            },
+            ast::TypeDecl::Enum(ty) => {
+                for variant in ty.variants() {
+                    if let Some(payload_ty) = variant.value_ty.as_ref() {
+                        self.verify_exported_type_expr(
+                            resolver,
+                            current_module,
+                            payload_ty,
+                            visiting_types,
+                            usage,
+                        )?;
+                    }
+                }
+            },
+        }
+
+        Ok(())
+    }
+
+    fn verify_exported_type_expr(
         &self,
         resolver: &SymbolResolver<'_>,
         current_module: ModuleIndex,
         ty: &ast::TypeExpr,
         visiting_types: &mut BTreeSet<GlobalItemIndex>,
+        usage: ExportedTypeUse,
     ) -> Result<(), Report> {
         match ty {
             ast::TypeExpr::Primitive(_) => Ok(()),
-            ast::TypeExpr::Ptr(ty) => self.verify_exported_signature_type_expr(
+            ast::TypeExpr::Ptr(ty) => self.verify_exported_type_expr(
                 resolver,
                 current_module,
                 &ty.pointee,
                 visiting_types,
+                usage,
             ),
-            ast::TypeExpr::Array(ty) => self.verify_exported_signature_type_expr(
+            ast::TypeExpr::Array(ty) => self.verify_exported_type_expr(
                 resolver,
                 current_module,
                 &ty.elem,
                 visiting_types,
+                usage,
             ),
             ast::TypeExpr::Struct(ty) => {
                 for field in ty.fields.iter() {
-                    self.verify_exported_signature_type_expr(
+                    self.verify_exported_type_expr(
                         resolver,
                         current_module,
                         &field.ty,
                         visiting_types,
+                        usage,
                     )?;
                 }
 
@@ -960,10 +1022,7 @@ impl Assembler {
 
                 if !symbol.visibility().is_public() {
                     return Err(Report::new(
-                        SemanticAnalysisError::PrivateTypeInExportedSignature {
-                            span: path.span(),
-                            defined: type_decl.name().span(),
-                        },
+                        usage.private_type_error(path.span(), type_decl.name().span()),
                     ));
                 }
 
@@ -971,28 +1030,13 @@ impl Assembler {
                     return Ok(());
                 }
 
-                match type_decl {
-                    ast::TypeDecl::Alias(alias) => {
-                        self.verify_exported_signature_type_expr(
-                            resolver,
-                            gid.module,
-                            &alias.ty,
-                            visiting_types,
-                        )?;
-                    },
-                    ast::TypeDecl::Enum(ty) => {
-                        for variant in ty.variants() {
-                            if let Some(payload_ty) = variant.value_ty.as_ref() {
-                                self.verify_exported_signature_type_expr(
-                                    resolver,
-                                    gid.module,
-                                    payload_ty,
-                                    visiting_types,
-                                )?;
-                            }
-                        }
-                    },
-                }
+                self.verify_exported_type_decl(
+                    resolver,
+                    gid.module,
+                    type_decl,
+                    visiting_types,
+                    usage,
+                )?;
 
                 visiting_types.remove(&gid);
                 Ok(())

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -820,31 +820,84 @@ impl Assembler {
                     continue;
                 }
 
-                let signature = match symbol.item() {
+                match symbol.item() {
                     SymbolItem::Procedure(proc) => {
                         let proc = proc.borrow();
-                        proc.signature().cloned()
+                        self.verify_exported_signature(&resolver, module_index, proc.signature())?;
                     },
-                    SymbolItem::Compiled(ItemInfo::Procedure(proc)) => proc.signature.clone(),
+                    SymbolItem::Compiled(ItemInfo::Procedure(proc)) => {
+                        self.verify_exported_signature(
+                            &resolver,
+                            module_index,
+                            proc.signature.as_deref(),
+                        )?;
+                    },
                     SymbolItem::Constant(_)
                     | SymbolItem::Type(_)
                     | SymbolItem::Compiled(ItemInfo::Constant(_))
-                    | SymbolItem::Compiled(ItemInfo::Type(_)) => None,
+                    | SymbolItem::Compiled(ItemInfo::Type(_)) => (),
                 };
-                let Some(signature) = signature else {
+            }
+
+            for import in module.imports() {
+                if !import.visibility().is_public() || !matches!(import.kind(), ast::ImportKind::Item)
+                {
+                    continue;
+                }
+
+                let target = import.target_path();
+                let context = SymbolResolutionContext {
+                    span: target.span(),
+                    module: module_index,
+                    kind: Some(InvokeKind::ProcRef),
+                };
+                let resolution =
+                    resolver.resolve_path(&context, target.as_deref()).map_err(Report::from)?;
+                let Some(gid) = resolution.into_global_id() else {
                     continue;
                 };
 
-                for ty in signature.args.iter().chain(signature.results.iter()) {
-                    let mut visiting_types = BTreeSet::default();
-                    self.verify_exported_signature_type_expr(
-                        &resolver,
-                        module_index,
-                        ty,
-                        &mut visiting_types,
-                    )?;
+                match self.linker[gid].item() {
+                    SymbolItem::Procedure(proc) => {
+                        let proc = proc.borrow();
+                        self.verify_exported_signature(&resolver, gid.module, proc.signature())?;
+                    },
+                    SymbolItem::Compiled(ItemInfo::Procedure(proc)) => {
+                        self.verify_exported_signature(
+                            &resolver,
+                            gid.module,
+                            proc.signature.as_deref(),
+                        )?;
+                    },
+                    SymbolItem::Constant(_)
+                    | SymbolItem::Type(_)
+                    | SymbolItem::Compiled(ItemInfo::Constant(_))
+                    | SymbolItem::Compiled(ItemInfo::Type(_)) => (),
                 }
             }
+        }
+
+        Ok(())
+    }
+
+    fn verify_exported_signature(
+        &self,
+        resolver: &SymbolResolver<'_>,
+        current_module: ModuleIndex,
+        signature: Option<&ast::FunctionType>,
+    ) -> Result<(), Report> {
+        let Some(signature) = signature else {
+            return Ok(());
+        };
+
+        for ty in signature.args.iter().chain(signature.results.iter()) {
+            let mut visiting_types = BTreeSet::default();
+            self.verify_exported_signature_type_expr(
+                resolver,
+                current_module,
+                ty,
+                &mut visiting_types,
+            )?;
         }
 
         Ok(())

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -12,7 +12,7 @@ use alloc::{
 
 use debuginfo::DebugInfoSections;
 use miden_assembly_syntax::{
-    MAX_REPEAT_COUNT, Parse, SemanticAnalysisError,
+    ExportedTypeUse, MAX_REPEAT_COUNT, Parse, SemanticAnalysisError,
     ast::{
         self, AttributeSet, Ident, InvocationTarget, InvokeKind, ItemIndex, ModuleKind,
         SymbolResolution, Visibility, types::FunctionType,
@@ -56,25 +56,6 @@ use crate::{
 /// This limit is intended to prevent stack overflows from maliciously deep block nesting while
 /// remaining far above typical program structure depth.
 pub(crate) const MAX_CONTROL_FLOW_NESTING: usize = 256;
-
-#[derive(Clone, Copy)]
-enum ExportedTypeUse {
-    ProcedureSignature,
-    TypeDeclaration,
-}
-
-impl ExportedTypeUse {
-    fn private_type_error(self, span: SourceSpan, defined: SourceSpan) -> SemanticAnalysisError {
-        match self {
-            Self::ProcedureSignature => {
-                SemanticAnalysisError::PrivateTypeInExportedSignature { span, defined }
-            },
-            Self::TypeDeclaration => {
-                SemanticAnalysisError::PrivateTypeInExportedType { span, defined }
-            },
-        }
-    }
-}
 
 #[derive(Debug)]
 enum PendingPackageExport {

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -41,7 +41,10 @@ use crate::{
     ast::Path,
     basic_block_builder::BasicBlockBuilder,
     fmp::{fmp_end_frame_sequence, fmp_initialization_sequence, fmp_start_frame_sequence},
-    linker::{Import, LinkLibrary, Linker, LinkerError, SymbolItem, SymbolResolutionContext},
+    linker::{
+        Import, LinkLibrary, Linker, LinkerError, SymbolItem, SymbolResolutionContext,
+        SymbolResolver,
+    },
     mast_forest_builder::{
         MastForestBuilder, MastNodeRef, SourceDebugGraph, SourceNodeId, SourceNodeRef,
         StaticLibrary,
@@ -801,7 +804,147 @@ impl Assembler {
             TargetType::Kernel => self.linker.link_kernel(root, support)?,
             _ => self.linker.link([root], support)?,
         };
+        self.verify_exported_signature_type_visibility(&module_indices)?;
         self.assemble_library_product(name, &module_indices, kind)
+    }
+
+    fn verify_exported_signature_type_visibility(
+        &self,
+        module_indices: &[ModuleIndex],
+    ) -> Result<(), Report> {
+        let resolver = SymbolResolver::new(&self.linker);
+        for module_index in module_indices.iter().copied() {
+            let module = &self.linker[module_index];
+            for symbol in module.symbols() {
+                if !symbol.visibility().is_public() {
+                    continue;
+                }
+
+                let signature = match symbol.item() {
+                    SymbolItem::Procedure(proc) => {
+                        let proc = proc.borrow();
+                        proc.signature().cloned()
+                    },
+                    SymbolItem::Compiled(ItemInfo::Procedure(proc)) => proc.signature.clone(),
+                    SymbolItem::Constant(_)
+                    | SymbolItem::Type(_)
+                    | SymbolItem::Compiled(ItemInfo::Constant(_))
+                    | SymbolItem::Compiled(ItemInfo::Type(_)) => None,
+                };
+                let Some(signature) = signature else {
+                    continue;
+                };
+
+                for ty in signature.args.iter().chain(signature.results.iter()) {
+                    let mut visiting_types = BTreeSet::default();
+                    self.verify_exported_signature_type_expr(
+                        &resolver,
+                        module_index,
+                        ty,
+                        &mut visiting_types,
+                    )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn verify_exported_signature_type_expr(
+        &self,
+        resolver: &SymbolResolver<'_>,
+        current_module: ModuleIndex,
+        ty: &ast::TypeExpr,
+        visiting_types: &mut BTreeSet<GlobalItemIndex>,
+    ) -> Result<(), Report> {
+        match ty {
+            ast::TypeExpr::Primitive(_) => Ok(()),
+            ast::TypeExpr::Ptr(ty) => self.verify_exported_signature_type_expr(
+                resolver,
+                current_module,
+                &ty.pointee,
+                visiting_types,
+            ),
+            ast::TypeExpr::Array(ty) => self.verify_exported_signature_type_expr(
+                resolver,
+                current_module,
+                &ty.elem,
+                visiting_types,
+            ),
+            ast::TypeExpr::Struct(ty) => {
+                for field in ty.fields.iter() {
+                    self.verify_exported_signature_type_expr(
+                        resolver,
+                        current_module,
+                        &field.ty,
+                        visiting_types,
+                    )?;
+                }
+
+                Ok(())
+            },
+            ast::TypeExpr::Ref(path) => {
+                let context = SymbolResolutionContext {
+                    span: path.span(),
+                    module: current_module,
+                    kind: None,
+                };
+                let resolution =
+                    resolver.resolve_path(&context, path.as_deref()).map_err(Report::from)?;
+
+                let gid = match resolution {
+                    SymbolResolution::Exact { gid, .. } => gid,
+                    SymbolResolution::Local(item) => current_module + item.into_inner(),
+                    SymbolResolution::External(_)
+                    | SymbolResolution::MastRoot(_)
+                    | SymbolResolution::Module { .. } => return Ok(()),
+                };
+
+                let symbol = &self.linker[gid];
+                let SymbolItem::Type(type_decl) = symbol.item() else {
+                    return Ok(());
+                };
+
+                if !symbol.visibility().is_public() {
+                    return Err(Report::new(
+                        SemanticAnalysisError::PrivateTypeInExportedSignature {
+                            span: path.span(),
+                            defined: type_decl.name().span(),
+                        },
+                    ));
+                }
+
+                if !visiting_types.insert(gid) {
+                    return Ok(());
+                }
+
+                match type_decl {
+                    ast::TypeDecl::Alias(alias) => {
+                        self.verify_exported_signature_type_expr(
+                            resolver,
+                            gid.module,
+                            &alias.ty,
+                            visiting_types,
+                        )?;
+                    },
+                    ast::TypeDecl::Enum(ty) => {
+                        for variant in ty.variants() {
+                            if let Some(payload_ty) = variant.value_ty.as_ref() {
+                                self.verify_exported_signature_type_expr(
+                                    resolver,
+                                    gid.module,
+                                    payload_ty,
+                                    visiting_types,
+                                )?;
+                            }
+                        }
+                    },
+                }
+
+                visiting_types.remove(&gid);
+                Ok(())
+            },
+        }
     }
 
     pub(crate) fn assemble_executable_modules(

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -6388,6 +6388,37 @@ fn exported_procedure_signature_with_cross_module_private_alias_dependency_is_re
 }
 
 #[test]
+fn exported_procedure_alias_signature_with_private_local_type_is_rejected() -> TestResult {
+    let context = TestContext::default();
+
+    let module = context.parse_module_with_path(
+        "cycle::module_a",
+        source_file!(
+            &context,
+            r#"
+            type PrivateType = felt
+
+            proc hidden(value: PrivateType)
+                nop
+            end
+
+            pub use ::cycle::module_a::hidden->exposed
+        "#
+        ),
+    )?;
+
+    let err = Assembler::new(context.source_manager())
+        .assemble_library("library", module, [])
+        .expect_err(
+            "expected exported procedure alias with private local type in signature to be rejected",
+        );
+    assert_diagnostic!(&err, "private type in exported procedure signature");
+    assert_diagnostic!(&err, "exported procedure signatures may only reference public types");
+
+    Ok(())
+}
+
+#[test]
 fn test_cross_module_constant_reexport_chain_in_procedure_scope() -> TestResult {
     let context = TestContext::new();
 

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -6299,6 +6299,54 @@ fn importing_private_type_from_another_module_is_rejected() -> TestResult {
 }
 
 #[test]
+fn exported_procedure_signature_referencing_private_local_type_is_rejected() {
+    let context = TestContext::default();
+
+    let err = context
+        .parse_module_with_path(
+            "cycle::module_a",
+            source_file!(
+                &context,
+                r#"
+                type PrivateType = felt
+
+                pub proc a_proc(value: PrivateType)
+                    nop
+                end
+            "#
+            ),
+        )
+        .expect_err("expected exported signature with private local type to be rejected");
+
+    assert_diagnostic!(&err, "private type in exported procedure signature");
+    assert_diagnostic!(&err, "exported procedure signatures may only reference public types");
+}
+
+#[test]
+fn exported_procedure_signature_with_absolute_private_local_type_is_rejected() {
+    let context = TestContext::default();
+
+    let err = context
+        .parse_module_with_path(
+            "cycle::module_a",
+            source_file!(
+                &context,
+                r#"
+                type PrivateType = felt
+
+                pub proc a_proc(value: ::cycle::module_a::PrivateType)
+                    nop
+                end
+            "#
+            ),
+        )
+        .expect_err("expected absolute private local type in exported signature to be rejected");
+
+    assert_diagnostic!(&err, "private type in exported procedure signature");
+    assert_diagnostic!(&err, "exported procedure signatures may only reference public types");
+}
+
+#[test]
 fn test_cross_module_constant_reexport_chain_in_procedure_scope() -> TestResult {
     let context = TestContext::new();
 

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -6347,6 +6347,47 @@ fn exported_procedure_signature_with_absolute_private_local_type_is_rejected() {
 }
 
 #[test]
+fn exported_procedure_signature_with_cross_module_private_alias_dependency_is_rejected()
+-> TestResult {
+    let context = TestContext::default();
+
+    let module_a = context.parse_module_with_path(
+        "cycle::module_a",
+        source_file!(
+            &context,
+            r#"
+            type PrivateType = felt
+            pub type PublicAlias = PrivateType
+        "#
+        ),
+    )?;
+
+    let module_b = context.parse_module_with_path(
+        "cycle::module_b",
+        source_file!(
+            &context,
+            r#"
+            use cycle::module_a
+
+            pub proc b_proc(value: module_a::PublicAlias)
+                nop
+            end
+        "#
+        ),
+    )?;
+
+    let err = Assembler::new(context.source_manager())
+        .assemble_library("library", module_a, [module_b])
+        .expect_err(
+            "expected exported signature with cross-module private alias dependency to be rejected",
+        );
+    assert_diagnostic!(&err, "private type in exported procedure signature");
+    assert_diagnostic!(&err, "exported procedure signatures may only reference public types");
+
+    Ok(())
+}
+
+#[test]
 fn test_cross_module_constant_reexport_chain_in_procedure_scope() -> TestResult {
     let context = TestContext::new();
 

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -6303,19 +6303,18 @@ fn exported_procedure_signature_referencing_private_local_type_is_rejected() {
     let context = TestContext::default();
 
     let err = context
-        .parse_module_with_path(
-            "cycle::module_a",
-            source_file!(
-                &context,
-                r#"
+        .parse_module(source_file!(
+            &context,
+            r#"
+                namespace cycle::module_a
+
                 type PrivateType = felt
 
                 pub proc a_proc(value: PrivateType)
                     nop
                 end
             "#
-            ),
-        )
+        ))
         .expect_err("expected exported signature with private local type to be rejected");
 
     assert_diagnostic!(&err, "private type in exported procedure signature");
@@ -6327,19 +6326,18 @@ fn exported_procedure_signature_with_absolute_private_local_type_is_rejected() {
     let context = TestContext::default();
 
     let err = context
-        .parse_module_with_path(
-            "cycle::module_a",
-            source_file!(
-                &context,
-                r#"
+        .parse_module(source_file!(
+            &context,
+            r#"
+                namespace cycle::module_a
+
                 type PrivateType = felt
 
                 pub proc a_proc(value: ::cycle::module_a::PrivateType)
                     nop
                 end
             "#
-            ),
-        )
+        ))
         .expect_err("expected absolute private local type in exported signature to be rejected");
 
     assert_diagnostic!(&err, "private type in exported procedure signature");
@@ -6347,75 +6345,57 @@ fn exported_procedure_signature_with_absolute_private_local_type_is_rejected() {
 }
 
 #[test]
-fn exported_procedure_signature_with_cross_module_private_alias_dependency_is_rejected()
--> TestResult {
+fn public_item_import_reexporting_private_signature_is_rejected() {
     let context = TestContext::default();
 
-    let module_a = context.parse_module_with_path(
-        "cycle::module_a",
-        source_file!(
+    let module = context
+        .parse_module(source_file!(
             &context,
             r#"
-            type PrivateType = felt
-            pub type PublicAlias = PrivateType
-        "#
-        ),
-    )?;
+                namespace cycle::module_a
 
-    let module_b = context.parse_module_with_path(
-        "cycle::module_b",
-        source_file!(
-            &context,
-            r#"
-            use cycle::module_a
+                type PrivateType = felt
 
-            pub proc b_proc(value: module_a::PublicAlias)
-                nop
-            end
-        "#
-        ),
-    )?;
+                pub use {hidden as exposed} from self
+
+                proc hidden(value: PrivateType)
+                    nop
+                end
+            "#
+        ))
+        .expect("private procedure signature should be valid before public re-export");
 
     let err = Assembler::new(context.source_manager())
-        .assemble_library("library", module_a, [module_b])
-        .expect_err(
-            "expected exported signature with cross-module private alias dependency to be rejected",
-        );
+        .assemble_library("library", module, None::<Box<Module>>)
+        .expect_err("expected public re-export of private signature to be rejected");
+
     assert_diagnostic!(&err, "private type in exported procedure signature");
     assert_diagnostic!(&err, "exported procedure signatures may only reference public types");
-
-    Ok(())
 }
 
 #[test]
-fn exported_procedure_alias_signature_with_private_local_type_is_rejected() -> TestResult {
+fn public_item_import_reexporting_private_type_is_rejected() {
     let context = TestContext::default();
 
-    let module = context.parse_module_with_path(
-        "cycle::module_a",
-        source_file!(
+    let module = context
+        .parse_module(source_file!(
             &context,
             r#"
-            type PrivateType = felt
+                namespace cycle::module_a
 
-            proc hidden(value: PrivateType)
-                nop
-            end
+                type PrivateType = felt
 
-            pub use ::cycle::module_a::hidden->exposed
-        "#
-        ),
-    )?;
+                pub use {PrivateType as PublicType} from self
+            "#
+        ))
+        .expect("private type should be valid before public re-export");
 
     let err = Assembler::new(context.source_manager())
-        .assemble_library("library", module, [])
-        .expect_err(
-            "expected exported procedure alias with private local type in signature to be rejected",
-        );
-    assert_diagnostic!(&err, "private type in exported procedure signature");
-    assert_diagnostic!(&err, "exported procedure signatures may only reference public types");
+        .assemble_library("library", module, None::<Box<Module>>)
+        .expect_err("expected public re-export of private type to be rejected");
 
-    Ok(())
+    assert_diagnostic!(&err, "private type in exported type declaration");
+    assert_diagnostic!(&err, "exported type declarations may only reference public types");
 }
 
 #[test]

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -6299,52 +6299,6 @@ fn importing_private_type_from_another_module_is_rejected() -> TestResult {
 }
 
 #[test]
-fn exported_procedure_signature_referencing_private_local_type_is_rejected() {
-    let context = TestContext::default();
-
-    let err = context
-        .parse_module(source_file!(
-            &context,
-            r#"
-                namespace cycle::module_a
-
-                type PrivateType = felt
-
-                pub proc a_proc(value: PrivateType)
-                    nop
-                end
-            "#
-        ))
-        .expect_err("expected exported signature with private local type to be rejected");
-
-    assert_diagnostic!(&err, "private type in exported procedure signature");
-    assert_diagnostic!(&err, "exported procedure signatures may only reference public types");
-}
-
-#[test]
-fn exported_procedure_signature_with_absolute_private_local_type_is_rejected() {
-    let context = TestContext::default();
-
-    let err = context
-        .parse_module(source_file!(
-            &context,
-            r#"
-                namespace cycle::module_a
-
-                type PrivateType = felt
-
-                pub proc a_proc(value: ::cycle::module_a::PrivateType)
-                    nop
-                end
-            "#
-        ))
-        .expect_err("expected absolute private local type in exported signature to be rejected");
-
-    assert_diagnostic!(&err, "private type in exported procedure signature");
-    assert_diagnostic!(&err, "exported procedure signatures may only reference public types");
-}
-
-#[test]
 fn public_item_import_reexporting_private_signature_is_rejected() {
     let context = TestContext::default();
 


### PR DESCRIPTION
This rejects private type references in public MASM APIs.

An exported procedure signature or public type could name a private local type. The private type could also be reached through an alias, an enum payload, a same-module absolute path, or a public pub use.

This PR checks public procedure signatures and public type declarations during semantic analysis. It also checks public item re-exports after linking.

Fixes #3092. Obsoletes #3154 