### PR TITLE
processor: provide means for constructing ResumeContext from package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.25.2 (2026-07-11)
+
+#### Enhancement
+
+- Support constructing initial `ResumeContext` for execution stepping from a `Package`, in order to ensure debug context is correctly initialized
+
 ## v0.25.1 (2026-07-10)
 
 #### Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,7 +1308,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "insta",
  "miden-ace-codegen",
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "env_logger",
  "insta",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "env_logger",
  "log",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "criterion",
  "derive_more",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "criterion",
  "env_logger",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "miden-format"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "clap",
  "miden-assembly-syntax-cst",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry-local"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "clap",
  "miden-assembly-syntax",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "insta",
  "itertools 0.14.0",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-air",
  "miden-assembly",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-crypto",
  "miden-test-serde-macros",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "lock_api",
  "loom",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-blake3-bench"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "clap",
  "codspeed-criterion-compat",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-synthetic-bench"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-processor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rust-version = "1.96.1"
 # Private workspace members inherit this version. Publishable crates keep their
 # own package versions so release tooling can publish only the crates selected
 # for a release.
-version = "0.25.1"
+version = "0.25.2"
 
 [profile.optimized]
 inherits = "release"

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-air"
-version = "0.25.1"
+version = "0.25.2"
 description = "Algebraic intermediate representation of Miden VM processor"
 documentation = "https://docs.rs/miden-air"
 readme = "README.md"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.25.1"
+version = "0.25.2"
 description = "Miden VM core components"
 documentation = "https://docs.rs/miden-core"
 readme = "README.md"

--- a/crates/ace-codegen/Cargo.toml
+++ b/crates/ace-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-ace-codegen"
-version = "0.25.1"
+version = "0.25.2"
 description = "ACE circuit codegen for Plonky3-based Miden AIRs."
 documentation = "https://docs.rs/miden-ace-codegen"
 readme = "README.md"

--- a/crates/assembly-syntax-cst/Cargo.toml
+++ b/crates/assembly-syntax-cst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax-cst"
-version = "0.25.1"
+version = "0.25.2"
 description = "Lossless concrete syntax tree support for the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax-cst"
 readme = "README.md"

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax"
-version = "0.25.1"
+version = "0.25.2"
 description = "Parsing and semantic analysis of the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax"
 readme = "README.md"

--- a/crates/assembly/Cargo.toml
+++ b/crates/assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly"
-version = "0.25.1"
+version = "0.25.2"
 description = "Miden VM assembly language"
 documentation = "https://docs.rs/miden-assembly"
 readme = "README.md"

--- a/crates/debug-types/Cargo.toml
+++ b/crates/debug-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-debug-types"
-version = "0.25.1"
+version = "0.25.2"
 description = "Core source-level debugging information types used throughout the Miden toolchain"
 documentation = "https://docs.rs/miden-debug-types"
 readme = "README.md"

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core-lib"
-version = "0.25.1"
+version = "0.25.2"
 description = "Miden VM core library"
 documentation = "https://docs.rs/miden-core-lib"
 readme = "README.md"

--- a/crates/lib/core/asm/miden-project.toml
+++ b/crates/lib/core/asm/miden-project.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.25.1"
+version = "0.25.2"
 
 [lib]
 namespace = "miden::core"

--- a/crates/mast-package/Cargo.toml
+++ b/crates/mast-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-mast-package"
-version = "0.25.1"
+version = "0.25.2"
 description = "Package containing a compiled Miden MAST artifact with declared dependencies and exports"
 documentation = "https://docs.rs/miden-mast-package"
 readme = "README.md"

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -19,8 +19,83 @@ use super::{
     DebugFunctionsSection, DebugPrimitiveType, DebugSourceAsmOp, DebugSourceGraphSection,
     DebugSourceInlineCall, DebugSourceMapSection, DebugSourceNode, DebugSourceNodeId,
     DebugSourceVar, DebugSourcesSection, DebugTypeIdx, DebugTypeInfo, DebugTypesSection,
-    DebugVariantInfo,
+    DebugVariantInfo, PackageDebugInfo,
 };
