### PR TITLE
package: fix improper validation of procedure names when extracting module info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.25.8 (2026-07-22)
+
+- Fix validation of procedure names in package manifest exports when extracting module info
+
 ## v0.25.7 (2026-07-20)
 
 - Use the `wincode` crate re-exported by `serde-wincode` for proof encoding.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "insta",
  "miden-ace-codegen",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "env_logger",
  "insta",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "env_logger",
  "log",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "criterion",
  "derive_more",
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "criterion",
  "env_logger",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "miden-format"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "clap",
  "miden-assembly-syntax-cst",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry-local"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "clap",
  "miden-assembly-syntax",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "insta",
  "itertools 0.14.0",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-air",
  "miden-assembly",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-crypto",
  "miden-test-serde-macros",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "lock_api",
  "loom",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-blake3-bench"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "clap",
  "codspeed-criterion-compat",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-synthetic-bench"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-processor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rust-version = "1.96.1"
 # Private workspace members inherit this version. Publishable crates keep their
 # own package versions so release tooling can publish only the crates selected
 # for a release.
-version = "0.25.7"
+version = "0.25.8"
 
 [profile.optimized]
 inherits = "release"

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-air"
-version = "0.25.7"
+version = "0.25.8"
 description = "Algebraic intermediate representation of Miden VM processor"
 documentation = "https://docs.rs/miden-air"
 readme = "README.md"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.25.7"
+version = "0.25.8"
 description = "Miden VM core components"
 documentation = "https://docs.rs/miden-core"
 readme = "README.md"

--- a/crates/ace-codegen/Cargo.toml
+++ b/crates/ace-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-ace-codegen"
-version = "0.25.7"
+version = "0.25.8"
 description = "ACE circuit codegen for Plonky3-based Miden AIRs."
 documentation = "https://docs.rs/miden-ace-codegen"
 readme = "README.md"

--- a/crates/assembly-syntax-cst/Cargo.toml
+++ b/crates/assembly-syntax-cst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax-cst"
-version = "0.25.7"
+version = "0.25.8"
 description = "Lossless concrete syntax tree support for the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax-cst"
 readme = "README.md"

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax"
-version = "0.25.7"
+version = "0.25.8"
 description = "Parsing and semantic analysis of the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax"
 readme = "README.md"

