### PR TITLE
assembly: link debug function info to source graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [BREAKING] Renamed module and kernel metadata APIs from `ModuleInfo`/`Kernel` to `ModuleDescriptor`/`KernelDescriptor`, including matching module descriptor method names ([#3356](https://github.com/0xMiden/miden-vm/pull/3356)).
 - Split package serialization assembly tests into their own module ([#3083](https://github.com/0xMiden/miden-vm/pull/3083)).
+- `DebugFunctionInfo` records are now linked to MAST node/source node, rather than MAST roots, as the latter lack sufficient precision for debug info purposes. ()
 
 #### Fixes
 

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -424,8 +424,9 @@ impl Assembler {
             .map(|module| module.parse(self.warnings_as_errors, self.source_manager.clone()))
             .collect::<Result<Vec<_>, Report>>()?;
 
+        let emit_debug_info = self.emit_debug_info;
         self.assemble_library_modules(name.into(), root, support, TargetType::Library)?
-            .into_artifact()
+            .into_artifact(emit_debug_info)
     }
 
     /// Assemble a library [`Package`] from the set of modules reachable from `root`.
@@ -453,8 +454,9 @@ impl Assembler {
         // Derive the package name from the namespace of the root module
         let name = root.path().as_str().replace("::", "-");
 
+        let emit_debug_info = self.emit_debug_info;
         self.assemble_library_modules(name.into(), root, support, TargetType::Library)?
-            .into_artifact()
+            .into_artifact(emit_debug_info)
     }
 
     /// Assembles the provided module into a kernel package.
@@ -468,8 +470,9 @@ impl Assembler {
         root: Box<ast::Module>,
         support: impl IntoIterator<Item = Box<ast::Module>>,
     ) -> Result<Box<Package>, Report> {
+        let emit_debug_info = self.emit_debug_info;
         self.assemble_library_modules(name.into(), root, support, TargetType::Kernel)?
-            .into_artifact()
+            .into_artifact(emit_debug_info)
     }
 
     /// Assemble a kernel [`Package`] from a standard Miden Assembly kernel project layout.
@@ -501,8 +504,9 @@ impl Assembler {
             self.warnings_as_errors,
         )?;
 
+        let emit_debug_info = self.emit_debug_info;
         self.assemble_library_modules(name.into(), root, support, TargetType::Kernel)?
-            .into_artifact()
+            .into_artifact(emit_debug_info)
     }
 
     /// Shared code used by both [`Self::assemble_library`] and [`Self::assemble_kernel`].
@@ -599,7 +603,16 @@ impl Assembler {
             .collect::<Result<BTreeMap<_, _>, _>>()?;
 
         let modules = self.package_modules(module_indices);
-        self.finish_library_product(name, mast_forest, source_graph, exports, modules, kind)
+        self.finish_library_product(
+            name,
+            mast_forest,
+            source_graph,
+            source_id_by_ref,
+            node_id_by_ref,
+            exports,
+            modules,
+            kind,
+        )
     }
 
     fn package_modules(&self, module_indices: &[ModuleIndex]) -> Vec<PackageModule> {
@@ -662,6 +675,7 @@ impl Assembler {
                 let resolved = match mast_forest_builder.get_procedure(gid) {
                     Some(proc) => ResolvedProcedure {
                         node: proc.body_node_ref(),
+                        source_node: proc.source_node_ref(),
                         signature: proc.signature(),
                     },
                     // We didn't find the procedure in our current MAST forest. We still need to
@@ -677,11 +691,16 @@ impl Assembler {
                             item.source_debug_root_id().map(DebugSourceNodeId::from),
                             mast_forest_builder,
                         )?;
-                        ResolvedProcedure { node, signature: item.signature.clone() }
+                        let source_node = mast_forest_builder.latest_source_ref_for_node_ref(node);
+                        ResolvedProcedure {
+                            node,
+                            source_node,
+                            signature: item.signature.clone(),
+                        }
                     },
                 };
                 let digest = item.digest;
-                let ResolvedProcedure { node, signature } = resolved;
+                let ResolvedProcedure { node, source_node, signature } = resolved;
                 let attributes = item.attributes.clone();
                 let pctx = ProcedureContext::new(
                     gid,
@@ -693,7 +712,7 @@ impl Assembler {
                     self.source_manager.clone(),
                 );
 
-                let procedure = pctx.into_procedure(digest, node);
+                let procedure = pctx.into_procedure(digest, node, source_node);
                 self.linker.register_procedure_root(gid, digest);
                 mast_forest_builder.insert_procedure(gid, procedure)?;
                 PendingPackageExport::Procedure(PendingProcedureExport {
@@ -798,7 +817,9 @@ impl Assembler {
             ));
         }
 
-        self.assemble_executable_modules(name.into(), program, [])?.into_artifact()
+        let emit_debug_info = self.emit_debug_info;
+        self.assemble_executable_modules(name.into(), program, [])?
+            .into_artifact(emit_debug_info)
     }
 
     pub(crate) fn assemble_library_modules(
@@ -1065,7 +1086,7 @@ impl Assembler {
             .expect("compilation succeeded but root not found in cache")
             .body_node_ref();
 
-        let (mast_forest, node_id_by_ref, source_graph, _) =
+        let (mast_forest, node_id_by_ref, source_graph, source_id_by_ref) =
             mast_forest_builder.build()?.into_parts_with_source_graph();
         let entry_node_id = *node_id_by_ref.get(&entry_node_ref).ok_or_else(|| {
             Report::msg(format!("entrypoint ref {entry_node_ref} was not finalized"))
@@ -1076,6 +1097,8 @@ impl Assembler {
             namespace,
             mast_forest,
             source_graph,
+            source_id_by_ref,
+            node_id_by_ref,
             entry_node_id,
             self.linker.kernel_package(),
         )
@@ -1086,6 +1109,8 @@ impl Assembler {
         name: PackageId,
         mast_forest: miden_core::mast::MastForest,
         source_graph: SourceDebugGraph,
+        source_id_by_ref: BTreeMap<SourceNodeRef, SourceNodeId>,
+        node_id_by_ref: BTreeMap<MastNodeRef, MastNodeId>,
         exports: BTreeMap<Arc<Path>, PackageExport>,
         modules: Vec<PackageModule>,
         kind: TargetType,
@@ -1103,7 +1128,7 @@ impl Assembler {
             )
             .map_err(Report::msg)?,
         );
-        let debug_info = self.emit_debug_info.then(|| {
+        let debug_info = if self.emit_debug_info {
             #[cfg_attr(not(feature = "std"), expect(unused_mut))]
             let mut debug_info = self.debug_info.clone();
             #[cfg(feature = "std")]
@@ -1111,12 +1136,24 @@ impl Assembler {
                 debug_info.trim_paths(&trimmer);
             }
             debug_info
-        });
+        } else {
+            self.debug_info.clone()
+        };
 
-        let source_graph =
-            self.emit_debug_info.then(|| self.apply_source_debug_options(source_graph));
+        let source_graph = if self.emit_debug_info {
+            self.apply_source_debug_options(source_graph)
+        } else {
+            source_graph
+        };
 
-        Ok(AssemblyProduct::new(package, None, debug_info, source_graph))
+        Ok(AssemblyProduct::new(
+            package,
+            None,
+            debug_info,
+            source_graph,
+            source_id_by_ref,
+            node_id_by_ref,
+        ))
     }
 
     fn static_libraries_for_builder(&self) -> Result<Vec<StaticLibrary<'_>>, Report> {
@@ -1148,6 +1185,8 @@ impl Assembler {
         namespace: Arc<Path>,
         mast_forest: miden_core::mast::MastForest,
         source_graph: SourceDebugGraph,
+        source_id_by_ref: BTreeMap<SourceNodeRef, SourceNodeId>,
+        node_id_by_ref: BTreeMap<MastNodeRef, MastNodeId>,
         entrypoint: MastNodeId,
         kernel: Option<Arc<Package>>,
     ) -> Result<AssemblyProduct, Report> {
@@ -1171,7 +1210,7 @@ impl Assembler {
             )
             .map_err(Report::msg)?,
         );
-        let debug_info = self.emit_debug_info.then(|| {
+        let debug_info = if self.emit_debug_info {
             #[cfg_attr(not(feature = "std"), expect(unused_mut))]
             let mut debug_info = self.debug_info.clone();
             #[cfg(feature = "std")]
@@ -1179,12 +1218,24 @@ impl Assembler {
                 debug_info.trim_paths(&trimmer);
             }
             debug_info
-        });
+        } else {
+            self.debug_info.clone()
+        };
 
-        let source_graph =
-            self.emit_debug_info.then(|| self.apply_source_debug_options(source_graph));
+        let source_graph = if self.emit_debug_info {
+            self.apply_source_debug_options(source_graph)
+        } else {
+            source_graph
+        };
 
-        Ok(AssemblyProduct::new(package, kernel, debug_info, source_graph))
+        Ok(AssemblyProduct::new(
+            package,
+            kernel,
+            debug_info,
+            source_graph,
+            source_id_by_ref,
+            node_id_by_ref,
+        ))
     }
 
     fn apply_source_debug_options(&self, source_graph: SourceDebugGraph) -> SourceDebugGraph {
@@ -1361,10 +1412,12 @@ impl Assembler {
         let proc_body_ref =
             self.compile_body(proc.iter(), &mut proc_ctx, body_wrapper, mast_forest_builder, 0)?;
 
+        let source_node_ref = mast_forest_builder.latest_source_ref_for_node_ref(proc_body_ref);
+
         let proc_mast_root = mast_forest_builder
             .mast_root_for_ref(proc_body_ref)
             .expect("no MAST node for compiled procedure");
-        Ok(proc_ctx.into_procedure(proc_mast_root, proc_body_ref))
+        Ok(proc_ctx.into_procedure(proc_mast_root, proc_body_ref, source_node_ref))
     }
 
     /// Creates assembly operation metadata for control flow nodes.
@@ -1627,12 +1680,14 @@ impl Assembler {
                     None,
                     mast_forest_builder,
                 )?;
-                Ok(ResolvedProcedure { node, signature: None })
+                let source_node = mast_forest_builder.latest_source_ref_for_node_ref(node);
+                Ok(ResolvedProcedure { node, source_node, signature: None })
             },
             SymbolResolution::Exact { gid, .. } => {
                 match mast_forest_builder.get_procedure(gid) {
                     Some(proc) => Ok(ResolvedProcedure {
                         node: proc.body_node_ref(),
+                        source_node: proc.source_node_ref(),
                         signature: proc.signature(),
                     }),
                     // We didn't find the procedure in our current MAST forest. We still need to
@@ -1648,7 +1703,13 @@ impl Assembler {
                                 p.source_debug_root_id().map(DebugSourceNodeId::from),
                                 mast_forest_builder,
                             )?;
-                            Ok(ResolvedProcedure { node, signature: p.signature.clone() })
+                            let source_node =
+                                mast_forest_builder.latest_source_ref_for_node_ref(node);
+                            Ok(ResolvedProcedure {
+                                node,
+                                source_node,
+                                signature: p.signature.clone(),
+                            })
                         },
                         SymbolItem::Procedure(_) => panic!(
                             "AST procedure {gid:?} exists in the linker, but not in the MastForestBuilder"
@@ -1760,5 +1821,6 @@ pub(crate) struct BodyWrapper {
 
 pub(super) struct ResolvedProcedure {
     pub node: MastNodeRef,
+    pub source_node: Option<SourceNodeRef>,
     pub signature: Option<Arc<FunctionType>>,
 }

--- a/crates/assembly/src/assembler/debuginfo.rs
+++ b/crates/assembly/src/assembler/debuginfo.rs
@@ -1,15 +1,16 @@
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 #[cfg(feature = "std")]
 use std::{
     path::{Path, PathBuf},
     string::ToString,
 };
 
+use miden_assembly_syntax::debuginfo::{ColumnNumber, LineNumber};
 #[cfg(feature = "std")]
 use miden_assembly_syntax::debuginfo::{FileLineCol, Location, Uri};
 use miden_mast_package::debug_info::{
-    DebugFieldInfo, DebugFunctionsSection, DebugPrimitiveType, DebugSourcesSection, DebugTypeIdx,
-    DebugTypeInfo, DebugTypesSection, DebugVariantInfo,
+    DebugFieldInfo, DebugPrimitiveType, DebugSourcesSection, DebugTypeIdx, DebugTypeInfo,
+    DebugTypesSection, DebugVariantInfo,
 };
 
 use crate::{
@@ -20,6 +21,7 @@ use crate::{
     },
     debuginfo::SourceManager,
     diagnostics::Report,
+    mast_forest_builder::{MastNodeRef, SourceNodeRef},
 };
 
 // DEBUG INFO SECTIONS
@@ -27,8 +29,11 @@ use crate::{
 
 #[derive(Clone)]
 pub struct DebugInfoSections {
-    /// The debug function section maintained by the assembler during assembly
-    pub debug_functions_section: DebugFunctionsSection,
+    /// The set of strings for the debug function section maintained by the assembler during
+    /// assembly
+    pub debug_function_strings: Vec<Arc<str>>,
+    /// The debug function records section maintained by the assembler during assembly
+    pub debug_function_infos: Vec<PendingDebugFunctionInfo>,
     /// The debug type section maintained by the assembler during assembly
     pub debug_types_section: DebugTypesSection,
     /// The debug sources section maintained by the assembler during assembly
@@ -38,11 +43,32 @@ pub struct DebugInfoSections {
 impl Default for DebugInfoSections {
     fn default() -> Self {
         Self {
-            debug_functions_section: DebugFunctionsSection::new(),
+            debug_function_strings: Default::default(),
+            debug_function_infos: Default::default(),
             debug_types_section: DebugTypesSection::new(),
             debug_sources_section: DebugSourcesSection::new(),
         }
     }
+}
+
+#[derive(Clone)]
+pub struct PendingDebugFunctionInfo {
+    /// The execution node that owns this function info.
+    pub node: MastNodeRef,
+    /// Source/debug occurrence linked to this function info.
+    pub source_node: Option<SourceNodeRef>,
+    /// Name of the function (index into string table)
+    pub name_idx: u32,
+    /// Linkage name / mangled name (index into string table, optional)
+    pub linkage_name_idx: Option<u32>,
+    /// File containing this function (index into file table)
+    pub file_idx: u32,
+    /// Line number where the function starts (1-indexed)
+    pub line: LineNumber,
+    /// Column number where the function starts (1-indexed)
+    pub column: ColumnNumber,
+    /// Type of this function (index into type table, optional)
+    pub type_idx: Option<DebugTypeIdx>,
 }
 
 impl DebugInfoSections {
@@ -54,12 +80,12 @@ impl DebugInfoSections {
         if let Ok(file_line_col) = source_manager.file_line_col(*procedure.span()) {
             let path_id =
                 self.debug_sources_section.add_string(Arc::from(file_line_col.uri.path()));
-            let file_id = self
+            let file_idx = self
                 .debug_sources_section
                 .add_file(miden_mast_package::debug_info::DebugFileInfo::new(path_id));
             let name = Arc::<str>::from(procedure.path().as_str());
-            let name_id = self.debug_functions_section.add_string(name.clone());
-            let type_index = if let Some(signature) = procedure.signature() {
+            let name_idx = self.add_debug_function_string(name.clone());
+            let type_idx = if let Some(signature) = procedure.signature() {
                 Some(register_debug_type(
                     &mut self.debug_types_section,
                     Some(name),
@@ -69,19 +95,17 @@ impl DebugInfoSections {
             } else {
                 None
             };
-            let func_info = miden_mast_package::debug_info::DebugFunctionInfo::new(
-                name_id,
-                file_id,
-                file_line_col.line,
-                file_line_col.column,
-            )
-            .with_mast_root(procedure.mast_root());
-            let func_info = if let Some(type_index) = type_index {
-                func_info.with_type(type_index)
-            } else {
-                func_info
+            let func_info = PendingDebugFunctionInfo {
+                node: procedure.body_node_ref(),
+                source_node: procedure.source_node_ref(),
+                name_idx,
+                linkage_name_idx: None,
+                file_idx,
+                line: file_line_col.line,
+                column: file_line_col.column,
+                type_idx,
             };
-            self.debug_functions_section.add_function(func_info);
+            self.debug_function_infos.push(func_info);
         }
 
         Ok(())
@@ -92,6 +116,17 @@ impl DebugInfoSections {
         for path in self.debug_sources_section.strings.iter_mut() {
             *path = trimmer.trim_path_string(path.as_ref());
         }
+    }
+
+    /// Adds a string to the debug functions string table and returns its index.
+    fn add_debug_function_string(&mut self, s: Arc<str>) -> u32 {
+        if let Some(idx) = self.debug_function_strings.iter().position(|existing| **existing == *s)
+        {
+            return idx as u32;
+        }
+        let idx = self.debug_function_strings.len() as u32;
+        self.debug_function_strings.push(s);
+        idx
     }
 }
 

--- a/crates/assembly/src/assembler/product.rs
+++ b/crates/assembly/src/assembler/product.rs
@@ -12,16 +12,20 @@ use crate::mast_forest_builder::SourceDebugGraph;
 pub struct AssemblyProduct {
     package: Box<Package>,
     kernel_package: Option<Arc<Package>>,
-    debug_info: Option<DebugInfoSections>,
-    source_graph: Option<SourceDebugGraph>,
+    debug_info: DebugInfoSections,
+    source_graph: SourceDebugGraph,
+    source_id_by_ref: BTreeMap<SourceNodeRef, SourceNodeId>,
+    node_id_by_ref: BTreeMap<MastNodeRef, MastNodeId>,
 }
 
 impl AssemblyProduct {
     pub(super) fn new(
         package: Box<Package>,
         kernel: Option<Arc<Package>>,
-        debug_info: Option<DebugInfoSections>,
-        source_graph: Option<SourceDebugGraph>,
+        debug_info: DebugInfoSections,
+        source_graph: SourceDebugGraph,
+        source_id_by_ref: BTreeMap<SourceNodeRef, SourceNodeId>,
+        node_id_by_ref: BTreeMap<MastNodeRef, MastNodeId>,
     ) -> Self {
         assert!(
             kernel.is_none() || !package.is_kernel(),
@@ -32,6 +36,8 @@ impl AssemblyProduct {
             kernel_package: kernel,
             debug_info,
             source_graph,
+            source_id_by_ref,
+            node_id_by_ref,
         }
     }
 
@@ -47,12 +53,14 @@ impl AssemblyProduct {
         Ok(())
     }
 
-    pub fn into_artifact(self) -> Result<Box<Package>, Report> {
+    pub fn into_artifact(self, emit_debug_info: bool) -> Result<Box<Package>, Report> {
         let Self {
             mut package,
             kernel_package,
             debug_info,
             source_graph,
+            source_id_by_ref,
+            node_id_by_ref,
         } = self;
         // Section: embedded kernel package
         if package.is_program()
@@ -86,39 +94,68 @@ impl AssemblyProduct {
             }
         }
 
+        if !emit_debug_info {
+            return Ok(package);
+        }
+
         // Section: debug info
-        if let Some(DebugInfoSections {
+        let DebugInfoSections {
             debug_sources_section,
-            debug_functions_section,
+            debug_function_infos,
+            debug_function_strings,
             debug_types_section,
-        }) = debug_info
+        } = debug_info;
         {
-            package
-                .sections
-                .push(Section::new(SectionId::DEBUG_SOURCES, debug_sources_section.to_bytes()));
+            let mut debug_functions_section =
+                miden_mast_package::debug_info::DebugFunctionsSection::new();
+            debug_functions_section.strings = debug_function_strings;
+            debug_functions_section.functions.reserve_exact(debug_function_infos.len());
+            debug_functions_section
+                .functions
+                .extend(debug_function_infos.into_iter().map(|pfi| {
+                    let node = node_id_by_ref[&pfi.node];
+                    let source_node = pfi
+                        .source_node
+                        .map(|sn| u32::from(source_id_by_ref[&sn]))
+                        .map(DebugSourceNodeId::from);
+                    miden_mast_package::debug_info::DebugFunctionInfo {
+                        node,
+                        source_node,
+                        name_idx: pfi.name_idx,
+                        linkage_name_idx: pfi.linkage_name_idx,
+                        file_idx: pfi.file_idx,
+                        line: pfi.line,
+                        column: pfi.column,
+                        type_idx: pfi.type_idx,
+                    }
+                }));
             package
                 .sections
                 .push(Section::new(SectionId::DEBUG_FUNCTIONS, debug_functions_section.to_bytes()));
             package
                 .sections
+                .push(Section::new(SectionId::DEBUG_SOURCES, debug_sources_section.to_bytes()));
+            package
+                .sections
                 .push(Section::new(SectionId::DEBUG_TYPES, debug_types_section.to_bytes()));
         }
-        if let Some(source_graph) = source_graph {
-            package.sections.push(Section::new(
-                SectionId::DEBUG_SOURCE_GRAPH,
-                source_graph_section(&source_graph)?.to_bytes(),
-            ));
-            package.sections.push(Section::new(
-                SectionId::DEBUG_SOURCE_MAP,
-                source_map_section(&source_graph)?.to_bytes(),
-            ));
-            let error_messages = error_messages_section(&source_graph);
-            if !error_messages.is_empty() {
-                package
-                    .sections
-                    .push(Section::new(SectionId::DEBUG_ERROR_MESSAGES, error_messages.to_bytes()));
-            }
+
+        package.sections.push(Section::new(
+            SectionId::DEBUG_SOURCE_GRAPH,
+            source_graph_section(&source_graph)?.to_bytes(),
+        ));
+        package.sections.push(Section::new(
+            SectionId::DEBUG_SOURCE_MAP,
+            source_map_section(&source_graph)?.to_bytes(),
+        ));
+
+        let error_messages = error_messages_section(&source_graph);
+        if !error_messages.is_empty() {
+            package
+                .sections
+                .push(Section::new(SectionId::DEBUG_ERROR_MESSAGES, error_messages.to_bytes()));
         }
+
         Ok(package)
     }
 }

--- a/crates/assembly/src/procedure.rs
+++ b/crates/assembly/src/procedure.rs
@@ -12,6 +12,7 @@ use super::{
     assembler::{MAX_PROC_LOCALS, error::AssemblerError},
     mast_forest_builder::MastNodeRef,
 };
+use crate::mast_forest_builder::SourceNodeRef;
 
 // PROCEDURE CONTEXT
 // ================================================================================================
@@ -136,7 +137,12 @@ impl ProcedureContext {
     /// `mast_root` and `body_node` must be consistent. That is, `body_node` must resolve to a MAST
     /// node whose digest equals `mast_root`.
     /// </div>
-    pub(crate) fn into_procedure(self, mast_root: Word, body_node_ref: MastNodeRef) -> Procedure {
+    pub(crate) fn into_procedure(
+        self,
+        mast_root: Word,
+        body_node_ref: MastNodeRef,
+        source_node_ref: Option<SourceNodeRef>,
+    ) -> Procedure {
         let is_syscall = self.is_kernel && self.visibility.is_public();
         Procedure::new(
             self.path,
@@ -146,6 +152,7 @@ impl ProcedureContext {
             self.num_locals as u32,
             mast_root,
             body_node_ref,
+            source_node_ref,
         )
         .with_span(self.span)
     }
@@ -181,6 +188,8 @@ pub struct Procedure {
     mast_root: Word,
     /// The assembly-time node reference which resolves to the above MAST root.
     body_node_ref: MastNodeRef,
+    /// The assembly-time source node reference for this procedure
+    source_node_ref: Option<SourceNodeRef>,
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -194,6 +203,7 @@ impl Procedure {
         num_locals: u32,
         mast_root: Word,
         body_node_ref: MastNodeRef,
+        source_node_ref: Option<SourceNodeRef>,
     ) -> Self {
         Self {
             span: SourceSpan::default(),
@@ -204,6 +214,7 @@ impl Procedure {
             num_locals,
             mast_root,
             body_node_ref,
+            source_node_ref,
         }
     }
 
@@ -260,6 +271,11 @@ impl Procedure {
     /// Returns the assembly-time node reference of this procedure.
     pub(crate) fn body_node_ref(&self) -> MastNodeRef {
         self.body_node_ref
+    }
+
+    /// Returns the assembly-time source node reference of this procedure.
+    pub(crate) fn source_node_ref(&self) -> Option<SourceNodeRef> {
+        self.source_node_ref
     }
 }
 

--- a/crates/assembly/src/project.rs
+++ b/crates/assembly/src/project.rs
@@ -352,7 +352,7 @@ where
             .extend_dependencies(runtime_dependencies.deps.into_values())
             .expect("assembled package manifest should have unique runtime dependencies");
 
-        let mut package = product.into_artifact()?;
+        let mut package = product.into_artifact(profile.should_emit_debug_info())?;
         package.name = project.target_package_name(target);
         package.version = project.version().into_inner().clone();
         package.description = project.description().map(|description| description.to_string());

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -3,7 +3,6 @@
 use alloc::{string::String, sync::Arc, vec::Vec};
 
 use miden_core::{
-    Word,
     mast::MastNodeId,
     serde::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
@@ -841,6 +840,14 @@ impl Deserializable for DebugFileInfo {
 
 impl Serializable for DebugFunctionInfo {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_u32(self.node.into());
+        if let Some(source_node) = self.source_node {
+            target.write_bool(true);
+            source_node.write_into(target);
+        } else {
+            target.write_bool(false);
+        }
+
         target.write_u32(self.name_idx);
 
         target.write_bool(self.linkage_name_idx.is_some());
@@ -856,16 +863,17 @@ impl Serializable for DebugFunctionInfo {
         if let Some(idx) = self.type_idx {
             target.write_u32(idx.as_u32());
         }
-
-        target.write_bool(self.mast_root.is_some());
-        if let Some(root) = &self.mast_root {
-            root.write_into(target);
-        }
     }
 }
 
 impl Deserializable for DebugFunctionInfo {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let node = MastNodeId::new_unchecked(source.read_u32()?);
+        let source_node = if source.read_bool()? {
+            Some(DebugSourceNodeId::read_from(source)?)
+        } else {
+            None
+        };
         let name_idx = source.read_u32()?;
 
         let has_linkage_name = source.read_bool()?;
@@ -888,21 +896,15 @@ impl Deserializable for DebugFunctionInfo {
             None
         };
 
-        let has_mast_root = source.read_bool()?;
-        let mast_root = if has_mast_root {
-            Some(Word::read_from(source)?)
-        } else {
-            None
-        };
-
         Ok(Self {
+            node,
+            source_node,
             name_idx,
             linkage_name_idx,
             file_idx,
             line,
             column,
             type_idx,
-            mast_root,
         })
     }
 }
@@ -1104,11 +1106,13 @@ mod tests {
     fn test_debug_functions_section_roundtrip() {
         let mut section = DebugFunctionsSection::new();
 
+        let node = MastNodeId::new_unchecked(0);
+        let source_node = Some(DebugSourceNodeId::from(42u32));
         let name_idx = section.add_string(Arc::from("test_function"));
 
         let line = LineNumber::new(10).unwrap();
         let column = ColumnNumber::new(1).unwrap();
-        let func = DebugFunctionInfo::new(name_idx, 0, line, column);
+        let func = DebugFunctionInfo::new(node, source_node, name_idx, 0, line, column);
         section.add_function(func);
 
         roundtrip(&section);
@@ -1316,18 +1320,6 @@ mod tests {
     fn test_file_info_with_checksum_roundtrip() {
         let file = DebugFileInfo::new(0).with_checksum([42u8; 32]);
         roundtrip(&file);
-    }
-
-    #[test]
-    fn test_function_with_mast_root_roundtrip() {
-        let line1 = LineNumber::new(1).unwrap();
-        let col1 = ColumnNumber::new(1).unwrap();
-        let func = DebugFunctionInfo::new(0, 0, line1, col1)
-            .with_linkage_name(1)
-            .with_type(DebugTypeIdx::from(2))
-            .with_mast_root(Word::default());
-
-        roundtrip(&func);
     }
 
     #[test]

--- a/crates/mast-package/src/debug_info/types.rs
+++ b/crates/mast-package/src/debug_info/types.rs
@@ -18,7 +18,6 @@
 use alloc::{boxed::Box, collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 
 use miden_core::{
-    Word,
     mast::{MastForestRootMap, MastNodeId},
     operations::DebugVarInfo,
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
@@ -482,26 +481,42 @@ impl PackageDebugInfo {
         let mut saw_error_messages = false;
 
         for (forest_index, debug_info) in inputs {
-            let type_map = merge_debug_types(forest_index, debug_info.types.as_ref(), &mut types)?;
-            saw_types |= debug_info.types.is_some();
-            let source_file_map =
-                merge_debug_sources(forest_index, debug_info.sources.as_ref(), &mut sources)?;
-            saw_sources |= debug_info.sources.is_some();
-            let function_map = merge_debug_functions(
-                forest_index,
-                debug_info.functions.as_ref(),
-                &mut functions,
-                &source_file_map,
-                &type_map,
-            )?;
-            saw_functions |= debug_info.functions.is_some();
-
             let source_graph = debug_info.source_graph.as_ref();
             let source_map = debug_info.source_map.as_ref();
             if source_graph.is_none() && source_map.is_some_and(|source_map| !source_map.is_empty())
             {
                 return Err(PackageDebugInfoMergeError::SourceMapWithoutGraph { forest_index });
             }
+
+            let type_map = merge_debug_types(forest_index, debug_info.types.as_ref(), &mut types)?;
+            saw_types |= debug_info.types.is_some();
+            let source_file_map =
+                merge_debug_sources(forest_index, debug_info.sources.as_ref(), &mut sources)?;
+            saw_sources |= debug_info.sources.is_some();
+
+            let source_id_map = if let Some(source_graph) = source_graph.as_ref() {
+                let mut source_id_map = BTreeMap::new();
+                for old_source_idx in 0..source_graph.nodes().len() {
+                    source_id_map.insert(
+                        DebugSourceNodeId::from(old_source_idx as u32),
+                        DebugSourceNodeId::from(nodes.len() as u32 + old_source_idx as u32),
+                    );
+                }
+                Some(source_id_map)
+            } else {
+                None
+            };
+
+            let function_map = merge_debug_functions(
+                forest_index,
+                debug_info.functions.as_ref(),
+                &mut functions,
+                root_map,
+                source_id_map.as_ref(),
+                &source_file_map,
+                &type_map,
+            )?;
+            saw_functions |= debug_info.functions.is_some();
 
             if let Some(section) = debug_info.error_messages.as_ref() {
                 saw_error_messages = true;
@@ -514,14 +529,7 @@ impl PackageDebugInfo {
                 continue;
             };
             saw_source_graph = true;
-
-            let mut source_id_map = BTreeMap::new();
-            for old_source_idx in 0..source_graph.nodes().len() {
-                source_id_map.insert(
-                    DebugSourceNodeId::from(old_source_idx as u32),
-                    DebugSourceNodeId::from(nodes.len() as u32 + old_source_idx as u32),
-                );
-            }
+            let source_id_map = source_id_map.unwrap();
 
             for (old_source_idx, source_node) in source_graph.nodes().iter().enumerate() {
                 let exec_node = root_map.map_node(forest_index, &source_node.exec_node).ok_or(
@@ -820,6 +828,8 @@ fn merge_debug_functions(
     forest_index: usize,
     section: Option<&DebugFunctionsSection>,
     output: &mut DebugFunctionsSection,
+    root_map: &MastForestRootMap,
+    source_id_map: Option<&BTreeMap<DebugSourceNodeId, DebugSourceNodeId>>,
     source_file_map: &BTreeMap<u32, u32>,
     type_map: &BTreeMap<u32, DebugTypeIdx>,
 ) -> Result<BTreeMap<u32, u32>, PackageDebugInfoMergeError> {
@@ -865,14 +875,25 @@ fn merge_debug_functions(
             .map(|idx| remap_type_idx(forest_index, idx, type_map))
             .transpose()?;
         let new_idx = output.functions.len() as u32;
+
+        let node = root_map.map_node(forest_index, &function.node).ok_or(
+            PackageDebugInfoMergeError::MissingExecNodeMapping {
+                forest_index,
+                exec_node: function.node,
+            },
+        )?;
+        let source_node = source_id_map
+            .zip(function.source_node)
+            .map(|(source_id_map, source_node)| source_id_map[&source_node]);
         output.add_function(DebugFunctionInfo {
+            node,
+            source_node,
             name_idx,
             linkage_name_idx,
             file_idx,
             line: function.line,
             column: function.column,
             type_idx,
-            mast_root: function.mast_root,
         });
         function_map.insert(old_idx as u32, new_idx);
     }
@@ -1650,6 +1671,37 @@ impl DebugPrimitiveType {
             _ => None,
         }
     }
+
+    /// Converts this debug type info to the corresponding HIR type.
+    ///
+    /// Returns `None` if the input type is `Void`
+    pub fn to_hir_type(&self) -> Option<miden_assembly_syntax::ast::types::Type> {
+        use miden_assembly_syntax::ast::types::{ArrayType, Type};
+        Some(match self {
+            Self::Void => return None,
+            Self::Bool => Type::I1,
+            Self::I8 => Type::I8,
+            Self::U8 => Type::U8,
+            Self::I16 => Type::I16,
+            Self::U16 => Type::U16,
+            Self::I32 => Type::I32,
+            Self::U32 => Type::U32,
+            Self::I64 => Type::I64,
+            Self::U64 => Type::U64,
+            Self::I128 => Type::I128,
+            Self::U128 => Type::U128,
+            // NOTE(pauls): This is intentional, as HIR does not have a 32-bit float type, but
+            // our primary use for converting from debug type to IR type is ABI details, which are
+            // the same for u32/f32
+            //
+            // A future release will add F32 to the HIR type system to close this gap
+            Self::F32 => Type::U32,
+            Self::F64 => Type::F64,
+            Self::Felt => Type::Felt,
+            Self::Word => Type::Array(Arc::new(ArrayType::new(Type::Felt, 4))),
+            Self::U256 => Type::U256,
+        })
+    }
 }
 
 /// Field information within a struct type.
@@ -1721,6 +1773,10 @@ impl DebugFileInfo {
 /// Links source-level function information to the compiled MAST representation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DebugFunctionInfo {
+    /// The execution node linked to this function info
+    pub node: MastNodeId,
+    /// Source/debug occurrence linked to this function info.
+    pub source_node: Option<DebugSourceNodeId>,
     /// Name of the function (index into string table)
     pub name_idx: u32,
     /// Linkage name / mangled name (index into string table, optional)
@@ -1733,22 +1789,27 @@ pub struct DebugFunctionInfo {
     pub column: ColumnNumber,
     /// Type of this function (index into type table, optional)
     pub type_idx: Option<DebugTypeIdx>,
-    /// MAST root digest of this function (if known).
-    /// This links the debug info to the compiled code.
-    pub mast_root: Option<Word>,
 }
 
 impl DebugFunctionInfo {
     /// Creates a new function info.
-    pub fn new(name_idx: u32, file_idx: u32, line: LineNumber, column: ColumnNumber) -> Self {
+    pub fn new(
+        node: MastNodeId,
+        source_node: Option<DebugSourceNodeId>,
+        name_idx: u32,
+        file_idx: u32,
+        line: LineNumber,
+        column: ColumnNumber,
+    ) -> Self {
         Self {
+            node,
+            source_node,
             name_idx,
             linkage_name_idx: None,
             file_idx,
             line,
             column,
             type_idx: None,
-            mast_root: None,
         }
     }
 
@@ -1761,12 +1822,6 @@ impl DebugFunctionInfo {
     /// Sets the type index.
     pub fn with_type(mut self, type_idx: DebugTypeIdx) -> Self {
         self.type_idx = Some(type_idx);
-        self
-    }
-
-    /// Sets the MAST root digest.
-    pub fn with_mast_root(mut self, mast_root: Word) -> Self {
-        self.mast_root = Some(mast_root);
         self
     }
 }
@@ -1881,6 +1936,8 @@ mod tests {
             let mut functions = DebugFunctionsSection::new();
             let name_idx = functions.add_string(Arc::from(alloc::format!("{context}_callee")));
             functions.add_function(DebugFunctionInfo::new(
+                block,
+                Some(source_node),
                 name_idx,
                 file_idx,
                 LineNumber::new(7).unwrap(),

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -1650,8 +1650,11 @@ mod tests {
         ));
 
         let mut functions = DebugFunctionsSection::new();
+        let node = package.get_export_node_id("app::entry");
         let name_idx = functions.add_string(Arc::from("app::entry"));
         functions.add_function(DebugFunctionInfo::new(
+            node,
+            None,
             name_idx,
             0,
             LineNumber::new(1).unwrap(),
@@ -1673,7 +1676,10 @@ mod tests {
 
         let mut functions = DebugFunctionsSection::new();
         let name_idx = functions.add_string(Arc::from("app::entry"));
+        let node = MastNodeId::new_unchecked(0);
         functions.add_function(DebugFunctionInfo::new(
+            node,
+            None,
             name_idx,
             0,
             LineNumber::new(1).unwrap(),
@@ -1681,7 +1687,7 @@ mod tests {
         ));
 
         let source_graph = DebugSourceGraphSection::from_parts(
-            vec![DebugSourceNode::new(MastNodeId::new_unchecked(0), vec![], 0, 1)],
+            vec![DebugSourceNode::new(node, vec![], 0, 1)],
             vec![source_node],
         );
         let source_map = DebugSourceMapSection::from_parts_with_inline_calls(


### PR DESCRIPTION
This PR modifies `DebugFunctionInfo` records such that they are linked to procedure code by `MastNodeId`/`DebugSourceNodeId`, rather than to a MAST root/digest. This allows us to link `DebugFunctionInfo` to the correct MAST and set of debug info for that function (e.g. source locations, debug variables, etc.), and vice versa (resolving debug info to a matching `DebugFunctionInfo` record).

The main thing I'm a little uncertain on is whether `MastNodeId` and `DebugSourceNodId` are needed, or if the latter is redundant. I've attempted to maintain both in the initial pass here, but let me know if I'm going about this the right way or not.

@huitseeker I'm thinking we can simplify how the debug info is structured in general. I think it's reasonable to say that without a source graph + source map, none of the other debug info is particularly useful, and so remove the `Option`-wrapping of all the `PackageDebugInfo` fields. The assembler at this point is going to either produce all of the sections within `PackageDebugInfo`, or none of them (`error_messages` is a bit unique in that we elide it even when emitting debug info, if there are no error messages to store). We could then make `PackageDebugInfo` a bit more ergonomic.

I'm expecting to expand function debug info emission a bit further with call frame information in a subsequent PR as well.