### PR TITLE
fix: long miden-format imports and configurable constant wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Restored compact SMT serialization budgets so an empty-subtree-only `NodeValue` can be read under a tight budget ([#3366](https://github.com/0xMiden/miden-vm/pull/3366)).
 - Built the crypto SVE archive from target cfg (`CARGO_CFG_TARGET_ARCH` / `CARGO_CFG_TARGET_FEATURE`) instead of `#[cfg(target_feature = "sve")]`, which does not fire in build scripts ([#3366](https://github.com/0xMiden/miden-vm/pull/3366)).
 - Qualified the word-wrapper derive macro's emitted `String` as `alloc::string::String` and wrapped the impl in `const _: () = { extern crate alloc; ... }` for `no_std` and `#![no_implicit_prelude]` consumers ([#3366](https://github.com/0xMiden/miden-vm/pull/3366)).
+- Fixed `miden-format` producing lines longer than the configured maximum for item imports and long `word(...)`/`event(...)` constant declarations; imports now wrap one item per line and the call head stays on the assignment line when it fits ([#3380](https://github.com/0xMiden/miden-vm/pull/3380)).
 
 ## miden-vm v0.25.5 (2026-07-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 - Restored compact SMT serialization budgets so an empty-subtree-only `NodeValue` can be read under a tight budget ([#3366](https://github.com/0xMiden/miden-vm/pull/3366)).
 - Built the crypto SVE archive from target cfg (`CARGO_CFG_TARGET_ARCH` / `CARGO_CFG_TARGET_FEATURE`) instead of `#[cfg(target_feature = "sve")]`, which does not fire in build scripts ([#3366](https://github.com/0xMiden/miden-vm/pull/3366)).
 - Qualified the word-wrapper derive macro's emitted `String` as `alloc::string::String` and wrapped the impl in `const _: () = { extern crate alloc; ... }` for `no_std` and `#![no_implicit_prelude]` consumers ([#3366](https://github.com/0xMiden/miden-vm/pull/3366)).
-- Fixed `miden-format` producing lines longer than the configured maximum for item imports and long `word(...)`/`event(...)` constant declarations; imports now wrap one item per line and the call head stays on the assignment line when it fits ([#3380](https://github.com/0xMiden/miden-vm/pull/3380)).
+- Fixed `miden-format` producing lines longer than the configured maximum for item imports; imports now wrap one item per line. Added `overflow_delimited_expr` to opt into keeping long `word(...)`/`event(...)` call heads on the assignment line when they fit ([#3380](https://github.com/0xMiden/miden-vm/pull/3380)).
 
 ## miden-vm v0.25.5 (2026-07-16)
 

--- a/crates/miden-format/README.md
+++ b/crates/miden-format/README.md
@@ -249,6 +249,8 @@ The syntax of `miden-format.toml` is currently just a set of key/value pairs def
 max_line_length = 100
 # The number of spaces used for indentation
 indent_width = 4
+# Keep overflowing delimited expressions on the assignment line
+overflow_delimited_expr = false
 ```
 
 ### Passing options via `--config`
@@ -257,7 +259,7 @@ The same options supported in `miden-format.toml` are supported via `--config`, 
 
 
 ```
-miden-format --config=max_line_length=80,indent_width=2
+miden-format --config=max_line_length=80,indent_width=2,overflow_delimited_expr=true
 ```
 
 #### Hypothetical future configuration

--- a/crates/miden-format/src/config.rs
+++ b/crates/miden-format/src/config.rs
@@ -24,6 +24,9 @@ pub struct Config {
     /// The maximum length (in characters) of any line before line breaks are introduced
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_line_length: Option<u8>,
+    /// Keep the opening token of delimited expressions on the assignment line when wrapping
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overflow_delimited_expr: Option<bool>,
 }
 
 /// Constructors
@@ -42,6 +45,9 @@ impl Config {
         if other.max_line_length.is_some() {
             self.max_line_length = other.max_line_length;
         }
+        if other.overflow_delimited_expr.is_some() {
+            self.overflow_delimited_expr = other.overflow_delimited_expr;
+        }
     }
 }
 
@@ -55,6 +61,11 @@ impl Config {
     #[inline]
     pub fn max_line_length(&self) -> usize {
         self.max_line_length.unwrap_or(DEFAULT_MAX_LINE_LENGTH) as usize
+    }
+
+    #[inline]
+    pub fn overflow_delimited_expr(&self) -> bool {
+        self.overflow_delimited_expr.unwrap_or(false)
     }
 }
 
@@ -100,6 +111,10 @@ impl clap::builder::TypedValueParser for ConfigValueParser {
                 Some(("max_line_length", value)) => {
                     config.max_line_length = Some(parse_u8(value, "max_line_length")?);
                 },
+                Some(("overflow_delimited_expr", value)) => {
+                    config.overflow_delimited_expr =
+                        Some(parse_bool(value, "overflow_delimited_expr")?);
+                },
                 _ => {
                     return Err(clap::Error::raw(
                         ErrorKind::ValueValidation,
@@ -116,6 +131,13 @@ impl clap::builder::TypedValueParser for ConfigValueParser {
 fn parse_u8(input: &str, prop: &str) -> Result<u8, clap::Error> {
     use clap::error::ErrorKind;
     input.parse::<u8>().map_err(|err| {
+        clap::Error::raw(ErrorKind::ValueValidation, format!("invalid value for {prop}: {err}"))
+    })
+}
+
+fn parse_bool(input: &str, prop: &str) -> Result<bool, clap::Error> {
+    use clap::error::ErrorKind;
+    input.parse::<bool>().map_err(|err| {
         clap::Error::raw(ErrorKind::ValueValidation, format!("invalid value for {prop}: {err}"))
     })
 }
@@ -144,10 +166,15 @@ mod tests {
     fn cli_config_accepts_documented_indent_width() {
         let command = clap::Command::new("miden-format");
         let config = ConfigValueParser
-            .parse_ref(&command, None, OsStr::new("indent_width=2,max_line_length=80"))
+            .parse_ref(
+                &command,
+                None,
+                OsStr::new("indent_width=2,max_line_length=80,overflow_delimited_expr=true"),
+            )
             .unwrap();
 
         assert_eq!(config.indent_size(), 2);
         assert_eq!(config.max_line_length(), 80);
+        assert!(config.overflow_delimited_expr());
     }
 }

--- a/crates/miden-format/src/formatter.rs
+++ b/crates/miden-format/src/formatter.rs
@@ -291,9 +291,8 @@ fn render_item_import_lines(
     }
 
     let specs = import.item_specs().map(render_import_specifier).collect::<Vec<_>>();
-    let items = format!("{{{}}}", specs.join(", "));
     let from = format!("from {path}");
-    let line = format!("{header} {items} {from}");
+    let line = format!("{header} {{{}}} {from}", specs.join(", "));
 
     if line_length(&line) <= config.max_line_length() {
         vec![line]
@@ -309,27 +308,19 @@ fn render_vertical_item_import_lines(
     indent: usize,
     config: &Config,
 ) -> Vec<String> {
-    if specs.is_empty() {
-        return vec![
-            format!("{header} {{}}"),
-            format!("{}{}", indent_string(indent + config.indent_size()), from),
-        ];
-    }
-
-    let mut lines = vec![format!("{header} {{")];
     let item_indent = indent_string(indent + config.indent_size());
-    for spec in specs {
+    let mut lines = vec![format!("{header} {{")];
+    for spec in &specs {
         lines.push(format!("{item_indent}{spec},"));
     }
 
-    let mut closing = format!("{}}}", indent_string(indent));
-    if line_length(&closing) + 1 + line_length(&from) <= config.max_line_length() {
-        closing.push(' ');
-        closing.push_str(&from);
-        lines.push(closing);
+    let indent_str = indent_string(indent);
+    let inline_closing = format!("{indent_str}}} {from}");
+    if line_length(&inline_closing) <= config.max_line_length() {
+        lines.push(inline_closing);
     } else {
-        lines.push(closing);
-        lines.push(format!("{}{}", indent_string(indent + config.indent_size()), from));
+        lines.push(format!("{indent_str}}}"));
+        lines.push(format!("{item_indent}{from}"));
     }
 
     lines

--- a/crates/miden-format/src/formatter.rs
+++ b/crates/miden-format/src/formatter.rs
@@ -290,19 +290,49 @@ fn render_item_import_lines(
         );
     }
 
-    let specs = import.item_specs().map(render_import_specifier).collect::<Vec<_>>().join(", ");
-    let items = format!("{{{specs}}}");
+    let specs = import.item_specs().map(render_import_specifier).collect::<Vec<_>>();
+    let items = format!("{{{}}}", specs.join(", "));
     let from = format!("from {path}");
     let line = format!("{header} {items} {from}");
 
     if line_length(&line) <= config.max_line_length() {
         vec![line]
     } else {
-        vec![
-            format!("{header} {items}"),
-            format!("{}{}", indent_string(indent + config.indent_size()), from),
-        ]
+        render_vertical_item_import_lines(header, specs, from, indent, config)
     }
+}
+
+fn render_vertical_item_import_lines(
+    header: String,
+    specs: Vec<String>,
+    from: String,
+    indent: usize,
+    config: &Config,
+) -> Vec<String> {
+    if specs.is_empty() {
+        return vec![
+            format!("{header} {{}}"),
+            format!("{}{}", indent_string(indent + config.indent_size()), from),
+        ];
+    }
+
+    let mut lines = vec![format!("{header} {{")];
+    let item_indent = indent_string(indent + config.indent_size());
+    for spec in specs {
+        lines.push(format!("{item_indent}{spec},"));
+    }
+
+    let mut closing = format!("{}}}", indent_string(indent));
+    if line_length(&closing) + 1 + line_length(&from) <= config.max_line_length() {
+        closing.push(' ');
+        closing.push_str(&from);
+        lines.push(closing);
+    } else {
+        lines.push(closing);
+        lines.push(format!("{}{}", indent_string(indent + config.indent_size()), from));
+    }
+
+    lines
 }
 
 fn render_commented_item_import_lines(
@@ -374,6 +404,10 @@ fn render_value_declaration(node: &SyntaxNode, indent: usize, config: &Config) -
         format!("{header}\n{body}")
     } else if line_length(&compact) <= config.max_line_length() {
         compact
+    } else if let Some(rendered) =
+        render_wrapped_value_call(&prefix_tokens, &value_tokens, indent, config)
+    {
+        rendered
     } else {
         let header = format!("{}{}", indent_string(indent), render_token_sequence(&prefix_tokens));
         let body = render_token_lines(&value_tokens, indent + config.indent_size(), true, config)
@@ -386,6 +420,51 @@ fn render_value_declaration(node: &SyntaxNode, indent: usize, config: &Config) -
     }
 
     rendered
+}
+
+fn render_wrapped_value_call(
+    prefix_tokens: &[SyntaxToken],
+    value_tokens: &[SyntaxToken],
+    indent: usize,
+    config: &Config,
+) -> Option<String> {
+    let (open_index, close_index) =
+        outer_group_indices(value_tokens, SyntaxKind::LParen, SyntaxKind::RParen)?;
+    if open_index == 0 {
+        return None;
+    }
+
+    let header_tokens = combine_tokens(prefix_tokens, &value_tokens[..=open_index]);
+    let header = format!("{}{}", indent_string(indent), render_token_sequence(&header_tokens));
+    if line_length(&header) > config.max_line_length() {
+        return None;
+    }
+
+    let items = split_top_level_items(&value_tokens[(open_index + 1)..close_index]);
+    let item_count = items.len();
+    let mut lines = vec![header];
+
+    for (index, item) in items.into_iter().enumerate() {
+        if item.is_empty() {
+            continue;
+        }
+
+        let mut item_lines = render_token_lines(&item, indent + config.indent_size(), true, config);
+        if index + 1 != item_count
+            && let Some(last_line) = item_lines.last_mut()
+        {
+            last_line.push(',');
+        }
+        lines.extend(item_lines);
+    }
+
+    lines.push(format!(
+        "{}{}",
+        indent_string(indent),
+        render_token_sequence(&value_tokens[close_index..])
+    ));
+
+    Some(lines.join("\n"))
 }
 
 fn render_type_decl(type_decl: &TypeDecl, indent: usize, config: &Config) -> String {
@@ -1902,6 +1981,86 @@ const X =
     }
 
     #[test]
+    fn wraps_long_item_imports_vertically() {
+        let source = "\
+use {
+    ACCOUNT_GET_ID_OFFSET,
+    ACCOUNT_GET_NONCE_OFFSET,
+    ACCOUNT_COMPUTE_COMMITMENT_OFFSET,
+    ACCOUNT_GET_CODE_COMMITMENT_OFFSET,
+    ACCOUNT_COMPUTE_STORAGE_COMMITMENT_OFFSET,
+    ACCOUNT_GET_VAULT_ROOT_OFFSET,
+    ACCOUNT_GET_ITEM_OFFSET,
+    ACCOUNT_HAS_STORAGE_SLOT_OFFSET,
+    ACCOUNT_GET_MAP_ITEM_OFFSET,
+    ACCOUNT_GET_ASSET_OFFSET,
+    ACCOUNT_GET_NUM_PROCEDURES_OFFSET,
+    ACCOUNT_GET_PROCEDURE_ROOT_OFFSET,
+    ACCOUNT_HAS_PROCEDURE_OFFSET,
+} from miden::protocol::kernel_proc_offsets
+";
+
+        let parse = parse_text(source);
+        assert!(!parse.has_errors(), "{:?}", parse.diagnostics());
+
+        let config = Config::default();
+        let formatted = format_syntax(&config, &parse.syntax());
+        let expected = "\
+use {
+    ACCOUNT_GET_ID_OFFSET,
+    ACCOUNT_GET_NONCE_OFFSET,
+    ACCOUNT_COMPUTE_COMMITMENT_OFFSET,
+    ACCOUNT_GET_CODE_COMMITMENT_OFFSET,
+    ACCOUNT_COMPUTE_STORAGE_COMMITMENT_OFFSET,
+    ACCOUNT_GET_VAULT_ROOT_OFFSET,
+    ACCOUNT_GET_ITEM_OFFSET,
+    ACCOUNT_HAS_STORAGE_SLOT_OFFSET,
+    ACCOUNT_GET_MAP_ITEM_OFFSET,
+    ACCOUNT_GET_ASSET_OFFSET,
+    ACCOUNT_GET_NUM_PROCEDURES_OFFSET,
+    ACCOUNT_GET_PROCEDURE_ROOT_OFFSET,
+    ACCOUNT_HAS_PROCEDURE_OFFSET,
+} from miden::protocol::kernel_proc_offsets
+";
+
+        assert_eq!(formatted, expected);
+        assert!(formatted.lines().all(|line| line.len() <= config.max_line_length()));
+
+        let reparsed = parse_text(&formatted);
+        assert!(!reparsed.has_errors(), "{:?}", reparsed.diagnostics());
+
+        let reformatted = format_syntax(&config, &reparsed.syntax());
+        assert_eq!(reformatted, formatted);
+    }
+
+    #[test]
+    fn keeps_long_const_call_head_with_assignment() {
+        let source = "\
+pub const ON_BEFORE_ASSET_ADDED_TO_ACCOUNT_PROC_ROOT_SLOT = word(\"miden::protocol::faucet::callback::on_before_asset_added_to_account\")
+";
+
+        let parse = parse_text(source);
+        assert!(!parse.has_errors(), "{:?}", parse.diagnostics());
+
+        let config = Config::default();
+        let formatted = format_syntax(&config, &parse.syntax());
+        let expected = "\
+pub const ON_BEFORE_ASSET_ADDED_TO_ACCOUNT_PROC_ROOT_SLOT = word(
+    \"miden::protocol::faucet::callback::on_before_asset_added_to_account\"
+)
+";
+
+        assert_eq!(formatted, expected);
+        assert!(formatted.lines().all(|line| line.len() <= config.max_line_length()));
+
+        let reparsed = parse_text(&formatted);
+        assert!(!reparsed.has_errors(), "{:?}", reparsed.diagnostics());
+
+        let reformatted = format_syntax(&config, &reparsed.syntax());
+        assert_eq!(reformatted, formatted);
+    }
+
+    #[test]
     fn formats_namespace_extern_package_and_submodule_forms() {
         let source = "\
 namespace   app::main # root
@@ -2117,10 +2276,9 @@ adv_map CIRCUIT_COMMITMENT = [1, 0, 0, 0, 2305843126251553075, 114890375379, 230
         let config = Config::default();
         let formatted = format_syntax(&config, &parse.syntax());
         let expected = "\
-const VERY_LONG_EVENT =
-    event(
-        \"miden::core::collections::sorted_array::lowerbound_key_value::extra_long\"
-    )
+const VERY_LONG_EVENT = event(
+    \"miden::core::collections::sorted_array::lowerbound_key_value::extra_long\"
+)
 adv_map CIRCUIT_COMMITMENT =
     [
         1,
@@ -2297,8 +2455,9 @@ end
         };
         let formatted = format_syntax(&config, &parse.syntax());
         let expected = "\
-pub use {lowerbound_key_value as lowerbound_key_value_long_alias}
-    from ::miden::core::collections::sorted_array
+pub use {
+    lowerbound_key_value as lowerbound_key_value_long_alias,
+} from ::miden::core::collections::sorted_array
 
 pub proc println_debug_message_with_context(
     message: ptr<u8, addrspace(byte)>,

--- a/crates/miden-format/src/formatter.rs
+++ b/crates/miden-format/src/formatter.rs
@@ -395,8 +395,9 @@ fn render_value_declaration(node: &SyntaxNode, indent: usize, config: &Config) -
         format!("{header}\n{body}")
     } else if line_length(&compact) <= config.max_line_length() {
         compact
-    } else if let Some(rendered) =
-        render_wrapped_value_call(&prefix_tokens, &value_tokens, indent, config)
+    } else if config.overflow_delimited_expr()
+        && let Some(rendered) =
+            render_wrapped_value_call(&prefix_tokens, &value_tokens, indent, config)
     {
         rendered
     } else {
@@ -2025,7 +2026,7 @@ use {
     }
 
     #[test]
-    fn keeps_long_const_call_head_with_assignment() {
+    fn wraps_long_const_call_head_on_next_line_by_default() {
         let source = "\
 pub const ON_BEFORE_ASSET_ADDED_TO_ACCOUNT_PROC_ROOT_SLOT = word(\"miden::protocol::faucet::callback::on_before_asset_added_to_account\")
 ";
@@ -2034,6 +2035,37 @@ pub const ON_BEFORE_ASSET_ADDED_TO_ACCOUNT_PROC_ROOT_SLOT = word(\"miden::protoc
         assert!(!parse.has_errors(), "{:?}", parse.diagnostics());
 
         let config = Config::default();
+        let formatted = format_syntax(&config, &parse.syntax());
+        let expected = "\
+pub const ON_BEFORE_ASSET_ADDED_TO_ACCOUNT_PROC_ROOT_SLOT =
+    word(
+        \"miden::protocol::faucet::callback::on_before_asset_added_to_account\"
+    )
+";
+
+        assert_eq!(formatted, expected);
+        assert!(formatted.lines().all(|line| line.len() <= config.max_line_length()));
+
+        let reparsed = parse_text(&formatted);
+        assert!(!reparsed.has_errors(), "{:?}", reparsed.diagnostics());
+
+        let reformatted = format_syntax(&config, &reparsed.syntax());
+        assert_eq!(reformatted, formatted);
+    }
+
+    #[test]
+    fn keeps_long_const_call_head_with_assignment_when_configured() {
+        let source = "\
+pub const ON_BEFORE_ASSET_ADDED_TO_ACCOUNT_PROC_ROOT_SLOT = word(\"miden::protocol::faucet::callback::on_before_asset_added_to_account\")
+";
+
+        let parse = parse_text(source);
+        assert!(!parse.has_errors(), "{:?}", parse.diagnostics());
+
+        let config = Config {
+            overflow_delimited_expr: Some(true),
+            ..Config::default()
+        };
         let formatted = format_syntax(&config, &parse.syntax());
         let expected = "\
 pub const ON_BEFORE_ASSET_ADDED_TO_ACCOUNT_PROC_ROOT_SLOT = word(
@@ -2267,9 +2299,10 @@ adv_map CIRCUIT_COMMITMENT = [1, 0, 0, 0, 2305843126251553075, 114890375379, 230
         let config = Config::default();
         let formatted = format_syntax(&config, &parse.syntax());
         let expected = "\
-const VERY_LONG_EVENT = event(
-    \"miden::core::collections::sorted_array::lowerbound_key_value::extra_long\"
-)
+const VERY_LONG_EVENT =
+    event(
+        \"miden::core::collections::sorted_array::lowerbound_key_value::extra_long\"
+    )
 adv_map CIRCUIT_COMMITMENT =
     [
         1,


### PR DESCRIPTION
`miden-format` could still create lines that were too long for item imports.

For item imports, it kept the whole import list on one line and moved only the `from` clause to the next line. A large import list could still be more than 400 characters long.

This PR changes the formatter so long item imports use one item per line.

It also adds an `overflow_delimited_expr` option for long delimited value expressions such as `pub const NAME = word("...")`. By default, long declarations keep the existing rustfmt-like style that moves the full expression to the next line. Projects that prefer the shorter style can set `overflow_delimited_expr = true` to keep `word(` or `event(` on the assignment line when that line still fits.

Closes #3363.
Closes #3364.