### PR TITLE
Use serde-wincode reexport for proof encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.25.7 (2026-07-20)
+
+- Use the `wincode` crate re-exported by `serde-wincode` for proof encoding.
+
 ## v0.25.6 (2026-07-19)
 
 - Update `wincode` dependency to v0.6.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "insta",
  "miden-ace-codegen",
@@ -1343,7 +1343,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "env_logger",
  "insta",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "env_logger",
  "log",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "criterion",
  "derive_more",
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "criterion",
  "env_logger",
@@ -1501,7 +1501,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "miden-format"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "clap",
  "miden-assembly-syntax-cst",
@@ -1600,7 +1600,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -1652,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry-local"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "clap",
  "miden-assembly-syntax",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "insta",
  "itertools 0.14.0",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-air",
  "miden-assembly",
@@ -1819,7 +1819,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-crypto",
  "miden-test-serde-macros",
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "lock_api",
  "loom",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-blake3-bench"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "clap",
  "codspeed-criterion-compat",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-synthetic-bench"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-processor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,7 +1740,6 @@ dependencies = [
  "serde-wincode",
  "tokio",
  "tracing",
- "wincode",
 ]
 
 [[package]]
@@ -1816,7 +1815,6 @@ dependencies = [
  "serde-wincode",
  "test-case",
  "thiserror",
- "wincode",
 ]
 
 [[package]]
