### PR TITLE
feat: add no-op handlers for readonly events in core lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.24.1 (TBD)
+
+#### Enhancements
+
+- Added no-op handlers for readonly debugger events to `CoreLibrary::handlers`, so hosts that load the core library can execute programs emitting those events without registering no-op handlers manually ([#3305](https://github.com/0xMiden/miden-vm/pull/3305)).
+
 ## v0.24.0 (2026-06-24)
 
 #### Enhancements

--- a/crates/lib/core/src/handlers/mod.rs
+++ b/crates/lib/core/src/handlers/mod.rs
@@ -15,6 +15,7 @@ pub mod ecdsa;
 pub mod eddsa_ed25519;
 pub mod falcon_div;
 pub mod keccak256;
+pub mod readonly;
 pub mod sha512;
 pub mod smt_peek;
 pub mod sorted_array;

--- a/crates/lib/core/src/handlers/readonly.rs
+++ b/crates/lib/core/src/handlers/readonly.rs
@@ -1,0 +1,55 @@
+//! No-op event handlers that never produce advice mutations and are therefore safe to ignore.
+//! Hosts that want to handle these events are expected to replace the no-op handlers.
+//!
+//! This enables communicating readonly events to hosts importing the core library without having
+//! to manually add these no-op handlers. This is a temporary solution. In the long-term, events
+//! themselves should be marked as readonly.
+
+use alloc::{sync::Arc, vec, vec::Vec};
+
+use miden_processor::{
+    ProcessorState,
+    advice::AdviceMutation,
+    event::{EventError, EventHandler, EventName},
+};
+
+// EVENT NAMES
+// ================================================================================================
+//
+// Only the debugger cares about `READONLY_MIDEN_DEBUG_*` events.
+
+/// Marks the start of a debug trace frame.
+pub const READONLY_MIDEN_DEBUG_FRAME_START: EventName =
+    EventName::new("readonly::miden_debug::frame_start");
+/// Marks the end of a debug trace frame.
+pub const READONLY_MIDEN_DEBUG_FRAME_END: EventName =
+    EventName::new("readonly::miden_debug::frame_end");
+/// Emitted when an assertion in a debug trace fails.
+pub const READONLY_MIDEN_DEBUG_ASSERTION_FAILED: EventName =
+    EventName::new("readonly::miden_debug::assertion_failed");
+/// Emitted for an unrecognized debug trace event.
+pub const READONLY_MIDEN_DEBUG_UNKNOWN: EventName =
+    EventName::new("readonly::miden_debug::unknown");
+/// Emitted by the Rust sdk's `println`.
+pub const READONLY_MIDEN_DEBUG_PRINTLN: EventName =
+    EventName::new("readonly::miden_debug::println");
+
+struct ReadonlyNoopHandler;
+
+impl EventHandler for ReadonlyNoopHandler {
+    fn on_event(&self, _process: &ProcessorState) -> Result<Vec<AdviceMutation>, EventError> {
+        Ok(vec![])
+    }
+}
+
+/// Returns no-op handlers for all readonly events.
+pub fn readonly_noop_handlers() -> Vec<(EventName, Arc<dyn EventHandler>)> {
+    let handler: Arc<dyn EventHandler> = Arc::new(ReadonlyNoopHandler);
+    vec![
+        (READONLY_MIDEN_DEBUG_FRAME_START, handler.clone()),
+        (READONLY_MIDEN_DEBUG_FRAME_END, handler.clone()),
+        (READONLY_MIDEN_DEBUG_ASSERTION_FAILED, handler.clone()),
+        (READONLY_MIDEN_DEBUG_UNKNOWN, handler.clone()),
+        (READONLY_MIDEN_DEBUG_PRINTLN, handler),
+    ]
+}

--- a/crates/lib/core/src/lib.rs
+++ b/crates/lib/core/src/lib.rs
@@ -27,6 +27,7 @@ use crate::handlers::{
     eddsa_ed25519::{EDDSA25519_VERIFY_EVENT_NAME, EddsaPrecompile},
     falcon_div::{FALCON_DIV_EVENT_NAME, handle_falcon_div},
     keccak256::{KECCAK_HASH_BYTES_EVENT_NAME, KeccakPrecompile},
+    readonly::readonly_noop_handlers,
     sha512::{SHA512_HASH_BYTES_EVENT_NAME, Sha512Precompile},
     smt_peek::{SMT_PEEK_EVENT_NAME, handle_smt_peek},
     sorted_array::{
@@ -156,6 +157,7 @@ impl CoreLibrary {
             (AEAD_DECRYPT_EVENT_NAME, Arc::new(handle_aead_decrypt)),
         ];
         handlers.extend(default_debug_handlers());
+        handlers.extend(readonly_noop_handlers());
         handlers
     }
 


### PR DESCRIPTION
Implements `Option A` from #3301 as temporary solution. This enables all hosts using core library handlers to process debugger events with no-op handlers. Without a handler, hosts raise an `UnknownEvent` error and abort execution.

Adding these handlers to the core library avoids having to add them to all hosts manually.

Event naming is up for debate because as of now the compiler still generates traces instead of events. So from that side there is no restriction on event names.

In the long term we want to encode the readonly property in event names/ids, which is `Option E` in #3301.

/cc @bobbinth, @bitwalker this is the hotfix we discussed today.