### PR TITLE
Make local lint fail on the same Clippy warnings as CI (#3257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Tightened LogUp lookup AIR docs and comments, removed unused operation-flag accessors, and added block-hash/op-group selector coverage ([#3309](https://github.com/0xMiden/miden-vm/pull/3309)).
 - [BREAKING] Optimize constraint evaluation step by dropping redundant transition guards on op-flag-gated constraints ([#3319](https://github.com/0xMiden/miden-vm/pull/3319)).
 - Documented the `sorted_array` lookup sortedness contract and added linear assertion helpers for proving word, key, and half-key ordering ([#3308](https://github.com/0xMiden/miden-vm/pull/3308)).
+- Made `make clippy` and `make lint` deny warnings so local linting fails on the same Clippy warnings as CI ([#3257](https://github.com/0xMiden/miden-vm/issues/3257)).
 
 ## v0.24.0 (2026-06-24)
 

--- a/Makefile
+++ b/Makefile
@@ -64,14 +64,18 @@ FEATURES_verifier        :=
 
 # -- linting --------------------------------------------------------------------------------------
 
+# Deny warnings locally so `make clippy`/`make lint` fail on the same warnings as CI,
+# which runs `make clippy` with RUSTFLAGS=-D warnings (see .github/workflows/lint.yml).
+DENY_WARNINGS := RUSTFLAGS="$(RUSTFLAGS) -D warnings"
+
 .PHONY: clippy
 clippy: ## Runs Clippy with configs (alias for xclippy)
-	cargo +stable xclippy
+	$(DENY_WARNINGS) cargo +stable xclippy
 
 
 .PHONY: xclippy
 xclippy: ## Runs Clippy with custom lint config from .cargo/config.toml
-	cargo +stable xclippy
+	$(DENY_WARNINGS) cargo +stable xclippy
 
 
 .PHONY: fix


### PR DESCRIPTION
## Describe your changes

Closes #3257.

### Rationale

CI's clippy job sets `RUSTFLAGS: -D warnings` before running `make clippy`
(see `.github/workflows/lint.yml`), but the local `clippy`/`xclippy` targets
ran `cargo +stable xclippy` without it, so the alias's `-W` lints only printed
warnings and `make lint` exited 0 while the same code failed CI. Contributors
only discovered warnings after opening a PR (e.g. #3221).

This adds a `DENY_WARNINGS := RUSTFLAGS="$(RUSTFLAGS) -D warnings"` variable
and applies it to the `clippy` and `xclippy` targets, so local linting fails
on exactly the same Clippy warnings as CI. Caller-provided `RUSTFLAGS` are
preserved, and the incremental `-W` lint list in `.cargo/config.toml` is
unchanged.

### Test plan

Followed the issue's repro steps on rustc 1.96.1 (the same toolchain CI
resolves to):

1. Planted a `clippy::needless_collect` warning → `make clippy` now fails
   (exit code 2) with the same diagnostic CI shows
   (`-D clippy::needless-collect` implied by `-D warnings`).
2. Removed the planted warning → full workspace clippy run passes clean
   with zero warnings.

To review: run `make clippy` on this branch with and without a planted
warning, or compare against `RUSTFLAGS='-D warnings' make clippy` on `next`.

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow conventions.
- [x] Commits are signed.
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality. — N/A, Makefile-only change; verified via the test plan above.
- [x] Documentation/comments updated according to changes.
- [x] Updated `CHANGELOG.md`.
