### PR TITLE
fix(assembly): assert program entrypoint has no locals in set_num_locals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 #### Fixes
 
 - [BREAKING] Bound MMR peak commitments to the leaf count by hashing `[num_leaves, 0, 0, 0] || padded_peaks`, and updated the core library `mmr::pack`/`mmr::unpack` procedures to use the same preimage ([#3388](https://github.com/0xMiden/miden-vm/pull/3388)).
+- Documented the program-entrypoint locals invariant on `Procedure::set_num_locals` and now assert it at that AST mutation site, so setting locals on an executable module's `begin`..`end` block panics at the producer boundary. The existing assembler assertion is retained as a backstop for entrypoints built directly via `Procedure::new` ([#3382](https://github.com/0xMiden/miden-vm/pull/3382)).
 - Validated `SectionId` on deserialization: `Section::read_from()` now rejects invalid identifiers and the `serde` path delegates to `FromStr`, keeping both readers on the same invariant ([#3277](https://github.com/0xMiden/miden-vm/pull/3277)).
 - Fixed `hash_elements_in_domain(&[], d)` colliding with `hash_elements_in_domain(&[ZERO; RATE_WIDTH], d)` for nonzero `d`, by absorbing a `ONE` padding marker on the empty-input branch ([#3366](https://github.com/0xMiden/miden-vm/pull/3366)).
 - Fixed `hash_bytes(&[])` returning `Word::default()`; the empty-bytes input now absorbs a padding marker and permutes, producing a nonzero digest consistent with the 10\* sponge padding rule ([#3366](https://github.com/0xMiden/miden-vm/pull/3366)).

--- a/crates/assembly-syntax/src/ast/procedure/procedure.rs
+++ b/crates/assembly-syntax/src/ast/procedure/procedure.rs
@@ -117,7 +117,18 @@ impl Procedure {
     }
 
     /// Override the number of locals allocated by this procedure.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_locals` is non-zero and this procedure is the program entrypoint (the
+    /// `begin`..`end` block of an executable module). The entrypoint executes on a fresh frame and
+    /// cannot allocate locals; producing one with locals is an unrecoverable bug in the AST
+    /// producer.
     pub fn set_num_locals(&mut self, num_locals: u16) {
+        assert!(
+            num_locals == 0 || !self.is_entrypoint(),
+            "program entrypoint cannot have locals"
+        );
         self.num_locals = num_locals;
     }
 }

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -1338,6 +1338,9 @@ impl Assembler {
             _ => panic!("expected item to be a procedure AST"),
         };
         let body_wrapper = if proc_ctx.is_program_entrypoint() {
+            // The primary check now lives at the AST mutation site (`Procedure::set_num_locals`).
+            // This backstop still catches entrypoints constructed with locals directly via
+            // `Procedure::new`, which bypasses that setter.
             assert!(num_locals == 0, "program entrypoint cannot have locals");
 
             Some(BodyWrapper {

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -7665,10 +7665,11 @@ fn test_num_locals_one_above_max_is_rejected() {
 /// Regression test for the AST-producer path in issue #3331.
 ///
 /// The `@locals(..)` grammar cannot attach locals to a `begin`..`end` block, so the parser can
-/// never produce an entrypoint with locals. On the contrary, the AST API can, the entrypoint compiles to an
-/// ordinary procedure reachable via `Module::procedures_mut`, and `Procedure::set_num_locals`
-/// bypasses the parser entirely. An entrypoint with locals is an unrecoverable producer bug, so the
-/// invariant is enforced at the mutation site and must panic there.
+/// never produce an entrypoint with locals. On the contrary, the AST API can, the entrypoint
+/// compiles to an ordinary procedure reachable via `Module::procedures_mut`, and
+/// `Procedure::set_num_locals` bypasses the parser entirely. An entrypoint with locals is an
+/// unrecoverable producer bug, so the invariant is enforced at the mutation site and must panic
+/// there.
 #[test]
 #[should_panic(expected = "program entrypoint cannot have locals")]
 fn test_entrypoint_with_locals_via_setter_panics() {

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -28,9 +28,12 @@ use miden_mast_package::{
 use miden_project::Linkage;
 
 use crate::{
-    Assembler, PathBuf,
+    Assembler, PathBuf, SourceSpan, Span,
     assembler::{MAX_CONTROL_FLOW_NESTING, MAX_PROC_LOCALS},
-    ast::{Module, ProcedureName, QualifiedProcedureName},
+    ast::{
+        Block, Instruction, Module, Op, Procedure, ProcedureName, QualifiedProcedureName,
+        Visibility,
+    },
     diagnostics::{IntoDiagnostic, Report},
     fmp::fmp_initialization_sequence,
     mast_forest_builder::MastForestBuilder,
@@ -7657,4 +7660,47 @@ fn test_num_locals_one_above_max_is_rejected() {
     let err = assemble_library_with_num_locals(&context, MAX_PROC_LOCALS + 1)
         .expect_err("assembling a procedure with MAX_PROC_LOCALS + 1 should fail");
     assert_diagnostic!(&err, "number of procedure locals 65533 exceeds the maximum of 65532");
+}
+
+/// Regression test for the AST-producer path in issue #3331.
+///
+/// The `@locals(..)` grammar cannot attach locals to a `begin`..`end` block, so the parser can
+/// never produce an entrypoint with locals. On the contrary, the AST API can, the entrypoint compiles to an
+/// ordinary procedure reachable via `Module::procedures_mut`, and `Procedure::set_num_locals`
+/// bypasses the parser entirely. An entrypoint with locals is an unrecoverable producer bug, so the
+/// invariant is enforced at the mutation site and must panic there.
+#[test]
+#[should_panic(expected = "program entrypoint cannot have locals")]
+fn test_entrypoint_with_locals_via_setter_panics() {
+    let context = TestContext::default();
+    let source = source_file!(&context, "begin push.1 drop end");
+    let mut program = context.parse_program(source).expect("failed to parse executable module");
+
+    for proc in program.procedures_mut() {
+        proc.set_num_locals(4);
+    }
+}
+
+/// The assembler keeps its own assertion as a backstop for entrypoints constructed with locals
+/// directly via `Procedure::new`, which bypasses the `set_num_locals` guard. This
+/// mirrors how the semantic analyzer lowers a `begin`..`end` block into a `main` procedure, but
+/// with a non-zero local count. See issue #3331.
+#[test]
+#[should_panic(expected = "program entrypoint cannot have locals")]
+fn test_entrypoint_with_locals_via_constructor_panics() {
+    let context = TestContext::default();
+
+    let body = Block::new(
+        SourceSpan::default(),
+        Vec::from([Op::Inst(Span::unknown(Instruction::Assertz))]),
+    );
+    let main =
+        Procedure::new(SourceSpan::default(), Visibility::Public, ProcedureName::main(), 4, body);
+
+    let mut module = Module::new_executable();
+    module
+        .define_procedure(main, context.source_manager())
+        .expect("failed to define entrypoint");
+
+    let _ = Assembler::new(context.source_manager()).assemble_program("test", module);
 }


### PR DESCRIPTION
## Describe your changes

An executable module's `begin`..`end` block compiles to an ordinary procedure reachable via `Module::procedures_mut`. The `@locals(..)` grammar can't attach locals to `begin`, so the parser can never produce an entrypoint with locals. But `Procedure::set_num_locals` can set them programmatically. When it did, assembly aborted with an `assert!` deep in `compile_procedure`, far from the offending mutation:

```rust
let mut module = /* parse an executable module: begin .. end */;
for proc in module.procedures_mut() {
    proc.set_num_locals(4);
}
Assembler::new(source_manager).assemble_program("test", module); // panics deep in the assembler
```

## Rationale

Per the discussion in #3331, an entrypoint with locals is an unrecoverable producer bug. The MASM AST is deliberately a superset of what MASM source permits. So this stays an assertion rather than becoming a recoverable diagnostic. The change just moves the enforcement closer to where the invalid state is produced and documents it:

- Document the invariant on `Procedure::set_num_locals` and assert it there, at the AST mutation site, so the failure surfaces at the producer boundary instead of deep in the assembler.
- Retain the assembler-side assertion as a backstop for entrypoints constructed directly via `Procedure::new`, which bypasses the setter.
- Add tests covering both the `set_num_locals` and `Procedure::new` programmatic-AST paths.

Closes #3331.

## Test Plan
- Added `test_entrypoint_with_locals_via_setter_panics` and `..._via_constructor_panics`; run `make test-assembly`.

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
- [x] Updated `CHANGELOG.md`
