### PR TITLE
fix(processor): replay unentered loops as ended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Fixes
 
 - Preserved semantic struct and field names when emitting debug types, so debug dumps no longer fall back to anonymous struct metadata ([#3269](https://github.com/0xMiden/miden-vm/pull/3269)).
+- Fixed parallel trace generation for `while.true` loops that exit before entering the body and are followed by another block ([#3278](https://github.com/0xMiden/miden-vm/pull/3278)).
 
 ## v0.23.3 (2026-05-26)
 

--- a/miden-vm/tests/integration/flow_control/mod.rs
+++ b/miden-vm/tests/integration/flow_control/mod.rs
@@ -55,6 +55,21 @@ fn conditional_loop() {
 }
 
 #[test]
+fn unentered_loop_with_following_block() {
+    let source = "
+        begin
+            push.2 push.1 push.0
+            while.true
+                push.3 drop
+            end
+            drop drop
+        end";
+
+    let test = build_test!(source);
+    test.check_constraints();
+}
+
+#[test]
 fn faulty_condition_from_loop() {
     let source = "
         begin

--- a/processor/src/trace/parallel/tracer/mod.rs
+++ b/processor/src/trace/parallel/tracer/mod.rs
@@ -290,7 +290,11 @@ impl<'a> CoreTraceGenerationTracer<'a> {
         continuation: &Continuation,
         processor: &ReplayProcessor,
     ) -> Option<bool> {
-        if let Continuation::FinishLoop { .. } = &continuation {
+        if let Continuation::FinishLoop { was_entered, .. } = &continuation {
+            if !was_entered {
+                return Some(false);
+            }
+
             let condition = processor.stack.get(0);
             return Some(condition == ONE);
         }


### PR DESCRIPTION
## Summary
- add a regression test for an unentered `while.true` followed by another basic block
- fix parallel trace replay so `FinishLoop { was_entered: false }` is treated as loop exit instead of reading the next stack item as a loop condition

## Details
When a head-controlled loop is not entered, the `LOOP` operation has already popped the false condition. The parallel trace generator was still reading `processor.stack.get(0)` for every `FinishLoop`, so ordinary stack data could be mistaken for a true loop condition and emit a bogus `REPEAT` row. That later violates decoder constraints / block-stack replay.

This is related to protocol issue https://github.com/0xMiden/protocol/issues/3113.

## Testing
- `cargo test -p miden-vm --test miden-cli unentered_loop_with_following_block -- --nocapture` (fails before fix, passes after)
- `cargo test -p miden-vm --test miden-cli flow_control -- --nocapture`
- `cargo test -p miden-processor trace::tests::decoder -- --nocapture`
- temporary protocol-next validation with only the issue repro test added and VM crates patched to this branch: `CARGO_TARGET_DIR=/Users/al/Code/Work/protocol/target cargo test -p miden-testing --test lib test_multisig_add_signer_from_single_signer -- --nocapture` (ECDSA + Falcon cases passed)
