### PR TITLE
Reduce processor compilation time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Enhancements
 
 - Added no-op handlers for readonly debugger events to `CoreLibrary::handlers`, so hosts that load the core library can execute programs emitting those events without registering no-op handlers manually ([#3305](https://github.com/0xMiden/miden-vm/pull/3305)).
+- Reduced optimized benchmark build time by relaxing forced inlining in processor execution helpers ([#3292](https://github.com/0xMiden/miden-vm/pull/3292)).
 
 ## v0.24.0 (2026-06-24)
 

--- a/processor/src/execution/basic_block.rs
+++ b/processor/src/execution/basic_block.rs
@@ -20,7 +20,7 @@ use crate::{
 // ================================================================================================
 
 /// Execute the given basic block node.
-#[inline(always)]
+#[inline]
 pub(super) fn execute_basic_block_node_from_start<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     basic_block_node: &BasicBlockNode,
@@ -75,7 +75,7 @@ where
 
 /// Executes the give basic block node starting from the specified operation index within the
 /// specified batch.
-#[inline(always)]
+#[inline]
 pub(super) fn execute_basic_block_node_from_op_idx<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     basic_block_node: &BasicBlockNode,
@@ -120,7 +120,7 @@ where
 }
 
 /// Executes the give basic block node starting from the RESPAN preceding the specified batch.
-#[inline(always)]
+#[inline]
 pub(super) fn execute_basic_block_node_from_batch<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     basic_block_node: &BasicBlockNode,
@@ -195,7 +195,7 @@ where
 }
 
 /// Execute the finish phase of a basic block node.
-#[inline(always)]
+#[inline]
 pub(super) fn finish_basic_block<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     node_id: MastNodeId,

--- a/processor/src/execution/call.rs
+++ b/processor/src/execution/call.rs
@@ -20,7 +20,7 @@ use crate::{
 // ================================================================================================
 
 /// Executes a Call node from the start.
-#[inline(always)]
+#[inline]
 pub(super) fn start_call_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     call_node: &CallNode,

--- a/processor/src/execution/dyn.rs
+++ b/processor/src/execution/dyn.rs
@@ -21,7 +21,7 @@ use crate::{
 // ================================================================================================
 
 /// Executes a Dyn node from the start.
-#[inline(always)]
+#[inline]
 pub(super) fn start_dyn_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     current_node_id: MastNodeId,

--- a/processor/src/execution/join.rs
+++ b/processor/src/execution/join.rs
@@ -13,7 +13,7 @@ use crate::{
 // ================================================================================================
 
 /// Executes a Join node from the start.
-#[inline(always)]
+#[inline]
 pub(super) fn start_join_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     join_node: &JoinNode,

--- a/processor/src/execution/loop.rs
+++ b/processor/src/execution/loop.rs
@@ -20,7 +20,7 @@ use crate::{
 /// inspected at the end of each iteration (REPEAT/END). Source-level guarding (`while.true`) is
 /// implemented by the assembler wrapping the LOOP in a SPLIT that selects the loop on a true
 /// condition and skips it on false.
-#[inline(always)]
+#[inline]
 pub(super) fn start_loop_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     loop_node: &LoopNode,
@@ -112,7 +112,7 @@ where
 ///
 /// Reads the boolean condition the body left on top of the stack. If `ONE`, fires REPEAT and
 /// re-enters the body; if `ZERO`, fires END and exits the loop. Any other value is an error.
-#[inline(always)]
+#[inline]
 pub(super) fn finish_loop_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     current_node_id: MastNodeId,

--- a/processor/src/execution/split.rs
+++ b/processor/src/execution/split.rs
@@ -14,7 +14,7 @@ use crate::{
 // ================================================================================================
 
 /// Executes a Split node from the start.
-#[inline(always)]
+#[inline]
 pub(super) fn start_split_node<P, H, S, T, F>(
     state: &mut ExecutionState<'_, P, H, S, T, F>,
     split_node: &SplitNode,


### PR DESCRIPTION
This is just the inlining (and therefore semver compatible) part of #3289, i.e. the three inlining commits of this PR cherry picked here

 CodSpeed benchmark build results:
```  ┌────────────────────────────────────┬─────────┬─────────┬─────────┐
  │ State                              │   Run 1 │   Run 2 │     Avg │
  ├────────────────────────────────────┼─────────┼─────────┼─────────┤
  │ origin/main                        │ 499.77s │ 500.69s │ 500.23s │
  │ issue-3271-inline-annotations-main │ 179.27s │ 180.15s │ 179.71s │
  └────────────────────────────────────┴─────────┴─────────┴─────────┘
  ```

  Command used:
```
env RUSTC_WRAPPER= CARGO_TARGET_DIR=/tmp/... SYNTH_SAMPLE_SIZE=10 \
    cargo codspeed build --measurement-mode walltime --profile optimized \
    -p miden-vm-synthetic-bench --bench synthetic_bench
```