### PR TITLE
ci: publish miden-format/miden-registry artifacts during release

### DIFF
--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag name for the release (e.g. v0.12.0)'
+        description: "Tag name for the release (e.g. v0.12.0)"
         required: true
         type: string
       packages:
@@ -155,10 +155,20 @@ jobs:
       - name: Prepare artifact
         run: |
           mv target/${{ matrix.target }}/optimized/miden-vm miden-vm-${{ matrix.target }}
+          mv target/${{ matrix.target }}/optimized/miden-format miden-format-${{ matrix.target }}
+          mv target/${{ matrix.target }}/optimized/miden-registry miden-registry-${{ matrix.target }}
       - name: Attest miden-vm
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
         with:
           subject-path: miden-vm-${{ matrix.target }}
+      - name: Attest miden-format
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: miden-format-${{ matrix.target }}
+      - name: Attest miden-registry
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: miden-registry-${{ matrix.target }}
       - name: Upload
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
@@ -167,7 +177,10 @@ jobs:
           set -euo pipefail
           # Reruns are safe after partial artifact upload: --clobber replaces
           # existing draft assets instead of failing on "already exists".
-          gh release upload --clobber "${RELEASE_TAG}" miden-vm-${{ matrix.target }}
+          gh release upload --clobber "${RELEASE_TAG}" \
+           miden-vm-${{ matrix.target }} \
+           miden-format-${{ matrix.target }} \
+           miden-registry-${{ matrix.target }}
       # Since the core.masp package is triplet independent, we only build it once.
       - name: Install nightly
         if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
@@ -205,7 +218,7 @@ jobs:
     environment: release
     permissions:
       contents: read
-      id-token: write  # Required for OIDC token exchange with crates.io
+      id-token: write # Required for OIDC token exchange with crates.io
 
     steps:
       - name: Checkout repository

--- a/Makefile
+++ b/Makefile
@@ -249,9 +249,20 @@ exec-info: ## Builds an executable with log tree enabled
 	cargo build --profile optimized $(FEATURES_LOG_TREE)
 
 .PHONY: exec-dist
-exec-dist: ## Builds the CLI for $(BUILD_TARGET) with --locked (for release artifact uploads)
-# NOTE: the resulting binary is stores in target/<$(BUILD_TARGET)>/optimized/
+exec-dist: miden-vm-dist miden-format-dist miden-registry-dist ## Builds CLIs for $(BUILD_TARGET) with --locked (for release artifact uploads)
+# NOTE: the resulting binaries are stored in target/<$(BUILD_TARGET)>/optimized/
+
+.PHONY: miden-vm-dist
+miden-vm-dist:
 	cargo build -p miden-vm --bin miden-vm --profile optimized $(FEATURES_CONCURRENT_EXEC) --target $(BUILD_TARGET) --locked
+
+.PHONY: miden-format-dist
+miden-format-dist:
+	cargo build -p miden-format --bin miden-format --profile optimized --target $(BUILD_TARGET) --locked
+
+.PHONY: miden-registry-dist
+miden-registry-dist:
+	cargo build -p miden-package-registry-local --bin miden-registry --profile optimized --target $(BUILD_TARGET) --locked
 
 .PHONY: packages
 packages: ## Builds .masp packages and store them in target/packages


### PR DESCRIPTION
This PR adds release artifacts for `miden-format`/`miden-registry` to the publish workflow and the `make exec-dist` target.