--- a/crates/assembly-syntax/src/ast/module.rs
+++ b/crates/assembly-syntax/src/ast/module.rs
@@ -859,10 +859,8 @@ impl crate::prettier::PrettyPrint for Module {
             + display(self.path().to_relative())
             + nl();
 
-        for (i, package) in self.extern_packages.iter().enumerate() {
-            if i > 0 {
-                doc += nl();
-            }
+        for package in self.extern_packages.iter() {
+            doc += nl();
             doc += const_text("extern package") + const_text(" ") + package.render();
         }
 

--- a/crates/assembly-syntax/src/ast/path/path.rs
+++ b/crates/assembly-syntax/src/ast/path/path.rs
@@ -325,11 +325,33 @@ impl Path {
         self.split_first().map(|(first, _)| first)
     }
 
-    /// Get the first non-root component of this path as a `str`
+    /// Get the last non-root component of this path as a `str`
     ///
     /// Returns `None` if the path is empty, or consists only of the root prefix.
     pub fn last(&self) -> Option<&str> {
         self.split_last().map(|(last, _)| last)
+    }
+
+    /// Get the last non-root component of this path as a [crate::ast::ProcedureName]
+    ///
+    /// Returns `Ok(None)` if the path is empty, or consists only of the root prefix.
+    pub fn procedure_name(&self) -> Result<Option<crate::ast::ProcedureName>, PathError> {
+        use crate::ast::ProcedureName;
+
+        let Some(last) = self.components().next_back() else {
+            return Ok(None);
+        };
+        let name = last?;
+        if name == PathComponent::Root {
+            return Ok(None);
+        }
+        if name.is_quoted() {
+            ProcedureName::new(format!("\"{}\"", name.as_str()))
+                .map(Some)
+                .map_err(PathError::InvalidComponent)
+        } else {
+            ProcedureName::new(name.as_str()).map(Some).map_err(PathError::InvalidComponent)
+        }
     }
 
     /// Splits this path on the first non-root component, returning it and a new [Path] of the

--- a/crates/assembly-syntax/src/ast/procedure/name.rs
+++ b/crates/assembly-syntax/src/ast/procedure/name.rs
@@ -131,7 +131,7 @@ impl FromStr for QualifiedProcedureName {
         if path.parent().is_none() {
             return Err(Report::msg("invalid procedure path: must be qualified with a namespace"));
         }
-        ProcedureName::validate(path.last().unwrap()).into_diagnostic()?;
+        let _ = path.procedure_name().into_diagnostic()?.unwrap();
         Ok(Self {
             span: SourceSpan::default(),
             path: path.into(),

--- a/crates/assembly-syntax/src/ast/tests.rs
+++ b/crates/assembly-syntax/src/ast/tests.rs
@@ -254,7 +254,8 @@ macro_rules! const_add {
 macro_rules! import {
     ($name:literal) => {{
         let path = $name.parse::<PathBuf>().expect("invalid import path");
-        let name = Ident::new(path.last().unwrap()).unwrap();
+        let leaf = path.components().next_back().unwrap().expect("valid path component");
+        let name = leaf.to_ident().expect("invalid identifier");
         Form::Import(ImportDecl::Module(ModuleImport::new(
             SourceSpan::UNKNOWN,
             Visibility::Private,

--- a/crates/assembly/Cargo.toml
+++ b/crates/assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly"
-version = "0.25.7"
+version = "0.25.8"
 description = "Miden VM assembly language"
 documentation = "https://docs.rs/miden-assembly"
 readme = "README.md"

--- a/crates/debug-types/Cargo.toml
+++ b/crates/debug-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-debug-types"
-version = "0.25.7"
+version = "0.25.8"
 description = "Core source-level debugging information types used throughout the Miden toolchain"
 documentation = "https://docs.rs/miden-debug-types"
 readme = "README.md"

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core-lib"
-version = "0.25.7"
+version = "0.25.8"
 description = "Miden VM core library"
 documentation = "https://docs.rs/miden-core-lib"
 readme = "README.md"

--- a/crates/lib/core/asm/miden-project.toml
+++ b/crates/lib/core/asm/miden-project.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.25.7"
+version = "0.25.8"
 
 [lib]
 namespace = "miden::core"

--- a/crates/mast-package/Cargo.toml
+++ b/crates/mast-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-mast-package"
-version = "0.25.7"
+version = "0.25.8"
 description = "Package containing a compiled Miden MAST artifact with declared dependencies and exports"
 documentation = "https://docs.rs/miden-mast-package"
 readme = "README.md"

--- a/crates/mast-package/src/package/manifest.rs
+++ b/crates/mast-package/src/package/manifest.rs
@@ -675,23 +675,39 @@ impl fmt::Debug for TypeExport {
 
 fn normalize_export(export: &mut PackageExport) -> Result<(), ManifestValidationError> {
     let canonical_path = canonicalize_export_path(export.path().as_ref())?;
-    let leaf = export_raw_leaf(&canonical_path)?;
 
     match export {
         PackageExport::Procedure(proc) => {
-            ast::ProcedureName::new(leaf).map_err(|err| {
-                ManifestValidationError::InvalidExportPath {
-                    path: proc.path.clone(),
-                    error: ast::PathError::InvalidComponent(err),
-                }
-            })?;
+            let _ = canonical_path
+                .procedure_name()
+                .map_err(|error| ManifestValidationError::InvalidExportPath {
+                    path: canonical_path.clone(),
+                    error,
+                })?
+                .ok_or_else(|| ManifestValidationError::InvalidExportPath {
+                    path: canonical_path.clone(),
+                    error: ast::PathError::Empty,
+                })?;
             proc.path = canonical_path;
         },
         PackageExport::Constant(ConstantExport { path, .. })
         | PackageExport::Type(TypeExport { path, .. }) => {
-            ast::Ident::new(leaf).map_err(|err| ManifestValidationError::InvalidExportPath {
-                path: path.clone(),
-                error: ast::PathError::InvalidComponent(err),
+            let leaf = canonical_path
+                .components()
+                .next_back()
+                .ok_or_else(|| ManifestValidationError::InvalidExportPath {
+                    path: canonical_path.clone(),
+                    error: ast::PathError::Empty,
+                })?
+                .map_err(|error| ManifestValidationError::InvalidExportPath {
+                    path: canonical_path.clone(),
+                    error,
+                })?;
+            let _ = ast::Ident::new(leaf.as_str()).map_err(|err| {
+                ManifestValidationError::InvalidExportPath {
+                    path: canonical_path.clone(),
+                    error: ast::PathError::InvalidComponent(err),
+                }
             })?;
             *path = canonical_path;
         },
@@ -737,18 +753,4 @@ fn canonicalize_export_path(path: &Path) -> Result<Arc<Path>, ManifestValidation
                 path: path.to_path_buf().into(),
             })?;
     Ok(Arc::<Path>::from(canonical.into_boxed_path()))
-}
-
-fn export_raw_leaf(path: &Arc<Path>) -> Result<&str, ManifestValidationError> {
-    use ast::PathComponent;
-    match path.components().next_back() {
-        Some(Ok(PathComponent::Normal(leaf))) => Ok(leaf),
-        Some(Err(error)) => {
-            Err(ManifestValidationError::InvalidExportPath { path: path.clone(), error })
-        },
-        Some(Ok(PathComponent::Root)) | None => Err(ManifestValidationError::InvalidExportPath {
-            path: path.clone(),
-            error: ast::PathError::Empty,
-        }),
-    }
 }

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -466,9 +466,9 @@ impl Package {
                     signature,
                     attributes,
                 }) => {
-                    let name = path.last().unwrap();
+                    let name = path.procedure_name().expect("valid procedure name").unwrap();
                     module.add_procedure_with_provenance(
-                        ast::ProcedureName::new(name).expect("valid procedure name"),
+                        name,
                         *digest,
                         signature.clone().map(Arc::new),
                         attributes.clone(),
@@ -478,11 +478,15 @@ impl Package {
                     );
                 },
                 PackageExport::Constant(ConstantExport { path, value }) => {
-                    let name = ast::Ident::new(path.last().unwrap()).expect("valid identifier");
+                    let name =
+                        path.components().next_back().unwrap().expect("valid path component");
+                    let name = name.to_ident().expect("valid identifier");
                     module.add_constant(name, value.clone());
                 },
                 PackageExport::Type(TypeExport { path, ty }) => {
-                    let name = ast::Ident::new(path.last().unwrap()).expect("valid identifier");
+                    let name =
+                        path.components().next_back().unwrap().expect("valid path component");
+                    let name = name.to_ident().expect("valid identifier");
                     module.add_type(name, ty.clone());
                 },
             }
@@ -561,9 +565,9 @@ impl Package {
                     signature,
                     attributes,
                 }) => {
-                    let name = path.last().unwrap();
+                    let name = path.procedure_name().expect("valid procedure name").unwrap();
                     module.add_procedure_with_provenance(
-                        ast::ProcedureName::new(name).expect("valid procedure name"),
+                        name,
                         *digest,
                         signature.clone().map(Arc::new),
                         attributes.clone(),
@@ -573,11 +577,15 @@ impl Package {
                     );
                 },
                 PackageExport::Constant(ConstantExport { path, value }) => {
-                    let name = ast::Ident::new(path.last().unwrap()).expect("valid identifier");
+                    let name =
+                        path.components().next_back().unwrap().expect("valid path component");
+                    let name = name.to_ident().expect("valid identifier");
                     module.add_constant(name, value.clone());
                 },
                 PackageExport::Type(TypeExport { path, ty }) => {
-                    let name = ast::Ident::new(path.last().unwrap()).expect("valid identifier");
+                    let name =
+                        path.components().next_back().unwrap().expect("valid path component");
+                    let name = name.to_ident().expect("valid identifier");
                     module.add_type(name, ty.clone());
                 },
             }

--- a/crates/miden-format/Cargo.toml
+++ b/crates/miden-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-format"
-version = "0.25.7"
+version = "0.25.8"
 description = "Formatter for the Miden Assembly language"
 documentation = "https://docs.rs/miden-format"
 readme = "README.md"

--- a/crates/package-registry-local/Cargo.toml
+++ b/crates/package-registry-local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry-local"
-version = "0.25.7"
+version = "0.25.8"
 description = "Filesystem-backed local package registry for Miden packages"
 documentation = "https://docs.rs/miden-package-registry-local"
 readme = "README.md"

--- a/crates/package-registry/Cargo.toml
+++ b/crates/package-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry"
-version = "0.25.7"
+version = "0.25.8"
 description = "Package registry interfaces and dependency resolution for Miden packages"
 documentation = "https://docs.rs/miden-package-registry"
 readme = "README.md"

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-project"
-version = "0.25.7"
+version = "0.25.8"
 description = "Interface for working with Miden projects"
 documentation = "https://docs.rs/miden-project"
 readme = "README.md"

--- a/crates/utils-core-derive/Cargo.toml
+++ b/crates/utils-core-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-core-derive"
-version = "0.25.7"
+version = "0.25.8"
 description = "Proc macro to derive enum dispatch trait implementations on miden-core structs"
 readme = "README.md"
 categories = ["development-tools::procedural-macro-helpers", "no-std"]

--- a/crates/utils-diagnostics/Cargo.toml
+++ b/crates/utils-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-diagnostics"
-version = "0.25.7"
+version = "0.25.8"
 description = "Diagnostic infrastructure used in the Miden assembler and VM"
 documentation = "https://docs.rs/miden-utils-diagnostics"
 readme = "README.md"

--- a/crates/utils-indexing/Cargo.toml
+++ b/crates/utils-indexing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-indexing"
-version = "0.25.7"
+version = "0.25.8"
 description = "Type-safe u32-indexed vector utilities for Miden"
 readme = "README.md"
 categories = ["development-tools", "no-std"]

--- a/crates/utils-sync/Cargo.toml
+++ b/crates/utils-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-sync"
-version = "0.25.7"
+version = "0.25.8"
 description = "no-std compatible locking primitives for the Miden project"
 documentation = "https://docs.rs/miden-utils-sync"
 readme = "README.md"

--- a/miden-core-fuzz/Cargo.lock
+++ b/miden-core-fuzz/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-assembly"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "log",
  "miden-assembly-syntax-cst",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "derive_more",
  "log",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "miden-crypto",
  "proptest",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "lock_api",
  "loom",

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-vm"
-version = "0.25.7"
+version = "0.25.8"
 description = "Miden virtual machine"
 documentation = "https://docs.rs/miden-vm"
 readme = "README.md"

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-processor"
-version = "0.25.7"
+version = "0.25.8"
 description = "Miden VM processor"
 documentation = "https://docs.rs/miden-processor"
 readme = "README.md"

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-prover"
-version = "0.25.7"
+version = "0.25.8"
 description = "Miden VM prover"
 documentation = "https://docs.rs/miden-prover"
 readme = "README.md"

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-verifier"
-version = "0.25.7"
+version = "0.25.8"
 description = "Miden VM execution verifier"
 documentation = "https://docs.rs/miden-verifier"
 readme = "README.md"


### PR DESCRIPTION
This bug would cause any attempt to read package module info to fail if the procedure name was a quoted identifier (commonly needed for symbols emitted from languages like Rust).