### PR TITLE
perf: override `ext_square` for `ExtensionAlgebra`

### DIFF
--- a/crates/field/src/native/mod.rs
+++ b/crates/field/src/native/mod.rs
@@ -18,7 +18,8 @@ use p3_field::{
     Field, InjectiveMonomial, Packable, PermutationMonomial, PrimeCharacteristicRing, PrimeField,
     PrimeField64, RawDataSerializable, TwoAdicField,
     extension::{
-        Binomial, BinomiallyExtendable, ExtensionAlgebra, HasTwoAdicBinomialExtension, binomial_mul,
+        Binomial, BinomiallyExtendable, ExtensionAlgebra, HasTwoAdicBinomialExtension,
+        binomial_mul, binomial_square,
     },
     impl_raw_serializable_primefield64,
     integers::QuotientMap,
@@ -395,6 +396,11 @@ impl ExtensionAlgebra<Self, 2, Binomial<Self>> for Felt {
     fn ext_mul(a: &[Self; 2], b: &[Self; 2], res: &mut [Self; 2]) {
         binomial_mul::<Self, Self, Self, 2>(a, b, res, <Self as BinomiallyExtendable<2>>::W);
     }
+
+    #[inline]
+    fn ext_square(a: &[Self; 2], res: &mut [Self; 2]) {
+        binomial_square::<Self, Self, 2>(a, res, <Self as BinomiallyExtendable<2>>::W);
+    }
 }
 
 impl BinomiallyExtendable<2> for Felt {
@@ -422,6 +428,11 @@ impl ExtensionAlgebra<Self, 5, Binomial<Self>> for Felt {
     #[inline]
     fn ext_mul(a: &[Self; 5], b: &[Self; 5], res: &mut [Self; 5]) {
         binomial_mul::<Self, Self, Self, 5>(a, b, res, <Self as BinomiallyExtendable<5>>::W);
+    }
+
+    #[inline]
+    fn ext_square(a: &[Self; 5], res: &mut [Self; 5]) {
+        binomial_square::<Self, Self, 5>(a, res, <Self as BinomiallyExtendable<5>>::W);
     }
 }
 

--- a/crates/field/src/native/tests.rs
+++ b/crates/field/src/native/tests.rs
@@ -5,7 +5,7 @@ use p3_challenger::UniformSamplingField;
 use p3_field::{
     Field, InjectiveMonomial, PermutationMonomial, PrimeCharacteristicRing, PrimeField,
     PrimeField64, TwoAdicField,
-    extension::{BinomiallyExtendable, HasTwoAdicBinomialExtension},
+    extension::{Binomial, BinomiallyExtendable, ExtensionAlgebra, HasTwoAdicBinomialExtension},
     integers::QuotientMap,
 };
 use proptest::prelude::*;
@@ -205,6 +205,42 @@ proptest! {
         let g = <rand::distr::StandardUniform as Distribution<Goldilocks>>::sample(&rand::distr::StandardUniform, &mut rng1);
         let f = <rand::distr::StandardUniform as Distribution<Felt>>::sample(&rand::distr::StandardUniform, &mut rng2);
         prop_assert_eq!(f, g);
+    }
+
+    /// `ext_square` agrees with `ext_mul(a, a, _)` and with `Goldilocks`'s own specialized
+    /// kernel, for the quadratic extension.
+    #[test]
+    fn felt_ext_square_matches_ext_mul_and_goldilocks_quadratic(a in any::<[u64; 2]>()) {
+        let felt: [Felt; 2] = a.map(Felt::new_unchecked);
+        let gold: [Goldilocks; 2] = a.map(Goldilocks::new);
+
+        let mut mul_res = [Felt::ZERO; 2];
+        <Felt as ExtensionAlgebra<Felt, 2, Binomial<Felt>>>::ext_mul(&felt, &felt, &mut mul_res);
+        let mut sq_res = [Felt::ZERO; 2];
+        <Felt as ExtensionAlgebra<Felt, 2, Binomial<Felt>>>::ext_square(&felt, &mut sq_res);
+        prop_assert_eq!(mul_res, sq_res);
+
+        let mut g_sq_res = [Goldilocks::ZERO; 2];
+        <Goldilocks as ExtensionAlgebra<Goldilocks, 2, Binomial<Goldilocks>>>::ext_square(&gold, &mut g_sq_res);
+        prop_assert_eq!(sq_res.map(Goldilocks::from), g_sq_res);
+    }
+
+    /// `ext_square` agrees with `ext_mul(a, a, _)` and with `Goldilocks`'s own specialized
+    /// kernel, for the quintic extension.
+    #[test]
+    fn felt_ext_square_matches_ext_mul_and_goldilocks_quintic(a in any::<[u64; 5]>()) {
+        let felt: [Felt; 5] = a.map(Felt::new_unchecked);
+        let gold: [Goldilocks; 5] = a.map(Goldilocks::new);
+
+        let mut mul_res = [Felt::ZERO; 5];
+        <Felt as ExtensionAlgebra<Felt, 5, Binomial<Felt>>>::ext_mul(&felt, &felt, &mut mul_res);
+        let mut sq_res = [Felt::ZERO; 5];
+        <Felt as ExtensionAlgebra<Felt, 5, Binomial<Felt>>>::ext_square(&felt, &mut sq_res);
+        prop_assert_eq!(mul_res, sq_res);
+
+        let mut g_sq_res = [Goldilocks::ZERO; 5];
+        <Goldilocks as ExtensionAlgebra<Goldilocks, 5, Binomial<Goldilocks>>>::ext_square(&gold, &mut g_sq_res);
+        prop_assert_eq!(sq_res.map(Goldilocks::from), g_sq_res);
     }
 }
 


### PR DESCRIPTION
## Describe your changes

One missing override `ExtensionAlgebra` (leftover from Plonky3 migration issue in miden-crypto). Added proptests similarly to other methods.


## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md`