+
+// PACKAGE DEBUG INFO SERIALIZATION
+// ================================================================================================
+
+impl Serializable for PackageDebugInfo {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_bool(self.types.is_some());
+        if let Some(types) = self.types.as_ref() {
+            types.write_into(target);
+        }
+        target.write_bool(self.sources.is_some());
+        if let Some(sources) = self.sources.as_ref() {
+            sources.write_into(target);
+        }
+        target.write_bool(self.functions.is_some());
+        if let Some(functions) = self.functions.as_ref() {
+            functions.write_into(target);
+        }
+        target.write_bool(self.source_graph.is_some());
+        if let Some(source_graph) = self.source_graph.as_ref() {
+            source_graph.write_into(target);
+        }
+        target.write_bool(self.source_map.is_some());
+        if let Some(source_map) = self.source_map.as_ref() {
+            source_map.write_into(target);
+        }
+        target.write_bool(self.error_messages.is_some());
+        if let Some(error_messages) = self.error_messages.as_ref() {
+            error_messages.write_into(target);
+        }
+    }
+}
+
+impl Deserializable for PackageDebugInfo {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let types = if source.read_bool()? {
+            Some(DebugTypesSection::read_from(source)?)
+        } else {
+            None
+        };
+        let sources = if source.read_bool()? {
+            Some(DebugSourcesSection::read_from(source)?)
+        } else {
+            None
+        };
+        let functions = if source.read_bool()? {
+            Some(DebugFunctionsSection::read_from(source)?)
+        } else {
+            None
+        };
+        let source_graph = if source.read_bool()? {
+            Some(DebugSourceGraphSection::read_from(source)?)
+        } else {
+            None
+        };
+        let source_map = if source.read_bool()? {
+            Some(DebugSourceMapSection::read_from(source)?)
+        } else {
+            None
+        };
+        let error_messages = if source.read_bool()? {
+            Some(DebugErrorMessagesSection::read_from(source)?)
+        } else {
+            None
+        };
+        Ok(Self {
+            types,
+            sources,
+            functions,
+            source_graph,
+            source_map,
+            error_messages,
+        })
+    }
+}
 
 // DEBUG TYPES SECTION SERIALIZATION
 // ================================================================================================

--- a/crates/miden-format/Cargo.toml
+++ b/crates/miden-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-format"
-version = "0.25.1"
+version = "0.25.2"
 description = "Formatter for the Miden Assembly language"
 documentation = "https://docs.rs/miden-format"
 readme = "README.md"

--- a/crates/package-registry-local/Cargo.toml
+++ b/crates/package-registry-local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry-local"
-version = "0.25.1"
+version = "0.25.2"
 description = "Filesystem-backed local package registry for Miden packages"
 documentation = "https://docs.rs/miden-package-registry-local"
 readme = "README.md"

--- a/crates/package-registry/Cargo.toml
+++ b/crates/package-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry"
-version = "0.25.1"
+version = "0.25.2"
 description = "Package registry interfaces and dependency resolution for Miden packages"
 documentation = "https://docs.rs/miden-package-registry"
 readme = "README.md"

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-project"
-version = "0.25.1"
+version = "0.25.2"
 description = "Interface for working with Miden projects"
 documentation = "https://docs.rs/miden-project"
 readme = "README.md"

--- a/crates/utils-core-derive/Cargo.toml
+++ b/crates/utils-core-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-core-derive"
-version = "0.25.1"
+version = "0.25.2"
 description = "Proc macro to derive enum dispatch trait implementations on miden-core structs"
 readme = "README.md"
 categories = ["development-tools::procedural-macro-helpers", "no-std"]

--- a/crates/utils-diagnostics/Cargo.toml
+++ b/crates/utils-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-diagnostics"
-version = "0.25.1"
+version = "0.25.2"
 description = "Diagnostic infrastructure used in the Miden assembler and VM"
 documentation = "https://docs.rs/miden-utils-diagnostics"
 readme = "README.md"

--- a/crates/utils-indexing/Cargo.toml
+++ b/crates/utils-indexing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-indexing"
-version = "0.25.1"
+version = "0.25.2"
 description = "Type-safe u32-indexed vector utilities for Miden"
 readme = "README.md"
 categories = ["development-tools", "no-std"]

