### PR TITLE
ci: speed up test feedback and remove duplicate crypto tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,14 +3,3 @@
 fail-fast = false
 # Put a bound on hanging/slow tests
 slow-timeout = { period = "10m", terminate-after = 1, grace-period = "15s" }
-
-[test-groups]
-serialized = { max-threads = 1 }
-
-[[profile.default.overrides]]
-filter = 'test(cli_test)'
-test-group = 'serialized'
-
-[[profile.ci.overrides]]
-filter = 'test(cli_test)'
-test-group = 'serialized'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,9 @@ jobs:
       - name: Install rust
         run: rustup update --no-self-update
       - name: Build tests
-        run: make test-build
+        run: make test-build NEXTEST_PROFILE=ci
       - name: test
-        run: make test
+        run: make test NEXTEST_PROFILE=ci
 
   crypto-test:
     name: crypto test on warpbuild

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,17 +1367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "escargot"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c3aea32bc97b500c9ca6a72b768a26e558264303d101d3409cf6d57a9ed0cf"
-dependencies = [
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,7 +2706,6 @@ dependencies = [
  "assert_cmd",
  "clap",
  "criterion",
- "escargot",
  "hex",
  "miden-assembly",
  "miden-core",
@@ -2733,6 +2721,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-forest",

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 	@printf "  make test-assembly-syntax        # Test assembly-syntax crate\n"
 	@printf "  make test-core                   # Test core crate\n"
 	@printf "  make test-vm                     # Test miden-vm crate\n"
-	@printf "  make test-crypto                 # Test imported crypto crates\n"
+	@printf "  make test-crypto                 # Test specialized crypto feature configurations\n"
 	@printf "  make test-processor              # Test processor crate\n"
 	@printf "  make test-prover                 # Test prover crate\n"
 	@printf "  make test-core-lib               # Test core-lib crate\n"
@@ -27,6 +27,12 @@ help:
 	@printf "  make test-fast                   # Fast tests (no proptests/CLI)\n"
 	@printf "  make test-skip-proptests         # All tests except proptests\n"
 	@printf "  make check-features              # Check all feature combinations with cargo-hack\n\n"
+	@printf "Suite boundaries:\n"
+	@printf "  make test                        # Standard workspace suite (includes proptests and CLI)\n"
+	@printf "  make test-docs                   # Documentation tests\n"
+	@printf "  make test-crypto                 # Persistent-storage and lifted-STARK configurations\n"
+	@printf "  make test-loom                   # Loom concurrency-model tests (opt-in)\n"
+	@printf "  make check-features              # Feature-combination compilation checks\n\n"
 
 
 # -- environment toggles --------------------------------------------------------------------------
@@ -40,8 +46,6 @@ ALL_FEATURES             := --all-features
 # Workspace-wide test features
 WORKSPACE_TEST_FEATURES  := concurrent,testing,executable
 FAST_TEST_FEATURES       := concurrent,testing
-CRYPTO_TEST_PACKAGES     := -p miden-crypto -p miden-crypto-derive -p miden-field -p miden-serde-utils -p miden-crypto-wycheproof-tests
-CRYPTO_TEST_FEATURES     := miden-crypto/concurrent,miden-crypto/testing,miden-field/testing
 MIDEN_CRYPTO_FUZZ_TARGETS := smt word merkle merkle_store smt_serde partial_smt mmr crypto aead signatures
 MIDEN_SERDE_UTILS_FUZZ_TARGETS := primitives collections string vint64 goldilocks budgeted
 MIDEN_STARK_TEST_PACKAGES := -p miden-lifted-air -p miden-lifted-stark -p miden-stateful-hasher -p miden-stark-transcript
@@ -172,19 +176,16 @@ test-%: ## Tests a specific crate; accepts 'test=' to pass a selector or nextest
 
 .PHONY: test-build
 test-build: ## Build the test binaries for the workspace (no run)
-	$(MAKE) core-test-build NEXTEST_PROFILE=ci FEATURES="$(WORKSPACE_TEST_FEATURES)"
+	$(MAKE) core-test-build FEATURES="$(WORKSPACE_TEST_FEATURES)"
 
 .PHONY: test
-test: ## Run all tests for the workspace
-	$(MAKE) core-test NEXTEST_PROFILE=ci FEATURES="$(WORKSPACE_TEST_FEATURES)"
+test: ## Run the standard workspace test suite
+	$(MAKE) core-test FEATURES="$(WORKSPACE_TEST_FEATURES)"
 
 .PHONY: test-crypto
-test-crypto: ## Run imported crypto crate tests and crypto-specific feature tests
-	cargo nextest run \
-		--profile ci \
-		--cargo-profile test-dev \
-		$(CRYPTO_TEST_PACKAGES) \
-		--features $(CRYPTO_TEST_FEATURES)
+# Ordinary crypto, field, serde, derive, and Wycheproof tests run in the standard workspace suite.
+# This target only adds feature configurations which that suite does not cover.
+test-crypto: ## Run crypto tests requiring specialized feature configurations
 	cargo nextest run \
 		--profile ci \
 		--cargo-profile test-dev \

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,6 @@ help:
 	@printf "  make test-fast                   # Fast tests (no proptests/CLI)\n"
 	@printf "  make test-skip-proptests         # All tests except proptests\n"
 	@printf "  make check-features              # Check all feature combinations with cargo-hack\n\n"
-	@printf "Suite boundaries:\n"
-	@printf "  make test                        # Standard workspace suite (includes proptests and CLI)\n"
-	@printf "  make test-docs                   # Documentation tests\n"
-	@printf "  make test-crypto                 # Persistent-storage and lifted-STARK configurations\n"
-	@printf "  make test-loom                   # Loom concurrency-model tests (opt-in)\n"
-	@printf "  make check-features              # Feature-combination compilation checks\n\n"
 
 
 # -- environment toggles --------------------------------------------------------------------------

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -92,12 +92,12 @@ tracing-forest = { workspace = true, optional = true, features = ["ansi", "small
 [dev-dependencies]
 assert_cmd = { version = "2.1" }
 criterion = { workspace = true, features = ["async_tokio"] }
-escargot = { version = "0.5" }
 miden-assembly = { workspace = true, features = ["testing"] }
 miden-precompiles.workspace = true
 miden-processor = { workspace = true, features = ["testing"] }
 miden-test-serde-macros.workspace = true
 miden-utils-testing.workspace = true
 predicates = { version = "3.1" }
+tempfile.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 walkdir.workspace = true

--- a/miden-vm/tests/integration/cli/cli_test.rs
+++ b/miden-vm/tests/integration/cli/cli_test.rs
@@ -1,59 +1,36 @@
 use std::{
-    fs,
+    env, fs,
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
+    process::Command,
 };
 
 use assert_cmd::prelude::*;
 use miden_mast_package::Package;
 use predicates::prelude::*;
+use tempfile::TempDir;
 
-fn bin_under_test() -> escargot::CargoRun {
-    escargot::CargoBuild::new()
-        .bin("miden-vm")
-        .features("executable")
-        .current_release()
-        .current_target()
-        .run()
-        .unwrap_or_else(|err| {
-            // Process the error string to add borders.
-            let formatted_err = err.to_string()
-                .lines()
-                // Add a "│" prefix to each line.
-                .map(|line| format!("│\t{line}"))
-                .collect::<Vec<_>>()
-                .join("\n");
-
-            // Print the error message that provides context and a specific command.
-            panic!(
-                "\n\
-                Failed to build `miden-vm.\n\
-                Original cargo error:\n\
-                ┌──────────────────────────────────────────────────\n\
-                {formatted_err}\n\
-                └──────────────────────────────────────────────────\n\
-                To reproduce this failure manually, run the following command:\n\
-                $ cargo build -p miden-vm --no-default-features --features \"executable,internal\"\n\n"
-            );
-        })
+fn bin_under_test(working_dir: &Path) -> Command {
+    let binary = env::var("NEXTEST_BIN_EXE_miden_vm")
+        .or_else(|_| env::var("CARGO_BIN_EXE_miden-vm"))
+        .expect("the test runner should provide the path to the miden-vm binary");
+    let mut command = Command::new(binary);
+    command.current_dir(working_dir);
+    command
 }
 
-fn test_file_path(name: &str) -> PathBuf {
-    let id = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time should be after Unix epoch")
-        .as_nanos();
-    std::env::temp_dir().join(format!("miden-vm-cli-{name}-{id}"))
+fn fixture(path: impl AsRef<Path>) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(path)
 }
 
 #[test]
 // Tt test might be an overkill to test only that the 'run' cli command
 // outputs steps and ms.
 fn cli_run() {
-    let mut cmd = bin_under_test().command();
+    let working_dir = TempDir::new().unwrap();
+    let mut cmd = bin_under_test(working_dir.path());
 
     cmd.arg("run")
-        .arg("./masm-examples/fib/fib.masm")
+        .arg(fixture("masm-examples/fib/fib.masm"))
         .arg("-n")
         .arg("1")
         .arg("-m")
@@ -71,45 +48,44 @@ fn cli_run() {
 
 #[test]
 fn run_rejects_missing_inferred_inputs_file() {
-    let program_path = test_file_path("missing-run-inputs").with_extension("masm");
+    let working_dir = TempDir::new().unwrap();
+    let program_path = working_dir.path().join("miden-vm-cli-missing-run-inputs-test.masm");
     fs::write(&program_path, "begin push.1 end").unwrap();
 
-    let mut cmd = bin_under_test().command();
+    let mut cmd = bin_under_test(working_dir.path());
     cmd.arg("run").arg(&program_path);
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("Failed to open input file"))
-        .stderr(predicate::str::contains("miden-vm-cli-missing-run-inputs-"))
-        .stderr(predicate::str::contains(".inputs"))
+        .stderr(predicate::str::contains("miden-vm-cli-missing-run-"))
+        .stderr(predicate::str::contains("test.inputs"))
         .stderr(predicate::str::contains("No such file or directory"));
-
-    fs::remove_file(program_path).unwrap();
 }
 
 #[test]
 fn prove_rejects_missing_inferred_inputs_file() {
-    let program_path = test_file_path("missing-prove-inputs").with_extension("masm");
+    let working_dir = TempDir::new().unwrap();
+    let program_path = working_dir.path().join("miden-vm-cli-missing-prove-inputs-test.masm");
     fs::write(&program_path, "begin push.1 end").unwrap();
 
-    let mut cmd = bin_under_test().command();
+    let mut cmd = bin_under_test(working_dir.path());
     cmd.arg("prove").arg(&program_path);
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("Failed to open input file"))
-        .stderr(predicate::str::contains("miden-vm-cli-missing-prove-inputs-"))
-        .stderr(predicate::str::contains(".inputs"))
+        .stderr(predicate::str::contains("miden-vm-cli-missing-prove-"))
+        .stderr(predicate::str::contains("test.inputs"))
         .stderr(predicate::str::contains("No such file or directory"));
-
-    fs::remove_file(program_path).unwrap();
 }
 
 #[test]
 fn cli_bundle_debug() {
-    let output_file = std::env::temp_dir().join("cli_bundle_debug.masp");
+    let working_dir = TempDir::new().unwrap();
+    let output_file = working_dir.path().join("cli_bundle_debug.masp");
 
-    let mut cmd = bin_under_test().command();
+    let mut cmd = bin_under_test(working_dir.path());
     cmd.arg("bundle")
-        .arg("./tests/integration/cli/data/lib/mod.masm")
+        .arg(fixture("tests/integration/cli/data/lib/mod.masm"))
         .arg("--namespace")
         .arg("lib")
         .arg("--output")
@@ -127,16 +103,16 @@ fn cli_bundle_debug() {
                     .is_some_and(|source_map| !source_map.asm_ops().is_empty())
             });
     assert!(found_one_asm_op);
-    fs::remove_file(&output_file).unwrap();
 }
 
 #[test]
 fn cli_bundle_no_exports() {
-    let mut cmd = bin_under_test().command();
+    let working_dir = TempDir::new().unwrap();
+    let mut cmd = bin_under_test(working_dir.path());
     cmd.arg("bundle")
         .arg("--namespace")
         .arg("lib")
-        .arg("./tests/integration/cli/data/lib_noexports/mod.masm");
+        .arg(fixture("tests/integration/cli/data/lib_noexports/mod.masm"));
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("package must contain at least one exported procedure"));
@@ -144,72 +120,74 @@ fn cli_bundle_no_exports() {
 
 #[test]
 fn cli_bundle_kernel() {
-    let output_file = std::env::temp_dir().join("cli_bundle_kernel.masp");
+    let working_dir = TempDir::new().unwrap();
+    let output_file = working_dir.path().join("cli_bundle_kernel.masp");
 
-    let mut cmd = bin_under_test().command();
+    let mut cmd = bin_under_test(working_dir.path());
     cmd.arg("bundle")
-        .arg("./tests/integration/cli/data/kernel_main.masm")
+        .arg(fixture("tests/integration/cli/data/kernel_main.masm"))
         .arg("--kernel")
         .arg("--output")
         .arg(output_file.as_path());
     cmd.assert().success();
-    fs::remove_file(&output_file).unwrap()
 }
 
 /// A kernel can bundle with a library w/o exports.
 #[test]
 fn cli_bundle_kernel_noexports() {
-    let output_file = std::env::temp_dir().join("cli_bundle_kernel_noexports.masp");
+    let working_dir = TempDir::new().unwrap();
+    let output_file = working_dir.path().join("cli_bundle_kernel_noexports.masp");
 
-    let mut cmd = bin_under_test().command();
+    let mut cmd = bin_under_test(working_dir.path());
     cmd.arg("bundle")
-        .arg("./tests/integration/cli/data/kernel_noexports.masm")
+        .arg(fixture("tests/integration/cli/data/kernel_noexports.masm"))
         .arg("--kernel")
         .arg("--output")
         .arg(output_file.as_path());
     cmd.assert().success();
-    fs::remove_file(&output_file).unwrap()
 }
 
 #[test]
 fn cli_bundle_output() {
-    let mut cmd = bin_under_test().command();
+    let working_dir = TempDir::new().unwrap();
+    let output_file = working_dir.path().join("cli_bundle_output.masp");
+    let mut cmd = bin_under_test(working_dir.path());
     cmd.arg("bundle")
-        .arg("./tests/integration/cli/data/lib/mod.masm")
+        .arg(fixture("tests/integration/cli/data/lib/mod.masm"))
         .arg("--namespace")
         .arg("lib")
         .arg("--output")
         .arg("cli_bundle_output.masp");
     cmd.assert().success();
-    assert!(Path::new("cli_bundle_output.masp").exists());
-    fs::remove_file("cli_bundle_output.masp").unwrap()
+    assert!(output_file.exists());
 }
 
 // First compile a library to a .masp file, then run a program that uses it.
 #[test]
 fn cli_run_with_lib() {
-    let mut cmd = bin_under_test().command();
+    let working_dir = TempDir::new().unwrap();
+    let output_file = working_dir.path().join("cli_run_with_lib.masp");
+    let mut cmd = bin_under_test(working_dir.path());
     cmd.arg("bundle")
-        .arg("./tests/integration/cli/data/lib/mod.masm")
+        .arg(fixture("tests/integration/cli/data/lib/mod.masm"))
         .arg("--namespace")
         .arg("lib")
         .arg("--output")
         .arg("cli_run_with_lib.masp");
     cmd.assert().success();
 
-    let mut cmd = bin_under_test().command();
+    let mut cmd = bin_under_test(working_dir.path());
     cmd.arg("run")
-        .arg("./tests/integration/cli/data/main.masm")
+        .arg(fixture("tests/integration/cli/data/main.masm"))
         .arg("-l")
-        .arg("./cli_run_with_lib.masp");
+        .arg(&output_file);
     cmd.assert().success();
-
-    fs::remove_file("cli_run_with_lib.masp").unwrap();
 }
 
 #[test]
 fn test_advmap_cli() {
-    let mut cmd = bin_under_test().command();
-    cmd.arg("run").arg("./tests/integration/cli/data/adv_map.masm");
+    let working_dir = TempDir::new().unwrap();
+    let mut cmd = bin_under_test(working_dir.path());
+    cmd.arg("run").arg(fixture("tests/integration/cli/data/adv_map.masm"));
     cmd.assert().success();
 }


### PR DESCRIPTION
# Summary

- Reuse Cargo's built `miden-vm` binary in CLI tests (rather than run escargot on each).
- Give each CLI test its own temporary directory so the tests can run together.
- Stop local tests after the first failure, while CI still reports every failure.
- Remove 774 crypto tests repeated by a second CI job 🤦 .
- Keep the `persistent-forest` and lifted-STARK test runs.

## Why

Each CLI test started Cargo again to build `miden-vm`. This work ran ten times and could wait on Cargo's build lock. Shared output paths also forced the tests to run one at a time.

`make test` also used CI settings on developer machines. It kept starting tests after a failure instead of returning sooner.

The main workspace job already runs the ordinary crypto suite. The crypto job ran the same 774 tests again.

## Effects

Local tests now stop scheduling work after the first failure. GitHub Actions selects the CI settings directly, so CI still runs to the end and reports every failure.

CLI tests no longer start nested Cargo processes or leave shared files in the repository. New CLI tests must keep their files inside their temporary directory to remain safe when run together.

The main workspace job still runs ordinary crypto tests for VM, crypto, and workspace changes. The crypto job still covers the `persistent-forest` and lifted-STARK settings outside the standard suite.