### PR TITLE
ci: reduce blake3 nonregression noise

### DIFF
--- a/.github/workflows/blake3-nonregression.yml
+++ b/.github/workflows/blake3-nonregression.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: "5"
         type: string
+      regression_min_delta_ms:
+        description: Minimum absolute slowdown before the workflow fails.
+        required: false
+        default: "1"
+        type: string
       rayon_num_threads:
         description: RAYON_NUM_THREADS value used for the prove command.
         required: false
@@ -44,16 +49,6 @@ on:
         description: Criterion warm-up time for proof-heavy axes.
         required: false
         default: "1"
-        type: string
-      light_measurement_time_secs:
-        description: Criterion measurement time for light axes.
-        required: false
-        default: "15"
-        type: string
-      light_warm_up_time_secs:
-        description: Criterion warm-up time for light axes.
-        required: false
-        default: "3"
         type: string
       bench_axes:
         description: "Comma-separated axes: all, execute_trace_inputs_sync, build_trace, prove_trace_sync, e2e_prove."
@@ -122,13 +117,12 @@ jobs:
           INPUT_BASELINE_REF: ${{ inputs.baseline_ref }}
           INPUT_CURRENT_REF: ${{ inputs.current_ref }}
           INPUT_THRESHOLD_PCT: ${{ inputs.regression_threshold_pct }}
+          INPUT_MIN_DELTA_MS: ${{ inputs.regression_min_delta_ms }}
           INPUT_RAYON_THREADS: ${{ inputs.rayon_num_threads }}
           INPUT_SAMPLE_SIZE: ${{ inputs.sample_size }}
           INPUT_LIGHT_SAMPLE_SIZE: ${{ inputs.light_sample_size }}
           INPUT_MEASUREMENT_TIME_SECS: ${{ inputs.measurement_time_secs }}
           INPUT_WARM_UP_TIME_SECS: ${{ inputs.warm_up_time_secs }}
-          INPUT_LIGHT_MEASUREMENT_TIME_SECS: ${{ inputs.light_measurement_time_secs }}
-          INPUT_LIGHT_WARM_UP_TIME_SECS: ${{ inputs.light_warm_up_time_secs }}
           INPUT_BENCH_AXES: ${{ inputs.bench_axes }}
         shell: bash
         run: |
@@ -164,6 +158,7 @@ jobs:
             current_ref="${GITHUB_SHA}"
             baseline_ref="${BEFORE_SHA}"
             threshold_pct="5"
+            min_delta_ms="1"
             rayon_threads="8"
             sample_size="10"
             light_sample_size="200"
@@ -176,13 +171,14 @@ jobs:
             baseline_ref="${INPUT_BASELINE_REF}"
             current_ref="${INPUT_CURRENT_REF}"
             threshold_pct="${INPUT_THRESHOLD_PCT}"
+            min_delta_ms="${INPUT_MIN_DELTA_MS}"
             rayon_threads="${INPUT_RAYON_THREADS}"
             sample_size="${INPUT_SAMPLE_SIZE}"
             light_sample_size="${INPUT_LIGHT_SAMPLE_SIZE}"
             measurement_time_secs="${INPUT_MEASUREMENT_TIME_SECS}"
             warm_up_time_secs="${INPUT_WARM_UP_TIME_SECS}"
-            light_measurement_time_secs="${INPUT_LIGHT_MEASUREMENT_TIME_SECS}"
-            light_warm_up_time_secs="${INPUT_LIGHT_WARM_UP_TIME_SECS}"
+            light_measurement_time_secs="15"
+            light_warm_up_time_secs="3"
             bench_axes="${INPUT_BENCH_AXES}"
           fi
 
@@ -192,6 +188,10 @@ jobs:
 
           if [[ -z "${threshold_pct}" ]]; then
             threshold_pct="5"
+          fi
+
+          if [[ -z "${min_delta_ms}" ]]; then
+            min_delta_ms="1"
           fi
 
           if [[ -z "${rayon_threads}" ]]; then
