### PR TITLE
test: port unentered loop regression to next

### DIFF
--- a/miden-vm/tests/integration/flow_control/mod.rs
+++ b/miden-vm/tests/integration/flow_control/mod.rs
@@ -58,6 +58,21 @@ fn conditional_loop() {
 }
 
 #[test]
+fn unentered_loop_with_following_block() {
+    let source = "
+        begin
+            push.2 push.1 push.0
+            while.true
+                push.3 drop
+            end
+            drop drop
+        end";
+
+    let test = build_test!(source);
+    test.check_constraints();
+}
+
+#[test]
 fn faulty_condition_from_loop() {
     let source = "
         begin


### PR DESCRIPTION
Add the unentered_loop_with_following_block regression from #3278 to the next branch flow-control tests.

The test passes on next without the main-side processor replay fix, proving #3278 does not need to be back-ported to next.
