### PR TITLE
Prevent debug info fuzz OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Removed overly aggressive validation check that prevented defining virtual executable targets in Miden projects
 - Constrained Core AIR stack routes for control and stream operations, preventing unconstrained stack values across `SYSCALL`, `EVALCIRCUIT`, `CALLER`, `MSTREAM`, `PIPE`, `REPEAT`, `SWAPW2`, and `SWAPW3` ([#3249](https://github.com/0xMiden/miden-vm/pull/3249)).
 - Stack depth limits now properly include all active contexts' overflow stacks ([#3261](https://github.com/0xMiden/miden-vm/pull/3261)).
+- Bounded debug-info section deserialization so malformed lengths cannot exhaust memory ([#3279](https://github.com/0xMiden/miden-vm/pull/3279)).
 
 #### Enhancements
 - Improved O(n²) to O(log n) name conflict checks in `Module::define_*` methods by introducing a `BTreeMap` name index; also narrowed `items_mut()` to return an iterator instead of `&mut Vec<Export>` to preserve the index invariant ([#3218](https://github.com/0xMiden/miden-vm/pull/3218)).

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,6 +35,44 @@ pub mod serde {
         BudgetedReader, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
         SliceReader,
     };
+
+    /// Reads and validates a serialized length before it is used for allocation.
+    pub fn read_bounded_len<R: ByteReader>(
+        source: &mut R,
+        label: &str,
+        min_element_size: usize,
+    ) -> Result<usize, DeserializationError> {
+        let len = source.read_usize()?;
+        validate_bounded_len(source, label, len, min_element_size)?;
+        Ok(len)
+    }
+
+    /// Validates that a serialized length fits both the reader budget and remaining input.
+    pub fn validate_bounded_len<R: ByteReader>(
+        source: &R,
+        label: &str,
+        len: usize,
+        min_element_size: usize,
+    ) -> Result<(), DeserializationError> {
+        let max_len = source.max_alloc(min_element_size);
+        if len > max_len {
+            return Err(DeserializationError::InvalidValue(alloc::format!(
+                "{label} count {len} exceeds budget {max_len}"
+            )));
+        }
+
+        let min_bytes = len.checked_mul(min_element_size).ok_or_else(|| {
+            DeserializationError::InvalidValue(alloc::format!(
+                "{label} count {len} overflows minimum serialized size {min_element_size}"
+            ))
+        })?;
+        source.check_eor(min_bytes).map_err(|err| match err {
+            DeserializationError::UnexpectedEOF => DeserializationError::InvalidValue(
+                alloc::format!("{label} count {len} exceeds remaining input"),
+            ),
+            err => err,
+        })
+    }
 }
 
 pub mod crypto {

--- a/core/src/operations/debug_metadata/debug_var.rs
+++ b/core/src/operations/debug_metadata/debug_var.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{format, sync::Arc, vec::Vec};
 use core::{fmt, num::NonZeroU32};
 
 use miden_debug_types::FileLineCol;
@@ -245,7 +245,7 @@ impl Deserializable for DebugVarLocation {
                 Ok(Self::Local(i16::from_le_bytes(bytes)))
             },
             4 => {
-                let bytes = Vec::<u8>::read_from(source)?;
+                let bytes = read_bounded_bytes(source, "debug variable expression bytes")?;
                 Ok(Self::Expression(bytes))
             },
             5 => {
@@ -273,7 +273,7 @@ impl Serializable for DebugVarInfo {
 
 impl Deserializable for DebugVarInfo {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let name: Arc<str> = String::read_from(source)?.into();
+        let name = read_bounded_string(source, "debug variable name bytes")?;
         let value_location = DebugVarLocation::read_from(source)?;
         let type_id = Option::<u32>::read_from(source)?;
         let arg_index = Option::<u32>::read_from(source)?
@@ -295,6 +295,47 @@ impl Deserializable for DebugVarInfo {
     }
 }
 
+fn read_bounded_string<R: ByteReader>(
+    source: &mut R,
+    label: &str,
+) -> Result<Arc<str>, DeserializationError> {
+    let len = source.read_usize()?;
+    validate_len(source, label, len)?;
+    let bytes = source.read_slice(len)?;
+    let value = core::str::from_utf8(bytes)
+        .map_err(|err| DeserializationError::InvalidValue(format!("{err}")))?;
+    Ok(Arc::from(value))
+}
+
+fn read_bounded_bytes<R: ByteReader>(
+    source: &mut R,
+    label: &str,
+) -> Result<Vec<u8>, DeserializationError> {
+    let len = source.read_usize()?;
+    validate_len(source, label, len)?;
+    source.read_slice(len).map(<[u8]>::to_vec)
+}
+
+fn validate_len<R: ByteReader>(
+    source: &R,
+    label: &str,
+    len: usize,
+) -> Result<(), DeserializationError> {
+    let max_len = source.max_alloc(1);
+    if len > max_len {
+        return Err(DeserializationError::InvalidValue(format!(
+            "{label} count {len} exceeds budget {max_len}"
+        )));
+    }
+
+    source.check_eor(len).map_err(|err| match err {
+        DeserializationError::UnexpectedEOF => DeserializationError::InvalidValue(format!(
+            "{label} count {len} exceeds remaining input"
+        )),
+        err => err,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;
@@ -308,6 +349,30 @@ mod tests {
     fn debug_var_info_display_simple() {
         let var = DebugVarInfo::new("x", DebugVarLocation::Stack(0));
         assert_eq!(var.to_string(), "var.x = stack[0]");
+    }
+
+    #[test]
+    fn debug_var_info_rejects_oversized_name_length() {
+        let bytes = [0x08, 0x2a, 0xfe, 0xfe, 0x01];
+        let mut reader = SliceReader::new(&bytes);
+        let err = DebugVarInfo::read_from(&mut reader).unwrap_err();
+        let DeserializationError::InvalidValue(message) = err else {
+            panic!("expected InvalidValue error");
+        };
+        assert!(message.contains("debug variable name bytes count"));
+        assert!(message.contains("exceeds remaining input"));
+    }
+
+    #[test]
+    fn debug_var_location_rejects_oversized_expression_length() {
+        let bytes = [4, 0x08, 0x2a, 0xfe, 0xfe, 0x01];
+        let mut reader = SliceReader::new(&bytes);
+        let err = DebugVarLocation::read_from(&mut reader).unwrap_err();
+        let DeserializationError::InvalidValue(message) = err else {
+            panic!("expected InvalidValue error");
+        };
+        assert!(message.contains("debug variable expression bytes count"));
+        assert!(message.contains("exceeds remaining input"));
     }
 
     #[test]

--- a/core/src/operations/debug_metadata/debug_var.rs
+++ b/core/src/operations/debug_metadata/debug_var.rs
@@ -7,7 +7,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     Felt,
-    serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    serde::{
+        ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+        read_bounded_len,
+    },
 };
 
 // DEBUG VARIABLE INFO
@@ -299,8 +302,7 @@ fn read_bounded_string<R: ByteReader>(
     source: &mut R,
     label: &str,
 ) -> Result<Arc<str>, DeserializationError> {
-    let len = source.read_usize()?;
-    validate_len(source, label, len)?;
+    let len = read_bounded_len(source, label, 1)?;
     let bytes = source.read_slice(len)?;
     let value = core::str::from_utf8(bytes)
         .map_err(|err| DeserializationError::InvalidValue(format!("{err}")))?;
@@ -311,29 +313,8 @@ fn read_bounded_bytes<R: ByteReader>(
     source: &mut R,
     label: &str,
 ) -> Result<Vec<u8>, DeserializationError> {
-    let len = source.read_usize()?;
-    validate_len(source, label, len)?;
+    let len = read_bounded_len(source, label, 1)?;
     source.read_slice(len).map(<[u8]>::to_vec)
-}
-
-fn validate_len<R: ByteReader>(
-    source: &R,
-    label: &str,
-    len: usize,
-) -> Result<(), DeserializationError> {
-    let max_len = source.max_alloc(1);
-    if len > max_len {
-        return Err(DeserializationError::InvalidValue(format!(
-            "{label} count {len} exceeds budget {max_len}"
-        )));
-    }
-
-    source.check_eor(len).map_err(|err| match err {
-        DeserializationError::UnexpectedEOF => DeserializationError::InvalidValue(format!(
-            "{label} count {len} exceeds remaining input"
-        )),
-        err => err,
-    })
 }
 
 #[cfg(test)]

--- a/crates/debug-types/src/lib.rs
+++ b/crates/debug-types/src/lib.rs
@@ -13,7 +13,7 @@ mod span;
 
 #[cfg(feature = "arbitrary")]
 use alloc::vec;
-use alloc::{string::String, sync::Arc};
+use alloc::{format, string::String, sync::Arc};
 
 use miden_crypto::utils::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
@@ -262,8 +262,37 @@ impl Serializable for Uri {
 
 impl Deserializable for Uri {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        String::read_from(source).map(Self::from)
+        read_bounded_string(source).map(Self::from)
     }
+}
+
+fn read_bounded_string<R: ByteReader>(source: &mut R) -> Result<String, DeserializationError> {
+    let len = source.read_usize()?;
+    validate_len(source, "uri bytes", len)?;
+    let bytes = source.read_slice(len)?;
+    core::str::from_utf8(bytes)
+        .map(String::from)
+        .map_err(|err| DeserializationError::InvalidValue(format!("{err}")))
+}
+
+fn validate_len<R: ByteReader>(
+    source: &R,
+    label: &str,
+    len: usize,
+) -> Result<(), DeserializationError> {
+    let max_len = source.max_alloc(1);
+    if len > max_len {
+        return Err(DeserializationError::InvalidValue(format!(
+            "{label} count {len} exceeds budget {max_len}"
+        )));
+    }
+
+    source.check_eor(len).map_err(|err| match err {
+        DeserializationError::UnexpectedEOF => DeserializationError::InvalidValue(format!(
+            "{label} count {len} exceeds remaining input"
+        )),
+        err => err,
+    })
 }
 
 impl core::str::FromStr for Uri {
@@ -308,7 +337,21 @@ impl Arbitrary for Uri {
 
 #[cfg(test)]
 mod tests {
+    use miden_crypto::utils::{Deserializable, DeserializationError, SliceReader};
+
     use super::*;
+
+    #[test]
+    fn uri_rejects_oversized_length_prefix() {
+        let bytes = [0x08, 0x2a, 0xfe, 0xfe, 0x01];
+        let mut reader = SliceReader::new(&bytes);
+        let err = Uri::read_from(&mut reader).unwrap_err();
+        let DeserializationError::InvalidValue(message) = err else {
+            panic!("expected InvalidValue error");
+        };
+        assert!(message.contains("uri bytes count"));
+        assert!(message.contains("exceeds remaining input"));
+    }
 
     #[test]
     fn uri_scheme_extraction() {

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -428,6 +428,7 @@ fn read_source_asm_op<R: ByteReader>(
 }
 
 fn min_source_map_asm_op_row_serialized_size() -> usize {
+    // The location index is conditional and is omitted for location-less rows.
     DebugSourceNodeId::min_serialized_size() + 4 + 1 + 4 + 4 + 1
 }
 
@@ -1084,6 +1085,26 @@ mod tests {
         );
 
         roundtrip(&section);
+    }
+
+    #[test]
+    fn test_debug_source_map_locationless_asm_op_min_size() {
+        let source_node = DebugSourceNodeId::from(0);
+        let section = DebugSourceMapSection::from_parts(
+            alloc::vec![DebugSourceAsmOp::new(
+                source_node,
+                2,
+                None,
+                "test::ctx".into(),
+                "add".into(),
+                1,
+            )],
+            alloc::vec![],
+        );
+
+        let bytes = section.to_bytes();
+        let deserialized = DebugSourceMapSection::read_from_bytes(&bytes).unwrap();
+        assert_eq!(deserialized.asm_ops(), section.asm_ops());
     }
 
     #[test]

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -5,7 +5,10 @@ use alloc::{string::String, sync::Arc, vec::Vec};
 use miden_core::{
     Word,
     mast::MastNodeId,
-    serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    serde::{
+        ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+        read_bounded_len,
+    },
 };
 use miden_debug_types::{ByteIndex, ColumnNumber, LineNumber, Location, Uri};
 
@@ -832,8 +835,7 @@ impl Deserializable for DebugFunctionInfo {
 // ================================================================================================
 
 fn read_string<R: ByteReader>(source: &mut R) -> Result<Arc<str>, DeserializationError> {
-    let len = source.read_usize()?;
-    validate_len(source, "debug string bytes", len, 1)?;
+    let len = read_bounded_len(source, "debug string bytes", 1)?;
     let bytes = source.read_slice(len)?;
     let s = core::str::from_utf8(bytes).map_err(|err| {
         DeserializationError::InvalidValue(alloc::format!("invalid utf-8 in string: {err}"))
@@ -859,42 +861,6 @@ fn read_debug_type_indices<R: ByteReader>(
 ) -> Result<Vec<DebugTypeIdx>, DeserializationError> {
     let len = read_bounded_len(source, label, DebugTypeIdx::min_serialized_size())?;
     source.read_many_iter(len)?.collect::<Result<_, _>>()
-}
-
-fn read_bounded_len<R: ByteReader>(
-    source: &mut R,
-    label: &str,
-    min_element_size: usize,
-) -> Result<usize, DeserializationError> {
-    let len = source.read_usize()?;
-    validate_len(source, label, len, min_element_size)?;
-    Ok(len)
-}
-
-fn validate_len<R: ByteReader>(
-    source: &R,
-    label: &str,
-    len: usize,
-    min_element_size: usize,
-) -> Result<(), DeserializationError> {
-    let max_len = source.max_alloc(min_element_size);
-    if len > max_len {
-        return Err(DeserializationError::InvalidValue(alloc::format!(
-            "{label} count {len} exceeds budget {max_len}"
-        )));
-    }
-
-    let min_bytes = len.checked_mul(min_element_size).ok_or_else(|| {
-        DeserializationError::InvalidValue(alloc::format!(
-            "{label} count {len} overflows minimum serialized size {min_element_size}"
-        ))
-    })?;
-    source.check_eor(min_bytes).map_err(|err| match err {
-        DeserializationError::UnexpectedEOF => DeserializationError::InvalidValue(alloc::format!(
-            "{label} count {len} exceeds remaining input"
-        )),
-        err => err,
-    })
 }
 
 #[cfg(test)]

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -52,19 +52,13 @@ impl Deserializable for DebugTypesSection {
         // Manual bounds check required: read_string is a local helper, not Deserializable,
         // so we can't use read_many_iter. Each string serializes to at least 1 byte (the
         // varint length prefix), so max_alloc(1) bounds the vector pre-allocation.
-        let strings_len = source.read_usize()?;
-        let max_strings = source.max_alloc(1);
-        if strings_len > max_strings {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "debug_types strings count {strings_len} exceeds budget {max_strings}"
-            )));
-        }
+        let strings_len = read_bounded_len(source, "debug_types strings", 1)?;
         let mut strings = Vec::with_capacity(strings_len);
         for _ in 0..strings_len {
             strings.push(read_string(source)?);
         }
 
-        let types_len = source.read_usize()?;
+        let types_len = read_bounded_len(source, "debug_types types", 1)?;
         let types = source.read_many_iter(types_len)?.collect::<Result<_, _>>()?;
 
         Ok(Self { version, strings, types })
@@ -104,19 +98,13 @@ impl Deserializable for DebugSourcesSection {
         // Manual bounds check required: read_string is a local helper, not Deserializable,
         // so we can't use read_many_iter. Each string serializes to at least 1 byte (the
         // varint length prefix), so max_alloc(1) bounds the vector pre-allocation.
-        let strings_len = source.read_usize()?;
-        let max_strings = source.max_alloc(1);
-        if strings_len > max_strings {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "debug_sources strings count {strings_len} exceeds budget {max_strings}"
-            )));
-        }
+        let strings_len = read_bounded_len(source, "debug_sources strings", 1)?;
         let mut strings = Vec::with_capacity(strings_len);
         for _ in 0..strings_len {
             strings.push(read_string(source)?);
         }
 
-        let files_len = source.read_usize()?;
+        let files_len = read_bounded_len(source, "debug_sources files", 1)?;
         let files = source.read_many_iter(files_len)?.collect::<Result<_, _>>()?;
 
         Ok(Self { version, strings, files })
@@ -156,19 +144,13 @@ impl Deserializable for DebugFunctionsSection {
         // Manual bounds check required: read_string is a local helper, not Deserializable,
         // so we can't use read_many_iter. Each string serializes to at least 1 byte (the
         // varint length prefix), so max_alloc(1) bounds the vector pre-allocation.
-        let strings_len = source.read_usize()?;
-        let max_strings = source.max_alloc(1);
-        if strings_len > max_strings {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "debug_functions strings count {strings_len} exceeds budget {max_strings}"
-            )));
-        }
+        let strings_len = read_bounded_len(source, "debug_functions strings", 1)?;
         let mut strings = Vec::with_capacity(strings_len);
         for _ in 0..strings_len {
             strings.push(read_string(source)?);
         }
 
-        let functions_len = source.read_usize()?;
+        let functions_len = read_bounded_len(source, "debug_functions functions", 1)?;
         let functions = source.read_many_iter(functions_len)?.collect::<Result<_, _>>()?;
 
         Ok(Self { version, strings, functions })
@@ -191,7 +173,7 @@ impl Deserializable for DebugSourceNode {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         Ok(Self {
             exec_node: MastNodeId::new_unchecked(source.read_u32()?),
-            children: Vec::<DebugSourceNodeId>::read_from(source)?,
+            children: read_debug_source_node_ids(source, "debug_source_node children")?,
             op_start: source.read_u32()?,
             op_end: source.read_u32()?,
         })
@@ -219,8 +201,9 @@ impl Deserializable for DebugSourceGraphSection {
             )));
         }
 
-        let nodes = Vec::<DebugSourceNode>::read_from(source)?;
-        let roots = Vec::<DebugSourceNodeId>::read_from(source)?;
+        let nodes_len = read_bounded_len(source, "debug_source_graph nodes", 1)?;
+        let nodes = source.read_many_iter(nodes_len)?.collect::<Result<_, _>>()?;
+        let roots = read_debug_source_node_ids(source, "debug_source_graph roots")?;
         Ok(Self::from_parts(nodes, roots))
     }
 }
@@ -353,44 +336,36 @@ impl Deserializable for DebugSourceMapSection {
             )));
         }
 
-        let locations_len = source.read_usize()?;
-        let max_locations = source.max_alloc(MIN_REQUIRED_LOCATION_SERIALIZED_SIZE);
-        if locations_len > max_locations {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "debug_source_map locations count {locations_len} exceeds budget {max_locations}"
-            )));
-        }
+        let locations_len = read_bounded_len(
+            source,
+            "debug_source_map locations",
+            MIN_REQUIRED_LOCATION_SERIALIZED_SIZE,
+        )?;
         let mut locations = Vec::with_capacity(locations_len);
         for _ in 0..locations_len {
             locations.push(read_required_location(source)?);
         }
 
-        let strings_len = source.read_usize()?;
-        let max_strings = source.max_alloc(1);
-        if strings_len > max_strings {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "debug_source_map strings count {strings_len} exceeds budget {max_strings}"
-            )));
-        }
+        let strings_len = read_bounded_len(source, "debug_source_map strings", 1)?;
         let mut strings = Vec::with_capacity(strings_len);
         for _ in 0..strings_len {
-            strings.push(String::read_from(source)?);
+            strings.push(read_owned_string(source)?);
         }
 