@@ -221,6 +221,11 @@ jobs:
 
           if [[ ! "${threshold_pct}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
             echo "regression_threshold_pct must be numeric" >&2
+            exit 1
+          fi
+
+          if [[ ! "${min_delta_ms}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+            echo "regression_min_delta_ms must be numeric" >&2
             exit 1
           fi
 
@@ -294,6 +299,7 @@ jobs:
             echo "baseline_sha=${baseline_sha}"
             echo "current_sha=${current_sha}"
             echo "threshold_pct=${threshold_pct}"
+            echo "min_delta_ms=${min_delta_ms}"
             echo "rayon_threads=${rayon_threads}"
             echo "sample_size=${sample_size}"
             echo "light_sample_size=${light_sample_size}"
@@ -401,6 +407,7 @@ jobs:
           GITHUB_WORKSPACE_PATH: ${{ github.workspace }}
           ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
           THRESHOLD_PCT: ${{ steps.refs.outputs.threshold_pct }}
+          MIN_DELTA_MS: ${{ steps.refs.outputs.min_delta_ms }}
         shell: bash
         run: |
           set -euo pipefail
@@ -410,6 +417,7 @@ jobs:
             --summary-out "${ARTIFACT_DIR}/summary.md" \
             --json-out "${ARTIFACT_DIR}/comparison.json" \
             --threshold-pct "${THRESHOLD_PCT}" \
+            --min-regression-ms "${MIN_DELTA_MS}" \
             --github-output "${GITHUB_OUTPUT}"
 
       - name: Publish job summary
@@ -477,7 +485,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - benchmark
-    if: always() && github.event_name == 'push' && needs.benchmark.outputs.current_sha != '' && needs.benchmark.outputs.summary != ''
+    if: always() && github.event_name == 'push' && needs.benchmark.outputs.regression == 'true' && needs.benchmark.outputs.current_sha != '' && needs.benchmark.outputs.summary != ''
     permissions:
       contents: write
     steps:

--- a/benches/blake3-bench/src/bin/blake3-nonregression.rs
+++ b/benches/blake3-bench/src/bin/blake3-nonregression.rs
@@ -69,6 +69,8 @@ enum Commands {
         json_out: PathBuf,
         #[arg(long)]
         threshold_pct: f64,
+        #[arg(long, default_value_t = 1.0)]
+        min_regression_ms: f64,
         #[arg(long)]
         github_output: Option<PathBuf>,
     },
@@ -113,11 +115,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             summary_out,
             json_out,
             threshold_pct,
+            min_regression_ms,
             github_output,
         } => {
             let baseline: BenchmarkResult = serde_json::from_str(&fs::read_to_string(&baseline)?)?;
             let current: BenchmarkResult = serde_json::from_str(&fs::read_to_string(&current)?)?;
-            let comparison = compare_results(&baseline, &current, threshold_pct)?;
+            let comparison =
+                compare_results(&baseline, &current, threshold_pct, min_regression_ms)?;
             write_json(&json_out, &comparison)?;
             write_text(&summary_out, &summary_markdown(&comparison))?;
             if let Some(github_output) = github_output {
@@ -191,6 +195,7 @@ mod tests {
             &result_with_metric("base", "e2e_prove", 1_000.0),
             &result_with_metric("head", "e2e_prove", 1_100.0),
             5.0,
+            1.0,
         )
         .unwrap();
         let summary = summary_markdown(&comparison);
@@ -212,9 +217,48 @@ mod tests {
             metric("build_trace", "criterion", Some(120.0), None),
         );
 
-        let comparison = compare_results(&baseline, &current, 5.0).unwrap();
+        let comparison = compare_results(&baseline, &current, 5.0, 1.0).unwrap();
 
         assert!(comparison.regression);
+    }
+
+    #[test]
+    fn comparison_ignores_tiny_secondary_axis_delta() {
+        let mut baseline = result_with_metric("base", "e2e_prove", 1_000.0);
+        baseline.metrics.insert(
+            "to_row_major_matrix".to_string(),
+            metric("to_row_major_matrix", "span", None, Some(0.01)),
+        );
+        let mut current = result_with_metric("head", "e2e_prove", 1_010.0);
+        current.metrics.insert(
+            "to_row_major_matrix".to_string(),
+            metric("to_row_major_matrix", "span", None, Some(0.25)),
+        );
+
+        let comparison = compare_results(&baseline, &current, 5.0, 1.0).unwrap();
+
+        assert!(!comparison.regression);
+        assert!(comparison.regression_rows.is_empty());
+    }
+
+    #[test]
+    fn comparison_reports_tracing_spans_without_failing() {
+        let mut baseline = result_with_metric("base", "e2e_prove", 1_000.0);
+        baseline.metrics.insert(
+            "commit_to_quotient_poly_chunks".to_string(),
+            metric("commit_to_quotient_poly_chunks", "tracing-span", None, Some(1_429.53)),
+        );
+        let mut current = result_with_metric("head", "e2e_prove", 1_010.0);
+        current.metrics.insert(
+            "commit_to_quotient_poly_chunks".to_string(),
+            metric("commit_to_quotient_poly_chunks", "tracing-span", None, Some(1_546.65)),
+        );
+
+        let comparison = compare_results(&baseline, &current, 5.0, 1.0).unwrap();
+
+        assert!(!comparison.regression);
+        assert!(comparison.regression_rows.is_empty());
+        assert_eq!(comparison.top_slowdowns[0].name, "commit_to_quotient_poly_chunks");
     }
 
     fn metric(name: &str, source: &str, mean_ms: Option<f64>, duration_ms: Option<f64>) -> Metric {

--- a/benches/blake3-bench/src/bin/blake3_nonregression/compare.rs
+++ b/benches/blake3-bench/src/bin/blake3_nonregression/compare.rs
@@ -6,6 +6,7 @@ pub(crate) fn compare_results(
     baseline: &BenchmarkResult,
     current: &BenchmarkResult,
     threshold_pct: f64,
+    min_regression_ms: f64,
 ) -> Result<Comparison, Box<dyn std::error::Error>> {
     let primary = current.primary_metric.clone();
     let baseline_primary = baseline
@@ -50,7 +51,11 @@ pub(crate) fn compare_results(
     rows.sort_by(|a, b| b.delta_pct.partial_cmp(&a.delta_pct).unwrap_or(std::cmp::Ordering::Equal));
     let regression_rows = rows
         .iter()
-        .filter(|row| row.delta_pct > threshold_pct)
+        .filter(|row| {
+            row.source == "criterion"
+                && row.delta_pct > threshold_pct
+                && row.delta_ms > min_regression_ms
+        })
         .cloned()
         .collect::<Vec<_>>();
     let top_slowdowns = rows.iter().filter(|row| row.delta_pct > 0.0).take(5).cloned().collect();
@@ -59,6 +64,7 @@ pub(crate) fn compare_results(
         status: if regression { "regression" } else { "ok" }.to_string(),
         regression,
         threshold_pct,
+        min_regression_ms,
         primary_metric: primary,
         baseline_sha: baseline.git_sha.clone(),
         current_sha: current.git_sha.clone(),

--- a/benches/blake3-bench/src/bin/blake3_nonregression/model.rs
+++ b/benches/blake3-bench/src/bin/blake3_nonregression/model.rs
@@ -47,6 +47,7 @@ pub(crate) struct Comparison {
     pub(crate) status: String,
     pub(crate) regression: bool,
     pub(crate) threshold_pct: f64,
+    pub(crate) min_regression_ms: f64,
     pub(crate) primary_metric: String,
     pub(crate) baseline_sha: String,
     pub(crate) current_sha: String,

--- a/benches/blake3-bench/src/bin/blake3_nonregression/report.rs
+++ b/benches/blake3-bench/src/bin/blake3_nonregression/report.rs
@@ -12,7 +12,8 @@ pub(crate) fn summary_markdown(result: &Comparison) -> String {
         "## Blake3 1-to-1 Non-Regression".to_string(),
         String::new(),
         format!("Status: **{status}**"),
-        format!("Threshold: `{:.2}%`", result.threshold_pct),
+        format!("Criterion failure threshold: `{:.2}%`", result.threshold_pct),
+        format!("Minimum absolute slowdown: `{}`", fmt_ms(Some(result.min_regression_ms))),
         format!("Primary metric: `{}`", result.primary_metric),
         format!("Baseline: `{baseline}` ({})", fmt_ms(Some(result.baseline_primary_ms))),
         format!("Current: `{current}` ({})", fmt_ms(Some(result.current_primary_ms))),
@@ -37,14 +38,14 @@ pub(crate) fn summary_markdown(result: &Comparison) -> String {
         ));
     }
     if !result.regression_rows.is_empty() {
-        lines.extend([String::new(), "Regressions over threshold:".to_string()]);
+        lines.extend([String::new(), "Criterion regressions over threshold:".to_string()]);
         for row in &result.regression_rows {
             lines.push(format!(
                 "- `{}` moved by {} ({}) against a {:.2}% threshold.",
                 row.name,
                 fmt_delta(Some(row.delta_ms)),
                 fmt_pct(Some(row.delta_pct)),
-                result.threshold_pct
+                result.threshold_pct,
             ));
         }
     }

--- a/benches/blake3-bench/src/bin/snapshots/blake3_nonregression__tests__comparison_summary.snap
+++ b/benches/blake3-bench/src/bin/snapshots/blake3_nonregression__tests__comparison_summary.snap
@@ -7,7 +7,8 @@ expression: summary
 ## Blake3 1-to-1 Non-Regression
 
 Status: **REGRESSION**
-Threshold: `5.00%`
+Criterion failure threshold: `5.00%`
+Minimum absolute slowdown: `1.00 ms`
 Primary metric: `e2e_prove`
 Baseline: `base` (1000.00 ms)
 Current: `head` (1100.00 ms)
@@ -17,7 +18,7 @@ Overall delta: `+100.00 ms` (+10.00%)
 | --- | --- | ---: | ---: | ---: | ---: |
 | e2e_prove | criterion | 1000.00 ms | 1100.00 ms | +100.00 ms | +10.00% |
 
-Regressions over threshold:
+Criterion regressions over threshold:
 - `e2e_prove` moved by +100.00 ms (+10.00%) against a 5.00% threshold.
 
 Top slowdowns:


### PR DESCRIPTION
The Blake3 nonregression workflow was failing on tracing span changes even when the Criterion benchmark stayed under the 5 percent limit. It also posted a commit comment for every pushed run, including passing runs.

This changes the failure rule so only Criterion results can fail the job, and only when the change is over both 5 percent and 1 ms. Tracing spans still appear in the report. The workflow now comments only on failed benchmark runs. The manual trigger is back under the GitHub input limit.