### PR TITLE
Reduce processor compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.25.0 (TBD)
 
+#### Changes
+
+- Added a Blake3 pure execution benchmark axis and reduced processor benchmark compile time by relaxing forced inlining in execution helpers ([#3289](https://github.com/0xMiden/miden-vm/pull/3289)).
+
 ## v0.24.0 (2026-06-24)
 
 #### Enhancements

--- a/benches/blake3-bench/benches/blake3_bench.rs
+++ b/benches/blake3-bench/benches/blake3_bench.rs
@@ -128,7 +128,10 @@ fn blake3_bench(c: &mut Criterion) {
             group.bench_function("execute_sync", |b| {
                 b.iter_batched(
                     || fixture.clone(),
-                    |fixture| black_box(execute_program(&fixture)),
+                    |fixture| {
+                        execute_program(&fixture);
+                        black_box(())
+                    },
                     BatchSize::SmallInput,
                 );
             });

--- a/benches/blake3-bench/benches/blake3_bench.rs
+++ b/benches/blake3-bench/benches/blake3_bench.rs
@@ -3,14 +3,19 @@ use std::{hint::black_box, time::Duration};
 use codspeed_criterion_compat as criterion;
 use criterion::{BatchSize, Criterion, SamplingMode, criterion_group, criterion_main};
 use miden_vm_blake3_bench::{
-    BENCH_GROUP, Blake3Fixture, build_trace, execute_trace_inputs, prove_and_verify_once,
-    prove_span_duration, prove_trace, repo_root_from_manifest,
+    BENCH_GROUP, Blake3Fixture, build_trace, execute_program, execute_trace_inputs,
+    prove_and_verify_once, prove_span_duration, prove_trace, repo_root_from_manifest,
 };
 
-const ALL_AXES: [&str; 4] =
-    ["execute_trace_inputs_sync", "build_trace", "prove_trace_sync", "e2e_prove"];
+const ALL_AXES: [&str; 5] = [
+    "execute_sync",
+    "execute_trace_inputs_sync",
+    "build_trace",
+    "prove_trace_sync",
+    "e2e_prove",
+];
 const PROOF_AXES: [&str; 2] = ["e2e_prove", "prove_trace_sync"];
-const LIGHT_AXES: [&str; 2] = ["execute_trace_inputs_sync", "build_trace"];
+const LIGHT_AXES: [&str; 3] = ["execute_sync", "execute_trace_inputs_sync", "build_trace"];
 
 fn env_usize(name: &str, default: usize) -> usize {
     match std::env::var(name) {
@@ -49,6 +54,7 @@ fn resolve_axes() -> Vec<&'static str> {
         match axis {
             "all" => requested.extend(ALL_AXES),
             "e2e_prove" | "prove" | "prove_program_sync" => requested.push("e2e_prove"),
+            "execute_sync" => requested.push("execute_sync"),
             "execute_trace_inputs_sync" => requested.push("execute_trace_inputs_sync"),
             "prove_trace_sync" => requested.push("prove_trace_sync"),
             "build_trace" => requested.push("build_trace"),
@@ -117,6 +123,16 @@ fn blake3_bench(c: &mut Criterion) {
     if LIGHT_AXES.iter().any(|axis| has_axis(&axes, axis)) {
         let mut group = c.benchmark_group(BENCH_GROUP);
         configure_group(&mut group, light_sample_size, measurement_time_secs, warm_up_time_secs);
+
+        if has_axis(&axes, "execute_sync") {
+            group.bench_function("execute_sync", |b| {
+                b.iter_batched(
+                    || fixture.clone(),
+                    |fixture| black_box(execute_program(&fixture)),
+                    BatchSize::SmallInput,
+                );
+            });
+        }
 
         if has_axis(&axes, "execute_trace_inputs_sync") {
             group.bench_function("execute_trace_inputs_sync", |b| {

--- a/benches/blake3-bench/src/bin/blake3_nonregression/criterion_results.rs
+++ b/benches/blake3-bench/src/bin/blake3_nonregression/criterion_results.rs
@@ -57,10 +57,16 @@ pub(crate) fn collect_result(
 fn select_primary_metric(
     metrics: &BTreeMap<String, Metric>,
 ) -> Result<&str, Box<dyn std::error::Error>> {
-    [PRIMARY_METRIC, "prove_trace_sync", "build_trace", "execute_trace_inputs_sync"]
-        .into_iter()
-        .find(|metric| metrics.contains_key(*metric))
-        .ok_or_else(|| "no supported primary metric found in benchmark result".into())
+    [
+        PRIMARY_METRIC,
+        "prove_trace_sync",
+        "build_trace",
+        "execute_trace_inputs_sync",
+        "execute_sync",
+    ]
+    .into_iter()
+    .find(|metric| metrics.contains_key(*metric))
+    .ok_or_else(|| "no supported primary metric found in benchmark result".into())
 }
 
 fn collect_criterion_metrics(

--- a/benches/blake3-bench/src/lib.rs
+++ b/benches/blake3-bench/src/lib.rs
@@ -133,6 +133,19 @@ pub fn execute_trace_inputs(fixture: &Blake3Fixture) -> TraceBuildInputs {
     }
 }
 
+pub fn execute_program(fixture: &Blake3Fixture) {
+    let mut host = host_for_fixture(fixture);
+    let processor = FastProcessor::new_with_options(
+        fixture.stack_inputs,
+        fixture.advice_inputs.clone(),
+        execution_options(),
+    )
+    .expect("processor advice inputs should fit advice map limits");
+    processor
+        .execute_sync(&fixture.program, &mut host)
+        .expect("failed to execute Blake3 benchmark");
+}
+
 pub fn prove_program(fixture: &Blake3Fixture) {
     let _span = tracing::info_span!("prove_program_sync").entered();
     prove_trace(execute_trace_inputs(fixture));

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -383,7 +383,7 @@ impl OperationError {
     pub fn with_package_source_context(
         self,
         context: PackageSourceDebugContext<'_>,
-        host: &impl BaseHost,
+        host: &(dyn BaseHost + '_),
         op_idx: Option<usize>,
     ) -> ExecutionError {
         let (label, source_file) =
@@ -487,7 +487,7 @@ impl<'a> PackageSourceDebugContext<'a> {
 
 fn label_and_source_file_from_location(
     location: Option<&Location>,
-    host: &impl BaseHost,
+    host: &(dyn BaseHost + '_),
 ) -> (SourceSpan, Option<Arc<SourceFile>>) {
     location.map_or_else(
         || (SourceSpan::UNKNOWN, None),
@@ -517,7 +517,7 @@ pub fn advice_error_with_context(err: AdviceError) -> ExecutionError {
 pub fn advice_error_with_package_source_context(
     err: AdviceError,
     context: PackageSourceDebugContext<'_>,
-    host: &impl BaseHost,
+    host: &(dyn BaseHost + '_),
     op_idx: Option<usize>,
 ) -> ExecutionError {
     let (label, source_file) =
@@ -548,7 +548,7 @@ pub fn event_error_with_context(
 pub fn event_error_with_package_source_context(
     error: EventError,
     context: PackageSourceDebugContext<'_>,
-    host: &impl BaseHost,
+    host: &(dyn BaseHost + '_),
     op_idx: Option<usize>,
     event_id: EventId,
     event_name: Option<EventName>,
@@ -574,7 +574,7 @@ pub fn procedure_not_found_with_context(root_digest: Word) -> ExecutionError {
 pub fn procedure_not_found_with_package_source_context(
     root_digest: Word,
     context: PackageSourceDebugContext<'_>,
-    host: &impl BaseHost,
+    host: &(dyn BaseHost + '_),
 ) -> ExecutionError {
     let (label, source_file) =
         label_and_source_file_from_location(context.assembly_location(None), host);
@@ -585,7 +585,7 @@ pub fn procedure_not_found_with_package_source_context(
 pub fn malformed_mast_forest_with_context(
     root_digest: Word,
     context: Option<PackageSourceDebugContext<'_>>,
-    host: &impl BaseHost,
+    host: &(dyn BaseHost + '_),
 ) -> ExecutionError {
     let err = OperationError::MalformedMastForestInHost { root_digest };
     match context {
@@ -620,7 +620,7 @@ pub trait MapExecErrWithOpIdx<T> {
     fn map_exec_err_with_package_source_op_idx(
         self,
         context: Option<PackageSourceDebugContext<'_>>,
-        _host: &impl BaseHost,
+        _host: &(dyn BaseHost + '_),
         _op_idx: usize,
     ) -> Result<T, ExecutionError>
     where
@@ -674,7 +674,7 @@ impl<T> MapExecErrWithOpIdx<T> for Result<T, OperationError> {
     fn map_exec_err_with_package_source_op_idx(
         self,
         context: Option<PackageSourceDebugContext<'_>>,
-        host: &impl BaseHost,
+        host: &(dyn BaseHost + '_),
         op_idx: usize,
     ) -> Result<T, ExecutionError> {
         match (self, context) {
@@ -759,7 +759,7 @@ impl<T> MapExecErrWithOpIdx<T> for Result<T, MemoryError> {
     fn map_exec_err_with_package_source_op_idx(
         self,
         context: Option<PackageSourceDebugContext<'_>>,
-        host: &impl BaseHost,
+        host: &(dyn BaseHost + '_),
         op_idx: usize,
     ) -> Result<T, ExecutionError> {
         match (self, context) {
@@ -829,7 +829,7 @@ impl<T> MapExecErrWithOpIdx<T> for Result<T, SystemEventError> {
     fn map_exec_err_with_package_source_op_idx(
         self,
         context: Option<PackageSourceDebugContext<'_>>,
-        host: &impl BaseHost,
+        host: &(dyn BaseHost + '_),
         op_idx: usize,
     ) -> Result<T, ExecutionError> {
         match (self, context) {
@@ -894,7 +894,7 @@ impl<T> MapExecErrWithOpIdx<T> for Result<T, IoError> {
     fn map_exec_err_with_package_source_op_idx(
         self,
         context: Option<PackageSourceDebugContext<'_>>,
-        host: &impl BaseHost,
+        host: &(dyn BaseHost + '_),
         op_idx: usize,
     ) -> Result<T, ExecutionError> {
         match (self, context) {
@@ -953,7 +953,7 @@ impl<T> MapExecErrWithOpIdx<T> for Result<T, CryptoError> {
     fn map_exec_err_with_package_source_op_idx(
         self,
         context: Option<PackageSourceDebugContext<'_>>,
-        host: &impl BaseHost,
+        host: &(dyn BaseHost + '_),
         op_idx: usize,
     ) -> Result<T, ExecutionError> {
         match (self, context) {
@@ -1013,7 +1013,7 @@ impl<T> MapExecErrWithOpIdx<T> for Result<T, AceEvalError> {
     fn map_exec_err_with_package_source_op_idx(
         self,
         context: Option<PackageSourceDebugContext<'_>>,
-        host: &impl BaseHost,
+        host: &(dyn BaseHost + '_),
         op_idx: usize,
     ) -> Result<T, ExecutionError> {
         match (self, context) {

--- a/processor/src/execution/basic_block.rs
+++ b/processor/src/execution/basic_block.rs
@@ -20,7 +20,7 @@ use crate::{
 // ================================================================================================
 
 /// Execute the given basic block node.
-#[inline(always)]
+#[inline]
 pub(super) fn execute_basic_block_node_from_start<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     basic_block_node: &BasicBlockNode,
@@ -75,7 +75,7 @@ where
 
 /// Executes the give basic block node starting from the specified operation index within the
 /// specified batch.
-#[inline(always)]
+#[inline]
 pub(super) fn execute_basic_block_node_from_op_idx<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     basic_block_node: &BasicBlockNode,
@@ -120,7 +120,7 @@ where
 }
 
 /// Executes the give basic block node starting from the RESPAN preceding the specified batch.
-#[inline(always)]
+#[inline]
 pub(super) fn execute_basic_block_node_from_batch<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     basic_block_node: &BasicBlockNode,
@@ -195,7 +195,7 @@ where
 }
 
 /// Execute the finish phase of a basic block node.
-#[inline(always)]
+#[inline]
 pub(super) fn finish_basic_block<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     node_id: MastNodeId,

--- a/processor/src/execution/call.rs
+++ b/processor/src/execution/call.rs
@@ -20,7 +20,7 @@ use crate::{
 // ================================================================================================
 
 /// Executes a Call node from the start.
-#[inline(always)]
+#[inline]
 pub(super) fn start_call_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     call_node: &CallNode,

--- a/processor/src/execution/dyn.rs
+++ b/processor/src/execution/dyn.rs
@@ -21,7 +21,7 @@ use crate::{
 // ================================================================================================
 
 /// Executes a Dyn node from the start.
-#[inline(always)]
+#[inline]
 pub(super) fn start_dyn_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     current_node_id: MastNodeId,

--- a/processor/src/execution/join.rs
+++ b/processor/src/execution/join.rs
@@ -13,7 +13,7 @@ use crate::{
 // ================================================================================================
 
 /// Executes a Join node from the start.
-#[inline(always)]
+#[inline]
 pub(super) fn start_join_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     join_node: &JoinNode,

--- a/processor/src/execution/loop.rs
+++ b/processor/src/execution/loop.rs
@@ -20,7 +20,7 @@ use crate::{
 /// inspected at the end of each iteration (REPEAT/END). Source-level guarding (`while.true`) is
 /// implemented by the assembler wrapping the LOOP in a SPLIT that selects the loop on a true
 /// condition and skips it on false.
-#[inline(always)]
+#[inline]
 pub(super) fn start_loop_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     loop_node: &LoopNode,
@@ -112,7 +112,7 @@ where
 ///
 /// Reads the boolean condition the body left on top of the stack. If `ONE`, fires REPEAT and
 /// re-enters the body; if `ZERO`, fires END and exits the loop. Any other value is an error.
-#[inline(always)]
+#[inline]
 pub(super) fn finish_loop_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     current_node_id: MastNodeId,

--- a/processor/src/execution/mod.rs
+++ b/processor/src/execution/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     BaseHost, BreakReason, ContextId, ExecutionError, Kernel, Stopper, Word,
     continuation_stack::{Continuation, ContinuationStack},
     errors::PackageSourceDebugContext,
+    host::default::NoopHost,
     mast::{ExecutableMastForest, MastNode, MastNodeId},
     operation::OperationError,
     processor::{Processor, SystemInterface},
@@ -50,7 +51,7 @@ pub(crate) struct ExecutionState<'a, P, H, S, T, F> {
     pub current_source_node_id: Option<DebugSourceNodeId>,
 }
 
-impl<'a, P, H, S, T, F> ExecutionState<'a, P, H, S, T, F> {
+impl<'a, P, H: BaseHost, S, T, F> ExecutionState<'a, P, H, S, T, F> {
     pub fn current_source_node_id(&self) -> Option<DebugSourceNodeId> {
         self.current_source_node_id
     }
@@ -83,10 +84,7 @@ impl<'a, P, H, S, T, F> ExecutionState<'a, P, H, S, T, F> {
         ))
     }
 
-    pub fn operation_error_with_current_context(&self, err: OperationError) -> ExecutionError
-    where
-        H: BaseHost,
-    {
+    pub fn operation_error_with_current_context(&self, err: OperationError) -> ExecutionError {
         match self.package_source_context() {
             Some(context) => err.with_package_source_context(context, self.host, None),
             None => err.with_context(),
@@ -182,7 +180,7 @@ pub(crate) fn execute_impl<P, S, T, F>(
     continuation_stack: &mut ContinuationStack<F>,
     current_forest: &mut F,
     kernel: &Kernel,
-    host: &mut impl BaseHost,
+    mut host: &mut dyn BaseHost,
     tracer: &mut T,
     stopper: &S,
     source_debug_info: &mut Option<Arc<PackageDebugInfo>>,
@@ -193,8 +191,65 @@ where
     T: Tracer<Processor = P, Forest = F>,
     F: ExecutableMastForest + Clone,
 {
+    execute_impl_inner(
+        processor,
+        continuation_stack,
+        current_forest,
+        kernel,
+        &mut host,
+        tracer,
+        stopper,
+        source_debug_info,
+    )
+}
+
+pub(crate) fn execute_impl_noop_host<P, S, T, F>(
+    processor: &mut P,
+    continuation_stack: &mut ContinuationStack<F>,
+    current_forest: &mut F,
+    kernel: &Kernel,
+    host: &mut NoopHost,
+    tracer: &mut T,
+    stopper: &S,
+    source_debug_info: &mut Option<Arc<PackageDebugInfo>>,
+) -> ControlFlow<InternalBreakReason<F>>
+where
+    P: Processor,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
+{
+    execute_impl_inner(
+        processor,
+        continuation_stack,
+        current_forest,
+        kernel,
+        host,
+        tracer,
+        stopper,
+        source_debug_info,
+    )
+}
+
+fn execute_impl_inner<P, H, S, T, F>(
+    processor: &mut P,
+    continuation_stack: &mut ContinuationStack<F>,
+    current_forest: &mut F,
+    kernel: &Kernel,
+    host: &mut H,
+    tracer: &mut T,
+    stopper: &S,
+    source_debug_info: &mut Option<Arc<PackageDebugInfo>>,
+) -> ControlFlow<InternalBreakReason<F>>
+where
+    P: Processor,
+    H: BaseHost,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
+{
     if source_debug_info.is_none() && !continuation_stack.tracks_source_nodes() {
-        return execute_impl_pure(
+        execute_impl_pure(
             processor,
             continuation_stack,
             current_forest,
@@ -202,9 +257,39 @@ where
             host,
             tracer,
             stopper,
-        );
-    };
+        )
+    } else {
+        execute_impl_with_source(
+            processor,
+            continuation_stack,
+            current_forest,
+            kernel,
+            host,
+            tracer,
+            stopper,
+            source_debug_info,
+        )
+    }
+}
 
+#[inline(never)]
+fn execute_impl_with_source<P, H, S, T, F>(
+    processor: &mut P,
+    continuation_stack: &mut ContinuationStack<F>,
+    current_forest: &mut F,
+    kernel: &Kernel,
+    host: &mut H,
+    tracer: &mut T,
+    stopper: &S,
+    source_debug_info: &mut Option<Arc<PackageDebugInfo>>,
+) -> ControlFlow<InternalBreakReason<F>>
+where
+    P: Processor,
+    H: BaseHost,
+    S: Stopper<Processor = P, Forest = F>,
+    T: Tracer<Processor = P, Forest = F>,
+    F: ExecutableMastForest + Clone,
+{
     let mut state = ExecutionState {
         processor,
         continuation_stack,
@@ -319,18 +404,20 @@ where
     ControlFlow::Continue(())
 }
 
-#[inline(always)]
-fn execute_impl_pure<P, S, T, F>(
+#[cfg_attr(debug_assertions, inline(never))]
+#[cfg_attr(not(debug_assertions), inline(always))]
+fn execute_impl_pure<P, H, S, T, F>(
     processor: &mut P,
     continuation_stack: &mut ContinuationStack<F>,
     current_forest: &mut F,
     kernel: &Kernel,
-    host: &mut impl BaseHost,
+    host: &mut H,
     tracer: &mut T,
     stopper: &S,
 ) -> ControlFlow<InternalBreakReason<F>>
 where
     P: Processor,
+    H: BaseHost,
     S: Stopper<Processor = P, Forest = F>,
     T: Tracer<Processor = P, Forest = F>,
     F: ExecutableMastForest + Clone,

--- a/processor/src/execution/operations/mod.rs
+++ b/processor/src/execution/operations/mod.rs
@@ -38,16 +38,17 @@ const DOUBLE_WORD_SIZE: Felt = Felt::new_unchecked(8);
 /// - If a control flow operation is provided.
 /// - If an `Emit` operation is provided.
 #[inline(always)]
-pub(crate) fn execute_op<P, T>(
+pub(crate) fn execute_op<P, H, T>(
     processor: &mut P,
     op: &Operation,
     op_idx: usize,
-    host: &mut impl BaseHost,
+    host: &mut H,
     tracer: &mut T,
     package_source_context: Option<PackageSourceDebugContext<'_>>,
 ) -> Result<OperationHelperRegisters, ExecutionError>
 where
     P: Processor,
+    H: BaseHost,
     T: Tracer<Processor = P>,
 {
     let user_op_helpers =

--- a/processor/src/execution/split.rs
+++ b/processor/src/execution/split.rs
@@ -14,7 +14,7 @@ use crate::{
 // ================================================================================================
 
 /// Executes a Split node from the start.
-#[inline(always)]
+#[inline]
 pub(super) fn start_split_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     split_node: &SplitNode,

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -83,6 +83,19 @@ pub trait BaseHost {
     }
 }
 
+impl<T: BaseHost + ?Sized> BaseHost for &mut T {
+    fn get_label_and_source_file(
+        &self,
+        location: &Location,
+    ) -> (SourceSpan, Option<Arc<SourceFile>>) {
+        (**self).get_label_and_source_file(location)
+    }
+
+    fn resolve_event(&self, event_id: EventId) -> Option<&EventName> {
+        (**self).resolve_event(event_id)
+    }
+}
+
 /// Defines a synchronous interface by which the VM can interact with the host during execution.
 pub trait SyncHost: BaseHost {
     /// Returns MAST forest corresponding to the specified digest, or None if the MAST forest for

--- a/processor/src/trace/parallel/processor.rs
+++ b/processor/src/trace/parallel/processor.rs
@@ -21,7 +21,7 @@ use crate::{
     continuation_stack::{Continuation, ContinuationStack},
     errors::OperationError,
     execution::{
-        InternalBreakReason, execute_impl, finish_emit_op_execution,
+        InternalBreakReason, execute_impl_noop_host, finish_emit_op_execution,
         finish_load_mast_forest_from_dyn_start, finish_load_mast_forest_from_external,
     },
     host::default::NoopHost,
@@ -150,7 +150,7 @@ impl ReplayProcessor {
         let stopper = &ReplayStopper;
         let mut package_debug_info = None;
 
-        while let ControlFlow::Break(internal_break_reason) = execute_impl(
+        while let ControlFlow::Break(internal_break_reason) = execute_impl_noop_host(
             self,
             continuation_stack,
             current_forest,


### PR DESCRIPTION
On top of #3274.

This PR reduces compile time for the processor benchmark path in #3271. The root cause is forced inlining in large generic execution helpers. This change keeps forced inlining on the pure replay path and on the inner operation loop. It changes the source aware path and the basic block helpers to `#[inline]`, so LLVM can decide when to inline them.

The direct Blake3 comparison uses the parent of this work as the base and the current branch head as the tip. The run used all four Blake3 axes, with 10 proof samples, 1000 light samples, 3 seconds of measurement time, and 1 second of warmup.

Base: `1e91767e90ab9e4f8df08991a8ee174b4574b995`.

Tip: `30dee80d26f928213d9a1381c9ccd99901baed36`.

Criterion results:

* `e2e_prove` improved from `9187.2998497 ms` to `9086.9550542 ms`. This is `1.09%` faster.
* `prove_trace_sync` changed from `9288.9703209 ms` to `9573.5592793 ms`. This is `3.06%` slower in this run.
* `execute_trace_inputs_sync` improved from `18.111430051 ms` to `8.24616859 ms`. This is `54.47%` faster.
* `build_trace` improved from `108.006259741 ms` to `56.828919122 ms`. This is `47.38%` faster.

~Proof spans also improved:~ (obsolete, see [below](https://github.com/0xMiden/miden-vm/pull/3289#issuecomment-4806404033))

~* `prove_program_sync` wall time improved from `13186.812667 ms` to `8400.075417 ms`. This is `36.30%` faster.~
~* `build aux traces` improved from `51.48075 ms` to `37.603667 ms`. This is `26.96%` faster.~
~* `commit to aux traces` improved from `1003.236458 ms` to `629.976166 ms`. This is `37.21%` faster.~
~* `commit to main traces` improved from `3460.164125 ms` to `2065.563666 ms`. This is `40.30%` faster.~
~* `commit to quotient poly chunks` improved from `1070.276875 ms` to `715.463625 ms`. This is `33.15%` faster.~
~* `evaluate constraints` improved from `6814.079292 ms` to `4449.177041 ms`. This is `34.71%` faster.~
~* `open` improved from `680.16025 ms` to `408.692417 ms`. This is `39.91%` faster.~

Build time at the final branch tip:

* The adjusted `test-dev` build for the processor test command took `1m18s`, with `real 79.12s`, `user 537.61s`, and `sys 32.76s`.
* The same build without the `miden-processor` profile override took `2m06s`, with `real 127.23s`, `user 723.99s`, and `sys 35.23s`.
* The build without the profile override is still about `1.61x` slower, so this PR keeps the profile override.

Earlier branch measurements show the compile time change across the work:

* The Blake3 benchmark build improved from `5m00s` to `3m46s`.
* The optimized runner build improved from `11m02s` to `3m27s`.
* The adjusted processor test build improved from `6m04s` to `1m18s`.
* The same processor test build without the profile override improved from `24m34s` to `2m06s`.

The code changes are small:

* The source aware execution path is separate from the pure execution loop.
* `NoopHost` trace replay still uses static dispatch.
* Source aware node handlers use `#[inline]` instead of `#[inline(always)]`.
* Basic block helper functions use `#[inline]` instead of `#[inline(always)]`.
* The inner operation batch helper and the pure replay helpers still use `#[inline(always)]`.

The `finalize_clock_cycle` annotations are unchanged because changing them did not improve compile time.