-        let asm_ops_len = source.read_usize()?;
-        let max_asm_ops = source.max_alloc(min_source_map_asm_op_row_serialized_size());
-        if asm_ops_len > max_asm_ops {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "debug_source_map asm op count {asm_ops_len} exceeds budget {max_asm_ops}"
-            )));
-        }
+        let asm_ops_len = read_bounded_len(
+            source,
+            "debug_source_map asm ops",
+            min_source_map_asm_op_row_serialized_size(),
+        )?;
         let mut asm_ops = Vec::with_capacity(asm_ops_len);
         for _ in 0..asm_ops_len {
             asm_ops.push(read_source_asm_op(source, &locations, &strings)?);
         }
 
-        let debug_vars = Vec::<DebugSourceVar>::read_from(source)?;
-        let inline_calls = Vec::<DebugSourceInlineCall>::read_from(source)?;
+        let debug_vars_len = read_bounded_len(source, "debug_source_map debug vars", 1)?;
+        let debug_vars = source.read_many_iter(debug_vars_len)?.collect::<Result<_, _>>()?;
+        let inline_calls_len = read_bounded_len(source, "debug_source_map inline calls", 1)?;
+        let inline_calls = source.read_many_iter(inline_calls_len)?.collect::<Result<_, _>>()?;
         Ok(Self::from_parts_with_inline_calls(asm_ops, debug_vars, inline_calls))
     }
 }
