### PR TITLE
fix: Reuse debug source map tables during package load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [BREAKING] Add missing constraint in Bitwise chiplet ([#3386](https://github.com/0xMiden/miden-vm/pull/3386)).
 - [BREAKING] Fixed a soundness gap in the chiplets AIR where a chiplet section's first-row initialization was skipped when the preceding section was empty. A program that uses memory but performs no `u32and`/`u32xor` operations produces an empty bitwise section, which caused the memory chiplet to skip its "values not being written must be zero" reset; a malicious prover could exploit this to forge a read of never-written memory. Each section's first row is now identified from the chiplet selectors at the boundary rather than from the previous chiplet's last row, so the initialization holds no matter which preceding sections are empty. The ACE section-start reset was hardened the same way as a precaution ([#3387](https://github.com/0xMiden/miden-vm/pull/3387)).
 - [BREAKING] Optimize periodic columns evaluation for fewer ACE gates ([#3347](https://github.com/0xMiden/miden-vm/pull/3347)).
+- [BREAKING] Reused serialized debug source map tables during package load, avoiding a slow table rebuild and changing `DebugSourceAsmOp` fields to shared values ([#3395](https://github.com/0xMiden/miden-vm/pull/3395)).
 
 #### Fixes
 

--- a/crates/assembly/src/mast_forest_builder/static_import.rs
+++ b/crates/assembly/src/mast_forest_builder/static_import.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
+use alloc::{collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 
 use miden_core::{
     Word,
@@ -450,10 +450,10 @@ impl MastForestBuilder {
                 (
                     row.op_idx as usize,
                     AssemblyOp::new(
-                        row.location.clone(),
-                        row.context_name.clone(),
+                        row.location().cloned(),
+                        String::from(row.context_name()),
                         row.num_cycles,
-                        row.op.clone(),
+                        String::from(row.op()),
                     ),
                 )
             })

--- a/crates/assembly/src/project/tests.rs
+++ b/crates/assembly/src/project/tests.rs
@@ -584,7 +584,7 @@ end
             .expect("root package should contain source map")
             .asm_ops()
             .iter()
-            .find(|row| row.context_name == context_name)
+            .find(|row| row.context_name() == context_name)
             .map(|row| row.source_node)
             .unwrap_or_else(|| panic!("missing asm-op row for {context_name}"))
     };
@@ -603,11 +603,7 @@ end
         .into_iter()
         .filter(|&source_node| debug_info.source_node(source_node).unwrap().exec_node == depa_exec)
         .map(|source_node| {
-            debug_info
-                .first_asm_op_for_source_node(source_node)
-                .unwrap()
-                .context_name
-                .as_str()
+            debug_info.first_asm_op_for_source_node(source_node).unwrap().context_name()
         })
         .collect::<Vec<_>>();
     assert!(contexts_for_deduped_exec.contains(&"depa_ctx"));
@@ -635,7 +631,7 @@ end
         round_tripped_debug_info
             .first_asm_op_for_source_node(depa_source)
             .unwrap()
-            .context_name,
+            .context_name(),
         "depa_ctx",
     );
     assert_eq!(

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -1,6 +1,6 @@
 //! Serialization and deserialization for the debug_info section.
 
-use alloc::{collections::BTreeSet, string::String, sync::Arc, vec::Vec};
+use alloc::{string::String, sync::Arc, vec::Vec};
 
 use miden_core::{
     Word,
@@ -436,18 +436,9 @@ impl Deserializable for DebugSourceMapSection {
             min_source_map_asm_op_row_serialized_size(),
         )?;
         let mut asm_ops = Vec::with_capacity(asm_ops_len);
-        let mut used_locations = alloc::vec![false; locations.len()];
-        let mut used_strings = alloc::vec![false; strings.len()];
         for _ in 0..asm_ops_len {
-            asm_ops.push(read_source_asm_op(
-                source,
-                &locations,
-                &strings,
-                &mut used_locations,
-                &mut used_strings,
-            )?);
+            asm_ops.push(read_source_asm_op(source, &locations, &strings)?);
         }
-        validate_source_map_tables(&locations, &strings, &used_locations, &used_strings)?;
 
         let debug_vars_len = read_bounded_len(source, "debug_source_map debug vars", 1)?;
         let debug_vars = source.read_many_iter(debug_vars_len)?.collect::<Result<_, _>>()?;
@@ -484,8 +475,6 @@ fn read_source_asm_op<R: ByteReader>(
     source: &mut R,
     locations: &[Arc<Location>],
     strings: &[Arc<str>],
-    used_locations: &mut [bool],
-    used_strings: &mut [bool],
 ) -> Result<DebugSourceAsmOp, DeserializationError> {
     let source_node = DebugSourceNodeId::read_from(source)?;
     let op_idx = source.read_u32()?;
@@ -497,13 +486,12 @@ fn read_source_asm_op<R: ByteReader>(
                 locations.len()
             ))
         })?;
-        used_locations[location_idx] = true;
         Some(Arc::clone(location))
     } else {
         None
     };
-    let context_name = read_source_map_string_ref(source, strings, used_strings)?;
-    let op = read_source_map_string_ref(source, strings, used_strings)?;
+    let context_name = read_source_map_string_ref(source, strings)?;
+    let op = read_source_map_string_ref(source, strings)?;
     let num_cycles = source.read_u8()?;
     Ok(DebugSourceAsmOp::from_shared(
         source_node,
@@ -535,7 +523,6 @@ fn write_source_map_string_ref<W: ByteWriter>(
 fn read_source_map_string_ref<R: ByteReader>(
     source: &mut R,
     strings: &[Arc<str>],
-    used_strings: &mut [bool],
 ) -> Result<Arc<str>, DeserializationError> {
     let string_idx = source.read_u32()? as usize;
     let string = strings.get(string_idx).ok_or_else(|| {
@@ -544,47 +531,7 @@ fn read_source_map_string_ref<R: ByteReader>(
             strings.len()
         ))
     })?;
-    used_strings[string_idx] = true;
     Ok(Arc::clone(string))
-}
-
-fn validate_source_map_tables(
-    locations: &[Arc<Location>],
-    strings: &[Arc<str>],
-    used_locations: &[bool],
-    used_strings: &[bool],
-) -> Result<(), DeserializationError> {
-    let mut unique_locations = BTreeSet::new();
-    for (idx, location) in locations.iter().enumerate() {
-        if !unique_locations.insert(Arc::clone(location)) {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "debug_source_map location table entry {idx} duplicates an earlier location"
-            )));
-        }
-    }
-
-    let mut unique_strings = BTreeSet::new();
-    for (idx, string) in strings.iter().enumerate() {
-        if !unique_strings.insert(Arc::clone(string)) {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "debug_source_map string table entry {idx} duplicates an earlier string"
-            )));
-        }
-    }
-
-    if let Some(idx) = used_locations.iter().position(|used| !*used) {
-        return Err(DeserializationError::InvalidValue(alloc::format!(
-            "debug_source_map location table entry {idx} is not referenced by asm ops"
-        )));
-    }
-
-    if let Some(idx) = used_strings.iter().position(|used| !*used) {
-        return Err(DeserializationError::InvalidValue(alloc::format!(
-            "debug_source_map string table entry {idx} is not referenced by asm ops"
-        )));
-    }
-
-    Ok(())
 }
 
 // DEBUG ERROR MESSAGES SECTION SERIALIZATION
