### PR TITLE
assembly: implement missing source provider functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.25.3 (2026-07-14)
+
+- Add package post-processing hooks to the `ProjectSourceProvider` trait ([#3375](https://github.com/0xMiden/miden-vm/pull/3375)).
+
 ## v0.25.2 (2026-07-12)
 
 - Update `wincode` dependency to v0.5.5.

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -40,7 +40,7 @@ mod debug;
 mod errors;
 mod library;
 mod module;
-mod namespaces;
+pub mod namespaces;
 mod resolver;
 mod rewrites;
 mod symbols;
@@ -68,12 +68,13 @@ pub use self::{
     callgraph::{CallGraph, CycleError},
     errors::LinkerError,
     library::{LinkLibrary, Linkage},
+    namespaces::NamespaceGraph,
     resolver::{ResolverCache, SymbolResolutionContext, SymbolResolver},
     symbols::{Import, Symbol, SymbolItem},
 };
 use self::{
     module::{LinkModule, ModuleSource},
-    namespaces::{NamespaceGraph, ResolvedImports},
+    namespaces::ResolvedImports,
     resolver::*,
 };
 

--- a/crates/assembly/src/linker/mod.rs
+++ b/crates/assembly/src/linker/mod.rs
@@ -384,7 +384,7 @@ impl Linker {
     /// Returns a new [Linker] instantiated from the provided kernel and kernel info module.
     ///
     /// Note: it is assumed that kernel and kernel_module are consistent, but this is not checked.
-    pub(super) fn with_kernel(
+    pub fn with_kernel(
         source_manager: Arc<dyn SourceManager>,
         kernel_package: Arc<MastPackage>,
     ) -> Result<Self, Report> {
@@ -403,10 +403,7 @@ impl Linker {
     ///
     /// This will panic if the kernel is empty, or the provided kernel module info is not valid for
     /// a kernel.
-    pub(super) fn link_with_kernel(
-        &mut self,
-        kernel_package: Arc<MastPackage>,
-    ) -> Result<(), Report> {
+    pub fn link_with_kernel(&mut self, kernel_package: Arc<MastPackage>) -> Result<(), Report> {
         if !kernel_package.is_kernel() {
             return Err(Report::msg("invalid kernel package: not a kernel"));
         }
@@ -724,6 +721,11 @@ impl Linker {
 // ------------------------------------------------------------------------------------------------
 /// Accessors/Queries
 impl Linker {
+    /// Get access to all module information maintained by the linker
+    pub fn modules(&self) -> &[LinkModule] {
+        self.modules.as_slice()
+    }
+
     /// Get an iterator over the external libraries the linker has linked against
     pub fn libraries(&self) -> impl Iterator<Item = &LinkLibrary> {
         self.libraries.values()
@@ -806,7 +808,7 @@ impl Linker {
     }
 
     /// Resolves the user-defined type signature of the given procedure to the HIR type signature
-    pub(super) fn resolve_signature(
+    pub fn resolve_signature(
         &self,
         gid: GlobalItemIndex,
     ) -> Result<Option<Arc<types::FunctionType>>, LinkerError> {
@@ -868,8 +870,8 @@ impl Linker {
         Ok(Arc::new(types::FunctionType::new(cc, args, results)))
     }
 
-    /// Resolves a [GlobalProcedureIndex] to the known attributes of that procedure
-    pub(super) fn resolve_attributes(&self, gid: GlobalItemIndex) -> AttributeSet {
+    /// Resolves a [GlobalItemIndex] to the known attributes of that procedure
+    pub fn resolve_attributes(&self, gid: GlobalItemIndex) -> AttributeSet {
         match self[gid].item() {
             SymbolItem::Compiled(ItemInfo::Procedure(proc)) => proc.attributes.clone(),
             SymbolItem::Procedure(proc) => {
@@ -883,7 +885,7 @@ impl Linker {
     }
 
     /// Resolves a [GlobalItemIndex] to a concrete [ast::types::Type]
-    pub(super) fn resolve_type(
+    pub fn resolve_type(
         &self,
         span: SourceSpan,
         gid: GlobalItemIndex,
@@ -943,7 +945,7 @@ impl Linker {
 /// Const evaluation
 impl Linker {
     /// Evaluate `expr` to a concrete constant value, in the context of the given item.
-    pub(super) fn const_eval(
+    pub fn const_eval(
         &self,
         gid: GlobalItemIndex,
         expr: &ast::ConstantExpr,

--- a/crates/assembly/src/linker/resolver/symbol_resolver.rs
+++ b/crates/assembly/src/linker/resolver/symbol_resolver.rs
@@ -72,7 +72,7 @@ impl<'a> SymbolResolver<'a> {
     }
 
     /// Create a new [SymbolResolver] with precomputed namespace and import resolutions.
-    pub(crate) fn with_namespaces(
+    pub fn with_namespaces(
         graph: &'a Linker,
         namespaces: &'a NamespaceGraph,
         imports: &'a ResolvedImports,
@@ -166,7 +166,7 @@ impl<'a> SymbolResolver<'a> {
         }
     }
 
-    pub(crate) fn resolve_constant_path(
+    pub fn resolve_constant_path(
         &self,
         context: &SymbolResolutionContext,
         path: Span<&Path>,
@@ -182,7 +182,7 @@ impl<'a> SymbolResolver<'a> {
         }
     }
 
-    pub(crate) fn resolve_type_path(
+    pub fn resolve_type_path(
         &self,
         context: &SymbolResolutionContext,
         path: Span<&Path>,

--- a/crates/assembly/src/project.rs
+++ b/crates/assembly/src/project.rs
@@ -43,7 +43,7 @@ impl Assembler {
         store: &'a mut S,
     ) -> Result<ProjectAssembler<'a, S>, Report>
     where
-        S: PackageCache + ?Sized,
+        S: PackageCache,
     {
         let masm_provider = Box::new(MasmSourceProvider) as Box<_>;
         self.for_project_at_path_with_providers(manifest_path, store, [masm_provider])
@@ -57,7 +57,7 @@ impl Assembler {
         providers: impl IntoIterator<Item = Box<dyn ProjectSourceProvider>>,
     ) -> Result<ProjectAssembler<'a, S>, Report>
     where
-        S: PackageCache + ?Sized,
+        S: PackageCache,
     {
         let manifest_path = manifest_path.as_ref();
         let source_manager = self.source_manager();
@@ -82,7 +82,7 @@ impl Assembler {
         store: &'a mut S,
     ) -> Result<ProjectAssembler<'a, S>, Report>
     where
-        S: PackageCache + ?Sized,
+        S: PackageCache,
     {
         let masm_provider = Box::new(MasmSourceProvider) as Box<_>;
         self.for_project_with_providers(project, store, [masm_provider])
@@ -96,7 +96,7 @@ impl Assembler {
         providers: impl IntoIterator<Item = Box<dyn ProjectSourceProvider>>,
     ) -> Result<ProjectAssembler<'a, S>, Report>
     where
-        S: PackageCache + ?Sized,
+        S: PackageCache,
     {
         let source_manager = self.source_manager();
         let dependency_graph =
@@ -187,7 +187,7 @@ impl SourceProviderRegistry {
     }
 }
 
-pub struct ProjectAssembler<'a, S: PackageCache + ?Sized> {
+pub struct ProjectAssembler<'a, S: PackageCache> {
     assembler: Assembler,
     project: Arc<ProjectPackage>,
     dependency_graph: DependencyGraph,
@@ -197,7 +197,7 @@ pub struct ProjectAssembler<'a, S: PackageCache + ?Sized> {
 
 impl<'a, S> ProjectAssembler<'a, S>
 where
-    S: PackageCache + ?Sized,
+    S: PackageCache,
 {
     pub fn with_source_provider(
         &mut self,
@@ -324,6 +324,7 @@ where
             target,
             profile_name,
             &self.source_provider,
+            &*self.store,
         )? {
             sections.push(provenance.to_section());
         }
@@ -595,6 +596,7 @@ where
             origin,
             manifest_path,
             &self.source_provider,
+            self.store,
         )?;
 
         match PackageBuildProvenance::from_package(&package)? {
@@ -671,6 +673,7 @@ where
             target,
             profile,
             self.dependency_graph.as_ref(),
+            self.store,
             self.assembler.source_manager(),
         )?;
         context.with_warnings_as_errors(self.assembler.warnings_as_errors());

--- a/crates/assembly/src/project.rs
+++ b/crates/assembly/src/project.rs
@@ -358,6 +358,9 @@ where
         package.version = project.version().into_inner().clone();
         package.description = project.description().map(|description| description.to_string());
         package.sections.extend(sections);
+
+        self.apply_post_assembly_hooks(&mut package, project.clone(), target, profile)?;
+
         let package = Arc::from(package);
 
         let resolved = ResolvedPackage {
@@ -666,27 +669,9 @@ where
         target: &Target,
         profile: &Profile,
     ) -> Result<ProjectSourceInputs, Report> {
-        let manifest_path = project.expect_manifest_path()?;
-        let mut context = TargetAssemblyContext::new(
-            project.clone(),
-            manifest_path,
-            target,
-            profile,
-            self.dependency_graph.as_ref(),
-            self.store,
-            self.assembler.source_manager(),
-        )?;
-        context.with_warnings_as_errors(self.assembler.warnings_as_errors());
+        let (provider, context) =
+            self.get_provider_and_target_assembly_context(&project, target, profile)?;
 
-        let extension = context.resolved_target_root.extension().ok_or_else(|| {
-            Report::msg(format!(
-                "invalid target 'path' {}: path must have an extension",
-                context.resolved_target_root.display()
-            ))
-        })?;
-        let extension = extension.to_string_lossy();
-
-        let provider = self.source_provider.get_provider(extension.as_ref()).ok_or_else(|| Report::msg(format!("unsupported target file type '{extension}': no provider has been registered for that file type")))?;
         let inputs = provider.provide_sources(&context)?;
         match target.ty {
             TargetType::Executable if !inputs.root.kind().is_executable() => {
@@ -711,6 +696,52 @@ where
             },
             _ => Ok(inputs),
         }
+    }
+
+    fn apply_post_assembly_hooks(
+        &self,
+        package: &mut MastPackage,
+        project: Arc<ProjectPackage>,
+        target: &Target,
+        profile: &Profile,
+    ) -> Result<(), Report> {
+        let (provider, context) =
+            self.get_provider_and_target_assembly_context(&project, target, profile)?;
+
+        provider.post_process_package(package, &context)?;
+
+        Ok(())
+    }
+
+    fn get_provider_and_target_assembly_context<'this>(
+        &'this self,
+        project: &'this Arc<ProjectPackage>,
+        target: &'this Target,
+        profile: &'this Profile,
+    ) -> Result<(&'this dyn ProjectSourceProvider, TargetAssemblyContext<'this>), Report> {
+        let manifest_path = project.expect_manifest_path()?;
+        let mut context = TargetAssemblyContext::new(
+            project.clone(),
+            manifest_path,
+            target,
+            profile,
+            self.dependency_graph.as_ref(),
+            self.store,
+            self.assembler.source_manager(),
+        )?;
+        context.with_warnings_as_errors(self.assembler.warnings_as_errors());
+
+        let extension = context.resolved_target_root.extension().ok_or_else(|| {
+            Report::msg(format!(
+                "invalid target 'path' {}: path must have an extension",
+                context.resolved_target_root.display()
+            ))
+        })?;
+        let extension = extension.to_string_lossy();
+
+        let provider = self.source_provider.get_provider(extension.as_ref()).ok_or_else(|| Report::msg(format!("unsupported target file type '{extension}': no provider has been registered for that file type")))?;
+
+        Ok((provider, context))
     }
 }
 

--- a/crates/assembly/src/project.rs
+++ b/crates/assembly/src/project.rs
@@ -310,7 +310,7 @@ where
         }
 
         let ProjectSourceInputs { root, support } =
-            self.load_target_sources(project.as_ref(), target, profile)?;
+            self.load_target_sources(project.clone(), target, profile)?;
 
         // Collect specific well-known custom sections produced by the project assembler
         let mut sections = Vec::new();
@@ -320,7 +320,7 @@ where
         // This is produced before actual assembly, while we still have the sources on hand
         if let Some(provenance) = self.dependency_graph.build_source_provenance(
             &package_id,
-            project.as_ref(),
+            project.clone(),
             target,
             profile_name,
             &self.source_provider,
@@ -410,7 +410,7 @@ where
                 match self.try_reuse_registered_source_package(
                     package_id,
                     &node_version,
-                    &project,
+                    project.clone(),
                     &target,
                     profile_name,
                     origin,
@@ -571,7 +571,7 @@ where
         &self,
         package_id: &PackageId,
         version: &miden_project::SemVer,
-        project: &ProjectPackage,
+        project: Arc<ProjectPackage>,
         target: &Target,
         profile_name: &str,
         origin: &ProjectSourceOrigin,
@@ -660,13 +660,13 @@ where
 
     fn load_target_sources(
         &self,
-        project: &ProjectPackage,
+        project: Arc<ProjectPackage>,
         target: &Target,
         profile: &Profile,
     ) -> Result<ProjectSourceInputs, Report> {
         let manifest_path = project.expect_manifest_path()?;
         let mut context = TargetAssemblyContext::new(
-            project,
+            project.clone(),
             manifest_path,
             target,
             profile,

--- a/crates/assembly/src/project/dependency_graph.rs
+++ b/crates/assembly/src/project/dependency_graph.rs
@@ -88,7 +88,7 @@ impl DependencyGraph {
     pub fn build_source_provenance(
         &self,
         package_id: &PackageId,
-        project: &ProjectPackage,
+        project: Arc<ProjectPackage>,
         target: &Target,
         profile_name: &str,
         source_provider: &SourceProviderRegistry,
@@ -119,7 +119,7 @@ impl DependencyGraph {
     pub fn expected_source_provenance(
         &self,
         package_id: &PackageId,
-        project: &ProjectPackage,
+        project: Arc<ProjectPackage>,
         target: &Target,
         profile_name: &str,
         origin: &ProjectSourceOrigin,
@@ -144,7 +144,7 @@ impl DependencyGraph {
     fn expected_source_provenance_with_visited(
         &self,
         package_id: &PackageId,
-        project: &ProjectPackage,
+        project: Arc<ProjectPackage>,
         target: &Target,
         profile_name: &str,
         origin: &ProjectSourceOrigin,
@@ -173,7 +173,7 @@ impl DependencyGraph {
             ProjectSourceOrigin::Path | ProjectSourceOrigin::Root => {
                 let source_manager = self.source_manager.clone();
                 let context = TargetAssemblyContext::new(
-                    project,
+                    project.clone(),
                     manifest_path,
                     target,
                     profile,
@@ -279,7 +279,7 @@ impl DependencyGraph {
                     })?;
                 let provenance = self.expected_source_provenance_with_visited(
                     package_id,
-                    &project,
+                    project,
                     &target,
                     profile_name,
                     origin,

--- a/crates/assembly/src/project/dependency_graph.rs
+++ b/crates/assembly/src/project/dependency_graph.rs
@@ -9,7 +9,7 @@ use std::path::Path as FsPath;
 
 use miden_assembly_syntax::diagnostics::Report;
 use miden_core::{Word, utils::hash_string_to_word};
-use miden_package_registry::{PackageId, PackageRegistry};
+use miden_package_registry::{PackageId, PackageRegistry, PackageRegistryAndProvider};
 use miden_project::{
     Package as ProjectPackage, ProjectDependencyGraph, ProjectDependencyGraphBuilder,
     ProjectDependencyNode, ProjectDependencyNodeProvenance, ProjectSource, ProjectSourceOrigin,
@@ -92,6 +92,7 @@ impl DependencyGraph {
         target: &Target,
         profile_name: &str,
         source_provider: &SourceProviderRegistry,
+        package_registry: &dyn PackageRegistryAndProvider,
     ) -> Result<Option<PackageBuildProvenance>, Report> {
         let Some(node) = self.dependency_graph.get(package_id) else {
             return Ok(None);
@@ -111,6 +112,7 @@ impl DependencyGraph {
                     origin,
                     manifest_path,
                     source_provider,
+                    package_registry,
                 )
                 .map(Some),
         }
@@ -125,6 +127,7 @@ impl DependencyGraph {
         origin: &ProjectSourceOrigin,
         manifest_path: &FsPath,
         source_provider: &SourceProviderRegistry,
+        package_registry: &dyn PackageRegistryAndProvider,
     ) -> Result<PackageBuildProvenance, Report> {
         self.expected_source_provenance_with_visited(
             package_id,
@@ -134,6 +137,7 @@ impl DependencyGraph {
             origin,
             manifest_path,
             source_provider,
+            package_registry,
             &mut BTreeSet::new(),
         )
     }
@@ -150,12 +154,14 @@ impl DependencyGraph {
         origin: &ProjectSourceOrigin,
         manifest_path: &FsPath,
         source_provider: &SourceProviderRegistry,
+        package_registry: &dyn PackageRegistryAndProvider,
         visiting: &mut BTreeSet<PackageId>,
     ) -> Result<PackageBuildProvenance, Report> {
         let dependency_hash = self.compute_dependency_closure_hash(
             package_id,
             profile_name,
             source_provider,
+            package_registry,
             visiting,
         )?;
         let profile = project.resolve_profile(profile_name)?;
@@ -178,6 +184,7 @@ impl DependencyGraph {
                     target,
                     profile,
                     &self.dependency_graph,
+                    package_registry,
                     source_manager,
                 )?;
                 Ok(PackageBuildProvenance::Path {
@@ -194,6 +201,7 @@ impl DependencyGraph {
         package_id: &PackageId,
         profile_name: &str,
         source_provider: &SourceProviderRegistry,
+        package_registry: &dyn PackageRegistryAndProvider,
         visiting: &mut BTreeSet<PackageId>,
     ) -> Result<Word, Report> {
         if !visiting.insert(package_id.clone()) {
@@ -228,6 +236,7 @@ impl DependencyGraph {
                     &edge.dependency,
                     profile_name,
                     source_provider,
+                    package_registry,
                     visiting,
                 )?);
             }
@@ -244,6 +253,7 @@ impl DependencyGraph {
         package_id: &PackageId,
         profile_name: &str,
         source_provider: &SourceProviderRegistry,
+        package_registry: &dyn PackageRegistryAndProvider,
         visiting: &mut BTreeSet<PackageId>,
     ) -> Result<String, Report> {
         let node = self.dependency_graph.get(package_id).ok_or_else(|| {
@@ -285,6 +295,7 @@ impl DependencyGraph {
                     origin,
                     manifest_path,
                     source_provider,
+                    package_registry,
                     visiting,
                 )?;
                 Ok(format!("source:{package_id}:{}\n", provenance.describe()))

--- a/crates/assembly/src/project/providers.rs
+++ b/crates/assembly/src/project/providers.rs
@@ -10,7 +10,7 @@ use super::*;
 /// implementations of the [ProjectSourceProvider] trait.
 pub struct TargetAssemblyContext<'a> {
     /// The package manifest for the target being assembled
-    pub package: &'a ProjectPackage,
+    pub package: Arc<ProjectPackage>,
     /// The resolved/canonicalized package manifest path
     pub manifest_path: &'a std::path::Path,
     /// The resolved/canonicalized path to the directory containing `manifest_path`
@@ -31,7 +31,7 @@ pub struct TargetAssemblyContext<'a> {
 
 impl<'a> TargetAssemblyContext<'a> {
     pub fn new(
-        package: &'a ProjectPackage,
+        package: Arc<ProjectPackage>,
         manifest_path: &'a std::path::Path,
         target: &'a Target,
         profile: &'a Profile,

--- a/crates/assembly/src/project/providers.rs
+++ b/crates/assembly/src/project/providers.rs
@@ -1,6 +1,7 @@
 mod masm;
 
 use miden_assembly_syntax::debuginfo::SourceManager;
+use miden_package_registry::PackageRegistryAndProvider;
 use miden_project::ProjectDependencyGraph;
 
 pub use self::masm::MasmSourceProvider;
@@ -25,6 +26,8 @@ pub struct TargetAssemblyContext<'a> {
     pub dependency_graph: &'a ProjectDependencyGraph,
     /// The current source manager
     pub source_manager: Arc<dyn SourceManager>,
+    /// The current package store of the assembler
+    pub package_registry: &'a dyn PackageRegistryAndProvider,
     /// The assembler-wide `warnings_as_errors` flag
     pub warnings_as_errors: bool,
 }
@@ -36,6 +39,7 @@ impl<'a> TargetAssemblyContext<'a> {
         target: &'a Target,
         profile: &'a Profile,
         dependency_graph: &'a ProjectDependencyGraph,
+        package_registry: &'a dyn PackageRegistryAndProvider,
         source_manager: Arc<dyn SourceManager>,
     ) -> Result<Self, Report> {
         let project_root = manifest_path.parent().ok_or_else(|| {
@@ -64,6 +68,7 @@ impl<'a> TargetAssemblyContext<'a> {
             profile,
             dependency_graph,
             source_manager,
+            package_registry,
             warnings_as_errors: false,
         })
     }

--- a/crates/assembly/src/project/providers.rs
+++ b/crates/assembly/src/project/providers.rs
@@ -80,16 +80,17 @@ impl<'a> TargetAssemblyContext<'a> {
     }
 }
 
-/// This trait provides source file inputs for a Miden Assembly project, regardless of the source
-/// language it was derived from.
+/// This trait provides source file inputs and package post-processing hooks for a Miden Assembly
+/// project, regardless of the source language it was derived from.
 ///
 /// For Miden Assembly source projects this is straightforward, see [MasmSourceProvider].
 ///
 /// For languages other than MASM, which require a compilation step to produce Miden Assembly AST
-/// from the source language prior to assembly, this trait provides the necessary hooks so that
-/// the project assembler can request compilation of a project in source form on-demand.
-/// Implementors are given all available information needed to compile to MASM, and are expected
-/// to return requested artifacts to the project assembler.
+/// from the source language prior to assembly, and may have differing means for providing package
+/// metadata (advice data, account component metadata, custom sections), this trait provides the
+/// necessary hooks so that the project assembler can request compilation of a project in source
+/// form on-demand. Implementors are given all available information needed to compile to MASM, and
+/// are expected to return requested artifacts to the project assembler.
 ///
 /// Source providers are registered by the file type (i.e. file extension used by the source file)
 /// with the assembler when it is created. Only one source provider per-file-type is allowed.
@@ -119,4 +120,20 @@ pub trait ProjectSourceProvider {
         &self,
         context: &TargetAssemblyContext<'_>,
     ) -> Result<ProjectSourceProvenanceInputs, Report>;
+
+    /// Called after a project target - whose sources were provided via this trait- has been
+    /// assembled to a package, so that the provider can do any language-specific post-processing
+    /// of the assembled package before it is frozen and submitted to the package cache/registry.
+    ///
+    /// The default implementation is a no-op.
+    ///
+    /// The `context` given is the same as given to [`ProjectSourceProvider::provide_sources`].
+    #[allow(unused_variables)]
+    fn post_process_package(
+        &self,
+        package: &mut MastPackage,
+        context: &TargetAssemblyContext<'_>,
+    ) -> Result<(), Report> {
+        Ok(())
+    }
 }

--- a/crates/assembly/src/project/target_selector.rs
+++ b/crates/assembly/src/project/target_selector.rs
@@ -9,7 +9,7 @@ pub enum ProjectTargetSelector<'a> {
 }
 
 impl<'a> ProjectTargetSelector<'a> {
-    pub(super) fn select_target(&self, project: &ProjectPackage) -> Result<Target, Report> {
+    pub fn select_target(&self, project: &ProjectPackage) -> Result<Target, Report> {
         match self {
             ProjectTargetSelector::Library => project
                 .library_target()

--- a/crates/package-registry/src/lib.rs
+++ b/crates/package-registry/src/lib.rs
@@ -210,6 +210,15 @@ pub trait PackageProvider {
     ) -> Result<Arc<MastPackage>, Report>;
 }
 
+/// A marker trait for types implementing both [PackageRegistry] and [PackageProvider], which make
+/// them capable of both resolving packages and loading their associated artifacts.
+///
+/// This trait does not need to be directly implemented - it has a blanket impl for all types that
+/// implement both [PackageRegistry] and [PackageProvider]
+pub trait PackageRegistryAndProvider: PackageRegistry + PackageProvider {}
+
+impl<T: ?Sized + PackageProvider + PackageRegistry> PackageRegistryAndProvider for T {}
+
 /// A writable metadata index for package records.
 pub trait PackageIndex: PackageRegistry {
     type Error: fmt::Display;
@@ -222,7 +231,7 @@ pub trait PackageIndex: PackageRegistry {
 }
 
 /// A writable package cache used to store assembled package artifacts resolved during assembly.
-pub trait PackageCache: PackageRegistry + PackageProvider {
+pub trait PackageCache: PackageRegistryAndProvider {
     type Error: fmt::Display;
 
     /// Cache `package`, returning the fully-qualified stored version.


### PR DESCRIPTION
This PR provides missing metadata/functionality needed for implementations of `ProjectSourceProvider` to be able to not only derive project source inputs, but also finalize assembled packages derived from those inputs, in order to wire up metadata, custom sections, etc.

This set of commits is based on `main`, so we can release them as a patch release for v0.25. The changes are purely additive, except in one subtle area: the type parameter of `ProjectAssembler` that specifies what implementation of `PackageCache` it uses has to be `Sized` now (previously the bound was `S: ?Sized + PackageCache`, now it is simply `S: PackageCache). This is required because `TargetAssemblyContext` needs to carry a `dyn` reference to a `PackageRegistry`/`PackageProvider` (supertraits of `PackageCache`), but a reference to an unsized type cannot be cast to a `dyn` reference. This doesn't actually change any of our current uses of these APIs (all instances of `S` have always been `Sized`), but it is technically breaking. However, the only consumer of these APIs currently is the compiler, and assembler internals, and since v0.25 just released, there has basically been no time for new consumers to be implemented - I think this is case where it is safe to release as a patch.