### PR TITLE
Improve untrusted MAST overspec warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@
 - [BREAKING] Removed unused public APIs and narrowed test-only helper visibility across VM and crypto crates ([#3424](https://github.com/0xMiden/miden-vm/pull/3424)).
 - Enable simd128 Plonky3 backend for WASM builds and added related CI job ([#3433](https://github.com/0xMiden/miden-vm/pull/3433)).
 - [BREAKING] Bumped Plonky3 related dependencies to integrate SVE2 and WASM-SIMD128 speed-ups and include a NEON bugfix. ([#3441](https://github.com/0xMiden/miden-vm/pull/3441)).
+- [BREAKING] Changed `Package::read_from_trusted` and `Package::read_from_bytes_trusted` to skip embedded MAST and manifest cross-check validation, removed the package unchecked readers, and kept untrusted package reads on `Package::read_from` and `Package::read_from_bytes`, which validate MAST and drop debug sections ([#3418](https://github.com/0xMiden/miden-vm/pull/3418)).
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,10 @@
 
 #### Fixes
 
+- Restored public `miden-lifted-stark` testing constants to preserve compatibility with version 0.28.1.
+- Changed overspecified untrusted MAST forest input with wire hashes from an error log to a warning, and included the caller location in the warning ([#3418](https://github.com/0xMiden/miden-vm/pull/3418)).
+- [BREAKING] Bound MMR peak commitments to the leaf count by hashing `[num_leaves, 0, 0, 0] || padded_peaks`, and updated the core library `mmr::pack`/`mmr::unpack` procedures to use the same preimage ([#3388](https://github.com/0xMiden/miden-vm/pull/3388)).
+- Documented the program-entrypoint locals invariant on `Procedure::set_num_locals` and now assert it at that AST mutation site, so setting locals on an executable module's `begin`..`end` block panics at the producer boundary. The existing assembler assertion is retained as a backstop for entrypoints built directly via `Procedure::new` ([#3382](https://github.com/0xMiden/miden-vm/pull/3382)).
 - Validated `SectionId` on deserialization: `Section::read_from()` now rejects invalid identifiers and the `serde` path delegates to `FromStr`, keeping both readers on the same invariant ([#3277](https://github.com/0xMiden/miden-vm/pull/3277)).
 - Fixed `hash_bytes(&[])` returning `Word::default()`; the empty-bytes input now absorbs a padding marker and permutes, producing a nonzero digest consistent with the 10\* sponge padding rule ([#3366](https://github.com/0xMiden/miden-vm/pull/3366)).
 - Fixed a latent `CryptoBox` (IES) key-derivation bug: HKDF-SHA256 output is now reduced into canonical Felts via `AeadScheme::key_from_uniform_bytes` instead of being fed into canonical decoding, which rejected noncanonical limbs at ~2^-30 per key ([#3366](https://github.com/0xMiden/miden-vm/pull/3366)).

--- a/core/src/mast/serialization/mod.rs
+++ b/core/src/mast/serialization/mod.rs
@@ -90,7 +90,7 @@
 #[cfg(test)]
 use alloc::string::ToString;
 use alloc::{boxed::Box, format, vec::Vec};
-use core::mem::size_of;
+use core::{mem::size_of, panic::Location};
 
 use miden_utils_sync::OnceLockCompat;
 
@@ -778,27 +778,32 @@ impl super::UntrustedMastForest {
     }
 }
 
-pub(super) fn read_untrusted_with_flags<R: ByteReader>(
+pub(super) fn read_untrusted_with_flags_and_caller<R: ByteReader>(
     source: &mut R,
+    caller: &'static Location<'static>,
 ) -> Result<(super::UntrustedMastForest, u8), DeserializationError> {
     let (flags, forest) = decode_from_reader(source, true)?;
-    log_untrusted_overspecification(flags);
+    log_untrusted_overspecification(flags, caller);
     Ok((forest, flags.bits()))
 }
 
-pub(super) fn read_untrusted_with_flags_and_allocation_budget<R: ByteReader>(
+pub(super) fn read_untrusted_with_flags_allocation_budget_and_caller<R: ByteReader>(
     source: &mut R,
     allocation_budget: usize,
+    caller: &'static Location<'static>,
 ) -> Result<(super::UntrustedMastForest, u8), DeserializationError> {
     let (flags, forest) = decode_from_reader_inner(source, true, Some(allocation_budget))?;
-    log_untrusted_overspecification(flags);
+    log_untrusted_overspecification(flags, caller);
     Ok((forest, flags.bits()))
 }
 
-fn log_untrusted_overspecification(flags: WireFlags) {
+fn log_untrusted_overspecification(flags: WireFlags, caller: &'static Location<'static>) {
     if !flags.is_hashless() {
-        log::error!(
-            "UntrustedMastForest expected HASHLESS input; supplied artifact includes wire node hashes, and validation will recompute them and require them to match"
+        log::warn!(
+            "UntrustedMastForest expected HASHLESS input at {}:{}:{}; supplied artifact includes wire node hashes, and validation will recompute them and require them to match",
+            caller.file(),
+            caller.line(),
+            caller.column(),
         );
     }
 }
@@ -866,8 +871,9 @@ impl Deserializable for super::UntrustedMastForest {
     /// After deserialization, callers should use [`super::UntrustedMastForest::validate()`]
     /// to verify structural integrity and recompute all node hashes before using
     /// the forest.
+    #[track_caller]
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        read_untrusted_with_flags(source).map(|(forest, _flags)| forest)
+        super::UntrustedMastForest::read_from_reader(source)
     }
 
     /// Deserializes an [`super::UntrustedMastForest`] from bytes using budgeted deserialization.
@@ -878,6 +884,7 @@ impl Deserializable for super::UntrustedMastForest {
     /// After deserialization, callers should use [`super::UntrustedMastForest::validate()`]
     /// to verify structural integrity and recompute all node hashes before using
     /// the forest.
+    #[track_caller]
     fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
         super::UntrustedMastForest::read_from_bytes(bytes)
     }

--- a/core/src/mast/serialization/tests.rs
+++ b/core/src/mast/serialization/tests.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 struct TestLogger {
-    messages: Mutex<Vec<String>>,
+    messages: Mutex<Vec<(log::Level, String)>>,
 }
 
 impl log::Log for TestLogger {
@@ -30,7 +30,7 @@ impl log::Log for TestLogger {
 
     fn log(&self, record: &log::Record<'_>) {
         if self.enabled(record.metadata()) {
-            self.messages.lock().unwrap().push(record.args().to_string());
+            self.messages.lock().unwrap().push((record.level(), record.args().to_string()));
         }
     }
 
@@ -41,11 +41,14 @@ static TEST_LOGGER: TestLogger = TestLogger { messages: Mutex::new(Vec::new()) }
 static TEST_LOGGER_INIT: Once = Once::new();
 static TEST_LOGGER_GUARD: Mutex<()> = Mutex::new(());
 
-fn with_captured_error_logs<T>(f: impl FnOnce() -> T) -> (T, Vec<String>) {
-    with_captured_logs(log::LevelFilter::Error, f)
+fn with_captured_warn_logs<T>(f: impl FnOnce() -> T) -> (T, Vec<(log::Level, String)>) {
+    with_captured_logs(log::LevelFilter::Warn, f)
 }
 
-fn with_captured_logs<T>(level: log::LevelFilter, f: impl FnOnce() -> T) -> (T, Vec<String>) {
+fn with_captured_logs<T>(
+    level: log::LevelFilter,
+    f: impl FnOnce() -> T,
+) -> (T, Vec<(log::Level, String)>) {
     TEST_LOGGER_INIT.call_once(|| {
         log::set_logger(&TEST_LOGGER).expect("test logger should be installed once");
     });
@@ -1742,12 +1745,14 @@ fn assert_untrusted_overspec_logging(
     expected_nodes: u32,
     expected_log_fragments: &[&str],
 ) {
-    let (result, logs) = with_captured_error_logs(|| UntrustedMastForest::read_from_bytes(bytes));
+    let (result, logs) = with_captured_warn_logs(|| UntrustedMastForest::read_from_bytes(bytes));
 
     let untrusted = result.unwrap();
     assert_eq!(logs.len(), expected_log_fragments.len());
     for expected in expected_log_fragments {
-        assert!(logs.iter().any(|msg| msg.contains(expected)));
+        assert!(logs.iter().any(|(level, msg)| {
+            *level == log::Level::Warn && msg.contains(expected) && msg.contains("input at ")
+        }));
     }
     assert_eq!(untrusted.validate().unwrap().num_nodes(), expected_nodes);
 
@@ -1777,6 +1782,52 @@ fn test_untrusted_overspecification_logging_matches_wire_mode() {
 
     let bytes = forest.to_bytes();
     assert_untrusted_overspec_logging(&bytes, forest.num_nodes(), &["wire node hashes"]);
+}
+
+#[test]
+fn test_untrusted_overspecification_logging_tracks_trait_call_site() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add])
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let bytes = forest.to_bytes();
+    let mut reader = SliceReader::new(&bytes);
+    let expected_line = line!() + 2;
+    let (result, logs) =
+        with_captured_warn_logs(|| <UntrustedMastForest as Deserializable>::read_from(&mut reader));
+
+    result.unwrap();
+    let expected_location = format!("{}:{expected_line}:", file!());
+    assert!(logs.iter().any(|(level, msg)| {
+        *level == log::Level::Warn
+            && msg.contains("wire node hashes")
+            && msg.contains(&expected_location)
+    }));
+}
+
+#[test]
+fn test_untrusted_overspecification_logging_tracks_trait_bytes_call_site() {
+    let mut forest = MastForest::new();
+    let block_id = BasicBlockNodeBuilder::new(vec![Operation::Add])
+        .add_to_forest(&mut forest)
+        .unwrap();
+    forest.make_root(block_id);
+
+    let bytes = forest.to_bytes();
+    let expected_line = line!() + 2;
+    let (result, logs) = with_captured_warn_logs(|| {
+        <UntrustedMastForest as Deserializable>::read_from_bytes(&bytes)
+    });
+
+    result.unwrap();
+    let expected_location = format!("{}:{expected_line}:", file!());
+    assert!(logs.iter().any(|(level, msg)| {
+        *level == log::Level::Warn
+            && msg.contains("wire node hashes")
+            && msg.contains(&expected_location)
+    }));
 }
 
 /// Test that untrusted validation in hashless mode recomputes non-external digests without any

--- a/core/src/mast/untrusted.rs
+++ b/core/src/mast/untrusted.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use core::panic::Location;
 
 use super::{AdviceMap, MastForest, MastForestError, serialization};
 use crate::serde::{BudgetedReader, ByteReader, DeserializationError, SliceReader};
@@ -76,6 +77,18 @@ impl UntrustedMastForestReadOptions {
 }
 
 impl UntrustedMastForest {
+    /// Deserializes an [`UntrustedMastForest`] from a byte reader.
+    ///
+    /// Note: This method does not apply budgeting. For untrusted bytes, prefer
+    /// [`read_from_bytes`](Self::read_from_bytes) or
+    /// [`read_from_bytes_with_options`](Self::read_from_bytes_with_options).
+    #[track_caller]
+    pub fn read_from_reader<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let caller = Location::caller();
+        serialization::read_untrusted_with_flags_and_caller(source, caller)
+            .map(|(forest, _flags)| forest)
+    }
+
     /// Validates the forest by checking structural invariants and recomputing all node hashes.
     ///
     /// This method performs a complete validation of the deserialized forest:
@@ -142,6 +155,7 @@ impl UntrustedMastForest {
     /// // Validate before use
     /// let forest = untrusted.validate()?;
     /// ```
+    #[track_caller]
     pub fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
         Self::read_from_bytes_with_options(bytes, UntrustedMastForestReadOptions::default())
     }
@@ -151,16 +165,20 @@ impl UntrustedMastForest {
     /// The wire byte budget limits wire-driven parsing and collection pre-sizing. The validation
     /// helper-allocation budget is derived from that wire budget and caps tracked hashless helper
     /// allocations such as digest slot tables and rebuilt digest tables.
+    #[track_caller]
     pub fn read_from_bytes_with_options(
         bytes: &[u8],
         options: UntrustedMastForestReadOptions,
     ) -> Result<Self, DeserializationError> {
+        let caller = Location::caller();
         let wire_byte_budget = options.wire_byte_budget(bytes.len());
         let mut reader = BudgetedReader::new(SliceReader::new(bytes), wire_byte_budget);
-        let (forest, _flags) = serialization::read_untrusted_with_flags_and_allocation_budget(
-            &mut reader,
-            options.validation_allocation_budget(wire_byte_budget),
-        )?;
+        let (forest, _flags) =
+            serialization::read_untrusted_with_flags_allocation_budget_and_caller(
+                &mut reader,
+                options.validation_allocation_budget(wire_byte_budget),
+                caller,
+            )?;
         if reader.has_more_bytes() {
             return Err(DeserializationError::InvalidValue(
                 "extra bytes after MastForest payload".into(),

--- a/crates/assembly/src/project.rs
+++ b/crates/assembly/src/project.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use miden_assembly_syntax::{ast::ModuleKind, diagnostics::Report};
+use miden_core::serde::Deserializable;
 use miden_mast_package::{Package as MastPackage, TargetType};
 use miden_package_registry::{PackageCache, PackageId, Version as PackageVersion};
 use miden_project::{
@@ -998,7 +999,7 @@ fn load_selected_preassembled_package(
 fn load_package_from_path(path: &FsPath) -> Result<Arc<MastPackage>, Report> {
     let bytes = fs::read(path)
         .map_err(|error| Report::msg(format!("failed to read '{}': {error}", path.display())))?;
-    let package = MastPackage::read_from_bytes_trusted(&bytes).map_err(|error| {
+    let package = MastPackage::read_from_bytes(&bytes).map_err(|error| {
         Report::msg(format!("failed to decode package '{}': {error}", path.display()))
     })?;
     Ok(Arc::new(package))

--- a/crates/assembly/src/project/tests.rs
+++ b/crates/assembly/src/project/tests.rs
@@ -5,7 +5,7 @@ use miden_core::{
     mast::{BasicBlockNodeBuilder, MastForest, MastNodeExt, MastNodeId},
     operations::Operation,
     serde::{Deserializable, Serializable, SliceReader},
-    utils::hash_string_to_word,
+    utils::{Idx, hash_string_to_word},
 };
 use miden_mast_package::{
     PackageExport, PackageModule, ProcedureExport, Section, SectionId,
@@ -445,7 +445,7 @@ fn push_export_module_path(
 }
 
 #[test]
-fn static_linking_drops_untrusted_dependency_debug_rows() {
+fn static_linking_keeps_validated_dependency_debug_rows() {
     let tempdir = TempDir::new().unwrap();
 
     let depa = debug_bearing_static_package(
@@ -509,8 +509,8 @@ end
         })
     };
     assert!(
-        !has_context("depa_ctx") && !has_context("depb_ctx"),
-        "untrusted preassembled dependency debug rows should be dropped",
+        has_context("depa_ctx") && has_context("depb_ctx"),
+        "validated preassembled dependency debug rows should be retained",
     );
 
     let round_tripped = MastPackage::read_from_bytes_trusted(&package.to_bytes())
@@ -528,8 +528,8 @@ end
         })
     };
     assert!(
-        !has_round_tripped_context("depa_ctx") && !has_round_tripped_context("depb_ctx"),
-        "round-tripped root debug should not regain dropped dependency debug rows",
+        has_round_tripped_context("depa_ctx") && has_round_tripped_context("depb_ctx"),
+        "round-tripped root debug should retain dependency debug rows",
     );
 }
 

--- a/crates/assembly/src/project/tests.rs
+++ b/crates/assembly/src/project/tests.rs
@@ -2,7 +2,7 @@ use std::{path::Path, process::Command, string::String, sync::Arc};
 
 use miden_assembly_syntax::{ast::DebugVarLocation, source_file};
 use miden_core::{
-    mast::{BasicBlockNodeBuilder, MastForest, MastNodeExt},
+    mast::{BasicBlockNodeBuilder, MastForest, MastNodeExt, MastNodeId},
     operations::Operation,
     serde::{Deserializable, Serializable, SliceReader},
     utils::hash_string_to_word,
@@ -445,7 +445,7 @@ fn push_export_module_path(
 }
 
 #[test]
-fn static_linking_preserves_debug_rows_for_deduped_execution_nodes() {
+fn static_linking_drops_untrusted_dependency_debug_rows() {
     let tempdir = TempDir::new().unwrap();
 
     let depa = debug_bearing_static_package(
@@ -501,54 +501,17 @@ end
         .debug_info()
         .expect("package debug sections should decode")
         .expect("root package should contain debug info");
-    let source_for_context = |context_name: &str| {
-        debug_info
-            .nodes()
-            .iter()
-            .enumerate()
-            .find(|(_, node)| {
-                node.asm_ops.iter().any(|row| {
-                    debug_info.get_string(row.context_name_idx).as_deref() == Some(context_name)
-                })
+    let has_context = |context_name: &str| {
+        debug_info.nodes().iter().any(|node| {
+            node.asm_ops.iter().any(|row| {
+                debug_info.get_string(row.context_name_idx).as_deref() == Some(context_name)
             })
-            .map(|(source_idx, _)| DebugSourceNodeId::from(source_idx as u32))
-            .unwrap_or_else(|| panic!("missing asm-op row for {context_name}"))
-    };
-    let depa_source = source_for_context("depa_ctx");
-    let depb_source = source_for_context("depb_ctx");
-    assert_ne!(depa_source, depb_source, "static package source occurrences must stay distinct",);
-
-    let depa_exec = debug_info.source_node(depa_source).unwrap().exec_node;
-    let depb_exec = debug_info.source_node(depb_source).unwrap().exec_node;
-    assert_eq!(
-        depa_exec, depb_exec,
-        "identical static dependency bodies should dedup to one execution node",
-    );
-
-    let contexts_for_deduped_exec = [depa_source, depb_source]
-        .into_iter()
-        .filter(|&source_node| debug_info.source_node(source_node).unwrap().exec_node == depa_exec)
-        .map(|source_node| {
-            let row = debug_info.first_asm_op_for_source_node(source_node).unwrap();
-            debug_info.get_string(row.context_name_idx).unwrap()
         })
-        .collect::<Vec<_>>();
-    assert!(contexts_for_deduped_exec.iter().any(|context| context.as_ref() == "depa_ctx"));
-    assert!(contexts_for_deduped_exec.iter().any(|context| context.as_ref() == "depb_ctx"));
-
-    let vars_at_source_start = |source_node_id| {
-        let op_start = debug_info.source_node(source_node_id).unwrap().op_start;
-        debug_info
-            .debug_vars_for_operation(source_node_id, op_start)
-            .map(|row| debug_info.get_string(row.name_idx).unwrap())
-            .collect::<Vec<_>>()
     };
-    let depa_vars = vars_at_source_start(depa_source);
-    let depb_vars = vars_at_source_start(depb_source);
-    assert_eq!(depa_vars.len(), 1);
-    assert_eq!(depa_vars[0].as_ref(), "depa_var");
-    assert_eq!(depb_vars.len(), 1);
-    assert_eq!(depb_vars[0].as_ref(), "depb_var");
+    assert!(
+        !has_context("depa_ctx") && !has_context("depb_ctx"),
+        "untrusted preassembled dependency debug rows should be dropped",
+    );
 
     let round_tripped = MastPackage::read_from_bytes_trusted(&package.to_bytes())
         .expect("root package should deserialize as trusted");
@@ -556,19 +519,18 @@ end
         .debug_info()
         .expect("round-tripped debug sections should decode")
         .expect("round-tripped package should contain debug info");
-    let depa_asm_op = round_tripped_debug_info.first_asm_op_for_source_node(depa_source).unwrap();
-    assert_eq!(
-        round_tripped_debug_info.get_string(depa_asm_op.context_name_idx).as_deref(),
-        Some("depa_ctx"),
+    let has_round_tripped_context = |context_name: &str| {
+        round_tripped_debug_info.nodes().iter().any(|node| {
+            node.asm_ops.iter().any(|row| {
+                round_tripped_debug_info.get_string(row.context_name_idx).as_deref()
+                    == Some(context_name)
+            })
+        })
+    };
+    assert!(
+        !has_round_tripped_context("depa_ctx") && !has_round_tripped_context("depb_ctx"),
+        "round-tripped root debug should not regain dropped dependency debug rows",
     );
-    let depb_vars = {
-        let op_start = round_tripped_debug_info.source_node(depb_source).unwrap().op_start;
-        round_tripped_debug_info.debug_vars_for_operation(depb_source, op_start)
-    }
-    .map(|row| round_tripped_debug_info.get_string(row.name_idx).unwrap())
-    .collect::<Vec<_>>();
-    assert_eq!(depb_vars.len(), 1);
-    assert_eq!(depb_vars[0].as_ref(), "depb_var");
 }
 
 #[test]
@@ -2824,6 +2786,80 @@ end
 }
 
 #[test]
+fn preassembled_dependency_rejects_tampered_non_root_mast_node_after_graph_selection() {
+    let tempdir = TempDir::new().unwrap();
+    let dep_dir = tempdir.path().join("dep");
+    let dep_manifest = dep_dir.join("miden-project.toml");
+    write_file(
+        &dep_manifest,
+        r#"[package]
+name = "dep"
+version = "1.0.0"
+
+[lib]
+path = "lib.masm"
+namespace = "dep"
+"#,
+    );
+    write_file(
+        &dep_dir.join("lib.masm"),
+        r#"pub proc leaf
+    dup.0
+    if.true
+        push.2
+    else
+        push.3
+    end
+    drop
+    push.1
+end
+"#,
+    );
+
+    let mut context = TestContext::new();
+    let dep_package = context
+        .assemble_library_package(&dep_manifest, Some("dev"))
+        .expect("dependency package should assemble");
+    let dep_package_path = tempdir.path().join("dep.masp");
+    dep_package.write_to_file(&dep_package_path).unwrap();
+
+    let root_dir = tempdir.path().join("root");
+    let root_manifest = root_dir.join("miden-project.toml");
+    write_file(
+        &root_manifest,
+        r#"[package]
+name = "root"
+version = "1.0.0"
+
+[lib]
+path = "lib.masm"
+
+[dependencies]
+dep = { path = "../dep.masp", linkage = "static" }
+"#,
+    );
+    write_file(
+        &root_dir.join("lib.masm"),
+        r#"pub proc entry
+    exec.::dep::leaf
+end
+"#,
+    );
+
+    let mut project_assembler = context.project_assembler_for_path(&root_manifest).unwrap();
+    fs::write(&dep_package_path, package_bytes_with_spoofed_non_root_node_digest(&dep_package))
+        .unwrap();
+
+    let error = project_assembler
+        .assemble(ProjectTargetSelector::Library, "dev")
+        .expect_err("tampered preassembled dependency MAST should fail validation");
+    let error = error.to_string();
+    assert!(error.contains("failed to decode package"));
+    assert!(error.contains("invalid untrusted MAST forest"));
+    assert!(error.contains("hash mismatch for node"));
+}
+
+#[test]
 fn preassembled_dependency_must_match_graph_selected_runtime_dependencies() {
     let tempdir = TempDir::new().unwrap();
     let runtime_v1 = Arc::<MastPackage>::from(MastPackage::generate(
@@ -3197,4 +3233,94 @@ end
     );
 
     manifest_path
+}
+
+fn package_bytes_with_spoofed_non_root_node_digest(package: &MastPackage) -> Vec<u8> {
+    let forest = package.mast_forest();
+    let target_node = (0..forest.num_nodes())
+        .map(MastNodeId::new_unchecked)
+        .find(|node_id| !forest.procedure_roots().contains(node_id))
+        .expect("test package should contain a non-root node");
+
+    let mut output_bytes = Vec::new();
+    package.write_header_into(&mut output_bytes);
+    let forest_offset = output_bytes.len();
+    forest.write_into(&mut output_bytes);
+
+    let (node_hashes_start, internal_node_count) =
+        locate_first_node_hash(&output_bytes[forest_offset..]);
+    assert!(
+        target_node.to_usize() < internal_node_count,
+        "test package should not contain external nodes before the tampered node",
+    );
+
+    let spoofed_digest = hash_string_to_word("spoofed-preassembled-dependency-digest");
+    assert_ne!(
+        spoofed_digest,
+        forest[target_node].digest(),
+        "spoofed digest must differ from the original node digest",
+    );
+
+    let mut spoofed_digest_bytes = Vec::new();
+    spoofed_digest.write_into(&mut spoofed_digest_bytes);
+    assert_eq!(spoofed_digest_bytes.len(), 32, "Word must serialize to 32 bytes");
+
+    let digest_offset =
+        forest_offset + node_hashes_start + target_node.to_usize() * spoofed_digest_bytes.len();
+    output_bytes[digest_offset..digest_offset + spoofed_digest_bytes.len()]
+        .copy_from_slice(&spoofed_digest_bytes);
+
+    package.write_trailer_into(&mut output_bytes);
+
+    output_bytes
+}
+
+fn locate_first_node_hash(bytes: &[u8]) -> (usize, usize) {
+    // Header: magic[4] + flags[1] + version[3]
+    let mut offset = 0usize;
+    offset += 4;
+    offset += 1;
+    offset += 3;
+
+    let internal_node_count = read_usize_vint64(bytes, &mut offset);
+    let external_node_count = read_usize_vint64(bytes, &mut offset);
+    let node_count = internal_node_count
+        .checked_add(external_node_count)
+        .expect("node count overflow");
+
+    // Roots: len (usize) + elements (u32 LE)
+    let roots_len = read_usize_vint64(bytes, &mut offset);
+    offset += roots_len * 4;
+
+    // Basic block data: len (usize) + bytes
+    let bb_len = read_usize_vint64(bytes, &mut offset);
+    offset += bb_len;
+
+    offset += node_count * 8;
+    offset += external_node_count * 32;
+
+    (offset, internal_node_count)
+}
+
+fn read_usize_vint64(bytes: &[u8], offset: &mut usize) -> usize {
+    // This test patches raw bytes in place, so it needs byte offsets that
+    // ByteReader::read_usize does not expose.
+    let first_byte = bytes.get(*offset).copied().expect("out-of-bounds vint64 peek");
+    let length = first_byte.trailing_zeros() as usize + 1;
+
+    if length == 9 {
+        *offset += 1;
+        let end = (*offset).checked_add(8).expect("offset overflow while reading vint64");
+        let chunk: [u8; 8] = bytes[*offset..end].try_into().expect("out-of-bounds vint64");
+        *offset = end;
+        let value = u64::from_le_bytes(chunk);
+        usize::try_from(value).expect("encoded usize does not fit host usize")
+    } else {
+        let end = (*offset).checked_add(length).expect("offset overflow while reading vint64");
+        let mut encoded = [0u8; 8];
+        encoded[..length].copy_from_slice(&bytes[*offset..end]);
+        *offset = end;
+        let value = u64::from_le_bytes(encoded) >> length;
+        usize::try_from(value).expect("encoded usize does not fit host usize")
+    }
 }

--- a/crates/mast-package/README.md
+++ b/crates/mast-package/README.md
@@ -39,11 +39,8 @@ Package-owned debug information lives in optional debug custom sections, not in 
 - `Package::read_from` and `Package::read_from_bytes` are for untrusted artifacts. They validate
   the embedded MAST forest and discard package-owned debug sections before returning the package.
 - `Package::read_from_trusted` and `Package::read_from_bytes_trusted` are for trusted local files
-  or cache entries. They validate the embedded MAST forest and preserve package-owned debug
-  sections so `Package::debug_info` can decode them.
-- `Package::read_from_unchecked` and `Package::read_from_bytes_unchecked` are same-domain trusted
-  cache readers. They preserve package-owned debug sections, but skip MAST validation because the
-  bytes must already have been validated before persistence.
+  or cache entries. They skip embedded MAST and manifest cross-check validation and preserve
+  package-owned debug sections.
 
 Embedded kernel package bytes are carried in the opaque `kernel` custom section. An untrusted read
 may carry that section, but decoding the embedded kernel through the package API uses the

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -1365,9 +1365,10 @@ impl Package {
     #[cfg(feature = "std")]
     /// Reads a trusted local package file.
     ///
-    /// This preserves package-owned debug sections and should be used only for files/cache entries
-    /// controlled by the same trusted build or execution system. Use [`Self::read_from_bytes`] for
-    /// bytes received across a trust boundary.
+    /// This skips embedded MAST and manifest cross-check validation, preserves package-owned debug
+    /// sections, and should be used only for files/cache entries controlled by the same trusted
+    /// build or execution system. Use [`Self::read_from_bytes`] for bytes received across a trust
+    /// boundary.
     pub fn deserialize_from_file_trusted(
         path: impl AsRef<std::path::Path>,
     ) -> Result<Self, DeserializationError> {

--- a/crates/mast-package/src/package/serialization/mod.rs
+++ b/crates/mast-package/src/package/serialization/mod.rs
@@ -153,26 +153,6 @@ impl Package {
         Self::read_from_trusted(&mut reader)
     }
 
-    #[doc(hidden)]
-    #[track_caller]
-    pub fn read_from_validated_with_trusted_debug<R: ByteReader>(
-        source: &mut R,
-    ) -> Result<Self, DeserializationError> {
-        let header = Self::read_header_from(source)?;
-        let mast_forest = Self::read_mast_forest(source, true)?;
-        Self::read_from_with_header_and_mast(source, header, mast_forest, true, true)
-    }
-
-    #[doc(hidden)]
-    #[track_caller]
-    pub fn read_from_bytes_validated_with_trusted_debug(
-        bytes: &[u8],
-    ) -> Result<Self, DeserializationError> {
-        let budget = bytes.len().saturating_mul(PACKAGE_BYTE_READ_BUDGET_MULTIPLIER);
-        let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
-        Self::read_from_validated_with_trusted_debug(&mut reader)
-    }
-
     #[track_caller]
     fn read_mast_forest<R: ByteReader>(
         source: &mut R,
@@ -522,6 +502,56 @@ impl Serializable for PackageManifest {
 }
 
 impl PackageManifest {
+    pub fn read_from_trusted<R: ByteReader>(
+        source: &mut R,
+        mast: &MastForest,
+    ) -> Result<Self, DeserializationError> {
+        // Read exports
+        let exports_len = source.read_usize()?;
+        let max_exports = source.max_alloc(PackageExport::min_serialized_size());
+        if exports_len > max_exports {
+            return Err(DeserializationError::InvalidValue(format!(
+                "requested {exports_len} elements but reader can provide at most {max_exports}"
+            )));
+        }
+        let mut exports = Vec::with_capacity(exports_len);
+        for _ in 0..exports_len {
+            exports.push(PackageExport::read_from_trusted(source, mast)?);
+        }
+
+        // Read module surfaces
+        let modules_len = source.read_usize()?;
+        let max_modules = source.max_alloc(PackageModule::min_serialized_size());
+        if modules_len > max_modules {
+            return Err(DeserializationError::InvalidValue(format!(
+                "requested {modules_len} elements but reader can provide at most {max_modules}"
+            )));
+        }
+        let modules = source.read_many_iter(modules_len)?.collect::<Result<Vec<_>, _>>()?;
+
+        // Read dependencies
+        let dependencies = Vec::<Dependency>::read_from(source)?;
+
+        // Read entrypoint
+        let entrypoint = if source.read_bool()? {
+            Some(PathBuf::read_from(source).map(Arc::<ast::Path>::from)?)
+        } else {
+            None
+        };
+
+        PackageManifest::new(exports)
+            .and_then(|manifest| manifest.with_modules(modules))
+            .and_then(|manifest| manifest.with_dependencies(dependencies))
+            .and_then(|manifest| {
+                if let Some(entrypoint) = entrypoint {
+                    manifest.with_entrypoint(entrypoint)
+                } else {
+                    Ok(manifest)
+                }
+            })
+            .map_err(|error| DeserializationError::InvalidValue(error.to_string()))
+    }
+
     pub fn read_from_safe<R: ByteReader>(
         source: &mut R,
         mast: &MastForest,
@@ -656,6 +686,20 @@ impl Serializable for PackageExport {
 }
 
 impl PackageExport {
+    pub fn read_from_trusted<R: ByteReader>(
+        source: &mut R,
+        mast: &MastForest,
+    ) -> Result<Self, DeserializationError> {
+        match source.read_u8()? {
+            1 => ProcedureExport::read_from_trusted(source, mast).map(Self::Procedure),
+            2 => ConstantExport::read_from(source).map(Self::Constant),
+            3 => TypeExport::read_from(source).map(Self::Type),
+            invalid => Err(DeserializationError::InvalidValue(format!(
+                "unexpected PackageExport tag: '{invalid}'"
+            ))),
+        }
+    }
+
     pub fn read_from_safe<R: ByteReader>(
         source: &mut R,
         mast: &MastForest,
@@ -714,6 +758,39 @@ impl Serializable for ProcedureExport {
 }
 
 impl ProcedureExport {
+    pub fn read_from_trusted<R: ByteReader>(
+        source: &mut R,
+        mast: &MastForest,
+    ) -> Result<Self, DeserializationError> {
+        use miden_assembly_syntax::ast::types::FunctionType;
+        let path = PathBuf::read_from(source)?.into_boxed_path().into();
+        let node = if source.read_bool()? {
+            Some(MastNodeId::from_u32_safe(source.read_u32()?, mast)?)
+        } else {
+            None
+        };
+        let source_node = if source.read_bool()? {
+            Some(DebugSourceNodeId::read_from(source)?)
+        } else {
+            None
+        };
+        let digest = Word::read_from(source)?;
+        let signature = if source.read_bool()? {
+            Some(FunctionType::read_from(source)?)
+        } else {
+            None
+        };
+        let attributes = AttributeSet::read_from(source)?;
+        Ok(Self {
+            path,
+            node,
+            source_node,
+            digest,
+            signature,
+            attributes,
+        })
+    }
+
     pub fn read_from_safe<R: ByteReader>(
         source: &mut R,
         mast: &MastForest,

--- a/crates/mast-package/src/package/serialization/mod.rs
+++ b/crates/mast-package/src/package/serialization/mod.rs
@@ -31,13 +31,8 @@
 //! package. Use them for bytes received across a trust boundary.
 //!
 //! [`Package::read_from_trusted`] and [`Package::read_from_bytes_trusted`] are for local
-//! files/cache entries controlled by the same trusted build or execution system. They validate the
-//! embedded MAST forest, but defer package-owned debug validation until [`Package::debug_info`] is
-//! called.
-//!
-//! [`Package::read_from_unchecked`] and [`Package::read_from_bytes_unchecked`] are also trusted
-//! same-domain readers, but skip MAST validation. Use them only for bytes that were already
-//! validated before being persisted by the same trusted system.
+//! files/cache entries controlled by the same trusted build or execution system. They preserve
+//! package-owned debug sections and skip embedded MAST and manifest cross-check validation.
 //!
 //! Embedded kernel package bytes are stored in the opaque `kernel` custom section. Decoding an
 //! embedded kernel through the package API uses the untrusted reader, so nested package-owned debug
@@ -128,51 +123,30 @@ impl Package {
     ///
     /// # Trust boundary
     ///
-    /// This skips embedded MAST validation and trusts serialized node digests. Use it only for
-    /// bytes that were already validated before being persisted by the same trusted system.
+    /// This skips embedded MAST and manifest cross-check validation and trusts serialized node
+    /// digests. Use it only for bytes that were already validated before being persisted by the
+    /// same trusted system.
     ///
     /// Do not use this for user-controlled packages, network input, registry artifacts, or any
     /// other package that crosses a trust boundary. Use [`Package::read_from`] for those
     /// inputs.
-    pub fn read_from_unchecked<R: ByteReader>(
-        source: &mut R,
-    ) -> Result<Self, DeserializationError> {
+    pub fn read_from_trusted<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let header = Self::read_header_from(source)?;
         let mast_forest = Self::read_mast_forest(source, false)?;
-        Self::read_from_with_header_and_mast(source, header, mast_forest, false)
+        Self::read_from_with_header_and_mast(source, header, mast_forest, false, false)
     }
 
     /// Reads trusted package bytes without validating the embedded MAST forest.
     ///
     /// # Trust boundary
     ///
-    /// This skips embedded MAST validation and trusts serialized node digests. Use it only for
-    /// bytes that were already validated before being persisted by the same trusted system.
+    /// This skips embedded MAST and manifest cross-check validation and trusts serialized node
+    /// digests. Use it only for bytes that were already validated before being persisted by the
+    /// same trusted system.
     ///
     /// Do not use this for user-controlled packages, network input, registry artifacts, or any
     /// other package that crosses a trust boundary. Use [`Package::read_from_bytes`] for those
     /// inputs.
-    pub fn read_from_bytes_unchecked(bytes: &[u8]) -> Result<Self, DeserializationError> {
-        let mut source = SliceReader::new(bytes);
-        Self::read_from_unchecked(&mut source)
-    }
-
-    /// Reads a trusted local package while validating the embedded MAST forest.
-    ///
-    /// This keeps the same structural validation as [`Package::read_from`], but defers
-    /// package-owned debug validation until the metadata is used. Use this only for local files or
-    /// cache artifacts controlled by this process or build system. Do not use this for inbound
-    /// artifacts from an untrusted channel; use [`Package::read_from`] instead so debug sections
-    /// are validated before the package is exposed to callers.
-    pub fn read_from_trusted<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let header = Self::read_header_from(source)?;
-        let mast_forest = Self::read_mast_forest(source, true)?;
-        Self::read_from_with_header_and_mast(source, header, mast_forest, false)
-    }
-
-    /// Reads trusted local package bytes while validating the embedded MAST forest.
-    ///
-    /// See [`Package::read_from_trusted`].
     pub fn read_from_bytes_trusted(bytes: &[u8]) -> Result<Self, DeserializationError> {
         let budget = bytes.len().saturating_mul(PACKAGE_BYTE_READ_BUDGET_MULTIPLIER);
         let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
@@ -256,12 +230,17 @@ impl Package {
         source: &mut R,
         header: PackageHeader,
         mast: Arc<MastForest>,
+        validate_manifest: bool,
         validate_debug_sections: bool,
     ) -> Result<Self, DeserializationError> {
         let PackageHeader { name, version, description, kind } = header;
 
         // Read manifest
-        let manifest = PackageManifest::read_from_safe(source, &mast)?;
+        let manifest = if validate_manifest {
+            PackageManifest::read_from_safe(source, &mast)?
+        } else {
+            PackageManifest::read_from_trusted(source, &mast)?
+        };
 
         // Read custom sections
         let sections = Vec::<Section>::read_from(source)?;
@@ -286,9 +265,11 @@ impl Package {
             })?;
         }
 
-        package
-            .compute_interface_digest()
-            .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
+        if validate_manifest {
+            package
+                .compute_interface_digest()
+                .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
+        }
         package.recompute_mast_commitment();
 
         Ok(package)
@@ -302,7 +283,7 @@ impl Deserializable for Package {
         // Read MAST artifact
         let mast = Self::read_mast_forest(source, true)?;
 
-        Self::read_from_with_header_and_mast(source, header, mast, true)
+        Self::read_from_with_header_and_mast(source, header, mast, true, true)
     }
 
     fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {

--- a/crates/mast-package/src/package/serialization/mod.rs
+++ b/crates/mast-package/src/package/serialization/mod.rs
@@ -127,9 +127,9 @@ impl Package {
     /// digests. Use it only for bytes that were already validated before being persisted by the
     /// same trusted system.
     ///
-    /// Do not use this for user-controlled packages, network input, registry artifacts, or any
-    /// other package that crosses a trust boundary. Use [`Package::read_from`] for those
-    /// inputs.
+    /// Do not use this for user-controlled packages, network input, or any other package that
+    /// crosses a trust boundary. Use [`Package::read_from`] for those inputs.
+    #[track_caller]
     pub fn read_from_trusted<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let header = Self::read_header_from(source)?;
         let mast_forest = Self::read_mast_forest(source, false)?;
@@ -144,15 +144,36 @@ impl Package {
     /// digests. Use it only for bytes that were already validated before being persisted by the
     /// same trusted system.
     ///
-    /// Do not use this for user-controlled packages, network input, registry artifacts, or any
-    /// other package that crosses a trust boundary. Use [`Package::read_from_bytes`] for those
-    /// inputs.
+    /// Do not use this for user-controlled packages, network input, or any other package that
+    /// crosses a trust boundary. Use [`Package::read_from_bytes`] for those inputs.
+    #[track_caller]
     pub fn read_from_bytes_trusted(bytes: &[u8]) -> Result<Self, DeserializationError> {
         let budget = bytes.len().saturating_mul(PACKAGE_BYTE_READ_BUDGET_MULTIPLIER);
         let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
         Self::read_from_trusted(&mut reader)
     }
 
+    #[doc(hidden)]
+    #[track_caller]
+    pub fn read_from_validated_with_trusted_debug<R: ByteReader>(
+        source: &mut R,
+    ) -> Result<Self, DeserializationError> {
+        let header = Self::read_header_from(source)?;
+        let mast_forest = Self::read_mast_forest(source, true)?;
+        Self::read_from_with_header_and_mast(source, header, mast_forest, true, true)
+    }
+
+    #[doc(hidden)]
+    #[track_caller]
+    pub fn read_from_bytes_validated_with_trusted_debug(
+        bytes: &[u8],
+    ) -> Result<Self, DeserializationError> {
+        let budget = bytes.len().saturating_mul(PACKAGE_BYTE_READ_BUDGET_MULTIPLIER);
+        let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
+        Self::read_from_validated_with_trusted_debug(&mut reader)
+    }
+
+    #[track_caller]
     fn read_mast_forest<R: ByteReader>(
         source: &mut R,
         validate_mast_forest: bool,
@@ -277,6 +298,7 @@ impl Package {
 }
 
 impl Deserializable for Package {
+    #[track_caller]
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let header = Self::read_header_from(source)?;
 
@@ -286,6 +308,7 @@ impl Deserializable for Package {
         Self::read_from_with_header_and_mast(source, header, mast, true, true)
     }
 
+    #[track_caller]
     fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
         let budget = bytes.len().saturating_mul(PACKAGE_BYTE_READ_BUDGET_MULTIPLIER);
         let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);

--- a/crates/mast-package/src/package/serialization/mod.rs
+++ b/crates/mast-package/src/package/serialization/mod.rs
@@ -119,13 +119,13 @@ impl Package {
         }
     }
 
-    /// Reads a trusted package from `source` without validating the embedded MAST forest.
+    /// Reads a package from trusted storage without validating the embedded MAST forest.
     ///
     /// # Trust boundary
     ///
     /// This skips embedded MAST and manifest cross-check validation and trusts serialized node
-    /// digests. Use it only for bytes that were already validated before being persisted by the
-    /// same trusted system.
+    /// digests. Use it for a package written and retained by the same trusted system, such as a
+    /// local build cache.
     ///
     /// Do not use this for user-controlled packages, network input, or any other package that
     /// crosses a trust boundary. Use [`Package::read_from`] for those inputs.
@@ -136,13 +136,14 @@ impl Package {
         Self::read_from_with_header_and_mast(source, header, mast_forest, false, false)
     }
 
-    /// Reads trusted package bytes without validating the embedded MAST forest.
+    /// Reads package bytes from trusted storage without validating the embedded MAST forest.
     ///
     /// # Trust boundary
     ///
     /// This skips embedded MAST and manifest cross-check validation and trusts serialized node
-    /// digests. Use it only for bytes that were already validated before being persisted by the
-    /// same trusted system.
+    /// digests. Use it for a package written and retained by the same trusted system, such as a
+    /// local build cache. This method still applies the finite byte-read budget used by
+    /// [`Package::read_from_bytes`].
     ///
     /// Do not use this for user-controlled packages, network input, or any other package that
     /// crosses a trust boundary. Use [`Package::read_from_bytes`] for those inputs.
@@ -278,6 +279,13 @@ impl Package {
 }
 
 impl Deserializable for Package {
+    /// Reads and validates a package from potentially adversarial input.
+    ///
+    /// This validates the embedded MAST forest, manifest references, and package-owned debug
+    /// information before returning. The caller's [`ByteReader`] controls the resource budget. For
+    /// a byte slice, prefer [`Package::read_from_bytes`], which applies a finite byte-read budget.
+    /// Use [`Package::read_from_trusted`] for packages written and retained by the same trusted
+    /// system when repeating these checks is unnecessary.
     #[track_caller]
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let header = Self::read_header_from(source)?;
@@ -288,6 +296,12 @@ impl Deserializable for Package {
         Self::read_from_with_header_and_mast(source, header, mast, true, true)
     }
 
+    /// Reads and validates a package from a potentially adversarial byte slice.
+    ///
+    /// This is the recommended reader for untrusted package bytes. It applies a finite byte-read
+    /// budget and validates the embedded MAST forest, manifest references, and package-owned debug
+    /// information. Use [`Package::read_from_bytes_trusted`] for packages written and retained by
+    /// the same trusted system when repeating these checks is unnecessary.
     #[track_caller]
     fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
         let budget = bytes.len().saturating_mul(PACKAGE_BYTE_READ_BUDGET_MULTIPLIER);

--- a/crates/mast-package/src/package/serialization/tests.rs
+++ b/crates/mast-package/src/package/serialization/tests.rs
@@ -239,17 +239,6 @@ fn package_trusted_deserialization_preserves_trusted_debug_sections() {
     assert!(deserialized.debug_info().unwrap().is_some());
 }
 
-#[test]
-fn package_unchecked_deserialization_preserves_trusted_debug_sections() {
-    let package = build_package_with_debug_info();
-    let bytes = package.to_bytes();
-
-    let deserialized = Package::read_from_bytes_unchecked(&bytes).unwrap();
-
-    assert!(deserialized.sections.iter().any(|section| section.id == SectionId::DEBUG_INFO));
-    assert!(deserialized.debug_info().unwrap().is_some());
-}
-
 #[cfg(feature = "std")]
 #[test]
 fn package_deserialize_from_file_preserves_validated_debug_sections() {
@@ -696,7 +685,7 @@ fn regression_package_deserialisation_rejects_spoofed_mast_node_digests() {
 }
 
 #[test]
-fn unchecked_package_deserialisation_rejects_spoofed_mast_node_digests() {
+fn trusted_package_deserialisation_accepts_spoofed_mast_hashes() {
     // Build mast for:
     //
     // pub proc p
@@ -726,14 +715,21 @@ fn unchecked_package_deserialisation_rejects_spoofed_mast_node_digests() {
         debug_sections_trusted: true,
     };
 
-    let (bytes, _spoofed_digest) =
+    let (bytes, spoofed_digest) =
         build_package_bytes_with_spoofed_first_node_digest(&package, "spoofed-library-digest");
-    let err = Package::read_from_bytes_unchecked(&bytes)
-        .expect_err("expected package deserialization to reject inconsistent node digests");
+    let trusted = Package::read_from_bytes_trusted(&bytes)
+        .expect("trusted package deserialization should not recompute MAST hashes");
+    assert_eq!(trusted.mast_forest()[node_id].digest(), spoofed_digest);
+
+    let err = Package::read_from_bytes(&bytes)
+        .expect_err("untrusted package deserialization should reject spoofed MAST hashes");
     assert!(
-        err.to_string()
-            .contains("declared node id and digest do not correspond to a procedure root"),
-        "expected package manifest validation failure, got: {err}"
+        err.to_string().contains("invalid untrusted MAST forest"),
+        "expected untrusted-MAST validation failure, got: {err}"
+    );
+    assert!(
+        err.to_string().contains("hash mismatch for node"),
+        "expected digest mismatch failure, got: {err}"
     );
 }
 
@@ -838,7 +834,7 @@ fn package_deserialize_from_file_rejects_spoofed_kernel_mast_node_digests() {
 }
 
 #[test]
-fn unchecked_kernel_package_deserialisation_accepts_spoofed_mast_node_digests() {
+fn trusted_kernel_package_deserialisation_accepts_spoofed_mast_hashes() {
     // Build mast for:
     //
     // pub proc k1
@@ -868,16 +864,11 @@ fn unchecked_kernel_package_deserialisation_accepts_spoofed_mast_node_digests() 
         debug_sections_trusted: true,
     };
 
-    let (bytes, _spoofed_digest) =
+    let (bytes, spoofed_digest) =
         build_package_bytes_with_spoofed_first_node_digest(&package, "spoofed-kernel-digest");
-    let err = Package::read_from_bytes_unchecked(&bytes).expect_err(
-        "expected unchecked kernel deserialization to reject inconsistent node digests",
-    );
-    assert!(
-        err.to_string()
-            .contains("declared node id and digest do not correspond to a procedure root"),
-        "expected package manifest validation failure, got: {err}"
-    );
+    let trusted = Package::read_from_bytes_trusted(&bytes)
+        .expect("trusted kernel deserialization should not recompute MAST hashes");
+    assert_eq!(trusted.mast_forest()[node_id].digest(), spoofed_digest);
 }
 
 fn read_usize_vint64(bytes: &[u8], offset: &mut usize) -> usize {

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -297,7 +297,7 @@ impl LocalPackageRegistry {
         let Ok(bytes) = fs::read(path) else {
             return false;
         };
-        let Ok(loaded) = MastPackage::read_from_bytes(&bytes) else {
+        let Ok(loaded) = MastPackage::read_from_bytes_trusted(&bytes) else {
             return false;
         };
         let actual_version = Version::new(loaded.version.clone(), loaded.digest());
@@ -340,7 +340,7 @@ impl LocalPackageRegistry {
         };
 
         let bytes = fs::read(&path).map_err(LocalRegistryError::IndexRead)?;
-        let loaded = MastPackage::read_from_bytes(&bytes).map_err(|error| {
+        let loaded = MastPackage::read_from_bytes_trusted(&bytes).map_err(|error| {
             LocalRegistryError::PackageDecode {
                 path: path.clone(),
                 error: error.to_string(),
@@ -433,12 +433,12 @@ impl LocalPackageRegistry {
         bytes: &[u8],
     ) -> Result<(), LocalRegistryError> {
         match fs::read(legacy_path) {
-            Ok(existing_bytes) => match MastPackage::read_from_bytes(&existing_bytes) {
+            Ok(existing_bytes) => match MastPackage::read_from_bytes_trusted(&existing_bytes) {
                 Ok(existing_package) => {
                     let existing_version =
                         Version::new(existing_package.version.clone(), existing_package.digest());
                     if existing_package.name == package.name && existing_version == *version {
-                        if Self::matches_after_untrusted_package_read(&existing_package, package) {
+                        if Self::matches_after_trusted_package_read(&existing_package, package) {
                             write_file_atomically(artifact_path, &existing_bytes)
                                 .map_err(LocalRegistryError::IndexWrite)
                         } else {
@@ -469,9 +469,9 @@ impl LocalPackageRegistry {
         bytes: &[u8],
     ) -> Result<(), LocalRegistryError> {
         match fs::read(artifact_path) {
-            Ok(existing_bytes) => match MastPackage::read_from_bytes(&existing_bytes) {
+            Ok(existing_bytes) => match MastPackage::read_from_bytes_trusted(&existing_bytes) {
                 Ok(existing_package)
-                    if Self::matches_after_untrusted_package_read(&existing_package, package) =>
+                    if Self::matches_after_trusted_package_read(&existing_package, package) =>
                 {
                     Ok(())
                 },
@@ -497,8 +497,8 @@ impl LocalPackageRegistry {
         }
     }
 
-    fn matches_after_untrusted_package_read(existing: &MastPackage, package: &MastPackage) -> bool {
-        MastPackage::read_from_bytes(&package.to_bytes())
+    fn matches_after_trusted_package_read(existing: &MastPackage, package: &MastPackage) -> bool {
+        MastPackage::read_from_bytes_trusted(&package.to_bytes())
             .is_ok_and(|expected| existing == &expected)
     }
 
@@ -1162,7 +1162,7 @@ mod tests {
         assert_eq!(Some(conflicting_package.digest()), published.version.digest);
         let error = second_registry
             .cache_package(conflicting_package.into())
-            .expect_err("cache repair should revalidate the artifact under the index lock");
+            .expect_err("cache repair should check the artifact under the index lock");
         assert!(matches!(error, LocalRegistryError::DuplicateSemanticVersion { .. }));
         assert_eq!(fs::read(&published.artifact_path).unwrap(), repaired_bytes);
     }

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -12,7 +12,10 @@ use std::{
 };
 
 use miden_assembly_syntax::Report;
-use miden_core::{serde::Serializable, utils::DisplayHex};
+use miden_core::{
+    serde::{Deserializable, Serializable},
+    utils::DisplayHex,
+};
 use miden_mast_package::Package as MastPackage;
 use miden_package_registry::{
     InMemoryPackageRegistry, PackageCache, PackageId, PackageIndex, PackageProvider, PackageRecord,
@@ -225,7 +228,7 @@ impl LocalPackageRegistry {
     ) -> Result<PublishedPackage, LocalRegistryError> {
         let package_path = package_path.as_ref();
         let bytes = fs::read(package_path).map_err(LocalRegistryError::IndexRead)?;
-        let package = MastPackage::read_from_bytes_trusted(&bytes).map_err(|error| {
+        let package = MastPackage::read_from_bytes(&bytes).map_err(|error| {
             LocalRegistryError::PackageDecode {
                 path: package_path.to_path_buf(),
                 error: error.to_string(),
@@ -294,7 +297,7 @@ impl LocalPackageRegistry {
         let Ok(bytes) = fs::read(path) else {
             return false;
         };
-        let Ok(loaded) = MastPackage::read_from_bytes_trusted(&bytes) else {
+        let Ok(loaded) = MastPackage::read_from_bytes(&bytes) else {
             return false;
         };
         let actual_version = Version::new(loaded.version.clone(), loaded.digest());
@@ -337,7 +340,7 @@ impl LocalPackageRegistry {
         };
 
         let bytes = fs::read(&path).map_err(LocalRegistryError::IndexRead)?;
-        let loaded = MastPackage::read_from_bytes_trusted(&bytes).map_err(|error| {
+        let loaded = MastPackage::read_from_bytes(&bytes).map_err(|error| {
             LocalRegistryError::PackageDecode {
                 path: path.clone(),
                 error: error.to_string(),
@@ -430,12 +433,12 @@ impl LocalPackageRegistry {
         bytes: &[u8],
     ) -> Result<(), LocalRegistryError> {
         match fs::read(legacy_path) {
-            Ok(existing_bytes) => match MastPackage::read_from_bytes_trusted(&existing_bytes) {
+            Ok(existing_bytes) => match MastPackage::read_from_bytes(&existing_bytes) {
                 Ok(existing_package) => {
                     let existing_version =
                         Version::new(existing_package.version.clone(), existing_package.digest());
                     if existing_package.name == package.name && existing_version == *version {
-                        if &existing_package == package {
+                        if Self::matches_after_untrusted_package_read(&existing_package, package) {
                             write_file_atomically(artifact_path, &existing_bytes)
                                 .map_err(LocalRegistryError::IndexWrite)
                         } else {
@@ -466,8 +469,12 @@ impl LocalPackageRegistry {
         bytes: &[u8],
     ) -> Result<(), LocalRegistryError> {
         match fs::read(artifact_path) {
-            Ok(existing_bytes) => match MastPackage::read_from_bytes_trusted(&existing_bytes) {
-                Ok(existing_package) if &existing_package == package => Ok(()),
+            Ok(existing_bytes) => match MastPackage::read_from_bytes(&existing_bytes) {
+                Ok(existing_package)
+                    if Self::matches_after_untrusted_package_read(&existing_package, package) =>
+                {
+                    Ok(())
+                },
                 Ok(_) => Err(LocalRegistryError::DuplicateSemanticVersion {
                     package: package.name.clone(),
                     version: package.version.clone(),
@@ -488,6 +495,11 @@ impl LocalPackageRegistry {
                 bytes,
             ),
         }
+    }
+
+    fn matches_after_untrusted_package_read(existing: &MastPackage, package: &MastPackage) -> bool {
+        MastPackage::read_from_bytes(&package.to_bytes())
+            .is_ok_and(|expected| existing == &expected)
     }
 
     /// Derive the path in the artifact store for a package with `digest`
@@ -1032,6 +1044,23 @@ mod tests {
             .expect("cached package should be indexed");
         assert_eq!(shown.dependencies.len(), 1);
         assert!(reloaded.load_package(&PackageId::from("pkg"), &version).is_ok());
+    }
+
+    #[test]
+    fn cache_accepts_existing_debug_enabled_package_artifact() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let mut package = build_package("pkg", "1.0.0", []);
+        package
+            .sections
+            .push(Section::new(SectionId::DEBUG_SOURCE_MAP, Vec::from([1, 2, 3])));
+
+        let package = Arc::from(package);
+        let version = registry.cache_package(Arc::clone(&package)).unwrap();
+        let recached = registry.cache_package(package).unwrap();
+
+        assert_eq!(recached, version);
     }
 
     #[test]

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -340,12 +340,13 @@ impl LocalPackageRegistry {
         };
 
         let bytes = fs::read(&path).map_err(LocalRegistryError::IndexRead)?;
-        let loaded = MastPackage::read_from_bytes(&bytes).map_err(|error| {
-            LocalRegistryError::PackageDecode {
-                path: path.clone(),
-                error: error.to_string(),
-            }
-        })?;
+        let loaded =
+            MastPackage::read_from_bytes_validated_with_trusted_debug(&bytes).map_err(|error| {
+                LocalRegistryError::PackageDecode {
+                    path: path.clone(),
+                    error: error.to_string(),
+                }
+            })?;
 
         let actual_version = Version::new(loaded.version.clone(), loaded.digest());
         if loaded.name != *package || actual_version != *version {
@@ -1055,12 +1056,34 @@ mod tests {
         package
             .sections
             .push(Section::new(SectionId::DEBUG_SOURCE_MAP, Vec::from([1, 2, 3])));
+        let expected_sections = package.sections.clone();
 
         let package = Arc::from(package);
         let version = registry.cache_package(Arc::clone(&package)).unwrap();
         let recached = registry.cache_package(package).unwrap();
 
         assert_eq!(recached, version);
+        let loaded = registry.load_package(&PackageId::from("pkg"), &version).unwrap();
+        assert_eq!(loaded.sections, expected_sections);
+    }
+
+    #[test]
+    fn publish_preserves_debug_enabled_package_artifact_on_load() {
+        let tempdir = TempDir::new().unwrap();
+        let mut registry = load_registry(&tempdir);
+
+        let mut package = build_package("pkg", "1.0.0", []);
+        package
+            .sections
+            .push(Section::new(SectionId::DEBUG_SOURCE_MAP, Vec::from([1, 2, 3])));
+        let expected_sections = package.sections.clone();
+
+        let package_path = tempdir.path().join("pkg.masp");
+        package.write_to_file(&package_path).unwrap();
+        let published = registry.publish(&package_path).unwrap();
+
+        let loaded = registry.load_package(&PackageId::from("pkg"), &published.version).unwrap();
+        assert_eq!(loaded.sections, expected_sections);
     }
 
     #[test]

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -340,13 +340,12 @@ impl LocalPackageRegistry {
         };
 
         let bytes = fs::read(&path).map_err(LocalRegistryError::IndexRead)?;
-        let loaded =
-            MastPackage::read_from_bytes_validated_with_trusted_debug(&bytes).map_err(|error| {
-                LocalRegistryError::PackageDecode {
-                    path: path.clone(),
-                    error: error.to_string(),
-                }
-            })?;
+        let loaded = MastPackage::read_from_bytes(&bytes).map_err(|error| {
+            LocalRegistryError::PackageDecode {
+                path: path.clone(),
+                error: error.to_string(),
+            }
+        })?;
 
         let actual_version = Version::new(loaded.version.clone(), loaded.digest());
         if loaded.name != *package || actual_version != *version {
@@ -832,7 +831,10 @@ impl PackageStore for LocalPackageRegistry {
 
 #[cfg(test)]
 mod tests {
-    use miden_mast_package::{Dependency, Package, Section, SectionId, TargetType};
+    use miden_core::serde::Serializable;
+    use miden_mast_package::{
+        Dependency, Package, Section, SectionId, TargetType, debug_info::PackageDebugInfoBuilder,
+    };
     use tempfile::TempDir;
 
     use super::*;
@@ -859,6 +861,10 @@ mod tests {
         let index_path = tempdir.path().join("midenup").join("registry").join("index.toml");
         let artifact_dir = tempdir.path().join("sysroot").join("lib");
         LocalPackageRegistry::load(index_path, artifact_dir).expect("failed to load registry")
+    }
+
+    fn valid_debug_info_section() -> Section {
+        Section::new(SectionId::DEBUG_INFO, PackageDebugInfoBuilder::default().build().to_bytes())
     }
 
     #[test]
@@ -1053,9 +1059,7 @@ mod tests {
         let mut registry = load_registry(&tempdir);
 
         let mut package = build_package("pkg", "1.0.0", []);
-        package
-            .sections
-            .push(Section::new(SectionId::DEBUG_SOURCE_MAP, Vec::from([1, 2, 3])));
+        package.sections.push(valid_debug_info_section());
         let expected_sections = package.sections.clone();
 
         let package = Arc::from(package);
@@ -1073,9 +1077,7 @@ mod tests {
         let mut registry = load_registry(&tempdir);
 
         let mut package = build_package("pkg", "1.0.0", []);
-        package
-            .sections
-            .push(Section::new(SectionId::DEBUG_SOURCE_MAP, Vec::from([1, 2, 3])));
+        package.sections.push(valid_debug_info_section());
         let expected_sections = package.sections.clone();
 
         let package_path = tempdir.path().join("pkg.masp");

--- a/crates/project/src/dependencies/graph.rs
+++ b/crates/project/src/dependencies/graph.rs
@@ -15,7 +15,10 @@ use miden_assembly_syntax::{
     Report,
     debuginfo::{DefaultSourceManager, SourceManager, Uri},
 };
-use miden_core::utils::{DisplayHex, hash_string_to_word};
+use miden_core::{
+    serde::Deserializable,
+    utils::{DisplayHex, hash_string_to_word},
+};
 use miden_mast_package::Package as MastPackage;
 use miden_package_registry::{
     InMemoryPackageRegistry, PackageId, PackageRecord, PackageRegistry, PackageResolver, Version,
@@ -775,8 +778,8 @@ impl<'a, R: PackageRegistry + ?Sized> ProjectDependencyGraphBuilder<'a, R> {
     ) -> Result<CollectedDependencyNode, Report> {
         let path = path.canonicalize().map_err(|error| Report::msg(error.to_string()))?;
         let bytes = std::fs::read(&path).map_err(|error| Report::msg(error.to_string()))?;
-        let package = MastPackage::read_from_bytes_trusted(&bytes)
-            .map_err(|error| Report::msg(error.to_string()))?;
+        let package =
+            MastPackage::read_from_bytes(&bytes).map_err(|error| Report::msg(error.to_string()))?;
         self.ensure_dependency_name(expected_name, &package.name, Some(&path))?;
         let semver = package.version.clone();
         let selected = Version::new(semver, package.digest());

--- a/crates/project/src/dependencies/graph.rs
+++ b/crates/project/src/dependencies/graph.rs
@@ -15,10 +15,7 @@ use miden_assembly_syntax::{
     Report,
     debuginfo::{DefaultSourceManager, SourceManager, Uri},
 };
-use miden_core::{
-    serde::Deserializable,
-    utils::{DisplayHex, hash_string_to_word},
-};
+use miden_core::utils::{DisplayHex, hash_string_to_word};
 use miden_mast_package::Package as MastPackage;
 use miden_package_registry::{
     InMemoryPackageRegistry, PackageId, PackageRecord, PackageRegistry, PackageResolver, Version,
@@ -778,8 +775,8 @@ impl<'a, R: PackageRegistry + ?Sized> ProjectDependencyGraphBuilder<'a, R> {
     ) -> Result<CollectedDependencyNode, Report> {
         let path = path.canonicalize().map_err(|error| Report::msg(error.to_string()))?;
         let bytes = std::fs::read(&path).map_err(|error| Report::msg(error.to_string()))?;
-        let package =
-            MastPackage::read_from_bytes(&bytes).map_err(|error| Report::msg(error.to_string()))?;
+        let package = MastPackage::read_from_bytes_validated_with_trusted_debug(&bytes)
+            .map_err(|error| Report::msg(error.to_string()))?;
         self.ensure_dependency_name(expected_name, &package.name, Some(&path))?;
         let semver = package.version.clone();
         let selected = Version::new(semver, package.digest());

--- a/crates/project/src/dependencies/graph.rs
+++ b/crates/project/src/dependencies/graph.rs
@@ -15,7 +15,10 @@ use miden_assembly_syntax::{
     Report,
     debuginfo::{DefaultSourceManager, SourceManager, Uri},
 };
-use miden_core::utils::{DisplayHex, hash_string_to_word};
+use miden_core::{
+    serde::Deserializable,
+    utils::{DisplayHex, hash_string_to_word},
+};
 use miden_mast_package::Package as MastPackage;
 use miden_package_registry::{
     InMemoryPackageRegistry, PackageId, PackageRecord, PackageRegistry, PackageResolver, Version,
@@ -775,8 +778,8 @@ impl<'a, R: PackageRegistry + ?Sized> ProjectDependencyGraphBuilder<'a, R> {
     ) -> Result<CollectedDependencyNode, Report> {
         let path = path.canonicalize().map_err(|error| Report::msg(error.to_string()))?;
         let bytes = std::fs::read(&path).map_err(|error| Report::msg(error.to_string()))?;
-        let package = MastPackage::read_from_bytes_validated_with_trusted_debug(&bytes)
-            .map_err(|error| Report::msg(error.to_string()))?;
+        let package =
+            MastPackage::read_from_bytes(&bytes).map_err(|error| Report::msg(error.to_string()))?;
         self.ensure_dependency_name(expected_name, &package.name, Some(&path))?;
         let semver = package.version.clone();
         let selected = Version::new(semver, package.digest());

--- a/crates/serde-utils/src/lib.rs
+++ b/crates/serde-utils/src/lib.rs
@@ -515,6 +515,7 @@ pub trait Deserializable: Sized {
     /// Returns an error if:
     /// * The `source` does not contain enough bytes to deserialize `Self`.
     /// * Bytes read from the `source` do not represent a valid value for `Self`.
+    #[track_caller]
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError>;
 
     /// Returns the minimum serialized size for one instance of this type.
@@ -549,6 +550,7 @@ pub trait Deserializable: Sized {
     /// # Security
     /// This method is for trusted input. It does not bound allocations or reject trailing bytes.
     /// Use [`Deserializable::read_from_bytes_with_budget`] for attacker-controlled bytes.
+    #[track_caller]
     fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
         Self::read_from(&mut SliceReader::new(bytes))
     }
@@ -564,6 +566,7 @@ pub trait Deserializable: Sized {
     /// * The budget is exhausted before deserialization completes.
     /// * The `bytes` do not contain enough information to deserialize `Self`.
     /// * The `bytes` do not represent a valid value for `Self`.
+    #[track_caller]
     fn read_from_bytes_with_budget(
         bytes: &[u8],
         budget: usize,


### PR DESCRIPTION
~~This PR changes the untrusted MAST forest overspec log from `error!` to `warn!` and adds caller location to the warning. It also aligns package trusted readers with their names.~~

This PR hardens package deserialization across trust boundaries.

Untrusted package reads now validate the embedded MAST forest and decode package `DebugInfo` within fixed bounds. They validate that debug info against the package and retain it only after that succeeds.

Trusted package reads now mean what the name says. They trust the embedded MAST and manifest links. They also preserve package debug sections while skipping the cross-checks meant for hostile input.

The MAST warning is narrower now. If an untrusted MAST forest includes wire hashes, we log `warn!` with the caller location. The input is still accepted and validated by recomputing hashes. The warning is about wasted untrusted bytes, not corruption.

Local registry cache reads now use trusted package reads for cache reload and repair paths, including legacy artifact checks. The registry still validates package files passed to `publish(path)` before those bytes enter the artifact store. This keeps cache serialization unchanged and avoids routing same-domain cache bytes through the untrusted MAST warning path.

~~`Package::read_from` remains the untrusted reader for packages where debug sections are not needed. It validates the MAST and drops package debug sections.~~

`Package::read_from` and `Package::read_from_bytes` are the untrusted readers. They validate MAST and package debug info before returning the package.

~~`Package::read_from_untrusted` and `Package::read_from_bytes_untrusted` are new. They validate the MAST and package debug sections, then keep debug info.~~

No separate untrusted reader was added. The existing `Package::read_from` and `Package::read_from_bytes` keep that role.

~~`Package::read_from_unchecked` and `Package::read_from_bytes_unchecked` remain the way to trust bytes completely.~~

`Package::read_from_unchecked` and `Package::read_from_bytes_unchecked` were removed. Use `Package::read_from_trusted` and `Package::read_from_bytes_trusted` for same-domain trusted package bytes.

The DebugInfo path now rejects oversized payloads, oversized string and type tables, oversized strings, invalid references, bad spans, invalid layouts, and unsafe lookup shapes. Fuzz targets and regression seeds cover those hostile inputs.

Validation:

- `make check`
- `make test-fast`
- `make lint`
- `make check-features`

Roborev:

- `31284` passed with no issues.
