### PR TITLE
test: check core package version matches crate

### DIFF
--- a/crates/lib/core/src/lib.rs
+++ b/crates/lib/core/src/lib.rs
@@ -189,6 +189,20 @@ mod tests {
     use super::*;
 
     #[test]
+    fn core_package_version_matches_crate_version() {
+        let core_lib = CoreLibrary::default();
+        let package = core_lib.package();
+        let crate_version = env!("CARGO_PKG_VERSION")
+            .parse::<miden_mast_package::Version>()
+            .expect("crate version should be a valid package version");
+
+        assert_eq!(
+            &package.version, &crate_version,
+            "embedded core package version should track the miden-core-lib crate version",
+        );
+    }
+
+    #[test]
     fn test_compile() {
         let core_lib = CoreLibrary::default();
         let exists = core_lib


### PR DESCRIPTION
Adds a test that `CoreLib` isn't dragging behind the crate version. We can later edit it to be looser to encode any policy we choose in the future.