### PR TITLE
ci: reduce synthetic tx nonregression noise

### DIFF
--- a/.github/workflows/synthetic-tx-nonregression.yml
+++ b/.github/workflows/synthetic-tx-nonregression.yml
@@ -23,7 +23,7 @@ on:
       regression_min_delta_ms:
         description: Minimum absolute slowdown before the workflow fails.
         required: false
-        default: "1"
+        default: "5"
         type: string
       rayon_num_threads:
         description: RAYON_NUM_THREADS value used for the benchmark.
@@ -158,7 +158,7 @@ jobs:
             current_ref="${GITHUB_SHA}"
             baseline_ref="${BEFORE_SHA}"
             threshold_pct="5"
-            min_delta_ms="1"
+            min_delta_ms="5"
             rayon_threads="8"
             sample_size="10"
             measurement_time_secs="10"
@@ -187,7 +187,7 @@ jobs:
           fi
 
           if [[ -z "${min_delta_ms}" ]]; then
-            min_delta_ms="1"
+            min_delta_ms="5"
           fi
 
           if [[ -z "${rayon_threads}" ]]; then
@@ -436,7 +436,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - benchmark
-    if: always() && github.event_name == 'push' && needs.benchmark.outputs.current_sha != '' && needs.benchmark.outputs.summary != ''
+    if: always() && github.event_name == 'push' && needs.benchmark.outputs.regression == 'true' && needs.benchmark.outputs.current_sha != '' && needs.benchmark.outputs.summary != ''
     permissions:
       contents: write
     steps:

--- a/scripts/synthetic_tx_nonregression.py
+++ b/scripts/synthetic_tx_nonregression.py
@@ -13,7 +13,7 @@ import unittest.mock as mock
 from pathlib import Path
 from typing import Any
 
-DEFAULT_MIN_REGRESSION_MS = 1.0
+DEFAULT_MIN_REGRESSION_MS = 5.0
 
 
 def parse_args() -> argparse.Namespace:
@@ -493,12 +493,28 @@ class Tests(unittest.TestCase):
         self.assertTrue(result["regression"])
         self.assertEqual(result["max_delta_metric"], "bench-tx/a/verify")
 
-    def test_compare_ignores_sub_millisecond_noise(self) -> None:
+    def test_compare_ignores_small_absolute_delta(self) -> None:
         baseline = {"metrics": {"bench-tx/a/trace_prep": {"estimate_ms": 6.46}}}
         current = {"metrics": {"bench-tx/a/trace_prep": {"estimate_ms": 6.94}}}
         result = compare_results(baseline, current, 5.0)
         self.assertFalse(result["regression"])
         self.assertEqual(result["max_delta_metric"], "bench-tx/a/trace_prep")
+        self.assertEqual(result["regression_rows"], [])
+
+    def test_compare_ignores_trace_prep_delta_below_absolute_floor(self) -> None:
+        baseline = {
+            "metrics": {
+                "bench-tx/consume-b2agg-note-bridge-out/trace_prep": {"estimate_ms": 55.26591584210527}
+            }
+        }
+        current = {
+            "metrics": {
+                "bench-tx/consume-b2agg-note-bridge-out/trace_prep": {"estimate_ms": 58.434953205555544}
+            }
+        }
+        result = compare_results(baseline, current, 5.0)
+        self.assertFalse(result["regression"])
+        self.assertEqual(result["max_delta_metric"], "bench-tx/consume-b2agg-note-bridge-out/trace_prep")
         self.assertEqual(result["regression_rows"], [])
 
     def test_summary_markdown_uses_requested_report_shape(self) -> None:
@@ -529,7 +545,7 @@ class Tests(unittest.TestCase):
         self.assertIn("- Baseline: `1764d66ca1c6`", summary)
         self.assertIn("- Current: `1234567890ab`", summary)
         self.assertIn("- Threshold: `5.00%`", summary)
-        self.assertIn("- Minimum absolute slowdown: `1.00 ms`", summary)
+        self.assertIn("- Minimum absolute slowdown: `5.00 ms`", summary)
         self.assertIn("- Bench wall: 145,000.00 ms -> 152,000.00 ms (+7,000.00 ms, +4.83%)", summary)
         self.assertIn("### Result", summary)
         self.assertIn("- Status: **REGRESSION**", summary)


### PR DESCRIPTION
This is a direct follow-up to #3367 that performs the same modificaitons to the synthetic benchmark (given the variance of the GH machines).