@@ -1340,7 +1287,7 @@ mod tests {
     }
 
     #[test]
-    fn test_debug_source_map_deserialization_rejects_duplicate_interned_strings() {
+    fn test_debug_source_map_deserialization_accepts_duplicate_interned_strings() {
         let mut bytes = Vec::new();
         bytes.write_u8(DEBUG_SOURCE_MAP_VERSION);
         bytes.write_usize(0);
@@ -1360,11 +1307,14 @@ mod tests {
         bytes.write_usize(0);
         bytes.write_usize(0);
 
-        assert!(DebugSourceMapSection::read_from_bytes(&bytes).is_err());
+        let section = DebugSourceMapSection::read_from_bytes(&bytes).unwrap();
+        assert_eq!(section.strings().len(), 2);
+        assert_eq!(section.asm_ops()[0].context_name(), "test::ctx");
+        assert_eq!(section.asm_ops()[0].op(), "test::ctx");
     }
 
     #[test]
-    fn test_debug_source_map_deserialization_rejects_unused_interned_locations() {
+    fn test_debug_source_map_deserialization_accepts_unused_interned_locations() {
         let location =
             Location::new(Uri::new("file://test.masm"), ByteIndex::new(10), ByteIndex::new(14));
         let unused_location =
@@ -1392,7 +1342,9 @@ mod tests {
         bytes.write_usize(0);
         bytes.write_usize(0);
 
-        assert!(DebugSourceMapSection::read_from_bytes(&bytes).is_err());
+        let section = DebugSourceMapSection::read_from_bytes(&bytes).unwrap();
+        assert_eq!(section.locations().len(), 2);
+        assert_eq!(section.asm_ops()[0].location(), Some(&location));
     }
 
     #[test]

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -1,6 +1,6 @@
 //! Serialization and deserialization for the debug_info section.
 
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{collections::BTreeSet, string::String, sync::Arc, vec::Vec};
 
 use miden_core::{
     Word,
@@ -293,7 +293,7 @@ impl Serializable for DebugSourceAsmOp {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.source_node.write_into(target);
         target.write_u32(self.op_idx);
-        write_location(&self.location, target);
+        write_location(self.location(), target);
         self.context_name.write_into(target);
         self.op.write_into(target);
         target.write_u8(self.num_cycles);
@@ -311,9 +311,9 @@ impl Deserializable for DebugSourceAsmOp {
         Ok(Self {
             source_node,
             op_idx,
-            location,
-            context_name,
-            op,
+            location: location.map(Arc::new),
+            context_name: Arc::from(context_name),
+            op: Arc::from(op),
             num_cycles,
         })
     }
@@ -421,13 +421,13 @@ impl Deserializable for DebugSourceMapSection {
         )?;
         let mut locations = Vec::with_capacity(locations_len);
         for _ in 0..locations_len {
-            locations.push(read_required_location(source)?);
+            locations.push(Arc::new(read_required_location(source)?));
         }
 
         let strings_len = read_bounded_len(source, "debug_source_map strings", 1)?;
         let mut strings = Vec::with_capacity(strings_len);
         for _ in 0..strings_len {
-            strings.push(read_owned_string(source)?);
+            strings.push(Arc::from(read_owned_string(source)?));
         }
 
         let asm_ops_len = read_bounded_len(
@@ -436,22 +436,31 @@ impl Deserializable for DebugSourceMapSection {
             min_source_map_asm_op_row_serialized_size(),
         )?;
         let mut asm_ops = Vec::with_capacity(asm_ops_len);
+        let mut used_locations = alloc::vec![false; locations.len()];
+        let mut used_strings = alloc::vec![false; strings.len()];
         for _ in 0..asm_ops_len {
-            asm_ops.push(read_source_asm_op(source, &locations, &strings)?);
+            asm_ops.push(read_source_asm_op(
+                source,
+                &locations,
+                &strings,
+                &mut used_locations,
+                &mut used_strings,
+            )?);
         }
+        validate_source_map_tables(&locations, &strings, &used_locations, &used_strings)?;
 
         let debug_vars_len = read_bounded_len(source, "debug_source_map debug vars", 1)?;
         let debug_vars = source.read_many_iter(debug_vars_len)?.collect::<Result<_, _>>()?;
         let inline_calls_len = read_bounded_len(source, "debug_source_map inline calls", 1)?;
         let inline_calls = source.read_many_iter(inline_calls_len)?.collect::<Result<_, _>>()?;
-        Ok(Self::from_parts_with_inline_calls(asm_ops, debug_vars, inline_calls))
+        Ok(Self::from_interned_parts(locations, strings, asm_ops, debug_vars, inline_calls))
     }
 }
 
 fn write_source_asm_op<W: ByteWriter>(
     asm_op: &DebugSourceAsmOp,
-    locations: &[Location],
-    strings: &[String],
+    locations: &[Arc<Location>],
+    strings: &[Arc<str>],
     target: &mut W,
 ) {
     asm_op.source_node.write_into(target);
@@ -473,26 +482,30 @@ fn write_source_asm_op<W: ByteWriter>(
 
 fn read_source_asm_op<R: ByteReader>(
     source: &mut R,
-    locations: &[Location],
-    strings: &[String],
+    locations: &[Arc<Location>],
+    strings: &[Arc<str>],
+    used_locations: &mut [bool],
+    used_strings: &mut [bool],
 ) -> Result<DebugSourceAsmOp, DeserializationError> {
     let source_node = DebugSourceNodeId::read_from(source)?;
     let op_idx = source.read_u32()?;
     let location = if source.read_bool()? {
         let location_idx = source.read_u32()? as usize;
-        Some(locations.get(location_idx).cloned().ok_or_else(|| {
+        let location = locations.get(location_idx).ok_or_else(|| {
             DeserializationError::InvalidValue(alloc::format!(
                 "debug source asm op location index {location_idx} out of bounds for {} locations",
                 locations.len()
             ))
-        })?)
+        })?;
+        used_locations[location_idx] = true;
+        Some(Arc::clone(location))
     } else {
         None
     };
-    let context_name = read_source_map_string_ref(source, strings)?;
-    let op = read_source_map_string_ref(source, strings)?;
+    let context_name = read_source_map_string_ref(source, strings, used_strings)?;
+    let op = read_source_map_string_ref(source, strings, used_strings)?;
     let num_cycles = source.read_u8()?;
-    Ok(DebugSourceAsmOp::new(
+    Ok(DebugSourceAsmOp::from_shared(
         source_node,
         op_idx,
         location,
@@ -507,7 +520,11 @@ fn min_source_map_asm_op_row_serialized_size() -> usize {
     DebugSourceNodeId::min_serialized_size() + 4 + 1 + 4 + 4 + 1
 }
 
-fn write_source_map_string_ref<W: ByteWriter>(string: &String, strings: &[String], target: &mut W) {
+fn write_source_map_string_ref<W: ByteWriter>(
+    string: &Arc<str>,
+    strings: &[Arc<str>],
+    target: &mut W,
+) {
     let string_idx = strings
         .iter()
         .position(|candidate| candidate == string)
@@ -517,15 +534,57 @@ fn write_source_map_string_ref<W: ByteWriter>(string: &String, strings: &[String
 
 fn read_source_map_string_ref<R: ByteReader>(
     source: &mut R,
-    strings: &[String],
-) -> Result<String, DeserializationError> {
+    strings: &[Arc<str>],
+    used_strings: &mut [bool],
+) -> Result<Arc<str>, DeserializationError> {
     let string_idx = source.read_u32()? as usize;
-    strings.get(string_idx).cloned().ok_or_else(|| {
+    let string = strings.get(string_idx).ok_or_else(|| {
         DeserializationError::InvalidValue(alloc::format!(
             "debug source asm op string index {string_idx} out of bounds for {} strings",
             strings.len()
         ))
-    })
+    })?;
+    used_strings[string_idx] = true;
+    Ok(Arc::clone(string))
+}
+
+fn validate_source_map_tables(
+    locations: &[Arc<Location>],
+    strings: &[Arc<str>],
+    used_locations: &[bool],
+    used_strings: &[bool],
+) -> Result<(), DeserializationError> {
+    let mut unique_locations = BTreeSet::new();
+    for (idx, location) in locations.iter().enumerate() {
+        if !unique_locations.insert(Arc::clone(location)) {
+            return Err(DeserializationError::InvalidValue(alloc::format!(
+                "debug_source_map location table entry {idx} duplicates an earlier location"
+            )));
+        }
+    }
+
+    let mut unique_strings = BTreeSet::new();
+    for (idx, string) in strings.iter().enumerate() {
+        if !unique_strings.insert(Arc::clone(string)) {
+            return Err(DeserializationError::InvalidValue(alloc::format!(
+                "debug_source_map string table entry {idx} duplicates an earlier string"
+            )));
+        }
+    }
+
+    if let Some(idx) = used_locations.iter().position(|used| !*used) {
+        return Err(DeserializationError::InvalidValue(alloc::format!(
+            "debug_source_map location table entry {idx} is not referenced by asm ops"
+        )));
+    }
+
+    if let Some(idx) = used_strings.iter().position(|used| !*used) {
+        return Err(DeserializationError::InvalidValue(alloc::format!(
+            "debug_source_map string table entry {idx} is not referenced by asm ops"
+        )));
+    }
+
+    Ok(())
 }
 
 // DEBUG ERROR MESSAGES SECTION SERIALIZATION
@@ -573,7 +632,7 @@ impl Deserializable for DebugErrorMessagesSection {
     }
 }
 
-fn write_location<W: ByteWriter>(location: &Option<Location>, target: &mut W) {
+fn write_location<W: ByteWriter>(location: Option<&Location>, target: &mut W) {
     if let Some(location) = location {
         target.write_bool(true);
         write_required_location(location, target);
@@ -1207,7 +1266,7 @@ mod tests {
             alloc::vec![],
         );
 
-        assert_eq!(section.locations(), &[location]);
+        assert_eq!(section.locations(), &[Arc::new(location)]);
 
         let bytes = section.to_bytes();
         let deserialized = DebugSourceMapSection::read_from_bytes(&bytes).unwrap();
@@ -1230,10 +1289,10 @@ mod tests {
         assert_eq!(
             section.strings(),
             &[
-                String::from("test::ctx"),
-                String::from("add"),
-                String::from("mul"),
-                String::from("test::other"),
+                Arc::from("test::ctx"),
+                Arc::from("add"),
+                Arc::from("mul"),
+                Arc::from("test::other"),
             ]
         );
 
@@ -1241,6 +1300,99 @@ mod tests {
         let deserialized = DebugSourceMapSection::read_from_bytes(&bytes).unwrap();
         assert_eq!(deserialized.strings(), section.strings());
         assert_eq!(deserialized.asm_ops(), section.asm_ops());
+    }
+
+    #[test]
+    fn test_debug_source_map_deserialization_reuses_interned_tables() {
+        let source_node = DebugSourceNodeId::from(0);
+        let location =
+            Location::new(Uri::new("file://test.masm"), ByteIndex::new(10), ByteIndex::new(14));
+        let section = DebugSourceMapSection::from_parts(
+            alloc::vec![
+                DebugSourceAsmOp::new(
+                    source_node,
+                    0,
+                    Some(location.clone()),
+                    "test::ctx".into(),
+                    "push.1".into(),
+                    1,
+                ),
+                DebugSourceAsmOp::new(
+                    source_node,
+                    1,
+                    Some(location),
+                    "test::ctx".into(),
+                    "add".into(),
+                    1,
+                ),
+            ],
+            alloc::vec![],
+        );
+
+        let deserialized = DebugSourceMapSection::read_from_bytes(&section.to_bytes()).unwrap();
+        let first_row = &deserialized.asm_ops()[0];
+        let second_row = &deserialized.asm_ops()[1];
+
+        assert!(Arc::ptr_eq(first_row.location.as_ref().unwrap(), &deserialized.locations()[0]));
+        assert!(Arc::ptr_eq(second_row.location.as_ref().unwrap(), &deserialized.locations()[0],));
+        assert!(Arc::ptr_eq(&first_row.context_name, &deserialized.strings()[0]));
+        assert!(Arc::ptr_eq(&second_row.context_name, &deserialized.strings()[0]));
+    }
+
+    #[test]
+    fn test_debug_source_map_deserialization_rejects_duplicate_interned_strings() {
+        let mut bytes = Vec::new();
+        bytes.write_u8(DEBUG_SOURCE_MAP_VERSION);
+        bytes.write_usize(0);
+
+        bytes.write_usize(2);
+        "test::ctx".write_into(&mut bytes);
+        "test::ctx".write_into(&mut bytes);
+
+        bytes.write_usize(1);
+        DebugSourceNodeId::from(0).write_into(&mut bytes);
+        bytes.write_u32(0);
+        bytes.write_bool(false);
+        bytes.write_u32(0);
+        bytes.write_u32(1);
+        bytes.write_u8(1);
+
+        bytes.write_usize(0);
+        bytes.write_usize(0);
+
+        assert!(DebugSourceMapSection::read_from_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_debug_source_map_deserialization_rejects_unused_interned_locations() {
+        let location =
+            Location::new(Uri::new("file://test.masm"), ByteIndex::new(10), ByteIndex::new(14));
+        let unused_location =
+            Location::new(Uri::new("file://unused.masm"), ByteIndex::new(20), ByteIndex::new(24));
+
+        let mut bytes = Vec::new();
+        bytes.write_u8(DEBUG_SOURCE_MAP_VERSION);
+        bytes.write_usize(2);
+        write_required_location(&location, &mut bytes);
+        write_required_location(&unused_location, &mut bytes);
+
+        bytes.write_usize(2);
+        "test::ctx".write_into(&mut bytes);
+        "add".write_into(&mut bytes);
+
+        bytes.write_usize(1);
+        DebugSourceNodeId::from(0).write_into(&mut bytes);
+        bytes.write_u32(0);
+        bytes.write_bool(true);
+        bytes.write_u32(0);
+        bytes.write_u32(0);
+        bytes.write_u32(1);
+        bytes.write_u8(1);
+
+        bytes.write_usize(0);
+        bytes.write_usize(0);
+
+        assert!(DebugSourceMapSection::read_from_bytes(&bytes).is_err());
     }
 
     #[test]

--- a/crates/mast-package/src/debug_info/types.rs
+++ b/crates/mast-package/src/debug_info/types.rs
@@ -1196,11 +1196,11 @@ pub struct DebugSourceAsmOp {
     /// Operation index local to the reduced execution node.
     pub op_idx: u32,
     /// Optional source location for the assembly operation.
-    pub location: Option<Location>,
+    pub location: Option<Arc<Location>>,
     /// Assembly context name.
-    pub context_name: String,
+    pub context_name: Arc<str>,
     /// Assembly operation text.
-    pub op: String,
+    pub op: Arc<str>,
     /// Number of VM cycles taken by the operation.
     pub num_cycles: u8,
 }
@@ -1215,6 +1215,24 @@ impl DebugSourceAsmOp {
         op: String,
         num_cycles: u8,
     ) -> Self {
+        Self::from_shared(
+            source_node,
+            op_idx,
+            location.map(Arc::new),
+            Arc::from(context_name),
+            Arc::from(op),
+            num_cycles,
+        )
+    }
+
+    pub(crate) fn from_shared(
+        source_node: DebugSourceNodeId,
+        op_idx: u32,
+        location: Option<Arc<Location>>,
+        context_name: Arc<str>,
+        op: Arc<str>,
+        num_cycles: u8,
+    ) -> Self {
         Self {
             source_node,
             op_idx,
@@ -1223,6 +1241,21 @@ impl DebugSourceAsmOp {
             op,
             num_cycles,
         }
+    }
+
+    /// Returns the source location for this operation, if present.
+    pub fn location(&self) -> Option<&Location> {
+        self.location.as_deref()
+    }
+
+    /// Returns the assembly context name.
+    pub fn context_name(&self) -> &str {
+        self.context_name.as_ref()
+    }
+
+    /// Returns the assembly operation text.
+    pub fn op(&self) -> &str {
+        self.op.as_ref()
     }
 }
 
@@ -1288,9 +1321,9 @@ pub struct DebugSourceMapSection {
     /// Version of the debug source map format.
     version: u8,
     /// Deduplicated source locations referenced by assembly operation rows.
-    locations: Vec<Location>,
+    locations: Vec<Arc<Location>>,
     /// Deduplicated strings referenced by assembly operation rows.
-    strings: Vec<String>,
+    strings: Vec<Arc<str>>,
     /// Source-keyed assembly operation rows.
     asm_ops: Vec<DebugSourceAsmOp>,
     /// Source-keyed debug variable rows.
@@ -1319,12 +1352,22 @@ impl DebugSourceMapSection {
 
     /// Creates a source-keyed debug metadata section from rows, including inline calls.
     pub fn from_parts_with_inline_calls(
+        mut asm_ops: Vec<DebugSourceAsmOp>,
+        debug_vars: Vec<DebugSourceVar>,
+        inline_calls: Vec<DebugSourceInlineCall>,
+    ) -> Self {
+        let locations = intern_locations(&mut asm_ops);
+        let strings = intern_source_map_strings(&mut asm_ops);
+        Self::from_interned_parts(locations, strings, asm_ops, debug_vars, inline_calls)
+    }
+
+    pub(crate) fn from_interned_parts(
+        locations: Vec<Arc<Location>>,
+        strings: Vec<Arc<str>>,
         asm_ops: Vec<DebugSourceAsmOp>,
         debug_vars: Vec<DebugSourceVar>,
         inline_calls: Vec<DebugSourceInlineCall>,
     ) -> Self {
-        let locations = intern_locations(&asm_ops);
-        let strings = intern_source_map_strings(&asm_ops);
         Self {
             version: DEBUG_SOURCE_MAP_VERSION,
             locations,
@@ -1346,12 +1389,12 @@ impl DebugSourceMapSection {
     }
 
     /// Returns the deduplicated source locations referenced by assembly operation rows.
-    pub fn locations(&self) -> &[Location] {
+    pub fn locations(&self) -> &[Arc<Location>] {
         &self.locations
     }
 
     /// Returns the deduplicated strings referenced by assembly operation rows.
-    pub fn strings(&self) -> &[String] {
+    pub fn strings(&self) -> &[Arc<str>] {
         &self.strings
     }
 
@@ -1434,30 +1477,39 @@ impl DebugSourceMapSection {
     }
 }
 
-fn intern_locations(asm_ops: &[DebugSourceAsmOp]) -> Vec<Location> {
+fn intern_locations(asm_ops: &mut [DebugSourceAsmOp]) -> Vec<Arc<Location>> {
     let mut locations = Vec::new();
     let mut by_location = BTreeMap::new();
-    for location in asm_ops.iter().filter_map(|row| row.location.as_ref()) {
-        by_location.entry(location.clone()).or_insert_with(|| {
-            let idx = locations.len();
-            locations.push(location.clone());
-            idx
+    for location in asm_ops.iter_mut().filter_map(|row| row.location.as_mut()) {
+        let idx = *by_location.entry(Arc::clone(location)).or_insert_with(|| {
+            locations.push(Arc::clone(location));
+            locations.len() - 1
         });
+        *location = Arc::clone(&locations[idx]);
     }
     locations
 }
 
-fn intern_source_map_strings(asm_ops: &[DebugSourceAsmOp]) -> Vec<String> {
+fn intern_source_map_strings(asm_ops: &mut [DebugSourceAsmOp]) -> Vec<Arc<str>> {
     let mut strings = Vec::new();
     let mut by_string = BTreeMap::new();
-    for value in asm_ops.iter().flat_map(|row| [&row.context_name, &row.op]) {
-        by_string.entry(value.clone()).or_insert_with(|| {
-            let idx = strings.len();
-            strings.push(value.clone());
-            idx
-        });
+    for row in asm_ops {
+        intern_source_map_string(&mut row.context_name, &mut strings, &mut by_string);
+        intern_source_map_string(&mut row.op, &mut strings, &mut by_string);
     }
     strings
+}
+
+fn intern_source_map_string(
+    value: &mut Arc<str>,
+    strings: &mut Vec<Arc<str>>,
+    by_string: &mut BTreeMap<Arc<str>, usize>,
+) {
+    let idx = *by_string.entry(Arc::clone(value)).or_insert_with(|| {
+        strings.push(Arc::clone(value));
+        strings.len() - 1
+    });
+    *value = Arc::clone(&strings[idx]);
 }
 
 // DEBUG ERROR MESSAGES SECTION
@@ -1943,11 +1995,11 @@ mod tests {
         let source_b = source_graph.roots[1];
         assert_ne!(source_a, source_b);
         assert_eq!(
-            merged_debug.first_asm_op_for_source_node(source_a).unwrap().context_name,
+            merged_debug.first_asm_op_for_source_node(source_a).unwrap().context_name(),
             "alias_a",
         );
         assert_eq!(
-            merged_debug.first_asm_op_for_source_node(source_b).unwrap().context_name,
+            merged_debug.first_asm_op_for_source_node(source_b).unwrap().context_name(),
             "alias_b",
         );
         assert_eq!(
@@ -2039,7 +2091,7 @@ mod tests {
         let merged_child = source_graph.nodes[source_graph.roots[0].as_u32() as usize].children[0];
         assert_eq!(source_graph.nodes[merged_child.as_u32() as usize].exec_node, merged_callee,);
         assert_eq!(
-            merged_debug.first_asm_op_for_source_node(merged_child).unwrap().context_name,
+            merged_debug.first_asm_op_for_source_node(merged_child).unwrap().context_name(),
             "callee",
         );
     }
@@ -2082,10 +2134,10 @@ mod tests {
             ],
         );
 
-        assert_eq!(source_map.asm_op_for_operation(source_a, 0).unwrap().context_name, "alias_a",);
-        assert_eq!(source_map.asm_op_for_operation(source_b, 0).unwrap().context_name, "alias_b",);
+        assert_eq!(source_map.asm_op_for_operation(source_a, 0).unwrap().context_name(), "alias_a",);
+        assert_eq!(source_map.asm_op_for_operation(source_b, 0).unwrap().context_name(), "alias_b",);
         assert_eq!(
-            source_map.first_asm_op_for_source_node(source_b).unwrap().context_name,
+            source_map.first_asm_op_for_source_node(source_b).unwrap().context_name(),
             "alias_b",
         );
         let vars_b = source_map.debug_vars_for_operation(source_b, 0).collect::<Vec<_>>();

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -1593,7 +1593,7 @@ mod tests {
 
         assert_eq!(debug_info.source_node(source_node).unwrap().exec_node, exec_node);
         assert_eq!(
-            debug_info.asm_op_for_operation(source_node, 0).unwrap().context_name,
+            debug_info.asm_op_for_operation(source_node, 0).unwrap().context_name(),
             "app::entry"
         );
     }
@@ -2072,7 +2072,7 @@ mod tests {
 
         assert_eq!(debug_info.source_node(source_node).unwrap().exec_node, entrypoint_node);
         assert_eq!(
-            debug_info.first_asm_op_for_source_node(source_node).unwrap().context_name,
+            debug_info.first_asm_op_for_source_node(source_node).unwrap().context_name(),
             "alias_b"
         );
 
@@ -2198,11 +2198,14 @@ mod tests {
             merged_debug
                 .first_asm_op_for_source_node(placeholder_source)
                 .unwrap()
-                .context_name,
+                .context_name(),
             "placeholder",
         );
         assert_eq!(
-            merged_debug.first_asm_op_for_source_node(concrete_source).unwrap().context_name,
+            merged_debug
+                .first_asm_op_for_source_node(concrete_source)
+                .unwrap()
+                .context_name(),
             "concrete",
         );
     }
@@ -2241,8 +2244,8 @@ mod tests {
             debug_info
                 .first_asm_op_for_source_node(source_node)
                 .unwrap()
-                .context_name
-                .clone()
+                .context_name()
+                .into()
         }
 
         assert_eq!(

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -499,7 +499,7 @@ impl<'a> PackageSourceDebugContext<'a> {
             None => self.debug_info.first_asm_op_for_source_node(source_node_id),
         }?;
 
-        assembly_op.location.as_ref()
+        assembly_op.location()
     }
 }
 


### PR DESCRIPTION
This fixes a slow path when loading packages with debug info. The deserializer already reads the source map's location and string tables, but it rebuilt those tables from every asm op. Rust compiled packages can have many repeated source strings and locations, so package load became very slow.

The fix keeps the tables from the serialized section and makes each asm op point at those shared values. The deserializer also rejects tables with duplicate or unused entries.

This changes `DebugSourceAsmOp` to store shared `Arc` values. Callers use accessors for location, context_name, and op.
  
Closes #3394  