### PR TITLE
assembly: use trusted deserialization when resolving preassembled packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.25.5 (2026-07-16)
+
+- Use `Package::read_from_bytes_trusted` when loading preassembled packages from registry/cache during project assembly
+
 ## v0.25.4 (2026-07-16)
 
 - Add package post-processing hooks to the `ProjectSourceProvider` trait ([#3375](https://github.com/0xMiden/miden-vm/pull/3375)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,7 +1308,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "insta",
  "miden-ace-codegen",
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "env_logger",
  "insta",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "env_logger",
  "log",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "criterion",
  "derive_more",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "criterion",
  "env_logger",
@@ -1490,7 +1490,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "miden-format"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "clap",
  "miden-assembly-syntax-cst",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1657,7 +1657,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry-local"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "clap",
  "miden-assembly-syntax",
@@ -1674,7 +1674,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "insta",
  "itertools 0.14.0",
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-air",
  "miden-assembly",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-crypto",
  "miden-test-serde-macros",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "lock_api",
  "loom",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-blake3-bench"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "clap",
  "codspeed-criterion-compat",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-synthetic-bench"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-processor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rust-version = "1.96.1"
 # Private workspace members inherit this version. Publishable crates keep their
 # own package versions so release tooling can publish only the crates selected
 # for a release.
-version = "0.25.4"
+version = "0.25.5"
 
 [profile.optimized]
 inherits = "release"

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-air"
-version = "0.25.4"
+version = "0.25.5"
 description = "Algebraic intermediate representation of Miden VM processor"
 documentation = "https://docs.rs/miden-air"
 readme = "README.md"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.25.4"
+version = "0.25.5"
 description = "Miden VM core components"
 documentation = "https://docs.rs/miden-core"
 readme = "README.md"

--- a/crates/ace-codegen/Cargo.toml
+++ b/crates/ace-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-ace-codegen"
-version = "0.25.4"
+version = "0.25.5"
 description = "ACE circuit codegen for Plonky3-based Miden AIRs."
 documentation = "https://docs.rs/miden-ace-codegen"
 readme = "README.md"

--- a/crates/assembly-syntax-cst/Cargo.toml
+++ b/crates/assembly-syntax-cst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax-cst"
-version = "0.25.4"
+version = "0.25.5"
 description = "Lossless concrete syntax tree support for the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax-cst"
 readme = "README.md"

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax"
-version = "0.25.4"
+version = "0.25.5"
 description = "Parsing and semantic analysis of the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax"
 readme = "README.md"

--- a/crates/assembly/Cargo.toml
+++ b/crates/assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly"
-version = "0.25.4"
+version = "0.25.5"
 description = "Miden VM assembly language"
 documentation = "https://docs.rs/miden-assembly"
 readme = "README.md"

--- a/crates/debug-types/Cargo.toml
+++ b/crates/debug-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-debug-types"
-version = "0.25.4"
+version = "0.25.5"
 description = "Core source-level debugging information types used throughout the Miden toolchain"
 documentation = "https://docs.rs/miden-debug-types"
 readme = "README.md"

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core-lib"
-version = "0.25.4"
+version = "0.25.5"
 description = "Miden VM core library"
 documentation = "https://docs.rs/miden-core-lib"
 readme = "README.md"

--- a/crates/lib/core/asm/miden-project.toml
+++ b/crates/lib/core/asm/miden-project.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.25.4"
+version = "0.25.5"
 
 [lib]
 namespace = "miden::core"

--- a/crates/lib/core/src/lib.rs
+++ b/crates/lib/core/src/lib.rs
@@ -12,10 +12,7 @@ extern crate alloc;
 
 use alloc::{sync::Arc, vec, vec::Vec};
 
-use miden_core::{
-    events::EventName, mast::MastForest, precompile::PrecompileVerifierRegistry,
-    serde::Deserializable,
-};
+use miden_core::{events::EventName, mast::MastForest, precompile::PrecompileVerifierRegistry};
 use miden_mast_package::Package;
 use miden_processor::{HostLibrary, event::EventHandler};
 use miden_utils_sync::LazyLock;
@@ -175,7 +172,7 @@ impl CoreLibrary {
 impl Default for CoreLibrary {
     fn default() -> Self {
         static CORELIB: LazyLock<CoreLibrary> = LazyLock::new(|| {
-            let contents = Package::read_from_bytes(CoreLibrary::SERIALIZED)
+            let contents = Package::read_from_bytes_trusted(CoreLibrary::SERIALIZED)
                 .expect("failed to read core package!");
             CoreLibrary(Arc::new(contents))
         });

--- a/crates/mast-package/Cargo.toml
+++ b/crates/mast-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-mast-package"
-version = "0.25.4"
+version = "0.25.5"
 description = "Package containing a compiled Miden MAST artifact with declared dependencies and exports"
 documentation = "https://docs.rs/miden-mast-package"
 readme = "README.md"

--- a/crates/miden-format/Cargo.toml
+++ b/crates/miden-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-format"
-version = "0.25.4"
+version = "0.25.5"
 description = "Formatter for the Miden Assembly language"
 documentation = "https://docs.rs/miden-format"
 readme = "README.md"

--- a/crates/package-registry-local/Cargo.toml
+++ b/crates/package-registry-local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry-local"
-version = "0.25.4"
+version = "0.25.5"
 description = "Filesystem-backed local package registry for Miden packages"
 documentation = "https://docs.rs/miden-package-registry-local"
 readme = "README.md"

--- a/crates/package-registry/Cargo.toml
+++ b/crates/package-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry"
-version = "0.25.4"
+version = "0.25.5"
 description = "Package registry interfaces and dependency resolution for Miden packages"
 documentation = "https://docs.rs/miden-package-registry"
 readme = "README.md"

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-project"
-version = "0.25.4"
+version = "0.25.5"
 description = "Interface for working with Miden projects"
 documentation = "https://docs.rs/miden-project"
 readme = "README.md"

--- a/crates/project/src/dependencies/graph.rs
+++ b/crates/project/src/dependencies/graph.rs
@@ -773,12 +773,10 @@ impl<'a, R: PackageRegistry + ?Sized> ProjectDependencyGraphBuilder<'a, R> {
         expected_name: &str,
         requirement: Option<&VersionRequirement>,
     ) -> Result<CollectedDependencyNode, Report> {
-        use miden_core::serde::Deserializable;
-
         let path = path.canonicalize().map_err(|error| Report::msg(error.to_string()))?;
         let bytes = std::fs::read(&path).map_err(|error| Report::msg(error.to_string()))?;
-        let package =
-            MastPackage::read_from_bytes(&bytes).map_err(|error| Report::msg(error.to_string()))?;
+        let package = MastPackage::read_from_bytes_trusted(&bytes)
+            .map_err(|error| Report::msg(error.to_string()))?;
         self.ensure_dependency_name(expected_name, &package.name, Some(&path))?;
         let semver = package.version.clone();
         let selected = Version::new(semver, package.digest());

--- a/crates/utils-core-derive/Cargo.toml
+++ b/crates/utils-core-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-core-derive"
-version = "0.25.4"
+version = "0.25.5"
 description = "Proc macro to derive enum dispatch trait implementations on miden-core structs"
 readme = "README.md"
 categories = ["development-tools::procedural-macro-helpers", "no-std"]

--- a/crates/utils-diagnostics/Cargo.toml
+++ b/crates/utils-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-diagnostics"
-version = "0.25.4"
+version = "0.25.5"
 description = "Diagnostic infrastructure used in the Miden assembler and VM"
 documentation = "https://docs.rs/miden-utils-diagnostics"
 readme = "README.md"

--- a/crates/utils-indexing/Cargo.toml
+++ b/crates/utils-indexing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-indexing"
-version = "0.25.4"
+version = "0.25.5"
 description = "Type-safe u32-indexed vector utilities for Miden"
 readme = "README.md"
 categories = ["development-tools", "no-std"]

--- a/crates/utils-sync/Cargo.toml
+++ b/crates/utils-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-sync"
-version = "0.25.4"
+version = "0.25.5"
 description = "no-std compatible locking primitives for the Miden project"
 documentation = "https://docs.rs/miden-utils-sync"
 readme = "README.md"

--- a/miden-core-fuzz/Cargo.lock
+++ b/miden-core-fuzz/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-assembly"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "log",
  "miden-assembly-syntax-cst",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "derive_more",
  "log",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "miden-crypto",
  "proptest",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.25.4"
+version = "0.25.5"
 dependencies = [
  "lock_api",
  "loom",

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-vm"
-version = "0.25.4"
+version = "0.25.5"
 description = "Miden virtual machine"
 documentation = "https://docs.rs/miden-vm"
 readme = "README.md"

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-processor"
-version = "0.25.4"
+version = "0.25.5"
 description = "Miden VM processor"
 documentation = "https://docs.rs/miden-processor"
 readme = "README.md"

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-prover"
-version = "0.25.4"
+version = "0.25.5"
 description = "Miden VM prover"
 documentation = "https://docs.rs/miden-prover"
 readme = "README.md"

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-verifier"
-version = "0.25.4"
+version = "0.25.5"
 description = "Miden VM execution verifier"
 documentation = "https://docs.rs/miden-verifier"
 readme = "README.md"


### PR DESCRIPTION
This PR changes how preassembled packages are loaded from the project dependency graph to use `Package::read_from_bytes_trusted`, as we implicitly trust the package registry/cache. Without this, dependencies loaded from preassembled packages would have their debug information stripped, which would result in the final artifact missing debug info in some cases.