@@ -513,7 +488,8 @@ impl Deserializable for DebugErrorMessagesSection {
             )));
         }
 
-        let messages = Vec::<DebugErrorMessage>::read_from(source)?;
+        let messages_len = read_bounded_len(source, "debug_error_messages messages", 1)?;
+        let messages = source.read_many_iter(messages_len)?.collect::<Result<_, _>>()?;
         Ok(Self::from_parts(messages))
     }
 }
@@ -652,7 +628,7 @@ impl Deserializable for DebugTypeInfo {
             TYPE_TAG_STRUCT => {
                 let name_idx = source.read_u32()?;
                 let size = source.read_u32()?;
-                let fields_len = source.read_usize()?;
+                let fields_len = read_bounded_len(source, "debug struct fields", 1)?;
                 let fields = source.read_many_iter(fields_len)?.collect::<Result<_, _>>()?;
                 Ok(Self::Struct { name_idx, size, fields })
             },
@@ -663,14 +639,15 @@ impl Deserializable for DebugTypeInfo {
                 } else {
                     None
                 };
-                let param_type_indices = Vec::<DebugTypeIdx>::read_from(source)?;
+                let param_type_indices =
+                    read_debug_type_indices(source, "debug function parameters")?;
                 Ok(Self::Function { return_type_idx, param_type_indices })
             },
             TYPE_TAG_ENUM => {
                 let name_idx = source.read_u32()?;
                 let size = source.read_u32()?;
                 let discriminant_type_idx = DebugTypeIdx::from(source.read_u32()?);
-                let variants_len = source.read_usize()?;
+                let variants_len = read_bounded_len(source, "debug enum variants", 1)?;
                 let variants = source.read_many_iter(variants_len)?.collect::<Result<_, _>>()?;
                 Ok(Self::Enum {
                     name_idx,
@@ -856,11 +833,68 @@ impl Deserializable for DebugFunctionInfo {
 
 fn read_string<R: ByteReader>(source: &mut R) -> Result<Arc<str>, DeserializationError> {
     let len = source.read_usize()?;
+    validate_len(source, "debug string bytes", len, 1)?;
     let bytes = source.read_slice(len)?;
     let s = core::str::from_utf8(bytes).map_err(|err| {
         DeserializationError::InvalidValue(alloc::format!("invalid utf-8 in string: {err}"))
     })?;
     Ok(Arc::from(s))
+}
+
+fn read_owned_string<R: ByteReader>(source: &mut R) -> Result<String, DeserializationError> {
+    read_string(source).map(|value| String::from(value.as_ref()))
+}
+
+fn read_debug_source_node_ids<R: ByteReader>(
+    source: &mut R,
+    label: &str,
+) -> Result<Vec<DebugSourceNodeId>, DeserializationError> {
+    let len = read_bounded_len(source, label, DebugSourceNodeId::min_serialized_size())?;
+    source.read_many_iter(len)?.collect::<Result<_, _>>()
+}
+
+fn read_debug_type_indices<R: ByteReader>(
+    source: &mut R,
+    label: &str,
+) -> Result<Vec<DebugTypeIdx>, DeserializationError> {
+    let len = read_bounded_len(source, label, DebugTypeIdx::min_serialized_size())?;
+    source.read_many_iter(len)?.collect::<Result<_, _>>()
+}
+
+fn read_bounded_len<R: ByteReader>(
+    source: &mut R,
+    label: &str,
+    min_element_size: usize,
+) -> Result<usize, DeserializationError> {
+    let len = source.read_usize()?;
+    validate_len(source, label, len, min_element_size)?;
+    Ok(len)
+}
+
+fn validate_len<R: ByteReader>(
+    source: &R,
+    label: &str,
+    len: usize,
+    min_element_size: usize,
+) -> Result<(), DeserializationError> {
+    let max_len = source.max_alloc(min_element_size);
+    if len > max_len {
+        return Err(DeserializationError::InvalidValue(alloc::format!(
+            "{label} count {len} exceeds budget {max_len}"
+        )));
+    }
+
+    let min_bytes = len.checked_mul(min_element_size).ok_or_else(|| {
+        DeserializationError::InvalidValue(alloc::format!(
+            "{label} count {len} overflows minimum serialized size {min_element_size}"
+        ))
+    })?;
+    source.check_eor(min_bytes).map_err(|err| match err {
+        DeserializationError::UnexpectedEOF => DeserializationError::InvalidValue(alloc::format!(
+            "{label} count {len} exceeds remaining input"
+        )),
+        err => err,
+    })
 }
 
 #[cfg(test)]
@@ -1286,6 +1320,18 @@ mod tests {
 
         let mut reader = FixedBudgetReader::new(&functions_ok, 1);
         assert_eq!(DebugFunctionsSection::read_from(&mut reader).unwrap().strings.len(), 1);
+    }
+
+    #[test]
+    fn test_debug_functions_rejects_oversized_string_table_count() {
+        let bytes = [0x02, 0x08, 0x2a, 0xfe, 0xfe, 0x01];
+        let mut reader = miden_core::serde::SliceReader::new(&bytes);
+        let err = DebugFunctionsSection::read_from(&mut reader).unwrap_err();
+        let DeserializationError::InvalidValue(message) = err else {
+            panic!("expected InvalidValue error");
+        };
+        assert!(message.contains("debug_functions strings count"));
+        assert!(message.contains("exceeds remaining input"));
     }
 
     #[test]

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -1090,15 +1090,13 @@ mod tests {
     #[test]
     fn test_debug_source_map_locationless_asm_op_min_size() {
         let source_node = DebugSourceNodeId::from(0);
+        let asm_op = |op_idx| {
+            DebugSourceAsmOp::new(source_node, op_idx, None, "test::ctx".into(), "add".into(), 1)
+        };
         let section = DebugSourceMapSection::from_parts(
-            alloc::vec![DebugSourceAsmOp::new(
-                source_node,
-                2,
-                None,
-                "test::ctx".into(),
-                "add".into(),
-                1,
-            )],
+            // Three location-less rows exceed the trailing empty debug_vars/inline_calls
+            // length prefixes, so an overestimated row size rejects this section.
+            alloc::vec![asm_op(2), asm_op(3), asm_op(4)],
             alloc::vec![],
         );
 


### PR DESCRIPTION
Debug info deserialization trusted length prefixes before checking the remaining input. A malformed input could make the reader try to allocate a huge string table, which caused the daily fuzz job to run out of memory.

This fixes the issue by checking lengths before allocating debug info strings, byte buffers, and collections. The same bounded reads are used for nested URI and debug variable data.

Regression tests cover the failing fuzz input and the nested string/byte readers.