@@ -1870,7 +1868,6 @@ dependencies = [
  "serde-wincode",
  "thiserror",
  "tracing",
- "wincode",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,6 @@ miden-serde-utils = { version = "0.28", default-features = false }
 
 # Serialization
 serde-wincode = { version = "0.1", default-features = false, features = ["alloc"] }
-wincode       = { version = "0.6", default-features = false, features = ["alloc"] }
 
 # Third-party crates
 clap            = { version = "4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rust-version = "1.96.1"
 # Private workspace members inherit this version. Publishable crates keep their
 # own package versions so release tooling can publish only the crates selected
 # for a release.
-version = "0.25.6"
+version = "0.25.7"
 
 [profile.optimized]
 inherits = "release"

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-air"
-version = "0.25.6"
+version = "0.25.7"
 description = "Algebraic intermediate representation of Miden VM processor"
 documentation = "https://docs.rs/miden-air"
 readme = "README.md"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.25.6"
+version = "0.25.7"
 description = "Miden VM core components"
 documentation = "https://docs.rs/miden-core"
 readme = "README.md"

--- a/crates/ace-codegen/Cargo.toml
+++ b/crates/ace-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-ace-codegen"
-version = "0.25.6"
+version = "0.25.7"
 description = "ACE circuit codegen for Plonky3-based Miden AIRs."
 documentation = "https://docs.rs/miden-ace-codegen"
 readme = "README.md"

--- a/crates/assembly-syntax-cst/Cargo.toml
+++ b/crates/assembly-syntax-cst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax-cst"
-version = "0.25.6"
+version = "0.25.7"
 description = "Lossless concrete syntax tree support for the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax-cst"
 readme = "README.md"

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax"
-version = "0.25.6"
+version = "0.25.7"
 description = "Parsing and semantic analysis of the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax"
 readme = "README.md"

--- a/crates/assembly/Cargo.toml
+++ b/crates/assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly"
-version = "0.25.6"
+version = "0.25.7"
 description = "Miden VM assembly language"
 documentation = "https://docs.rs/miden-assembly"
 readme = "README.md"

--- a/crates/debug-types/Cargo.toml
+++ b/crates/debug-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-debug-types"
-version = "0.25.6"
+version = "0.25.7"
 description = "Core source-level debugging information types used throughout the Miden toolchain"
 documentation = "https://docs.rs/miden-debug-types"
 readme = "README.md"

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core-lib"
-version = "0.25.6"
+version = "0.25.7"
 description = "Miden VM core library"
 documentation = "https://docs.rs/miden-core-lib"
 readme = "README.md"

--- a/crates/lib/core/asm/miden-project.toml
+++ b/crates/lib/core/asm/miden-project.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.25.6"
+version = "0.25.7"
 
 [lib]
 namespace = "miden::core"

--- a/crates/mast-package/Cargo.toml
+++ b/crates/mast-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-mast-package"
-version = "0.25.6"
+version = "0.25.7"
 description = "Package containing a compiled Miden MAST artifact with declared dependencies and exports"
 documentation = "https://docs.rs/miden-mast-package"
 readme = "README.md"

--- a/crates/miden-format/Cargo.toml
+++ b/crates/miden-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-format"
-version = "0.25.6"
+version = "0.25.7"
 description = "Formatter for the Miden Assembly language"
 documentation = "https://docs.rs/miden-format"
 readme = "README.md"

--- a/crates/package-registry-local/Cargo.toml
+++ b/crates/package-registry-local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry-local"
-version = "0.25.6"
+version = "0.25.7"
 description = "Filesystem-backed local package registry for Miden packages"
 documentation = "https://docs.rs/miden-package-registry-local"
 readme = "README.md"

--- a/crates/package-registry/Cargo.toml
+++ b/crates/package-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry"
-version = "0.25.6"
+version = "0.25.7"
 description = "Package registry interfaces and dependency resolution for Miden packages"
 documentation = "https://docs.rs/miden-package-registry"
 readme = "README.md"

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-project"
-version = "0.25.6"
+version = "0.25.7"
 description = "Interface for working with Miden projects"
 documentation = "https://docs.rs/miden-project"
 readme = "README.md"

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -40,7 +40,6 @@ proptest = { workspace = true, optional = true }
 serde-wincode.workspace = true
 test-case = "3.2"
 thiserror.workspace = true
-wincode.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 pretty_assertions = { workspace = true, default-features = false, features = [

--- a/crates/test-utils/src/recursive_verifier.rs
+++ b/crates/test-utils/src/recursive_verifier.rs
@@ -37,6 +37,7 @@ use miden_crypto::{
         verifier::VerifierError as CryptoVerifierError,
     },
 };
+use serde_wincode::{SerdeCompat, wincode};
 
 use crate::crypto::{MerklePath, MerkleStore, PartialMerkleTree};
 
@@ -86,12 +87,11 @@ pub fn generate_advice_inputs(
     // 1. Deserialize STARK proof bytes.
     let proof_encoding_config = wincode::config::Configuration::default()
         .with_preallocation_size_limit::<MAX_STARK_PROOF_BYTES>();
-    let proof: StarkProofData<Felt, QuadFelt, P2Config> = <serde_wincode::SerdeCompat<
-        StarkProofData<Felt, QuadFelt, P2Config>,
-    > as wincode::config::Deserialize<_>>::deserialize(
-        proof_bytes, proof_encoding_config
-    )
-    .map_err(|e| VerifierError::ProofDeserializationError(e.to_string()))?;
+    let proof: StarkProofData<Felt, QuadFelt, P2Config> =
+        <SerdeCompat<StarkProofData<Felt, QuadFelt, P2Config>> as wincode::config::Deserialize<
+            _,
+        >>::deserialize(proof_bytes, proof_encoding_config)
+        .map_err(|e| VerifierError::ProofDeserializationError(e.to_string()))?;
 
     // 2. Build domain-separated challenger. Statement-owned inputs (fixed public values and kernel
     //    digests) plus the per-AIR trace heights are absorbed by the lifted verifier internally

--- a/crates/utils-core-derive/Cargo.toml
+++ b/crates/utils-core-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-core-derive"
-version = "0.25.6"
+version = "0.25.7"
 description = "Proc macro to derive enum dispatch trait implementations on miden-core structs"
 readme = "README.md"
 categories = ["development-tools::procedural-macro-helpers", "no-std"]

--- a/crates/utils-diagnostics/Cargo.toml
+++ b/crates/utils-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-diagnostics"
-version = "0.25.6"
+version = "0.25.7"
 description = "Diagnostic infrastructure used in the Miden assembler and VM"
 documentation = "https://docs.rs/miden-utils-diagnostics"
 readme = "README.md"

--- a/crates/utils-indexing/Cargo.toml
+++ b/crates/utils-indexing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-indexing"
-version = "0.25.6"
+version = "0.25.7"
 description = "Type-safe u32-indexed vector utilities for Miden"
 readme = "README.md"
 categories = ["development-tools", "no-std"]

--- a/crates/utils-sync/Cargo.toml
+++ b/crates/utils-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-sync"
-version = "0.25.6"
+version = "0.25.7"
 description = "no-std compatible locking primitives for the Miden project"
 documentation = "https://docs.rs/miden-utils-sync"
 readme = "README.md"

--- a/miden-core-fuzz/Cargo.lock
+++ b/miden-core-fuzz/Cargo.lock
@@ -708,7 +708,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-assembly"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "log",
  "miden-assembly-syntax-cst",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "derive_more",
  "log",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "miden-crypto",
  "proptest",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "lock_api",
  "loom",

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-vm"
-version = "0.25.6"
+version = "0.25.7"
 description = "Miden virtual machine"
 documentation = "https://docs.rs/miden-vm"
 readme = "README.md"

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-processor"
-version = "0.25.6"
+version = "0.25.7"
 description = "Miden VM processor"
 documentation = "https://docs.rs/miden-processor"
 readme = "README.md"

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -29,7 +29,6 @@ miden-crypto.workspace = true
 serde.workspace = true
 serde-wincode.workspace = true
 tracing.workspace = true
-wincode.workspace = true
 
 [dev-dependencies]
 miden-assembly.workspace = true

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-prover"
-version = "0.25.6"
+version = "0.25.7"
 description = "Miden VM prover"
 documentation = "https://docs.rs/miden-prover"
 readme = "README.md"

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -19,7 +19,7 @@ use miden_processor::{
     FastProcessor, Program,
     trace::{ExecutionTrace, build_trace},
 };
-use serde_wincode::SerdeCompat;
+use serde_wincode::{SerdeCompat, wincode};
 use tracing::instrument;
 
 mod proving_options;

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-verifier"
-version = "0.25.6"
+version = "0.25.7"
 description = "Miden VM execution verifier"
 documentation = "https://docs.rs/miden-verifier"
 readme = "README.md"

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -32,4 +32,3 @@ serde.workspace = true
 serde-wincode.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-wincode.workspace = true

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -13,7 +13,7 @@ use miden_crypto::stark::{
     StarkConfig, VerifierInstance, lmcs::Lmcs, proof::StarkProofData, verifier::VerifierError,
 };
 use serde::de::DeserializeOwned;
-use serde_wincode::SerdeCompat;
+use serde_wincode::{SerdeCompat, wincode};
 
 const MAX_STARK_PROOF_BYTES: usize = 64 * 1024 * 1024;
 


### PR DESCRIPTION
The root cause is that `SerdeCompat` implements `wincode` traits for the `wincode` crate used by `serde-wincode`. If a Miden crate also imports `wincode` directly, Cargo can pick two `wincode` versions. Then proof code can ask for one `SchemaRead` or `SchemaWrite` trait while `SerdeCompat` implements the other one.

This change makes each current proof encoding path use `serde_wincode::wincode` with `SerdeCompat`. It removes direct `wincode` dependencies from `miden-prover`, `miden-verifier`, and `miden-test-utils`.