--- a/crates/utils-sync/Cargo.toml
+++ b/crates/utils-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-sync"
-version = "0.25.1"
+version = "0.25.2"
 description = "no-std compatible locking primitives for the Miden project"
 documentation = "https://docs.rs/miden-utils-sync"
 readme = "README.md"

--- a/miden-core-fuzz/Cargo.lock
+++ b/miden-core-fuzz/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miden-assembly"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "log",
  "miden-assembly-syntax-cst",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "derive_more",
  "log",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "miden-crypto",
  "proptest",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "lock_api",
  "loom",

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-vm"
-version = "0.25.1"
+version = "0.25.2"
 description = "Miden virtual machine"
 documentation = "https://docs.rs/miden-vm"
 readme = "README.md"

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-processor"
-version = "0.25.1"
+version = "0.25.2"
 description = "Miden VM processor"
 documentation = "https://docs.rs/miden-processor"
 readme = "README.md"

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -5,7 +5,10 @@ use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 
 use miden_core::program::MIN_STACK_DEPTH;
 use miden_debug_types::{Location, SourceFile, SourceSpan};
-use miden_mast_package::debug_info::{DebugSourceNodeId, PackageDebugInfo};
+use miden_mast_package::{
+    PackageDebugInfoError,
+    debug_info::{DebugSourceNodeId, PackageDebugInfo},
+};
 use miden_utils_diagnostics::{Diagnostic, miette};
 
 use crate::{
@@ -108,6 +111,8 @@ pub enum ExecutionError {
     ProvingError(String),
     #[error(transparent)]
     HostError(#[from] HostError),
+    #[error(transparent)]
+    PackageDebugInfoError(#[from] PackageDebugInfoError),
 }
 
 impl ExecutionError {

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -9,6 +9,7 @@ use miden_core::{
     program::{MIN_STACK_DEPTH, Program, StackInputs, StackOutputs},
     utils::range,
 };
+use miden_mast_package::Package;
 
 use crate::{
     AdviceInputs, AdviceProvider, ContextId, ExecutionError, ExecutionOptions, ProcessorState,
@@ -278,6 +279,27 @@ impl FastProcessor {
             saved_overflow_len: 0,
             options,
             pc_transcript: PrecompileTranscript::new(),
+        })
+    }
+
+    /// Returns the resume context to be used with the first call to `step_sync()`.
+    ///
+    /// This function asserts that `package` is not of executable type - callers should ensure that
+    /// it is before calling
+    pub fn get_initial_resume_context_for_package(
+        &mut self,
+        package: Arc<Package>,
+    ) -> Result<ResumeContext, ExecutionError> {
+        let program = package.unwrap_program();
+        let package_debug_info = package.debug_info()?.map(Arc::new);
+        let current_forest = program.mast_forest().clone();
+        self.advice.extend_map(current_forest.advice_map()).map_exec_err_no_ctx()?;
+
+        Ok(ResumeContext {
+            current_forest,
+            continuation_stack: ContinuationStack::new(&program),
+            kernel: program.kernel().clone(),
+            package_debug_info,
         })
     }
 

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-prover"
-version = "0.25.1"
+version = "0.25.2"
 description = "Miden VM prover"
 documentation = "https://docs.rs/miden-prover"
 readme = "README.md"

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-verifier"
-version = "0.25.1"
+version = "0.25.2"
 description = "Miden VM execution verifier"
 documentation = "https://docs.rs/miden-verifier"
 readme = "README.md"


### PR DESCRIPTION
While migrating the debugger to v0.25, I discovered that we have no means of constructing an initial `ResumeContext` from  a package, and therefore the debug context for execution never gets initialized properly. The debugger requires the stepping APIs of the processor, which require a `ResumeContext` to call - the only way to construct one is via the `Processor` which only had an API that derived one from a `Program`, which lacks the necessary debug information.

This PR adds an additional API for constructing it from a package, while preserving the existing API - going forward we can probably remove the `Program` one, though it doesn't really cost anything to keep it around.

I've also set everything up so that this can be released as v0.25.2