### PR TITLE
assembly: expose more missing functionality of the assembler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## v0.25.3 (2026-07-14)
+## v0.25.3 (2026-07-16)
 
 - Add package post-processing hooks to the `ProjectSourceProvider` trait ([#3375](https://github.com/0xMiden/miden-vm/pull/3375)).
+- Expose some assembler configuration methods, and `ProjectAssembler::assemble_source_project` ([#3383](https://github.com/0xMiden/miden-vm/pull/3383)).
 
 ## v0.25.2 (2026-07-12)
 

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -236,15 +236,10 @@ impl Assembler {
         self
     }
 
-    #[cfg(feature = "std")]
-    pub(crate) fn with_emit_debug_info(mut self, yes: bool) -> Self {
-        self.emit_debug_info = yes;
-        self
-    }
-
-    #[cfg(feature = "std")]
-    pub(crate) fn with_trim_paths(mut self, yes: bool) -> Self {
-        self.trim_paths = yes;
+    /// Configure this assembler based on configuration in `profile`
+    pub fn with_profile(mut self, profile: &miden_project::Profile) -> Self {
+        self.emit_debug_info = profile.should_emit_debug_info();
+        self.trim_paths = profile.should_trim_paths();
         self
     }
 }

--- a/crates/assembly/src/lib.rs
+++ b/crates/assembly/src/lib.rs
@@ -47,7 +47,8 @@ pub use self::linker::LinkerError;
 #[cfg(feature = "std")]
 pub use self::project::{
     MasmSourceProvider, ProjectAssembler, ProjectSourceInputs, ProjectSourceProvenanceInputs,
-    ProjectSourceProvider, ProjectTargetSelector, SourceFileProvenance, TargetAssemblyContext,
+    ProjectSourceProvider, ProjectTargetSelector, ResolvedPackage, SourceFileProvenance,
+    SourceProviderRegistry, TargetAssemblyContext,
 };
 pub use self::{
     assembler::Assembler,

--- a/crates/assembly/src/project.rs
+++ b/crates/assembly/src/project.rs
@@ -207,10 +207,19 @@ where
         self
     }
 
+    /// Get the project being assembled
     pub fn project(&self) -> &ProjectPackage {
         self.project.as_ref()
     }
 
+    /// Assemble a target of the current project matching `target_selector`, using the configuration
+    /// under the profile `profile_name`.
+    ///
+    /// Returns an error if:
+    ///
+    /// * `target_selector` cannot find a matching target in the current project
+    /// * `profile_name` is not a profile defined in this project
+    /// * An error occurs during assembly of the project or one of its dependencies
     pub fn assemble(
         &mut self,
         target_selector: ProjectTargetSelector<'_>,
@@ -232,6 +241,8 @@ where
                 &library_target,
                 profile_name,
                 None,
+                None,
+                None,
                 &mut cache,
             )?)
         } else {
@@ -244,20 +255,44 @@ where
             &target,
             profile_name,
             required_lib,
+            None,
+            None,
             &mut cache,
         )
         .map(|resolved| resolved.package)
     }
 
-    fn assemble_source_package(
+    /// This is a low-level utility function of the project assembly infrastructure for assembling
+    /// a project target whose sources and source provenance may have already been computed by the
+    /// caller.
+    ///
+    /// In almost all cases you should prefer to use [`ProjectAssembler::assemble`].
+    ///
+    /// Callers are required to uphold the following invariants:
+    ///
+    /// * `package_id` must be the package identifier for `project` in the current dependency graph
+    /// * `target` must be a target extracted from `project`
+    /// * `required_lib` must be set if assembly of `target` would depend on another target of the
+    ///   same project (i.e. an executable target implicitly depends on the library target).
+    ///
+    /// It is invalid to provide `source_provenance` without `sources` - doing so will trigger an
+    /// assertion.
+    pub fn assemble_source_package(
         &mut self,
         package_id: PackageId,
         project: Arc<ProjectPackage>,
         target: &Target,
         profile_name: &str,
         required_lib: Option<ResolvedPackage>,
+        sources: Option<ProjectSourceInputs>,
+        source_provenance: Option<ProjectSourceProvenanceInputs>,
         cache: &mut BTreeMap<PackageId, ResolvedPackage>,
     ) -> Result<ResolvedPackage, Report> {
+        assert!(
+            source_provenance.is_none() || sources.is_some(),
+            "source provenance may only be provided with sources"
+        );
+
         let cache_key = project.target_package_name(target);
         if let Some(package) = cache.get(&cache_key).cloned() {
             assert_eq!(package.package.kind, target.ty);
@@ -265,11 +300,7 @@ where
         }
 
         let profile = project.resolve_profile(profile_name)?;
-        let mut assembler = self
-            .assembler
-            .clone()
-            .with_emit_debug_info(profile.should_emit_debug_info())
-            .with_trim_paths(profile.should_trim_paths());
+        let mut assembler = self.assembler.clone().with_profile(profile);
         let mut runtime_dependencies = RuntimeDependencies::default();
         debug_assert!(
             required_lib.is_none() || target.ty.is_executable(),
@@ -309,8 +340,11 @@ where
             runtime_dependencies.merge_package(dependency_package, edge.linkage)?;
         }
 
-        let ProjectSourceInputs { root, support } =
-            self.load_target_sources(project.clone(), target, profile)?;
+        let manually_provided_sources = sources.is_some();
+        let ProjectSourceInputs { root, support } = match sources {
+            Some(sources) => sources,
+            None => self.load_target_sources(project.clone(), target, profile)?,
+        };
 
         // Collect specific well-known custom sections produced by the project assembler
         let mut sections = Vec::new();
@@ -318,15 +352,21 @@ where
         // Section: build provenance
         //
         // This is produced before actual assembly, while we still have the sources on hand
-        if let Some(provenance) = self.dependency_graph.build_source_provenance(
-            &package_id,
-            project.clone(),
-            target,
-            profile_name,
-            &self.source_provider,
-            &*self.store,
-        )? {
-            sections.push(provenance.to_section());
+        let build_provenance = if source_provenance.is_some() || !manually_provided_sources {
+            self.dependency_graph.build_source_provenance(
+                &package_id,
+                project.clone(),
+                target,
+                profile_name,
+                &self.source_provider,
+                self.store,
+                source_provenance.as_ref(),
+            )?
+        } else {
+            None
+        };
+        if let Some(build_provenance) = build_provenance {
+            sections.push(build_provenance.to_section());
         }
 
         if let Some(kernel_package) = runtime_dependencies.kernel.clone() {
@@ -359,7 +399,10 @@ where
         package.description = project.description().map(|description| description.to_string());
         package.sections.extend(sections);
 
-        self.apply_post_assembly_hooks(&mut package, project.clone(), target, profile)?;
+        // We don't apply post-assembly hooks when assembling manually-provided sources
+        if !manually_provided_sources {
+            self.apply_post_assembly_hooks(&mut package, project.clone(), target, profile)?;
+        }
 
         let package = Arc::from(package);
 
@@ -434,6 +477,8 @@ where
                             project,
                             &target,
                             profile_name,
+                            None,
+                            None,
                             None,
                             cache,
                         )?;
@@ -600,6 +645,7 @@ where
             manifest_path,
             &self.source_provider,
             self.store,
+            None,
         )?;
 
         match PackageBuildProvenance::from_package(&package)? {
@@ -748,9 +794,9 @@ where
 // ================================================================================================
 
 #[derive(Clone)]
-struct ResolvedPackage {
-    package: Arc<MastPackage>,
-    linked_kernel_package: Option<Arc<MastPackage>>,
+pub struct ResolvedPackage {
+    pub package: Arc<MastPackage>,
+    pub linked_kernel_package: Option<Arc<MastPackage>>,
 }
 
 enum RegisteredSourcePackage {

--- a/crates/assembly/src/project/dependency_graph.rs
+++ b/crates/assembly/src/project/dependency_graph.rs
@@ -93,6 +93,7 @@ impl DependencyGraph {
         profile_name: &str,
         source_provider: &SourceProviderRegistry,
         package_registry: &dyn PackageRegistryAndProvider,
+        source_provenance: Option<&ProjectSourceProvenanceInputs>,
     ) -> Result<Option<PackageBuildProvenance>, Report> {
         let Some(node) = self.dependency_graph.get(package_id) else {
             return Ok(None);
@@ -113,6 +114,7 @@ impl DependencyGraph {
                     manifest_path,
                     source_provider,
                     package_registry,
+                    source_provenance,
                 )
                 .map(Some),
         }
@@ -128,6 +130,7 @@ impl DependencyGraph {
         manifest_path: &FsPath,
         source_provider: &SourceProviderRegistry,
         package_registry: &dyn PackageRegistryAndProvider,
+        source_provenance: Option<&ProjectSourceProvenanceInputs>,
     ) -> Result<PackageBuildProvenance, Report> {
         self.expected_source_provenance_with_visited(
             package_id,
@@ -138,6 +141,7 @@ impl DependencyGraph {
             manifest_path,
             source_provider,
             package_registry,
+            source_provenance,
             &mut BTreeSet::new(),
         )
     }
@@ -155,6 +159,7 @@ impl DependencyGraph {
         manifest_path: &FsPath,
         source_provider: &SourceProviderRegistry,
         package_registry: &dyn PackageRegistryAndProvider,
+        source_provenance: Option<&ProjectSourceProvenanceInputs>,
         visiting: &mut BTreeSet<PackageId>,
     ) -> Result<PackageBuildProvenance, Report> {
         let dependency_hash = self.compute_dependency_closure_hash(
@@ -172,6 +177,21 @@ impl DependencyGraph {
                 Ok(PackageBuildProvenance::Git {
                     repo: repo.to_string(),
                     resolved_revision: resolved_revision.to_string(),
+                    dependency_hash,
+                    build_settings,
+                })
+            },
+            ProjectSourceOrigin::Path | ProjectSourceOrigin::Root
+                if source_provenance.is_some() =>
+            {
+                Ok(PackageBuildProvenance::Path {
+                    source_hash: self.compute_path_source_hash_from_sources(
+                        &project,
+                        None,
+                        target,
+                        profile,
+                        source_provenance.unwrap(),
+                    ),
                     dependency_hash,
                     build_settings,
                 })
@@ -296,6 +316,7 @@ impl DependencyGraph {
                     manifest_path,
                     source_provider,
                     package_registry,
+                    None,
                     visiting,
                 )?;
                 Ok(format!("source:{package_id}:{}\n", provenance.describe()))
@@ -342,26 +363,51 @@ impl DependencyGraph {
                 "unsupported file type '{extension}': no source provider registered for that type"
             )));
         };
-        let ProjectSourceProvenanceInputs { root, support } =
-            source_provider.provide_source_provenance(context)?;
+        let source_provenance = source_provider.provide_source_provenance(context)?;
+
+        Ok(self.compute_path_source_hash_from_sources(
+            &context.package,
+            Some(context.project_root),
+            context.target,
+            context.profile,
+            &source_provenance,
+        ))
+    }
+
+    fn compute_path_source_hash_from_sources(
+        &self,
+        package: &miden_project::Package,
+        project_root: Option<&std::path::Path>,
+        target: &Target,
+        profile: &miden_project::Profile,
+        source_provenance: &ProjectSourceProvenanceInputs,
+    ) -> Word {
+        let ProjectSourceProvenanceInputs { root, support } = source_provenance;
 
         let mut inputs = Vec::with_capacity(1 + support.len());
-        let root_label = match root.path.strip_prefix(context.project_root) {
-            Ok(stripped) => stripped.display().to_string(),
-            Err(_) => root.path.display().to_string(),
+        let root_label = if let Some(project_root) = project_root {
+            match root.path.strip_prefix(project_root) {
+                Ok(stripped) => stripped.display().to_string(),
+                Err(_) => root.path.display().to_string(),
+            }
+        } else {
+            root.path.display().to_string()
         };
         inputs.push((format!("root:{root_label}"), root));
         for support_file in support {
-            let label = match support_file.path.strip_prefix(context.project_root) {
-                Ok(stripped) => stripped.display().to_string(),
-                Err(_) => support_file.path.display().to_string(),
+            let label = if let Some(project_root) = project_root {
+                match support_file.path.strip_prefix(project_root) {
+                    Ok(stripped) => stripped.display().to_string(),
+                    Err(_) => support_file.path.display().to_string(),
+                }
+            } else {
+                support_file.path.display().to_string()
             };
             inputs.push((format!("support:{label}"), support_file));
         }
         inputs.sort_by(|a, b| a.0.cmp(&b.0));
 
-        let mut material =
-            context.package.build_provenance_projection(context.target, context.profile);
+        let mut material = package.build_provenance_projection(target, profile);
         for (label, source_file) in inputs {
             material.push_str(&label);
             material.push('\n');
@@ -369,6 +415,6 @@ impl DependencyGraph {
             material.push('\n');
         }
 
-        Ok(hash_string_to_word(material.as_str()))
+        hash_string_to_word(material.as_str())
     }
 }


### PR DESCRIPTION
During migration of the compiler, I found additional missing APIs/functionality:

* Inability to configure the assembler debug info options (they were not exported for some reason)
* Removal of virtual targets from `ProjectAssembler` meant that we effectively always require the top-level project to be written to disk somewhere, when that is only really required for assembly of source dependencies. A lot of compiler test cases are completely virtual, so I've exposed `ProjectAssembler::assemble_source_package` with a slight modification to allow the sources and source provenance to be provided by the caller. This allows the top-level project to be completely virtualized, only requiring dependencies in source form to actually exist on disk somewhere.