### PR TITLE
feat: add no-op handlers for readonly events in core lib [backport]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.23.5 (2026-07-02)
 
+#### Enhancements
+
+- Added no-op handlers for readonly debugger events to `CoreLibrary::handlers`, so hosts that load the core library can execute programs emitting those events without registering no-op handlers manually ([#3316](https://github.com/0xMiden/miden-vm/pull/3316)).
+
 ## v0.23.4 (2026-06-23)
 
 - Preserved semantic struct and field names when emitting debug types, so debug dumps no longer fall back to anonymous struct metadata ([#3269](https://github.com/0xMiden/miden-vm/pull/3269)).

--- a/crates/lib/core/src/handlers/mod.rs
+++ b/crates/lib/core/src/handlers/mod.rs
@@ -14,6 +14,7 @@ pub mod ecdsa;
 pub mod eddsa_ed25519;
 pub mod falcon_div;
 pub mod keccak256;
+pub mod readonly;
 pub mod sha512;
 pub mod smt_peek;
 pub mod sorted_array;

--- a/crates/lib/core/src/handlers/readonly.rs
+++ b/crates/lib/core/src/handlers/readonly.rs
@@ -1,0 +1,40 @@
+//! No-op event handlers that never produce advice mutations and are therefore safe to ignore.
+//! Hosts that want to handle these events are expected to replace the no-op handlers.
+//!
+//! This enables communicating readonly events to hosts importing the core library without having
+//! to manually add these no-op handlers. This is a temporary solution. In the long-term, events
+//! themselves should be marked as readonly.
+
+use alloc::{vec, vec::Vec};
+
+use miden_processor::{
+    ProcessorState,
+    advice::AdviceMutation,
+    event::{EventError, EventName},
+};
+
+// EVENT NAMES
+// ================================================================================================
+//
+// Only the debugger cares about `READONLY_MIDEN_DEBUG_*` events.
+
+/// Marks the start of a debug trace frame.
+pub const READONLY_MIDEN_DEBUG_FRAME_START: EventName =
+    EventName::new("readonly::miden_debug::frame_start");
+/// Marks the end of a debug trace frame.
+pub const READONLY_MIDEN_DEBUG_FRAME_END: EventName =
+    EventName::new("readonly::miden_debug::frame_end");
+/// Emitted when an assertion in a debug trace fails.
+pub const READONLY_MIDEN_DEBUG_ASSERTION_FAILED: EventName =
+    EventName::new("readonly::miden_debug::assertion_failed");
+/// Emitted for an unrecognized debug trace event.
+pub const READONLY_MIDEN_DEBUG_UNKNOWN: EventName =
+    EventName::new("readonly::miden_debug::unknown");
+/// Emitted by the Rust sdk's `println`.
+pub const READONLY_MIDEN_DEBUG_PRINTLN: EventName =
+    EventName::new("readonly::miden_debug::println");
+
+/// Does nothing but return an empty vector of advice mutations.
+pub fn readonly_noop_handler(_process: &ProcessorState) -> Result<Vec<AdviceMutation>, EventError> {
+    Ok(vec![])
+}

--- a/crates/lib/core/src/lib.rs
+++ b/crates/lib/core/src/lib.rs
@@ -25,6 +25,11 @@ use crate::handlers::{
     eddsa_ed25519::{EDDSA25519_VERIFY_EVENT_NAME, EddsaPrecompile},
     falcon_div::{FALCON_DIV_EVENT_NAME, handle_falcon_div},
     keccak256::{KECCAK_HASH_BYTES_EVENT_NAME, KeccakPrecompile},
+    readonly::{
+        READONLY_MIDEN_DEBUG_ASSERTION_FAILED, READONLY_MIDEN_DEBUG_FRAME_END,
+        READONLY_MIDEN_DEBUG_FRAME_START, READONLY_MIDEN_DEBUG_PRINTLN,
+        READONLY_MIDEN_DEBUG_UNKNOWN, readonly_noop_handler,
+    },
     sha512::{SHA512_HASH_BYTES_EVENT_NAME, Sha512Precompile},
     smt_peek::{SMT_PEEK_EVENT_NAME, handle_smt_peek},
     sorted_array::{
@@ -143,6 +148,11 @@ impl CoreLibrary {
             (LOWERBOUND_ARRAY_EVENT_NAME, Arc::new(handle_lowerbound_array)),
             (LOWERBOUND_KEY_VALUE_EVENT_NAME, Arc::new(handle_lowerbound_key_value)),
             (AEAD_DECRYPT_EVENT_NAME, Arc::new(handle_aead_decrypt)),
+            (READONLY_MIDEN_DEBUG_FRAME_START, Arc::new(readonly_noop_handler)),
+            (READONLY_MIDEN_DEBUG_FRAME_END, Arc::new(readonly_noop_handler)),
+            (READONLY_MIDEN_DEBUG_ASSERTION_FAILED, Arc::new(readonly_noop_handler)),
+            (READONLY_MIDEN_DEBUG_UNKNOWN, Arc::new(readonly_noop_handler)),
+            (READONLY_MIDEN_DEBUG_PRINTLN, Arc::new(readonly_noop_handler)),
         ]
     }
 

--- a/miden-core-fuzz/Cargo.lock
+++ b/miden-core-fuzz/Cargo.lock
@@ -781,7 +781,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miden-assembly"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "aho-corasick",
  "lalrpop",
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "derive_more",
  "log",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "miden-crypto",
  "miden-debug-types",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "miden-crypto",
  "proptest",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "lock_api",
  "loom",


### PR DESCRIPTION
Backports #3305 to `v0.23`.