### PR TITLE
Make advice stack order explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `FastProcessor` `restore_call_state()` and `restore_context()` now return `OperationError::Internal` instead of panicking on empty stacks ([#3371](https://github.com/0xMiden/miden-vm/pull/3371), fixes [#3296](https://github.com/0xMiden/miden-vm/issues/3296)).
 
 - Opened the `LargeSmtForest` backend API for external implementations: made `LineageMutation::new` and `AppliedLineageMutation::new` public and added `LineageId::as_bytes` and `MutationSet::from_parts`.
+- [BREAKING] Added `AdviceStack` as the public advice stack type. `AdviceInputs` and `AdviceProvider` now use it, and the old raw stack field and `extend_stack` helpers were removed ([#3423](https://github.com/0xMiden/miden-vm/pull/3423)).
 - [BREAKING] Renamed module and kernel metadata APIs from `ModuleInfo`/`Kernel` to `ModuleDescriptor`/`KernelDescriptor`, including matching module descriptor method names ([#3356](https://github.com/0xMiden/miden-vm/pull/3356)).
 - Aligned workspace crate versions at `0.28.0`, except `midenc-hir-type`, so VM and crypto crates release as one version line.
 - Imported the Miden crypto crates, benches, fuzz targets, and Wycheproof tests into this workspace ([#3366](https://github.com/0xMiden/miden-vm/pull/3366)).

--- a/benches/synthetic-bench/benches/recursive_verify.rs
+++ b/benches/synthetic-bench/benches/recursive_verify.rs
@@ -51,7 +51,9 @@ use miden_core::{
 };
 use miden_core_lib::CoreLibrary;
 use miden_processor::{
-    DefaultHost, ExecutionOptions, FastProcessor, advice::AdviceInputs, trace::TraceLenSummary,
+    DefaultHost, ExecutionOptions, FastProcessor,
+    advice::{AdviceInputs, AdviceStack},
+    trace::TraceLenSummary,
 };
 use miden_prover::{PublicInputs, prove_sync};
 use miden_utils_testing::recursive_verifier::generate_advice_inputs;
@@ -607,9 +609,10 @@ fn recursive_proof_advice(fixture: &TxProofFixture) -> RecursiveProofAdvice {
     let verifier_inputs = generate_advice_inputs(fixture.proof.miden_proof().bytes(), pub_inputs)
         .expect("recursive advice");
 
+    let advice_stack = AdviceStack::try_from_values(verifier_inputs.advice_stack)
+        .expect("recursive advice stack values must be canonical");
     let advice_inputs = AdviceInputs::default()
-        .with_stack_values(verifier_inputs.advice_stack)
-        .expect("recursive advice stack values must be canonical")
+        .with_advice_stack(advice_stack)
         .with_merkle_store(verifier_inputs.store)
         .with_map(verifier_inputs.advice_map);
 

--- a/core/src/advice/mod.rs
+++ b/core/src/advice/mod.rs
@@ -12,7 +12,7 @@ mod map;
 pub use map::AdviceMap;
 
 mod stack;
-pub use stack::AdviceStackBuilder;
+pub use stack::{AdviceStack, AdviceStackBuilder};
 
 // ADVICE INPUTS
 // ================================================================================================
@@ -61,6 +61,17 @@ impl AdviceInputs {
     {
         self.stack.extend(iter);
         self
+    }
+
+    /// Replaces the advice stack with the provided typed stack.
+    pub fn with_advice_stack(mut self, stack: AdviceStack) -> Self {
+        self.stack = stack.into_elements();
+        self
+    }
+
+    /// Returns the advice stack as a typed stack.
+    pub fn advice_stack(&self) -> AdviceStack {
+        self.stack.clone().into()
     }
 
     /// Extends the map of values with the given argument, replacing previously inserted items.
@@ -114,7 +125,7 @@ impl Deserializable for AdviceInputs {
 mod tests {
     use alloc::vec::Vec;
 
-    use super::{AdviceInputs, AdviceStackBuilder};
+    use super::{AdviceInputs, AdviceStack, AdviceStackBuilder};
     use crate::{
         Felt, Word,
         serde::{Deserializable, Serializable},
@@ -140,6 +151,99 @@ mod tests {
         let advice2 = AdviceInputs::read_from_bytes(&bytes).unwrap();
 
         assert_eq!(advice1, advice2);
+    }
+
+    #[test]
+    fn advice_inputs_accept_typed_advice_stack() {
+        let mut stack = AdviceStack::new();
+        stack.push_element(Felt::new_unchecked(1));
+        stack.push_word(
+            [
+                Felt::new_unchecked(2),
+                Felt::new_unchecked(3),
+                Felt::new_unchecked(4),
+                Felt::new_unchecked(5),
+            ]
+            .into(),
+        );
+
+        let advice = AdviceInputs::default().with_advice_stack(stack.clone());
+
+        assert_eq!(advice.stack, stack.into_elements());
+        assert_eq!(advice.advice_stack(), advice.stack.into());
+    }
+
+    #[test]
+    fn advice_stack_consumes_word_sized_groups_top_first() {
+        let word0: Word = [
+            Felt::new_unchecked(1),
+            Felt::new_unchecked(2),
+            Felt::new_unchecked(3),
+            Felt::new_unchecked(4),
+        ]
+        .into();
+        let word1: Word = [
+            Felt::new_unchecked(5),
+            Felt::new_unchecked(6),
+            Felt::new_unchecked(7),
+            Felt::new_unchecked(8),
+        ]
+        .into();
+        let mut stack = AdviceStack::new();
+
+        stack.push_element(Felt::new_unchecked(0));
+        stack.push_word(word0);
+        stack.push_dword([word1, word0]);
+
+        assert_eq!(stack.consume_element(), Some(Felt::new_unchecked(0)));
+        assert_eq!(stack.consume_word(), Some(word0));
+        assert_eq!(stack.consume_dword(), Some([word1, word0]));
+        assert!(stack.is_empty());
+    }
+
+    #[test]
+    fn advice_stack_rejects_partial_dword_without_consuming() {
+        let word: Word = [
+            Felt::new_unchecked(1),
+            Felt::new_unchecked(2),
+            Felt::new_unchecked(3),
+            Felt::new_unchecked(4),
+        ]
+        .into();
+        let mut stack = AdviceStack::new();
+        stack.push_word(word);
+
+        assert_eq!(stack.consume_dword(), None);
+        assert_eq!(stack.consume_word(), Some(word));
+    }
+
+    #[test]
+    fn advice_stack_push_for_adv_push_matches_repeated_consumption() {
+        let values = [Felt::new_unchecked(1), Felt::new_unchecked(2), Felt::new_unchecked(3)];
+        let mut stack = AdviceStack::new();
+        stack.push_for_adv_push(&values);
+
+        assert_eq!(stack.consume_element(), Some(Felt::new_unchecked(3)));
+        assert_eq!(stack.consume_element(), Some(Felt::new_unchecked(2)));
+        assert_eq!(stack.consume_element(), Some(Felt::new_unchecked(1)));
+        assert!(stack.is_empty());
+    }
+
+    #[test]
+    fn advice_stack_push_for_adv_pipe_requires_dword_alignment() {
+        let values: Vec<Felt> = (1..=16).map(Felt::new_unchecked).collect();
+        let mut stack = AdviceStack::new();
+        stack.push_for_adv_pipe(&values);
+
+        assert_eq!(stack.into_elements(), values);
+    }
+
+    #[test]
+    #[should_panic(expected = "push_for_adv_pipe requires slice length to be a multiple of 8")]
+    fn advice_stack_push_for_adv_pipe_panics_on_misalignment() {
+        let values: Vec<Felt> = (1..=7).map(Felt::new_unchecked).collect();
+        let mut stack = AdviceStack::new();
+        stack.push_for_adv_pipe(&values);
     }
 
     // ADVICE STACK BUILDER TESTS

--- a/core/src/advice/mod.rs
+++ b/core/src/advice/mod.rs
@@ -3,8 +3,6 @@ use alloc::vec::Vec;
 use crate::{
     Felt, Word,
     crypto::merkle::MerkleStore,
-    field::QuotientMap,
-    program::InputError,
     serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 
@@ -12,7 +10,7 @@ mod map;
 pub use map::AdviceMap;
 
 mod stack;
-pub use stack::{AdviceStack, AdviceStackBuilder};
+pub use stack::AdviceStack;
 
 // ADVICE INPUTS
 // ================================================================================================
@@ -30,11 +28,7 @@ pub use stack::{AdviceStack, AdviceStackBuilder};
 ///    with Merkle trees.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AdviceInputs {
-    /// Advice stack values ordered from top to bottom.
-    ///
-    /// This field remains public for compatibility. Prefer [`AdviceInputs::with_advice_stack`]
-    /// and [`AdviceInputs::advice_stack`] for typed access.
-    pub stack: Vec<Felt>,
+    advice_stack: AdviceStack,
     pub map: AdviceMap,
     pub store: MerkleStore,
 }
@@ -43,39 +37,15 @@ impl AdviceInputs {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
-    /// Attempts to extend the stack values with the given sequence of integers, returning an error
-    /// if any of the numbers fails while converting to an element `[Felt]`.
-    pub fn with_stack_values<I>(mut self, iter: I) -> Result<Self, InputError>
-    where
-        I: IntoIterator<Item = u64>,
-    {
-        let stack = iter
-            .into_iter()
-            .map(|v| Felt::from_canonical_checked(v).ok_or(InputError::InvalidStackElement(v)))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        self.stack.extend(stack.iter());
-        Ok(self)
-    }
-
-    /// Extends the stack with the given elements.
-    pub fn with_stack<I>(mut self, iter: I) -> Self
-    where
-        I: IntoIterator<Item = Felt>,
-    {
-        self.stack.extend(iter);
-        self
-    }
-
     /// Replaces the advice stack with the provided typed stack.
     pub fn with_advice_stack(mut self, stack: AdviceStack) -> Self {
-        self.stack = stack.into_elements();
+        self.advice_stack = stack;
         self
     }
 
     /// Returns the advice stack as a typed stack.
     pub fn advice_stack(&self) -> AdviceStack {
-        self.stack.clone().into()
+        self.advice_stack.clone()
     }
 
     /// Extends the map of values with the given argument, replacing previously inserted items.
@@ -98,15 +68,21 @@ impl AdviceInputs {
 
     /// Extends the contents of this instance with the contents of the other instance.
     pub fn extend(&mut self, other: Self) {
-        self.stack.extend(other.stack);
+        self.advice_stack.push_elements(other.advice_stack.into_elements());
         self.map.extend(other.map);
         self.store.extend(other.store.inner_nodes());
+    }
+
+    /// Consumes this instance and returns its parts.
+    pub fn into_parts(self) -> (AdviceStack, AdviceMap, MerkleStore) {
+        (self.advice_stack, self.map, self.store)
     }
 }
 
 impl Serializable for AdviceInputs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let Self { stack, map, store } = self;
+        let Self { advice_stack, map, store } = self;
+        let stack: Vec<Felt> = advice_stack.iter().copied().collect();
         stack.write_into(target);
         map.write_into(target);
         store.write_into(target);
@@ -118,7 +94,7 @@ impl Deserializable for AdviceInputs {
         let stack = Vec::<Felt>::read_from(source)?;
         let map = AdviceMap::read_from(source)?;
         let store = MerkleStore::read_from(source)?;
-        Ok(Self { stack, map, store })
+        Ok(Self { advice_stack: stack.into(), map, store })
     }
 }
 
@@ -129,7 +105,7 @@ impl Deserializable for AdviceInputs {
 mod tests {
     use alloc::vec::Vec;
 
-    use super::{AdviceInputs, AdviceStack, AdviceStackBuilder};
+    use super::{AdviceInputs, AdviceStack};
     use crate::{
         Felt, Word,
         serde::{Deserializable, Serializable},
@@ -142,15 +118,18 @@ mod tests {
 
         assert_eq!(advice1, advice2);
 
-        let advice1 = AdviceInputs::default().with_stack_values([1, 2, 3].iter().copied()).unwrap();
-        let advice2 = AdviceInputs::default().with_stack_values([1, 2, 3].iter().copied()).unwrap();
+        let advice1 = AdviceInputs::default()
+            .with_advice_stack(AdviceStack::try_from_values([1, 2, 3]).unwrap());
+        let advice2 = AdviceInputs::default()
+            .with_advice_stack(AdviceStack::try_from_values([1, 2, 3]).unwrap());
 
         assert_eq!(advice1, advice2);
     }
 
     #[test]
     fn test_advice_inputs_serialization() {
-        let advice1 = AdviceInputs::default().with_stack_values([1, 2, 3].iter().copied()).unwrap();
+        let advice1 = AdviceInputs::default()
+            .with_advice_stack(AdviceStack::try_from_values([1, 2, 3]).unwrap());
         let bytes = advice1.to_bytes();
         let advice2 = AdviceInputs::read_from_bytes(&bytes).unwrap();
 
@@ -173,8 +152,7 @@ mod tests {
 
         let advice = AdviceInputs::default().with_advice_stack(stack.clone());
 
-        assert_eq!(advice.stack, stack.into_elements());
-        assert_eq!(advice.advice_stack(), advice.stack.into());
+        assert_eq!(advice.advice_stack(), stack);
     }
 
     #[test]
@@ -269,150 +247,20 @@ mod tests {
         );
     }
 
-    // ADVICE STACK BUILDER TESTS
+    // INTEGER INPUT TESTS
     // --------------------------------------------------------------------------------------------
 
     #[test]
-    fn test_builder_push_for_adv_push() {
-        // push_for_adv_push reverses the slice
-        // Input: [a, b, c] -> Builder stack: [c, b, a] (c on top)
-        let a = Felt::new_unchecked(1);
-        let b = Felt::new_unchecked(2);
-        let c = Felt::new_unchecked(3);
+    fn advice_stack_try_from_values_keeps_top_first_order() {
+        let stack = AdviceStack::try_from_values([1, 2, 3, 4]).unwrap();
 
-        let mut builder = AdviceStackBuilder::new();
-        builder.push_for_adv_push(&[a, b, c]);
-        let advice = builder.build();
-
-        // Builder stack is [c, b, a] with c on top (index 0)
-        // This becomes AdviceInputs.stack = [c, b, a]
-        assert_eq!(advice.stack, vec![c, b, a]);
-    }
-
-    #[test]
-    fn test_builder_push_word() {
-        let word: Word = [
-            Felt::new_unchecked(1),
-            Felt::new_unchecked(2),
-            Felt::new_unchecked(3),
-            Felt::new_unchecked(4),
-        ]
-        .into();
-
-        let mut builder = AdviceStackBuilder::new();
-        builder.push_word(word);
-        let advice = builder.build();
-
-        // Builder stack is [w0, w1, w2, w3] with w0 on top
         assert_eq!(
-            advice.stack,
+            stack.into_elements(),
             vec![
                 Felt::new_unchecked(1),
                 Felt::new_unchecked(2),
                 Felt::new_unchecked(3),
                 Felt::new_unchecked(4)
-            ]
-        );
-    }
-
-    #[test]
-    fn test_builder_push_for_adv_pipe() {
-        let slice: Vec<Felt> = (1..=8).map(Felt::new_unchecked).collect();
-
-        let mut builder = AdviceStackBuilder::new();
-        builder.push_for_adv_pipe(&slice);
-        let advice = builder.build();
-
-        assert_eq!(advice.stack, slice);
-    }
-
-    #[test]
-    #[should_panic(expected = "push_for_adv_pipe requires slice length to be a multiple of 8")]
-    fn test_builder_push_for_adv_pipe_panics_on_misalignment() {
-        let slice: Vec<Felt> = (1..=7).map(Felt::new_unchecked).collect();
-
-        let mut builder = AdviceStackBuilder::new();
-        builder.push_for_adv_pipe(&slice);
-        builder.build();
-    }
-
-    #[test]
-    fn test_builder_push_u64_slice() {
-        // push_u64_slice converts u64 to Felt without reversal
-        let mut builder = AdviceStackBuilder::new();
-        builder.push_u64_slice(&[1, 2, 3, 4]);
-        let advice = builder.build();
-
-        assert_eq!(
-            advice.stack,
-            vec![
-                Felt::new_unchecked(1),
-                Felt::new_unchecked(2),
-                Felt::new_unchecked(3),
-                Felt::new_unchecked(4)
-            ]
-        );
-    }
-
-    #[test]
-    fn test_builder_chaining_top_first() {
-        // First call adds elements consumed first (on top)
-        // Second call adds elements consumed second (below)
-        let a = Felt::new_unchecked(1);
-        let b = Felt::new_unchecked(2);
-        let c = Felt::new_unchecked(3);
-        let word: Word = [
-            Felt::new_unchecked(10),
-            Felt::new_unchecked(20),
-            Felt::new_unchecked(30),
-            Felt::new_unchecked(40),
-        ]
-        .into();
-
-        let mut builder = AdviceStackBuilder::new();
-        builder.push_for_adv_push(&[a, b, c]); // Consumed first
-        builder.push_word(word); // Consumed second
-        let advice = builder.build();
-
-        // Builder stack: [c, b, a, w0, w1, w2, w3]
-        // (c on top from reversed [a,b,c], then word below)
-        assert_eq!(
-            advice.stack,
-            vec![
-                c,
-                b,
-                a,
-                Felt::new_unchecked(10),
-                Felt::new_unchecked(20),
-                Felt::new_unchecked(30),
-                Felt::new_unchecked(40)
-            ]
-        );
-    }
-
-    #[test]
-    fn test_builder_multiple_push_for_adv_push() {
-        // Multiple calls should maintain top-first ordering
-        let first = [Felt::new_unchecked(1), Felt::new_unchecked(2)];
-        let second = [Felt::new_unchecked(3), Felt::new_unchecked(4)];
-
-        let mut builder = AdviceStackBuilder::new();
-        builder.push_for_adv_push(&first); // Consumed first
-        builder.push_for_adv_push(&second); // Consumed second
-        let advice = builder.build();
-
-        // First call: [2, 1] (reversed)
-        // Second call prepends: [4, 3, 2, 1] -> but wait, second is consumed AFTER first
-        // So second should go BELOW first in the stack
-        // Builder stack after first: [2, 1]
-        // Builder stack after second: [2, 1, 4, 3]
-        assert_eq!(
-            advice.stack,
-            vec![
-                Felt::new_unchecked(2),
-                Felt::new_unchecked(1),
-                Felt::new_unchecked(4),
-                Felt::new_unchecked(3)
             ]
         );
     }

--- a/core/src/advice/mod.rs
+++ b/core/src/advice/mod.rs
@@ -30,6 +30,10 @@ pub use stack::{AdviceStack, AdviceStackBuilder};
 ///    with Merkle trees.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AdviceInputs {
+    /// Advice stack values ordered from top to bottom.
+    ///
+    /// This field remains public for compatibility. Prefer [`AdviceInputs::with_advice_stack`]
+    /// and [`AdviceInputs::advice_stack`] for typed access.
     pub stack: Vec<Felt>,
     pub map: AdviceMap,
     pub store: MerkleStore,
@@ -244,6 +248,25 @@ mod tests {
         let values: Vec<Felt> = (1..=7).map(Felt::new_unchecked).collect();
         let mut stack = AdviceStack::new();
         stack.push_for_adv_pipe(&values);
+    }
+
+    #[test]
+    fn advice_stack_prepends_new_top_elements() {
+        let mut stack = AdviceStack::from(vec![Felt::new_unchecked(3), Felt::new_unchecked(4)]);
+
+        stack.prepend_element(Felt::new_unchecked(2));
+        stack.prepend_elements([Felt::new_unchecked(0), Felt::new_unchecked(1)]);
+
+        assert_eq!(
+            stack.into_elements(),
+            vec![
+                Felt::new_unchecked(0),
+                Felt::new_unchecked(1),
+                Felt::new_unchecked(2),
+                Felt::new_unchecked(3),
+                Felt::new_unchecked(4),
+            ]
+        );
     }
 
     // ADVICE STACK BUILDER TESTS

--- a/core/src/advice/mod.rs
+++ b/core/src/advice/mod.rs
@@ -68,7 +68,7 @@ impl AdviceInputs {
 
     /// Extends the contents of this instance with the contents of the other instance.
     pub fn extend(&mut self, other: Self) {
-        self.advice_stack.push_elements(other.advice_stack.into_elements());
+        self.advice_stack.append_elements(other.advice_stack.into_elements());
         self.map.extend(other.map);
         self.store.extend(other.store.inner_nodes());
     }
@@ -139,8 +139,8 @@ mod tests {
     #[test]
     fn advice_inputs_accept_typed_advice_stack() {
         let mut stack = AdviceStack::new();
-        stack.push_element(Felt::new_unchecked(1));
-        stack.push_word(
+        stack.append_element(Felt::new_unchecked(1));
+        stack.append_word(
             [
                 Felt::new_unchecked(2),
                 Felt::new_unchecked(3),
@@ -173,9 +173,9 @@ mod tests {
         .into();
         let mut stack = AdviceStack::new();
 
-        stack.push_element(Felt::new_unchecked(0));
-        stack.push_word(word0);
-        stack.push_dword([word1, word0]);
+        stack.append_element(Felt::new_unchecked(0));
+        stack.append_word(word0);
+        stack.append_dword([word1, word0]);
 
         assert_eq!(stack.consume_element(), Some(Felt::new_unchecked(0)));
         assert_eq!(stack.consume_word(), Some(word0));
@@ -193,17 +193,17 @@ mod tests {
         ]
         .into();
         let mut stack = AdviceStack::new();
-        stack.push_word(word);
+        stack.append_word(word);
 
         assert_eq!(stack.consume_dword(), None);
         assert_eq!(stack.consume_word(), Some(word));
     }
 
     #[test]
-    fn advice_stack_push_for_adv_push_matches_repeated_consumption() {
+    fn advice_stack_append_for_adv_push_matches_repeated_consumption() {
         let values = [Felt::new_unchecked(1), Felt::new_unchecked(2), Felt::new_unchecked(3)];
         let mut stack = AdviceStack::new();
-        stack.push_for_adv_push(&values);
+        stack.append_for_adv_push(&values);
 
         assert_eq!(stack.consume_element(), Some(Felt::new_unchecked(3)));
         assert_eq!(stack.consume_element(), Some(Felt::new_unchecked(2)));
@@ -212,27 +212,27 @@ mod tests {
     }
 
     #[test]
-    fn advice_stack_push_for_adv_pipe_requires_dword_alignment() {
+    fn advice_stack_append_for_adv_pipe_requires_dword_alignment() {
         let values: Vec<Felt> = (1..=16).map(Felt::new_unchecked).collect();
         let mut stack = AdviceStack::new();
-        stack.push_for_adv_pipe(&values);
+        stack.append_for_adv_pipe(&values);
 
         assert_eq!(stack.into_elements(), values);
     }
 
     #[test]
-    #[should_panic(expected = "push_for_adv_pipe requires slice length to be a multiple of 8")]
-    fn advice_stack_push_for_adv_pipe_panics_on_misalignment() {
+    #[should_panic(expected = "append_for_adv_pipe requires slice length to be a multiple of 8")]
+    fn advice_stack_append_for_adv_pipe_panics_on_misalignment() {
         let values: Vec<Felt> = (1..=7).map(Felt::new_unchecked).collect();
         let mut stack = AdviceStack::new();
-        stack.push_for_adv_pipe(&values);
+        stack.append_for_adv_pipe(&values);
     }
 
     #[test]
     fn advice_stack_prepends_new_top_elements() {
         let mut stack = AdviceStack::from(vec![Felt::new_unchecked(3), Felt::new_unchecked(4)]);
 
-        stack.prepend_element(Felt::new_unchecked(2));
+        stack.push_element(Felt::new_unchecked(2));
         stack.prepend_elements([Felt::new_unchecked(0), Felt::new_unchecked(1)]);
 
         assert_eq!(

--- a/core/src/advice/stack.rs
+++ b/core/src/advice/stack.rs
@@ -3,6 +3,155 @@ use alloc::{collections::VecDeque, vec::Vec};
 use super::{AdviceInputs, AdviceMap};
 use crate::{Felt, Word, crypto::merkle::MerkleStore};
 
+// ADVICE STACK
+// ================================================================================================
+
+/// Advice stack values ordered from top to bottom.
+///
+/// The front of the stack is the next element consumed by `adv_push`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AdviceStack {
+    stack: VecDeque<Felt>,
+}
+
+impl AdviceStack {
+    /// Creates a new empty advice stack.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of elements on this advice stack.
+    pub fn len(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// Returns true if this advice stack has no elements.
+    pub fn is_empty(&self) -> bool {
+        self.stack.is_empty()
+    }
+
+    /// Returns an iterator over elements from top to bottom.
+    pub fn iter(&self) -> impl Iterator<Item = &Felt> {
+        self.stack.iter()
+    }
+
+    /// Pushes a single element onto the advice stack.
+    ///
+    /// Elements are consumed in FIFO order: first pushed = first consumed by advice operations.
+    pub fn push_element(&mut self, value: Felt) -> &mut Self {
+        self.stack.push_back(value);
+        self
+    }
+
+    /// Extends the advice stack with raw elements ordered from top to bottom.
+    ///
+    /// Elements are consumed in FIFO order: first element in iter = first consumed.
+    pub fn push_elements<I>(&mut self, values: I) -> &mut Self
+    where
+        I: IntoIterator<Item = Felt>,
+    {
+        self.stack.extend(values);
+        self
+    }
+
+    /// Adds elements for consumption by multiple sequential `adv_push` instructions.
+    ///
+    /// After `repeat.n adv_push end`, the operand stack will have `slice[0]` on top.
+    pub fn push_for_adv_push(&mut self, slice: &[Felt]) -> &mut Self {
+        for elem in slice.iter().rev() {
+            self.stack.push_back(*elem);
+        }
+        self
+    }
+
+    /// Adds a word for consumption by `adv_loadw` or `adv_pushw`.
+    pub fn push_word(&mut self, word: Word) -> &mut Self {
+        self.stack.extend(word.iter().copied());
+        self
+    }
+
+    /// Adds two words for consumption by `adv_pipe`.
+    pub fn push_dword(&mut self, words: [Word; 2]) -> &mut Self {
+        for word in words {
+            self.push_word(word);
+        }
+        self
+    }
+
+    /// Adds elements for sequential consumption by `adv_pipe` operations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the slice length is not a multiple of 8 (double-word aligned).
+    pub fn push_for_adv_pipe(&mut self, slice: &[Felt]) -> &mut Self {
+        assert!(
+            slice.len().is_multiple_of(8),
+            "push_for_adv_pipe requires slice length to be a multiple of 8, got {}",
+            slice.len()
+        );
+
+        self.stack.extend(slice.iter().copied());
+        self
+    }
+
+    /// Consumes a single element from the top of the advice stack.
+    pub fn consume_element(&mut self) -> Option<Felt> {
+        self.stack.pop_front()
+    }
+
+    /// Consumes a word from the top of the advice stack.
+    pub fn consume_word(&mut self) -> Option<Word> {
+        if self.stack.len() < 4 {
+            return None;
+        }
+
+        Some(Word::new([
+            self.consume_element().expect("checked len"),
+            self.consume_element().expect("checked len"),
+            self.consume_element().expect("checked len"),
+            self.consume_element().expect("checked len"),
+        ]))
+    }
+
+    /// Consumes two words from the top of the advice stack.
+    pub fn consume_dword(&mut self) -> Option<[Word; 2]> {
+        if self.stack.len() < 8 {
+            return None;
+        }
+
+        Some([self.consume_word()?, self.consume_word()?])
+    }
+
+    /// Consumes `self` and returns elements ordered from top to bottom.
+    pub fn into_elements(self) -> Vec<Felt> {
+        self.stack.into_iter().collect()
+    }
+}
+
+impl From<Vec<Felt>> for AdviceStack {
+    fn from(stack: Vec<Felt>) -> Self {
+        Self { stack: stack.into() }
+    }
+}
+
+impl From<VecDeque<Felt>> for AdviceStack {
+    fn from(stack: VecDeque<Felt>) -> Self {
+        Self { stack }
+    }
+}
+
+impl From<AdviceStack> for Vec<Felt> {
+    fn from(stack: AdviceStack) -> Self {
+        stack.into_elements()
+    }
+}
+
+impl FromIterator<Felt> for AdviceStack {
+    fn from_iter<T: IntoIterator<Item = Felt>>(iter: T) -> Self {
+        Self { stack: iter.into_iter().collect() }
+    }
+}
+
 // ADVICE STACK BUILDER
 // ================================================================================================
 
@@ -27,8 +176,7 @@ use crate::{Felt, Word, crypto::merkle::MerkleStore};
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct AdviceStackBuilder {
-    /// Conceptual stack where front (index 0) is "top" (consumed first).
-    stack: VecDeque<Felt>,
+    stack: AdviceStack,
 }
 
 impl AdviceStackBuilder {
@@ -44,7 +192,7 @@ impl AdviceStackBuilder {
     ///
     /// Elements are consumed in FIFO order: first pushed = first consumed by advice operations.
     pub fn push_element(&mut self, value: Felt) -> &mut Self {
-        self.stack.push_back(value);
+        self.stack.push_element(value);
         self
     }
 
@@ -55,7 +203,7 @@ impl AdviceStackBuilder {
     where
         I: IntoIterator<Item = Felt>,
     {
-        self.stack.extend(values);
+        self.stack.push_elements(values);
         self
     }
 
@@ -80,11 +228,7 @@ impl AdviceStackBuilder {
     /// // Result: operand stack = [a, b, c, ...] with a on top
     /// ```
     pub fn push_for_adv_push(&mut self, slice: &[Felt]) -> &mut Self {
-        // Reverse the slice: we want slice[0] to be popped last (ending up on top of operand stack)
-        // So we add elements in reverse order to the back of our stack
-        for elem in slice.iter().rev() {
-            self.stack.push_back(*elem);
-        }
+        self.stack.push_for_adv_push(slice);
         self
     }
 
@@ -102,9 +246,7 @@ impl AdviceStackBuilder {
     /// // Result: operand stack = [w0, w1, w2, w3, ...] with w0 on top
     /// ```
     pub fn push_word(&mut self, word: Word) -> &mut Self {
-        for elem in word.iter() {
-            self.stack.push_back(*elem);
-        }
+        self.stack.push_word(word);
         self
     }
 
@@ -130,10 +272,7 @@ impl AdviceStackBuilder {
             "push_for_adv_pipe requires slice length to be a multiple of 8, got {}",
             slice.len()
         );
-
-        for elem in slice.iter() {
-            self.stack.push_back(*elem);
-        }
+        self.stack.push_for_adv_pipe(slice);
         self
     }
 
@@ -149,7 +288,7 @@ impl AdviceStackBuilder {
     /// // Elements consumed in order: 1, 2, 3, 4, 5, 6, 7, 8
     /// ```
     pub fn push_u64_slice(&mut self, values: &[u64]) -> &mut Self {
-        self.stack.extend(values.iter().map(|&v| Felt::new_unchecked(v)));
+        self.stack.push_elements(values.iter().map(|&v| Felt::new_unchecked(v)));
         self
     }
 
@@ -162,7 +301,7 @@ impl AdviceStackBuilder {
     /// expected by `AdviceInputs`, which will be reversed when creating an `AdviceProvider`.
     pub fn build(self) -> AdviceInputs {
         AdviceInputs {
-            stack: self.stack.into(),
+            stack: self.stack.into_elements(),
             map: AdviceMap::default(),
             store: MerkleStore::default(),
         }
@@ -170,18 +309,22 @@ impl AdviceStackBuilder {
 
     /// Builds the `AdviceInputs` with additional map and store data.
     pub fn build_with(self, map: AdviceMap, store: MerkleStore) -> AdviceInputs {
-        AdviceInputs { stack: self.stack.into(), map, store }
+        AdviceInputs {
+            stack: self.stack.into_elements(),
+            map,
+            store,
+        }
     }
 
     /// Builds just the advice stack as `Vec<u64>` for use with `build_test!` macro.
     ///
     /// This is a convenience method that avoids needing to modify the test infrastructure.
     pub fn build_vec_u64(self) -> Vec<u64> {
-        self.stack.into_iter().map(|f| f.as_canonical_u64()).collect()
+        self.stack.into_elements().into_iter().map(|f| f.as_canonical_u64()).collect()
     }
 
     /// Consumes the builder and returns the accumulated elements as `Vec<Felt>`.
     pub fn into_elements(self) -> Vec<Felt> {
-        self.stack.into_iter().collect()
+        self.stack.into_elements()
     }
 }

--- a/core/src/advice/stack.rs
+++ b/core/src/advice/stack.rs
@@ -54,6 +54,36 @@ impl AdviceStack {
         self
     }
 
+    /// Prepends raw elements ordered from top to bottom.
+    ///
+    /// The first element in `values` becomes the next element consumed by advice operations.
+    pub fn prepend_elements<I>(&mut self, values: I) -> &mut Self
+    where
+        I: IntoIterator<Item = Felt>,
+    {
+        let values: Vec<Felt> = values.into_iter().collect();
+        for value in values.into_iter().rev() {
+            self.stack.push_front(value);
+        }
+        self
+    }
+
+    /// Prepends a single element to the top of the advice stack.
+    pub fn prepend_element(&mut self, value: Felt) -> &mut Self {
+        self.stack.push_front(value);
+        self
+    }
+
+    /// Prepends a word to the top of the advice stack.
+    pub fn prepend_word(&mut self, word: Word) -> &mut Self {
+        self.prepend_elements(word.iter().copied())
+    }
+
+    /// Prepends another advice stack to the top of this stack.
+    pub fn prepend_stack(&mut self, stack: AdviceStack) -> &mut Self {
+        self.prepend_elements(stack.into_elements())
+    }
+
     /// Adds elements for consumption by multiple sequential `adv_push` instructions.
     ///
     /// After `repeat.n adv_push end`, the operand stack will have `slice[0]` on top.

--- a/core/src/advice/stack.rs
+++ b/core/src/advice/stack.rs
@@ -1,7 +1,6 @@
 use alloc::{collections::VecDeque, vec::Vec};
 
-use super::{AdviceInputs, AdviceMap};
-use crate::{Felt, Word, crypto::merkle::MerkleStore};
+use crate::{Felt, Word, field::QuotientMap, program::InputError};
 
 // ADVICE STACK
 // ================================================================================================
@@ -18,6 +17,23 @@ impl AdviceStack {
     /// Creates a new empty advice stack.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Creates an advice stack from integer values ordered from top to bottom.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any value is not a valid field element.
+    pub fn try_from_values<I>(values: I) -> Result<Self, InputError>
+    where
+        I: IntoIterator<Item = u64>,
+    {
+        values
+            .into_iter()
+            .map(|value| {
+                Felt::from_canonical_checked(value).ok_or(InputError::InvalidStackElement(value))
+            })
+            .collect()
     }
 
     /// Returns the number of elements on this advice stack.
@@ -179,182 +195,5 @@ impl From<AdviceStack> for Vec<Felt> {
 impl FromIterator<Felt> for AdviceStack {
     fn from_iter<T: IntoIterator<Item = Felt>>(iter: T) -> Self {
         Self { stack: iter.into_iter().collect() }
-    }
-}
-
-// ADVICE STACK BUILDER
-// ================================================================================================
-
-/// A builder for constructing advice stack inputs with intuitive ordering.
-///
-/// The builder maintains a conceptual advice stack where index 0 is the "top" - i.e., the element
-/// that will be consumed first. Method names indicate which MASM instruction pattern they target,
-/// abstracting away the internal transformations needed for correct element ordering.
-///
-/// # Building Direction
-///
-/// Building happens "top-first": the first method call adds elements that will be consumed first
-/// by the MASM code. Each subsequent method call adds elements "below" the previous ones.
-///
-/// # Example
-///
-/// ```ignore
-/// let advice = AdviceStackBuilder::new()
-///     .push_for_adv_push(&[a, b, c])  // Consumed first by adv_push adv_push adv_push
-///     .push_word(word)                // Consumed second by adv_loadw (or adv_pushw)
-///     .build();
-/// ```
-#[derive(Clone, Debug, Default)]
-pub struct AdviceStackBuilder {
-    stack: AdviceStack,
-}
-
-impl AdviceStackBuilder {
-    /// Creates a new empty builder.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    // STATE MUTATORS
-    // --------------------------------------------------------------------------------------------
-
-    /// Pushes a single element onto the advice stack.
-    ///
-    /// Elements are consumed in FIFO order: first pushed = first consumed by advice operations.
-    pub fn push_element(&mut self, value: Felt) -> &mut Self {
-        self.stack.push_element(value);
-        self
-    }
-
-    /// Extends the advice stack with raw elements (already ordered top-to-bottom).
-    ///
-    /// Elements are consumed in FIFO order: first element in iter = first consumed.
-    pub fn push_elements<I>(&mut self, values: I) -> &mut Self
-    where
-        I: IntoIterator<Item = Felt>,
-    {
-        self.stack.push_elements(values);
-        self
-    }
-
-    /// Adds elements for consumption by multiple sequential `adv_push` instructions.
-    ///
-    /// After `repeat.n adv_push end`, the operand stack will have `slice[0]` on top.
-    ///
-    /// # How it works
-    ///
-    /// Each `adv_push` pops one element from the advice stack and pushes it to the operand
-    /// stack. Since each push goes to the top, the first-popped element ends up at the bottom
-    /// of the n elements, and the last-popped element ends up on top.
-    ///
-    /// Therefore, this method reverses the slice internally so that `slice[0]` is popped last
-    /// and ends up on top of the operand stack.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// builder.push_for_adv_push(&[a, b, c]);
-    /// // MASM: adv_push adv_push adv_push
-    /// // Result: operand stack = [a, b, c, ...] with a on top
-    /// ```
-    pub fn push_for_adv_push(&mut self, slice: &[Felt]) -> &mut Self {
-        self.stack.push_for_adv_push(slice);
-        self
-    }
-
-    /// Adds a word for consumption by `adv_loadw` or `adv_pushw`.
-    ///
-    /// Both instructions consume the same 4 elements from the advice stack and place them on
-    /// the operand stack with `word[0]` on top; they differ only in whether the top operand
-    /// word is overwritten (`adv_loadw`) or the stack grows by 4 (`adv_pushw`).
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// builder.push_word([w0, w1, w2, w3].into());
-    /// // MASM: adv_loadw (or adv_pushw)
-    /// // Result: operand stack = [w0, w1, w2, w3, ...] with w0 on top
-    /// ```
-    pub fn push_word(&mut self, word: Word) -> &mut Self {
-        self.stack.push_word(word);
-        self
-    }
-
-    /// Adds elements for sequential consumption by `adv_pipe` operations.
-    ///
-    /// Elements are consumed in order: `slice[0..8]` first, then `slice[8..16]`, etc.
-    /// No reversal is applied.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the slice length is not a multiple of 8 (double-word aligned).
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// builder.push_for_adv_pipe(&elements); // elements.len() must be multiple of 8
-    /// // MASM: multiple adv_pipe calls
-    /// // Result: elements consumed in order [elements[0], elements[1], ...]
-    /// ```
-    pub fn push_for_adv_pipe(&mut self, slice: &[Felt]) -> &mut Self {
-        assert!(
-            slice.len().is_multiple_of(8),
-            "push_for_adv_pipe requires slice length to be a multiple of 8, got {}",
-            slice.len()
-        );
-        self.stack.push_for_adv_pipe(slice);
-        self
-    }
-
-    /// Extends the advice stack with u64 values converted to Felt.
-    ///
-    /// This is a convenience method for test data that is typically specified as u64.
-    /// Elements are consumed in FIFO order: first element = first consumed.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// builder.push_u64_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
-    /// // Elements consumed in order: 1, 2, 3, 4, 5, 6, 7, 8
-    /// ```
-    pub fn push_u64_slice(&mut self, values: &[u64]) -> &mut Self {
-        self.stack.push_elements(values.iter().map(|&v| Felt::new_unchecked(v)));
-        self
-    }
-
-    // INPUT BUILDERS
-    // --------------------------------------------------------------------------------------------
-
-    /// Builds the `AdviceInputs` from the accumulated stack.
-    ///
-    /// The builder's conceptual stack (with index 0 as top) is converted to the format
-    /// expected by `AdviceInputs`, which will be reversed when creating an `AdviceProvider`.
-    pub fn build(self) -> AdviceInputs {
-        AdviceInputs {
-            stack: self.stack.into_elements(),
-            map: AdviceMap::default(),
-            store: MerkleStore::default(),
-        }
-    }
-
-    /// Builds the `AdviceInputs` with additional map and store data.
-    pub fn build_with(self, map: AdviceMap, store: MerkleStore) -> AdviceInputs {
-        AdviceInputs {
-            stack: self.stack.into_elements(),
-            map,
-            store,
-        }
-    }
-
-    /// Builds just the advice stack as `Vec<u64>` for use with `build_test!` macro.
-    ///
-    /// This is a convenience method that avoids needing to modify the test infrastructure.
-    pub fn build_vec_u64(self) -> Vec<u64> {
-        self.stack.into_elements().into_iter().map(|f| f.as_canonical_u64()).collect()
-    }
-
-    /// Consumes the builder and returns the accumulated elements as `Vec<Felt>`.
-    pub fn into_elements(self) -> Vec<Felt> {
-        self.stack.into_elements()
     }
 }

--- a/core/src/advice/stack.rs
+++ b/core/src/advice/stack.rs
@@ -51,18 +51,18 @@ impl AdviceStack {
         self.stack.iter()
     }
 
-    /// Pushes a single element onto the advice stack.
+    /// Appends a single element to the bottom of the advice stack.
     ///
-    /// Elements are consumed in FIFO order: first pushed = first consumed by advice operations.
-    pub fn push_element(&mut self, value: Felt) -> &mut Self {
+    /// The appended element is consumed after all existing advice stack elements.
+    pub fn append_element(&mut self, value: Felt) -> &mut Self {
         self.stack.push_back(value);
         self
     }
 
-    /// Extends the advice stack with raw elements ordered from top to bottom.
+    /// Appends raw elements to the bottom of the advice stack.
     ///
-    /// Elements are consumed in FIFO order: first element in iter = first consumed.
-    pub fn push_elements<I>(&mut self, values: I) -> &mut Self
+    /// Values are ordered from top to bottom within the appended block.
+    pub fn append_elements<I>(&mut self, values: I) -> &mut Self
     where
         I: IntoIterator<Item = Felt>,
     {
@@ -84,8 +84,8 @@ impl AdviceStack {
         self
     }
 
-    /// Prepends a single element to the top of the advice stack.
-    pub fn prepend_element(&mut self, value: Felt) -> &mut Self {
+    /// Pushes a single element onto the top of the advice stack.
+    pub fn push_element(&mut self, value: Felt) -> &mut Self {
         self.stack.push_front(value);
         self
     }
@@ -100,39 +100,39 @@ impl AdviceStack {
         self.prepend_elements(stack.into_elements())
     }
 
-    /// Adds elements for consumption by multiple sequential `adv_push` instructions.
+    /// Appends elements for consumption by multiple sequential `adv_push` instructions.
     ///
     /// After `repeat.n adv_push end`, the operand stack will have `slice[0]` on top.
-    pub fn push_for_adv_push(&mut self, slice: &[Felt]) -> &mut Self {
+    pub fn append_for_adv_push(&mut self, slice: &[Felt]) -> &mut Self {
         for elem in slice.iter().rev() {
             self.stack.push_back(*elem);
         }
         self
     }
 
-    /// Adds a word for consumption by `adv_loadw` or `adv_pushw`.
-    pub fn push_word(&mut self, word: Word) -> &mut Self {
+    /// Appends a word for consumption by `adv_loadw` or `adv_pushw`.
+    pub fn append_word(&mut self, word: Word) -> &mut Self {
         self.stack.extend(word.iter().copied());
         self
     }
 
-    /// Adds two words for consumption by `adv_pipe`.
-    pub fn push_dword(&mut self, words: [Word; 2]) -> &mut Self {
+    /// Appends two words for consumption by `adv_pipe`.
+    pub fn append_dword(&mut self, words: [Word; 2]) -> &mut Self {
         for word in words {
-            self.push_word(word);
+            self.append_word(word);
         }
         self
     }
 
-    /// Adds elements for sequential consumption by `adv_pipe` operations.
+    /// Appends elements for sequential consumption by `adv_pipe` operations.
     ///
     /// # Panics
     ///
     /// Panics if the slice length is not a multiple of 8 (double-word aligned).
-    pub fn push_for_adv_pipe(&mut self, slice: &[Felt]) -> &mut Self {
+    pub fn append_for_adv_pipe(&mut self, slice: &[Felt]) -> &mut Self {
         assert!(
             slice.len().is_multiple_of(8),
-            "push_for_adv_pipe requires slice length to be a multiple of 8, got {}",
+            "append_for_adv_pipe requires slice length to be a multiple of 8, got {}",
             slice.len()
         );
 

--- a/crates/lib/core/src/dsa.rs
+++ b/crates/lib/core/src/dsa.rs
@@ -170,8 +170,7 @@ pub mod falcon512_poseidon2 {
         let digest_polynomials = Poseidon2::hash_elements(&polynomials);
         let challenge = (digest_polynomials[0], digest_polynomials[1]);
 
-        // Push [tau1, tau0] so that after extend_stack reversal + two `adv_push` ops,
-        // operand stack is [tau0, tau1, ...]
+        // Push [tau1, tau0] so two `adv_push` ops leave [tau0, tau1, ...] on the operand stack.
         let mut result: Vec<Felt> = vec![challenge.1, challenge.0];
         result.extend_from_slice(&polynomials);
         result.extend_from_slice(&nonce.to_elements());

--- a/crates/lib/core/src/handlers/aead_decrypt.rs
+++ b/crates/lib/core/src/handlers/aead_decrypt.rs
@@ -14,7 +14,7 @@ use miden_crypto::aead::{
 };
 use miden_processor::{
     ProcessorState,
-    advice::{AdviceMutation, MAX_ADVICE_STACK_SIZE},
+    advice::{AdviceMutation, AdviceStack, MAX_ADVICE_STACK_SIZE},
     event::EventError,
 };
 
@@ -34,7 +34,7 @@ pub const AEAD_DECRYPT_EVENT_NAME: EventName = EventName::new("miden::core::cryp
 /// 2. Reads authentication tag from memory at src_ptr + (num_blocks + 1) * 8
 /// 3. Constructs EncryptedData and decrypts using AEAD-Poseidon2
 /// 4. Extracts only the data blocks (first num_blocks * 8 elements) from plaintext
-/// 5. Pushes the data blocks (WITHOUT padding) onto the advice stack in reverse order
+/// 5. Pushes the data blocks (WITHOUT padding) onto the advice stack for `adv_pipe`
 ///
 /// Expected event payload order (excluding event id):
 /// `(key: Word, nonce: Word, src_ptr, dst_ptr, num_blocks)`.
@@ -113,10 +113,9 @@ pub fn handle_aead_decrypt(process: &ProcessorState) -> Result<Vec<AdviceMutatio
     let mut plaintext_data = plaintext_with_padding;
     plaintext_data.truncate(data_blocks_count);
 
-    // Push plaintext data (WITHOUT padding) onto advice stack.
-    // Values are provided in structural order; `extend_stack` ensures the first element
-    // ends up at the top of the advice stack, matching `adv_pipe` expectations.
-    let advice_stack_mutation = AdviceMutation::extend_stack(plaintext_data);
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_for_adv_pipe(&plaintext_data);
+    let advice_stack_mutation = AdviceMutation::extend_advice_stack(advice_stack);
 
     Ok(vec![advice_stack_mutation])
 }

--- a/crates/lib/core/src/handlers/aead_decrypt.rs
+++ b/crates/lib/core/src/handlers/aead_decrypt.rs
@@ -114,6 +114,7 @@ pub fn handle_aead_decrypt(process: &ProcessorState) -> Result<Vec<AdviceMutatio
     plaintext_data.truncate(data_blocks_count);
 
     let mut advice_stack = AdviceStack::new();
+    // MASM streams plaintext blocks to memory with one `adv_pipe` per block.
     advice_stack.push_for_adv_pipe(&plaintext_data);
     let advice_stack_mutation = AdviceMutation::extend_advice_stack(advice_stack);
 

--- a/crates/lib/core/src/handlers/aead_decrypt.rs
+++ b/crates/lib/core/src/handlers/aead_decrypt.rs
@@ -115,7 +115,7 @@ pub fn handle_aead_decrypt(process: &ProcessorState) -> Result<Vec<AdviceMutatio
 
     let mut advice_stack = AdviceStack::new();
     // MASM streams plaintext blocks to memory with one `adv_pipe` per block.
-    advice_stack.push_for_adv_pipe(&plaintext_data);
+    advice_stack.append_for_adv_pipe(&plaintext_data);
     let advice_stack_mutation = AdviceMutation::extend_advice_stack(advice_stack);
 
     Ok(vec![advice_stack_mutation])

--- a/crates/lib/core/src/handlers/falcon_div.rs
+++ b/crates/lib/core/src/handlers/falcon_div.rs
@@ -6,7 +6,11 @@
 use alloc::{vec, vec::Vec};
 
 use miden_core::{ZERO, events::EventName};
-use miden_processor::{ProcessorState, advice::AdviceMutation, event::EventError};
+use miden_processor::{
+    ProcessorState,
+    advice::{AdviceMutation, AdviceStack},
+    event::EventError,
+};
 
 use crate::handlers::u64_to_u32_elements;
 
@@ -65,15 +69,13 @@ pub fn handle_falcon_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>
     // Assertion from the original code: r_hi should always be zero for Falcon modulus
     assert_eq!(r_hi, ZERO);
 
-    // `mod_12289` consumes the quotient via `adv_push adv_push` and then the remainder via
-    // `adv_push`. `extend_stack([a, b, ...])` puts `a` on top of the advice stack (reverse
-    // iteration + push_front), and the mutations are applied in the order they appear in the
-    // returned vec. So applying remainder first then quotient leaves the advice stack, top first:
-    //     [q_hi, q_lo, r_lo, ...]
-    // `adv_push adv_push` pops q_hi then q_lo → operand [q_lo, q_hi, ...] (LE); the subsequent
-    // `adv_push` pops r_lo.
-    let remainder = AdviceMutation::extend_stack([r_lo]);
-    let quotient = AdviceMutation::extend_stack([q_hi, q_lo]);
+    let mut remainder_stack = AdviceStack::new();
+    remainder_stack.push_element(r_lo);
+    let remainder = AdviceMutation::extend_advice_stack(remainder_stack);
+
+    let mut quotient_stack = AdviceStack::new();
+    quotient_stack.push_elements([q_hi, q_lo]);
+    let quotient = AdviceMutation::extend_advice_stack(quotient_stack);
     Ok(vec![remainder, quotient])
 }
 

--- a/crates/lib/core/src/handlers/falcon_div.rs
+++ b/crates/lib/core/src/handlers/falcon_div.rs
@@ -70,10 +70,12 @@ pub fn handle_falcon_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>
     assert_eq!(r_hi, ZERO);
 
     let mut remainder_stack = AdviceStack::new();
+    // MASM consumes the remainder after the quotient, with one `adv_push`.
     remainder_stack.push_element(r_lo);
     let remainder = AdviceMutation::extend_advice_stack(remainder_stack);
 
     let mut quotient_stack = AdviceStack::new();
+    // MASM reads q_hi then q_lo with `adv_push adv_push`, so q_lo lands on top.
     quotient_stack.push_elements([q_hi, q_lo]);
     let quotient = AdviceMutation::extend_advice_stack(quotient_stack);
     Ok(vec![remainder, quotient])

--- a/crates/lib/core/src/handlers/falcon_div.rs
+++ b/crates/lib/core/src/handlers/falcon_div.rs
@@ -71,12 +71,12 @@ pub fn handle_falcon_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>
 
     let mut remainder_stack = AdviceStack::new();
     // MASM consumes the remainder after the quotient, with one `adv_push`.
-    remainder_stack.push_element(r_lo);
+    remainder_stack.append_element(r_lo);
     let remainder = AdviceMutation::extend_advice_stack(remainder_stack);
 
     let mut quotient_stack = AdviceStack::new();
     // MASM reads q_hi then q_lo with `adv_push adv_push`, so q_lo lands on top.
-    quotient_stack.push_elements([q_hi, q_lo]);
+    quotient_stack.append_elements([q_hi, q_lo]);
     let quotient = AdviceMutation::extend_advice_stack(quotient_stack);
     Ok(vec![remainder, quotient])
 }

--- a/crates/lib/core/src/handlers/precompiles/keccak256.rs
+++ b/crates/lib/core/src/handlers/precompiles/keccak256.rs
@@ -9,7 +9,11 @@ use miden_core::{
     utils::{bytes_to_packed_u32_elements, packed_u32_elements_to_bytes},
 };
 use miden_crypto::hash::keccak::Keccak256;
-use miden_processor::{ProcessorState, advice::AdviceMutation, event::EventError};
+use miden_processor::{
+    ProcessorState,
+    advice::{AdviceMutation, AdviceStack},
+    event::EventError,
+};
 
 use crate::handlers::read_memory_region;
 
@@ -47,7 +51,9 @@ pub fn handle_keccak256_digest(
         .into());
     }
 
-    Ok(vec![AdviceMutation::extend_stack(digest_felts)])
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_for_adv_pipe(&digest_felts);
+    Ok(vec![AdviceMutation::extend_advice_stack(advice_stack)])
 }
 
 fn read_memory_packed_u32(

--- a/crates/lib/core/src/handlers/precompiles/keccak256.rs
+++ b/crates/lib/core/src/handlers/precompiles/keccak256.rs
@@ -52,6 +52,7 @@ pub fn handle_keccak256_digest(
     }
 
     let mut advice_stack = AdviceStack::new();
+    // MASM consumes the digest with two `adv_pushw` calls, low word first and high word second.
     advice_stack.push_for_adv_pipe(&digest_felts);
     Ok(vec![AdviceMutation::extend_advice_stack(advice_stack)])
 }

--- a/crates/lib/core/src/handlers/precompiles/keccak256.rs
+++ b/crates/lib/core/src/handlers/precompiles/keccak256.rs
@@ -53,7 +53,7 @@ pub fn handle_keccak256_digest(
 
     let mut advice_stack = AdviceStack::new();
     // MASM consumes the digest with two `adv_pushw` calls, low word first and high word second.
-    advice_stack.push_for_adv_pipe(&digest_felts);
+    advice_stack.append_for_adv_pipe(&digest_felts);
     Ok(vec![AdviceMutation::extend_advice_stack(advice_stack)])
 }
 

--- a/crates/lib/core/src/handlers/precompiles/uint_field_inv.rs
+++ b/crates/lib/core/src/handlers/precompiles/uint_field_inv.rs
@@ -3,12 +3,16 @@
 use alloc::{vec, vec::Vec};
 
 use miden_core::{
-    Felt, ZERO,
+    Felt, Word, ZERO,
     deferred::{DeferredError, Node},
     events::EventName,
 };
 use miden_precompiles::{Limbs, UintDomain, UintPrecompile};
-use miden_processor::{ProcessorState, advice::AdviceMutation, event::EventError};
+use miden_processor::{
+    ProcessorState,
+    advice::{AdviceMutation, AdviceStack},
+    event::EventError,
+};
 
 /// Event used by generated field uint wrappers to request an inverse witness from the host.
 pub const UINT_FIELD_INV_EVENT_NAME: EventName =
@@ -42,7 +46,14 @@ pub fn handle_uint_field_inv(
         .map_err(|_| UintFieldInvError::ExpectedUintValue)?;
     let inverse = domain.inv(value).ok_or(UintFieldInvError::ZeroValue)?;
 
-    Ok(vec![AdviceMutation::extend_stack(inverse.map(Felt::from_u32))])
+    let inverse = inverse.map(Felt::from_u32);
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_dword([
+        Word::new([inverse[0], inverse[1], inverse[2], inverse[3]]),
+        Word::new([inverse[4], inverse[5], inverse[6], inverse[7]]),
+    ]);
+
+    Ok(vec![AdviceMutation::extend_advice_stack(advice_stack)])
 }
 
 fn limbs_from_value_node(node: &Node, domain: UintDomain) -> Result<Limbs, DeferredError> {

--- a/crates/lib/core/src/handlers/precompiles/uint_field_inv.rs
+++ b/crates/lib/core/src/handlers/precompiles/uint_field_inv.rs
@@ -48,6 +48,7 @@ pub fn handle_uint_field_inv(
 
     let inverse = inverse.map(Felt::from_u32);
     let mut advice_stack = AdviceStack::new();
+    // Generated MASM consumes the inverse with two `adv_pushw` calls: low limbs, then high limbs.
     advice_stack.push_dword([
         Word::new([inverse[0], inverse[1], inverse[2], inverse[3]]),
         Word::new([inverse[4], inverse[5], inverse[6], inverse[7]]),

--- a/crates/lib/core/src/handlers/precompiles/uint_field_inv.rs
+++ b/crates/lib/core/src/handlers/precompiles/uint_field_inv.rs
@@ -49,7 +49,7 @@ pub fn handle_uint_field_inv(
     let inverse = inverse.map(Felt::from_u32);
     let mut advice_stack = AdviceStack::new();
     // Generated MASM consumes the inverse with two `adv_pushw` calls: low limbs, then high limbs.
-    advice_stack.push_dword([
+    advice_stack.append_dword([
         Word::new([inverse[0], inverse[1], inverse[2], inverse[3]]),
         Word::new([inverse[4], inverse[5], inverse[6], inverse[7]]),
     ]);

--- a/crates/lib/core/src/handlers/smt_peek.rs
+++ b/crates/lib/core/src/handlers/smt_peek.rs
@@ -11,7 +11,11 @@ use miden_core::{
     crypto::merkle::{EmptySubtreeRoots, SMT_DEPTH, Smt},
     events::EventName,
 };
-use miden_processor::{ProcessorState, advice::AdviceMutation, event::EventError};
+use miden_processor::{
+    ProcessorState,
+    advice::{AdviceMutation, AdviceStack},
+    event::EventError,
+};
 
 /// Event name for the smt_peek operation.
 pub const SMT_PEEK_EVENT_NAME: EventName =
@@ -66,7 +70,7 @@ pub fn handle_smt_peek(process: &ProcessorState) -> Result<Vec<AdviceMutation>, 
     if node == *empty_leaf {
         // if the node is a root of an empty subtree, then there is no value associated with
         // the specified key
-        let mutation = AdviceMutation::extend_stack(Smt::EMPTY_VALUE);
+        let mutation = advice_stack_word_mutation(Smt::EMPTY_VALUE);
         Ok(vec![mutation])
     } else {
         let leaf_preimage = get_smt_leaf_preimage(process, node)?;
@@ -74,14 +78,14 @@ pub fn handle_smt_peek(process: &ProcessorState) -> Result<Vec<AdviceMutation>, 
         for (key_in_leaf, value_in_leaf) in leaf_preimage {
             if key == key_in_leaf {
                 // Found key - push value associated with key, and return
-                let mutation = AdviceMutation::extend_stack(value_in_leaf);
+                let mutation = advice_stack_word_mutation(value_in_leaf);
                 return Ok(vec![mutation]);
             }
         }
 
         // if we can't find any key in the leaf that matches `key`, it means no value is
         // associated with `key`
-        let mutation = AdviceMutation::extend_stack(Smt::EMPTY_VALUE);
+        let mutation = advice_stack_word_mutation(Smt::EMPTY_VALUE);
         Ok(vec![mutation])
     }
 }
@@ -112,6 +116,12 @@ fn get_smt_leaf_preimage(
             (key.into(), value.into())
         })
         .collect())
+}
+
+fn advice_stack_word_mutation(word: Word) -> AdviceMutation {
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_word(word);
+    AdviceMutation::extend_advice_stack(advice_stack)
 }
 
 // ERROR TYPES

--- a/crates/lib/core/src/handlers/smt_peek.rs
+++ b/crates/lib/core/src/handlers/smt_peek.rs
@@ -120,6 +120,7 @@ fn get_smt_leaf_preimage(
 
 fn advice_stack_word_mutation(word: Word) -> AdviceMutation {
     let mut advice_stack = AdviceStack::new();
+    // MASM callers consume the returned value with `adv_loadw` or `adv_pushw`.
     advice_stack.push_word(word);
     AdviceMutation::extend_advice_stack(advice_stack)
 }

--- a/crates/lib/core/src/handlers/smt_peek.rs
+++ b/crates/lib/core/src/handlers/smt_peek.rs
@@ -121,7 +121,7 @@ fn get_smt_leaf_preimage(
 fn advice_stack_word_mutation(word: Word) -> AdviceMutation {
     let mut advice_stack = AdviceStack::new();
     // MASM callers consume the returned value with `adv_loadw` or `adv_pushw`.
-    advice_stack.push_word(word);
+    advice_stack.append_word(word);
     AdviceMutation::extend_advice_stack(advice_stack)
 }
 

--- a/crates/lib/core/src/handlers/sorted_array.rs
+++ b/crates/lib/core/src/handlers/sorted_array.rs
@@ -1,7 +1,11 @@
 use alloc::{vec, vec::Vec};
 
 use miden_core::{Felt, Word, events::EventName, field::PrimeCharacteristicRing};
-use miden_processor::{MemoryError, ProcessorState, advice::AdviceMutation, event::EventError};
+use miden_processor::{
+    MemoryError, ProcessorState,
+    advice::{AdviceMutation, AdviceStack},
+    event::EventError,
+};
 
 /// Event name for the lowerbound_array operation.
 pub const LOWERBOUND_ARRAY_EVENT_NAME: EventName =
@@ -114,10 +118,9 @@ fn push_lowerbound_result(
 
     // If range is empty, result is end_ptr
     if addr_range.is_empty() {
-        return Ok(vec![AdviceMutation::extend_stack(vec![
-            Felt::from_u32(addr_range.end),
-            Felt::from_bool(false),
-        ])]);
+        let mut advice_stack = AdviceStack::new();
+        advice_stack.push_elements([Felt::from_u32(addr_range.end), Felt::from_bool(false)]);
+        return Ok(vec![AdviceMutation::extend_advice_stack(advice_stack)]);
     }
 
     // Helper function to get a word from memory and normalize it to the requested key size.
@@ -157,10 +160,12 @@ fn push_lowerbound_result(
         previous_word = word;
     }
 
-    Ok(vec![AdviceMutation::extend_stack(vec![
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_elements([
         Felt::from_u32(result.unwrap_or(addr_range.end)),
         Felt::from_bool(was_key_found),
-    ])])
+    ]);
+    Ok(vec![AdviceMutation::extend_advice_stack(advice_stack)])
 }
 
 /// Selectively zeroizes the felts in a [`Word`] based on the provided [`KeySize`].

--- a/crates/lib/core/src/handlers/sorted_array.rs
+++ b/crates/lib/core/src/handlers/sorted_array.rs
@@ -119,6 +119,7 @@ fn push_lowerbound_result(
     // If range is empty, result is end_ptr
     if addr_range.is_empty() {
         let mut advice_stack = AdviceStack::new();
+        // MASM consumes maybe_ptr first and was_found second with `adv_push adv_push`.
         advice_stack.push_elements([Felt::from_u32(addr_range.end), Felt::from_bool(false)]);
         return Ok(vec![AdviceMutation::extend_advice_stack(advice_stack)]);
     }
@@ -161,6 +162,7 @@ fn push_lowerbound_result(
     }
 
     let mut advice_stack = AdviceStack::new();
+    // MASM consumes maybe_ptr first and was_found second with `adv_push adv_push`.
     advice_stack.push_elements([
         Felt::from_u32(result.unwrap_or(addr_range.end)),
         Felt::from_bool(was_key_found),

--- a/crates/lib/core/src/handlers/sorted_array.rs
+++ b/crates/lib/core/src/handlers/sorted_array.rs
@@ -120,7 +120,7 @@ fn push_lowerbound_result(
     if addr_range.is_empty() {
         let mut advice_stack = AdviceStack::new();
         // MASM consumes maybe_ptr first and was_found second with `adv_push adv_push`.
-        advice_stack.push_elements([Felt::from_u32(addr_range.end), Felt::from_bool(false)]);
+        advice_stack.append_elements([Felt::from_u32(addr_range.end), Felt::from_bool(false)]);
         return Ok(vec![AdviceMutation::extend_advice_stack(advice_stack)]);
     }
 
@@ -163,7 +163,7 @@ fn push_lowerbound_result(
 
     let mut advice_stack = AdviceStack::new();
     // MASM consumes maybe_ptr first and was_found second with `adv_push adv_push`.
-    advice_stack.push_elements([
+    advice_stack.append_elements([
         Felt::from_u32(result.unwrap_or(addr_range.end)),
         Felt::from_bool(was_key_found),
     ]);

--- a/crates/lib/core/src/handlers/u128_div.rs
+++ b/crates/lib/core/src/handlers/u128_div.rs
@@ -30,7 +30,7 @@ pub const U128_DIV_EVENT_NAME: EventName = EventName::new("miden::core::math::u1
 /// Where (b0..b3) and (a0..a3) are the 32-bit limbs of the divisor and dividend respectively,
 /// with b0/a0 being the least significant limb.
 ///
-/// After two `padw adv_loadw` in MASM:
+/// After two `adv_pushw` instructions in MASM:
 ///   First:  loads [r0, r1, r2, r3] onto operand stack
 ///   Second: loads [q0, q1, q2, q3] onto operand stack
 ///
@@ -52,6 +52,7 @@ pub fn handle_u128_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>, 
     let (r0, r1, r2, r3) = u128_to_u32_felts(remainder);
 
     let mut advice_stack = AdviceStack::new();
+    // MASM consumes remainder with the first `adv_pushw` and quotient with the second one.
     advice_stack
         .push_word(Word::new([r0, r1, r2, r3]))
         .push_word(Word::new([q0, q1, q2, q3]));

--- a/crates/lib/core/src/handlers/u128_div.rs
+++ b/crates/lib/core/src/handlers/u128_div.rs
@@ -5,10 +5,10 @@
 
 use alloc::{vec, vec::Vec};
 
-use miden_core::Felt;
+use miden_core::{Felt, Word};
 use miden_processor::{
     ProcessorState,
-    advice::AdviceMutation,
+    advice::{AdviceMutation, AdviceStack},
     event::{EventError, EventName},
 };
 
@@ -51,7 +51,11 @@ pub fn handle_u128_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>, 
     let (q0, q1, q2, q3) = u128_to_u32_felts(quotient);
     let (r0, r1, r2, r3) = u128_to_u32_felts(remainder);
 
-    let mutation = AdviceMutation::extend_stack([r0, r1, r2, r3, q0, q1, q2, q3]);
+    let mut advice_stack = AdviceStack::new();
+    advice_stack
+        .push_word(Word::new([r0, r1, r2, r3]))
+        .push_word(Word::new([q0, q1, q2, q3]));
+    let mutation = AdviceMutation::extend_advice_stack(advice_stack);
     Ok(vec![mutation])
 }
 

--- a/crates/lib/core/src/handlers/u128_div.rs
+++ b/crates/lib/core/src/handlers/u128_div.rs
@@ -54,8 +54,8 @@ pub fn handle_u128_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>, 
     let mut advice_stack = AdviceStack::new();
     // MASM consumes remainder with the first `adv_pushw` and quotient with the second one.
     advice_stack
-        .push_word(Word::new([r0, r1, r2, r3]))
-        .push_word(Word::new([q0, q1, q2, q3]));
+        .append_word(Word::new([r0, r1, r2, r3]))
+        .append_word(Word::new([q0, q1, q2, q3]));
     let mutation = AdviceMutation::extend_advice_stack(advice_stack);
     Ok(vec![mutation])
 }

--- a/crates/lib/core/src/handlers/u256_div.rs
+++ b/crates/lib/core/src/handlers/u256_div.rs
@@ -25,16 +25,16 @@ pub const U256_DIV_EVENT_NAME: EventName = EventName::new("miden::core::math::u2
 ///   Advice stack: [...]
 ///
 /// Outputs:
-///   Advice stack: [r0..r7, q0..q7, ...]
+///   Advice stack: [r4..r7, r0..r3, q4..q7, q0..q3, ...]
 ///
 /// Where (b0..b7) and (a0..a7) are the 32-bit limbs of the divisor and dividend respectively,
 /// with b0/a0 being the least significant limb.
 ///
 /// After four `padw adv_loadw` in MASM:
-///   First:  loads [r0, r1, r2, r3] onto operand stack
-///   Second: loads [r4, r5, r6, r7]
-///   Third:  loads [q0, q1, q2, q3]
-///   Fourth: loads [q4, q5, q6, q7]
+///   First:  loads [r4, r5, r6, r7] onto operand stack
+///   Second: loads [r0, r1, r2, r3] onto operand stack
+///   Third:  loads [q4, q5, q6, q7] onto operand stack
+///   Fourth: loads [q0, q1, q2, q3] onto operand stack
 ///
 /// # Errors
 /// Returns an error if the divisor is ZERO or any limb is not a valid u32.
@@ -53,6 +53,8 @@ pub fn handle_u256_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>, 
     let r_felts = u256_to_u32_felts(remainder);
 
     let mut advice_stack = AdviceStack::new();
+    // MASM uses four `padw adv_loadw` instructions. Each load places the next lower word on top,
+    // so q0..q3 must be consumed last to finish above q4..q7, r0..r3, and r4..r7.
     advice_stack
         .push_word(Word::new([r_felts[4], r_felts[5], r_felts[6], r_felts[7]]))
         .push_word(Word::new([r_felts[0], r_felts[1], r_felts[2], r_felts[3]]))

--- a/crates/lib/core/src/handlers/u256_div.rs
+++ b/crates/lib/core/src/handlers/u256_div.rs
@@ -5,10 +5,10 @@
 
 use alloc::{vec, vec::Vec};
 
-use miden_core::Felt;
+use miden_core::{Felt, Word};
 use miden_processor::{
     ProcessorState,
-    advice::AdviceMutation,
+    advice::{AdviceMutation, AdviceStack},
     event::{EventError, EventName},
 };
 
@@ -52,18 +52,14 @@ pub fn handle_u256_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>, 
     let q_felts = u256_to_u32_felts(quotient);
     let r_felts = u256_to_u32_felts(remainder);
 
-    // Each `adv_loadw` pops 4 advice values and pushes them to the top of the operand stack.
-    // The MASM caller does four `adv_loadw`s; the LAST one ends up on top. To leave the operand
-    // stack in LE order [q0..q7, r0..r7, ...] (q0 on top, r7 at depth 15), we order advice so
-    // each subsequent `adv_loadw` brings the next-lower-significance word: r_hi, r_lo, q_hi,
-    // q_lo, with q_lo loaded last (and hence on top).
-    let mut advice = [Felt::from_u32(0); 16];
-    advice[0..4].copy_from_slice(&r_felts[4..8]);
-    advice[4..8].copy_from_slice(&r_felts[0..4]);
-    advice[8..12].copy_from_slice(&q_felts[4..8]);
-    advice[12..16].copy_from_slice(&q_felts[0..4]);
+    let mut advice_stack = AdviceStack::new();
+    advice_stack
+        .push_word(Word::new([r_felts[4], r_felts[5], r_felts[6], r_felts[7]]))
+        .push_word(Word::new([r_felts[0], r_felts[1], r_felts[2], r_felts[3]]))
+        .push_word(Word::new([q_felts[4], q_felts[5], q_felts[6], q_felts[7]]))
+        .push_word(Word::new([q_felts[0], q_felts[1], q_felts[2], q_felts[3]]));
 
-    Ok(vec![AdviceMutation::extend_stack(advice)])
+    Ok(vec![AdviceMutation::extend_advice_stack(advice_stack)])
 }
 
 /// Reads a u256 value from 8 consecutive stack positions starting at `start`.

--- a/crates/lib/core/src/handlers/u256_div.rs
+++ b/crates/lib/core/src/handlers/u256_div.rs
@@ -56,10 +56,10 @@ pub fn handle_u256_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>, 
     // MASM uses four `padw adv_loadw` instructions. Each load places the next lower word on top,
     // so q0..q3 must be consumed last to finish above q4..q7, r0..r3, and r4..r7.
     advice_stack
-        .push_word(Word::new([r_felts[4], r_felts[5], r_felts[6], r_felts[7]]))
-        .push_word(Word::new([r_felts[0], r_felts[1], r_felts[2], r_felts[3]]))
-        .push_word(Word::new([q_felts[4], q_felts[5], q_felts[6], q_felts[7]]))
-        .push_word(Word::new([q_felts[0], q_felts[1], q_felts[2], q_felts[3]]));
+        .append_word(Word::new([r_felts[4], r_felts[5], r_felts[6], r_felts[7]]))
+        .append_word(Word::new([r_felts[0], r_felts[1], r_felts[2], r_felts[3]]))
+        .append_word(Word::new([q_felts[4], q_felts[5], q_felts[6], q_felts[7]]))
+        .append_word(Word::new([q_felts[0], q_felts[1], q_felts[2], q_felts[3]]));
 
     Ok(vec![AdviceMutation::extend_advice_stack(advice_stack)])
 }

--- a/crates/lib/core/src/handlers/u64_div.rs
+++ b/crates/lib/core/src/handlers/u64_div.rs
@@ -7,7 +7,7 @@ use alloc::{vec, vec::Vec};
 
 use miden_processor::{
     ProcessorState,
-    advice::AdviceMutation,
+    advice::{AdviceMutation, AdviceStack},
     event::{EventError, EventName},
 };
 
@@ -96,12 +96,9 @@ pub fn handle_u64_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>, E
     let (q_hi, q_lo) = u64_to_u32_elements(quotient);
     let (r_hi, r_lo) = u64_to_u32_elements(remainder);
 
-    // Create mutations to extend the advice stack with the result.
-    // extend_stack([a,b,c,d]) puts 'a' on top due to reverse iteration + push_front
-    // So [q_hi, q_lo, r_hi, r_lo] puts q_hi on top
-    // After `adv_push adv_push`: pops q_hi then q_lo → operand stack [q_lo, q_hi, ...] (LE)
-    // After `adv_push adv_push`: pops r_hi then r_lo → operand stack [r_lo, r_hi, ...] (LE)
-    let mutation = AdviceMutation::extend_stack([q_hi, q_lo, r_hi, r_lo]);
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_elements([q_hi, q_lo, r_hi, r_lo]);
+    let mutation = AdviceMutation::extend_advice_stack(advice_stack);
     Ok(vec![mutation])
 }
 

--- a/crates/lib/core/src/handlers/u64_div.rs
+++ b/crates/lib/core/src/handlers/u64_div.rs
@@ -97,6 +97,8 @@ pub fn handle_u64_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>, E
     let (r_hi, r_lo) = u64_to_u32_elements(remainder);
 
     let mut advice_stack = AdviceStack::new();
+    // MASM reads quotient first with `adv_push adv_push`, so q_lo lands above q_hi.
+    // It reads remainder next with the same pattern, so r_lo lands above r_hi.
     advice_stack.push_elements([q_hi, q_lo, r_hi, r_lo]);
     let mutation = AdviceMutation::extend_advice_stack(advice_stack);
     Ok(vec![mutation])

--- a/crates/lib/core/src/handlers/u64_div.rs
+++ b/crates/lib/core/src/handlers/u64_div.rs
@@ -99,7 +99,7 @@ pub fn handle_u64_div(process: &ProcessorState) -> Result<Vec<AdviceMutation>, E
     let mut advice_stack = AdviceStack::new();
     // MASM reads quotient first with `adv_push adv_push`, so q_lo lands above q_hi.
     // It reads remainder next with the same pattern, so r_lo lands above r_hi.
-    advice_stack.push_elements([q_hi, q_lo, r_hi, r_lo]);
+    advice_stack.append_elements([q_hi, q_lo, r_hi, r_lo]);
     let mutation = AdviceMutation::extend_advice_stack(advice_stack);
     Ok(vec![mutation])
 }

--- a/crates/lib/core/tests/collections/mmr.rs
+++ b/crates/lib/core/tests/collections/mmr.rs
@@ -1,6 +1,6 @@
 use miden_core::WORD_SIZE;
 use miden_crypto::merkle::mmr::PartialMmr;
-use miden_processor::advice::AdviceStackBuilder;
+use miden_processor::advice::AdviceStack;
 use miden_utils_testing::{
     EMPTY_WORD, Felt, ONE, TRUNCATE_STACK_PROC, Word, ZERO,
     crypto::{
@@ -70,9 +70,8 @@ fn test_mmr_get_single_peak() -> Result<(), MerkleError> {
     let merkle_tree = MerkleTree::new(init_merkle_leaves(leaves))?;
     let merkle_root = merkle_tree.root();
     let merkle_store = MerkleStore::from(&merkle_tree);
-    let mut builder = AdviceStackBuilder::new();
-    builder.push_word(merkle_root);
-    let advice_stack = builder.build_vec_u64();
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_word(merkle_root);
 
     for pos in 0..(leaves.len() as u64) {
         let source = format!(
@@ -131,10 +130,9 @@ fn test_mmr_get_two_peaks() -> Result<(), MerkleError> {
     merkle_store.extend(merkle_tree1.inner_nodes());
     merkle_store.extend(merkle_tree2.inner_nodes());
 
-    let mut builder = AdviceStackBuilder::new();
-    builder.push_word(merkle_root1);
-    builder.push_word(merkle_root2);
-    let advice_stack = builder.build_vec_u64();
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_word(merkle_root1);
+    advice_stack.push_word(merkle_root2);
 
     let examples = [
         // absolute_pos, leaf
@@ -196,9 +194,8 @@ fn test_mmr_tree_with_one_element() -> Result<(), MerkleError> {
     let stack = word_to_ints(&merkle_root3);
 
     // Test case for single element MMR
-    let mut builder = AdviceStackBuilder::new();
-    builder.push_word(merkle_root3);
-    let advice_stack = builder.build_vec_u64();
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_word(merkle_root3);
     let source = format!(
         "
         use miden::core::collections::mmr
@@ -218,11 +215,10 @@ fn test_mmr_tree_with_one_element() -> Result<(), MerkleError> {
     test.expect_stack(&stack);
 
     // Test case for the single element tree in a MMR with multiple trees
-    let mut builder = AdviceStackBuilder::new();
-    builder.push_word(merkle_root1);
-    builder.push_word(merkle_root2);
-    builder.push_word(merkle_root3);
-    let advice_stack = builder.build_vec_u64();
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_word(merkle_root1);
+    advice_stack.push_word(merkle_root2);
+    advice_stack.push_word(merkle_root3);
     let num_leaves = leaves1.len() + leaves2.len() + leaves3.len();
     let source = format!(
         "

--- a/crates/lib/core/tests/collections/mmr.rs
+++ b/crates/lib/core/tests/collections/mmr.rs
@@ -71,7 +71,7 @@ fn test_mmr_get_single_peak() -> Result<(), MerkleError> {
     let merkle_root = merkle_tree.root();
     let merkle_store = MerkleStore::from(&merkle_tree);
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_word(merkle_root);
+    advice_stack.append_word(merkle_root);
 
     for pos in 0..(leaves.len() as u64) {
         let source = format!(
@@ -131,8 +131,8 @@ fn test_mmr_get_two_peaks() -> Result<(), MerkleError> {
     merkle_store.extend(merkle_tree2.inner_nodes());
 
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_word(merkle_root1);
-    advice_stack.push_word(merkle_root2);
+    advice_stack.append_word(merkle_root1);
+    advice_stack.append_word(merkle_root2);
 
     let examples = [
         // absolute_pos, leaf
@@ -195,7 +195,7 @@ fn test_mmr_tree_with_one_element() -> Result<(), MerkleError> {
 
     // Test case for single element MMR
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_word(merkle_root3);
+    advice_stack.append_word(merkle_root3);
     let source = format!(
         "
         use miden::core::collections::mmr
@@ -216,9 +216,9 @@ fn test_mmr_tree_with_one_element() -> Result<(), MerkleError> {
 
     // Test case for the single element tree in a MMR with multiple trees
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_word(merkle_root1);
-    advice_stack.push_word(merkle_root2);
-    advice_stack.push_word(merkle_root3);
+    advice_stack.append_word(merkle_root1);
+    advice_stack.append_word(merkle_root2);
+    advice_stack.append_word(merkle_root3);
     let num_leaves = leaves1.len() + leaves2.len() + leaves3.len();
     let source = format!(
         "

--- a/crates/lib/core/tests/collections/mod.rs
+++ b/crates/lib/core/tests/collections/mod.rs
@@ -1,5 +1,5 @@
 use miden_utils_testing::{
-    AdviceStackBuilder, EMPTY_WORD, Felt, TRUNCATE_STACK_PROC, Word, append_word_to_vec,
+    AdviceStack, EMPTY_WORD, Felt, TRUNCATE_STACK_PROC, Word, append_word_to_vec,
     crypto::{MerkleStore, Smt},
 };
 

--- a/crates/lib/core/tests/collections/smt.rs
+++ b/crates/lib/core/tests/collections/smt.rs
@@ -1173,12 +1173,12 @@ fn build_leaf_advice_value(entries: &[(Word, Word)]) -> Vec<Felt> {
         return Vec::new();
     }
 
-    let mut builder = AdviceStackBuilder::new();
+    let mut stack = AdviceStack::new();
     for (key, value) in entries {
-        builder.push_word(*key);
-        builder.push_word(*value);
+        stack.push_word(*key);
+        stack.push_word(*value);
     }
-    builder.into_elements()
+    stack.into_elements()
 }
 
 fn smt_insert(smt: &mut Smt, key: Word, value: Word) -> Word {

--- a/crates/lib/core/tests/collections/smt.rs
+++ b/crates/lib/core/tests/collections/smt.rs
@@ -1175,8 +1175,8 @@ fn build_leaf_advice_value(entries: &[(Word, Word)]) -> Vec<Felt> {
 
     let mut stack = AdviceStack::new();
     for (key, value) in entries {
-        stack.push_word(*key);
-        stack.push_word(*value);
+        stack.append_word(*key);
+        stack.append_word(*value);
     }
     stack.into_elements()
 }

--- a/crates/lib/core/tests/collections/sorted_array.rs
+++ b/crates/lib/core/tests/collections/sorted_array.rs
@@ -2,7 +2,11 @@ use miden_core_lib::{
     CoreLibrary,
     handlers::sorted_array::{LOWERBOUND_ARRAY_EVENT_NAME, LOWERBOUND_KEY_VALUE_EVENT_NAME},
 };
-use miden_processor::{ProcessorState, advice::AdviceMutation, event::EventError};
+use miden_processor::{
+    ProcessorState,
+    advice::{AdviceMutation, AdviceStack},
+    event::EventError,
+};
 
 use super::*;
 
@@ -973,7 +977,7 @@ fn build_lib_test(source: &str, op_stack: &[u64]) -> miden_utils_testing::Test {
 fn malicious_lowerbound_oob_above(
     _process: &ProcessorState,
 ) -> Result<Vec<AdviceMutation>, EventError> {
-    Ok(vec![AdviceMutation::extend_stack(vec![Felt::new_unchecked(204), Felt::ZERO])])
+    Ok(vec![advice_stack_mutation([Felt::new_unchecked(204), Felt::ZERO])])
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -981,7 +985,7 @@ fn malicious_lowerbound_oob_above(
 fn malicious_lowerbound_oob_below(
     _process: &ProcessorState,
 ) -> Result<Vec<AdviceMutation>, EventError> {
-    Ok(vec![AdviceMutation::extend_stack(vec![Felt::new_unchecked(40), Felt::ZERO])])
+    Ok(vec![advice_stack_mutation([Felt::new_unchecked(40), Felt::ZERO])])
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -989,5 +993,11 @@ fn malicious_lowerbound_oob_below(
 fn malicious_lowerbound_start_ptr(
     _process: &ProcessorState,
 ) -> Result<Vec<AdviceMutation>, EventError> {
-    Ok(vec![AdviceMutation::extend_stack(vec![Felt::new_unchecked(100), Felt::ZERO])])
+    Ok(vec![advice_stack_mutation([Felt::new_unchecked(100), Felt::ZERO])])
+}
+
+fn advice_stack_mutation(values: impl IntoIterator<Item = Felt>) -> AdviceMutation {
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_elements(values);
+    AdviceMutation::extend_advice_stack(advice_stack)
 }

--- a/crates/lib/core/tests/collections/sorted_array.rs
+++ b/crates/lib/core/tests/collections/sorted_array.rs
@@ -998,6 +998,6 @@ fn malicious_lowerbound_start_ptr(
 
 fn advice_stack_mutation(values: impl IntoIterator<Item = Felt>) -> AdviceMutation {
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_elements(values);
+    advice_stack.append_elements(values);
     AdviceMutation::extend_advice_stack(advice_stack)
 }

--- a/crates/lib/core/tests/crypto/aead.rs
+++ b/crates/lib/core/tests/crypto/aead.rs
@@ -8,7 +8,7 @@ use miden_crypto::aead::{
 };
 use miden_processor::{
     ProcessorState,
-    advice::AdviceMutation,
+    advice::{AdviceMutation, AdviceStack},
     event::{EventError, EventHandler},
 };
 use rand::SeedableRng;
@@ -184,7 +184,7 @@ fn test_decrypt_rejects_tampered_final_tag() {
     let valid_plaintext = plaintext;
     let malicious_handler: Arc<dyn EventHandler> =
         Arc::new(move |_process: &ProcessorState| -> Result<Vec<AdviceMutation>, EventError> {
-            Ok(vec![AdviceMutation::extend_stack(valid_plaintext.clone())])
+            Ok(vec![advice_stack_mutation(valid_plaintext.clone())])
         });
 
     let decrypt_event_id = AEAD_DECRYPT_EVENT_NAME.to_event_id();
@@ -443,7 +443,7 @@ fn test_decrypt_rejects_adversarial_plaintext_for_unrelated_ciphertext() {
     let adversarial_plaintext = plaintext;
     let malicious_handler: Arc<dyn EventHandler> =
         Arc::new(move |_process: &ProcessorState| -> Result<Vec<AdviceMutation>, EventError> {
-            Ok(vec![AdviceMutation::extend_stack(adversarial_plaintext.clone())])
+            Ok(vec![advice_stack_mutation(adversarial_plaintext.clone())])
         });
 
     let decrypt_event_id = AEAD_DECRYPT_EVENT_NAME.to_event_id();
@@ -460,6 +460,12 @@ fn test_decrypt_rejects_adversarial_plaintext_for_unrelated_ciphertext() {
     );
 
     expect_assert_error_code_from_msg!(test, "AEAD ciphertext mismatch");
+}
+
+fn advice_stack_mutation(values: Vec<Felt>) -> AdviceMutation {
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_elements(values);
+    AdviceMutation::extend_advice_stack(advice_stack)
 }
 
 #[test]

--- a/crates/lib/core/tests/crypto/aead.rs
+++ b/crates/lib/core/tests/crypto/aead.rs
@@ -464,7 +464,7 @@ fn test_decrypt_rejects_adversarial_plaintext_for_unrelated_ciphertext() {
 
 fn advice_stack_mutation(values: Vec<Felt>) -> AdviceMutation {
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_elements(values);
+    advice_stack.append_elements(values);
     AdviceMutation::extend_advice_stack(advice_stack)
 }
 

--- a/crates/lib/core/tests/crypto/circuit_evaluation.rs
+++ b/crates/lib/core/tests/crypto/circuit_evaluation.rs
@@ -2,7 +2,7 @@ use miden_ace_codegen::{AceCircuit, AceConfig, InputKey, LayoutKind};
 use miden_air::MIDEN_AIR_COUNT;
 use miden_core::{
     Felt, ONE, ZERO,
-    advice::AdviceStackBuilder,
+    advice::AdviceStack,
     field::{BasedVectorSpace, Field, PrimeCharacteristicRing, QuadFelt},
 };
 use miden_utils_testing::rand::rand_quad_felt;
@@ -119,9 +119,8 @@ fn multi_air_eval_circuit_masm() {
     memory_felts.resize(padded_len, ZERO);
     let num_adv_pipe = padded_len / 8;
 
-    let mut advice_builder = AdviceStackBuilder::new();
-    advice_builder.push_for_adv_pipe(&memory_felts);
-    let adv_stack = advice_builder.build_vec_u64();
+    let mut adv_stack = AdviceStack::new();
+    adv_stack.push_for_adv_pipe(&memory_felts);
 
     let pointer = 1 << 16;
     let num_vars = encoded.num_vars();

--- a/crates/lib/core/tests/crypto/circuit_evaluation.rs
+++ b/crates/lib/core/tests/crypto/circuit_evaluation.rs
@@ -120,7 +120,7 @@ fn multi_air_eval_circuit_masm() {
     let num_adv_pipe = padded_len / 8;
 
     let mut adv_stack = AdviceStack::new();
-    adv_stack.push_for_adv_pipe(&memory_felts);
+    adv_stack.append_for_adv_pipe(&memory_felts);
 
     let pointer = 1 << 16;
     let num_vars = encoded.num_vars();

--- a/crates/lib/core/tests/crypto/dsa.rs
+++ b/crates/lib/core/tests/crypto/dsa.rs
@@ -14,7 +14,7 @@ use miden_crypto::{
 use miden_precompiles::K1Scalar;
 use miden_processor::{
     DefaultHost, ExecutionError, ExecutionOptions, ExecutionOutput, FastProcessor, StackInputs,
-    advice::AdviceInputs,
+    advice::{AdviceInputs, AdviceStack},
 };
 use miden_utils_testing::crypto::Poseidon2;
 use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
@@ -343,9 +343,11 @@ fn run_core_program_with_advice(
         .with_library(&core_lib)
         .expect("failed to load CoreLibrary into the host");
 
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_elements(advice.iter().copied());
     let processor = FastProcessor::new_with_options(
         StackInputs::default(),
-        AdviceInputs::default().with_stack(advice.iter().copied()),
+        AdviceInputs::default().with_advice_stack(advice_stack),
         ExecutionOptions::default(),
     )
     .expect("processor construction");

--- a/crates/lib/core/tests/crypto/dsa.rs
+++ b/crates/lib/core/tests/crypto/dsa.rs
@@ -344,7 +344,7 @@ fn run_core_program_with_advice(
         .expect("failed to load CoreLibrary into the host");
 
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_elements(advice.iter().copied());
+    advice_stack.append_elements(advice.iter().copied());
     let processor = FastProcessor::new_with_options(
         StackInputs::default(),
         AdviceInputs::default().with_advice_stack(advice_stack),

--- a/crates/lib/core/tests/crypto/falcon.rs
+++ b/crates/lib/core/tests/crypto/falcon.rs
@@ -12,7 +12,7 @@ use miden_core::{
 use miden_core_lib::{CoreLibrary, dsa::falcon512_poseidon2};
 use miden_processor::{
     DefaultHost, ExecutionError, FastProcessor, ProcessorState, Program,
-    advice::{AdviceInputs, AdviceMutation},
+    advice::{AdviceInputs, AdviceMutation, AdviceStack},
     crypto::random::RandomCoin,
     event::EventError,
     operation::OperationError,
@@ -91,7 +91,7 @@ pub fn push_falcon_signature(process: &ProcessorState) -> Result<Vec<AdviceMutat
     let signature_result = falcon512_poseidon2::sign(&sk, msg)
         .ok_or(FalconError::MalformedSignatureKey { key_type: "Poseidon2 Falcon512" })?;
 
-    Ok(vec![AdviceMutation::extend_stack(signature_result)])
+    Ok(vec![advice_stack_mutation(signature_result)])
 }
 
 // EVENT ERROR
@@ -371,8 +371,8 @@ fn test_mod_12289_rejects_forged_remainder_zero(#[case] a_hi: u64, #[case] a_lo:
         let q_hi = Felt::new_unchecked(q >> 32);
         let q_lo = Felt::new_unchecked(q & 0xffff_ffff);
 
-        let remainder = AdviceMutation::extend_stack([ZERO]);
-        let quotient = AdviceMutation::extend_stack([q_hi, q_lo]);
+        let remainder = advice_stack_mutation([ZERO]);
+        let quotient = advice_stack_mutation([q_hi, q_lo]);
         Ok(vec![remainder, quotient])
     }
 
@@ -424,8 +424,8 @@ fn test_mod_12289_rejects_forged_addition_overflow() {
         let q_hi = Felt::new_unchecked(FORGED_Q >> 32);
         let q_lo = Felt::new_unchecked(FORGED_Q & 0xffff_ffff);
 
-        let remainder = AdviceMutation::extend_stack([Felt::new_unchecked(FORGED_R)]);
-        let quotient = AdviceMutation::extend_stack([q_hi, q_lo]);
+        let remainder = advice_stack_mutation([Felt::new_unchecked(FORGED_R)]);
+        let quotient = advice_stack_mutation([q_hi, q_lo]);
         Ok(vec![remainder, quotient])
     }
 
@@ -472,8 +472,8 @@ fn test_mod_12289_rejects_non_u32_remainder_advice() {
         let q_lo = Felt::new_unchecked(quotient & 0xffff_ffff);
         let forged_remainder = Felt::new_unchecked(Felt::ORDER_U64 - 1);
 
-        let remainder = AdviceMutation::extend_stack([forged_remainder]);
-        let quotient = AdviceMutation::extend_stack([q_hi, q_lo]);
+        let remainder = advice_stack_mutation([forged_remainder]);
+        let quotient = advice_stack_mutation([q_hi, q_lo]);
         Ok(vec![remainder, quotient])
     }
 
@@ -557,6 +557,12 @@ fn generate_test(
     let store = MerkleStore::new();
 
     (source, op_stack, adv_stack, store, advice_map)
+}
+
+fn advice_stack_mutation(values: impl IntoIterator<Item = Felt>) -> AdviceMutation {
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_elements(values);
+    AdviceMutation::extend_advice_stack(advice_stack)
 }
 
 // HELPER FUNCTIONS

--- a/crates/lib/core/tests/crypto/falcon.rs
+++ b/crates/lib/core/tests/crypto/falcon.rs
@@ -20,7 +20,7 @@ use miden_processor::{
 #[cfg(feature = "arbitrary")]
 use miden_utils_testing::proptest::proptest;
 use miden_utils_testing::{
-    AdviceStackBuilder, Word,
+    Word,
     crypto::{
         MerkleStore, Poseidon2,
         falcon512_poseidon2::{Polynomial, SecretKey},
@@ -211,8 +211,7 @@ fn test_falcon512_probabilistic_product_deterministic() {
 
     let h: Polynomial<Felt> = Polynomial::new(h_coeffs);
     let s2: Polynomial<Felt> = Polynomial::new(s2_coeffs);
-    let (operand_stack, advice_stack): (Vec<u64>, Vec<u64>) =
-        generate_data_probabilistic_product_test(h, s2, false);
+    let (operand_stack, advice_stack) = generate_data_probabilistic_product_test(h, s2, false);
 
     let test = build_test!(PROBABILISTIC_PRODUCT_SOURCE, &operand_stack, &advice_stack);
     let expected_stack = &[];
@@ -226,8 +225,7 @@ fn test_falcon512_probabilistic_product() {
     let mut rng = ChaCha20Rng::from_seed([0; 32]);
     let h: Polynomial<Felt> = Polynomial::new(random_coefficients_with_rng(&mut rng));
     let s2: Polynomial<Felt> = Polynomial::new(random_coefficients_with_rng(&mut rng));
-    let (operand_stack, advice_stack): (Vec<u64>, Vec<u64>) =
-        generate_data_probabilistic_product_test(h, s2, false);
+    let (operand_stack, advice_stack) = generate_data_probabilistic_product_test(h, s2, false);
 
     let test = build_test!(PROBABILISTIC_PRODUCT_SOURCE, &operand_stack, &advice_stack);
     let expected_stack = &[];
@@ -241,8 +239,7 @@ fn test_falcon512_probabilistic_product_failure() {
     let mut rng = rng();
     let h: Polynomial<Felt> = Polynomial::new(random_coefficients_with_rng(&mut rng));
     let s2: Polynomial<Felt> = Polynomial::new(random_coefficients_with_rng(&mut rng));
-    let (operand_stack, advice_stack): (Vec<u64>, Vec<u64>) =
-        generate_data_probabilistic_product_test(h, s2, true);
+    let (operand_stack, advice_stack) = generate_data_probabilistic_product_test(h, s2, true);
 
     let test = build_test!(PROBABILISTIC_PRODUCT_SOURCE, &operand_stack, &advice_stack);
 
@@ -604,7 +601,7 @@ fn generate_data_probabilistic_product_test(
     h: Polynomial<Felt>,
     s2: Polynomial<Felt>,
     test_failure: bool,
-) -> (Vec<u64>, Vec<u64>) {
+) -> (Vec<u64>, AdviceStack) {
     let mut rng = rng();
     let pi = mul_modulo_p(h.clone(), s2.clone());
     // lay the polynomials in order h then s2 then pi = h * s2
@@ -622,10 +619,9 @@ fn generate_data_probabilistic_product_test(
     let digest_polynomials = Poseidon2::hash_elements(&polynomials[..]);
     let tau0 = digest_polynomials[0];
     let tau1 = digest_polynomials[1];
-    let mut builder = AdviceStackBuilder::new();
-    builder.push_for_adv_push(&[tau0, tau1]);
-    builder.push_elements(polynomials.iter().copied());
-    let advice_stack = builder.build_vec_u64();
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_for_adv_push(&[tau0, tau1]);
+    advice_stack.push_elements(polynomials.iter().copied());
 
     // compute hash of h and place it on the stack.
     let h_hash = Poseidon2::hash_elements(&to_elements(h));

--- a/crates/lib/core/tests/crypto/falcon.rs
+++ b/crates/lib/core/tests/crypto/falcon.rs
@@ -558,7 +558,7 @@ fn generate_test(
 
 fn advice_stack_mutation(values: impl IntoIterator<Item = Felt>) -> AdviceMutation {
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_elements(values);
+    advice_stack.append_elements(values);
     AdviceMutation::extend_advice_stack(advice_stack)
 }
 
@@ -620,8 +620,8 @@ fn generate_data_probabilistic_product_test(
     let tau0 = digest_polynomials[0];
     let tau1 = digest_polynomials[1];
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_for_adv_push(&[tau0, tau1]);
-    advice_stack.push_elements(polynomials.iter().copied());
+    advice_stack.append_for_adv_push(&[tau0, tau1]);
+    advice_stack.append_elements(polynomials.iter().copied());
 
     // compute hash of h and place it on the stack.
     let h_hash = Poseidon2::hash_elements(&to_elements(h));

--- a/crates/lib/core/tests/debug.rs
+++ b/crates/lib/core/tests/debug.rs
@@ -22,7 +22,7 @@ use miden_core_lib::{
 use miden_processor::{
     DefaultHost, ExecutionError, ExecutionOptions, ExecutionOutput, HostLibrary, MemoryError,
     StackInputs,
-    advice::AdviceInputs,
+    advice::{AdviceInputs, AdviceStack},
     event::{EventHandler, EventName},
     execute_sync,
 };
@@ -405,11 +405,9 @@ fn print_mem_rejects_full_range() {
 
 #[test]
 fn print_adv_stack_all_outputs_advice_stack() {
-    let advice = AdviceInputs::default().with_stack([
-        Felt::new_unchecked(7),
-        Felt::new_unchecked(8),
-        Felt::new_unchecked(9),
-    ]);
+    let mut stack = AdviceStack::new();
+    stack.push_elements([Felt::new_unchecked(7), Felt::new_unchecked(8), Felt::new_unchecked(9)]);
+    let advice = AdviceInputs::default().with_advice_stack(stack);
     let source = "
     use miden::core::debug
     begin
@@ -426,12 +424,14 @@ fn print_adv_stack_all_outputs_advice_stack() {
 
 #[test]
 fn print_adv_stack_outputs_range() {
-    let advice = AdviceInputs::default().with_stack([
+    let mut stack = AdviceStack::new();
+    stack.push_elements([
         Felt::new_unchecked(7),
         Felt::new_unchecked(8),
         Felt::new_unchecked(9),
         Felt::new_unchecked(10),
     ]);
+    let advice = AdviceInputs::default().with_advice_stack(stack);
     let source = "
     use miden::core::debug
     begin
@@ -569,7 +569,9 @@ fn debug_handlers_compose_with_default_core_handlers() {
         exec.debug::print_adv_stack_all
     end
     ";
-    let advice = AdviceInputs::default().with_stack([Felt::new_unchecked(7)]);
+    let mut stack = AdviceStack::new();
+    stack.push_element(Felt::new_unchecked(7));
+    let advice = AdviceInputs::default().with_advice_stack(stack);
 
     let core_lib = CoreLibrary::default();
     let assembler = Assembler::default()

--- a/crates/lib/core/tests/debug.rs
+++ b/crates/lib/core/tests/debug.rs
@@ -406,7 +406,7 @@ fn print_mem_rejects_full_range() {
 #[test]
 fn print_adv_stack_all_outputs_advice_stack() {
     let mut stack = AdviceStack::new();
-    stack.push_elements([Felt::new_unchecked(7), Felt::new_unchecked(8), Felt::new_unchecked(9)]);
+    stack.append_elements([Felt::new_unchecked(7), Felt::new_unchecked(8), Felt::new_unchecked(9)]);
     let advice = AdviceInputs::default().with_advice_stack(stack);
     let source = "
     use miden::core::debug
@@ -425,7 +425,7 @@ fn print_adv_stack_all_outputs_advice_stack() {
 #[test]
 fn print_adv_stack_outputs_range() {
     let mut stack = AdviceStack::new();
-    stack.push_elements([
+    stack.append_elements([
         Felt::new_unchecked(7),
         Felt::new_unchecked(8),
         Felt::new_unchecked(9),
@@ -570,7 +570,7 @@ fn debug_handlers_compose_with_default_core_handlers() {
     end
     ";
     let mut stack = AdviceStack::new();
-    stack.push_element(Felt::new_unchecked(7));
+    stack.append_element(Felt::new_unchecked(7));
     let advice = AdviceInputs::default().with_advice_stack(stack);
 
     let core_lib = CoreLibrary::default();

--- a/crates/lib/core/tests/math/u64_mod.rs
+++ b/crates/lib/core/tests/math/u64_mod.rs
@@ -621,7 +621,6 @@ fn advice_push_u64div() {
     // stack from top [b_lo, b_hi, a_lo, a_hi] (divisor on top)
     let input_stack = stack![b_lo, b_hi, a_lo, a_hi];
     let test = build_test!(source, &input_stack);
-    // Handler uses extend_stack_for_adv_push which reverses for proper ordering.
     // Advice stack (top-to-bottom): [q_hi, q_lo, r_hi, r_lo]
     // First adv_push adv_push: pops q_hi then q_lo → [q_lo, q_hi, ...]
     // Second adv_push adv_push: pops r_hi then r_lo → [r_lo, r_hi, q_lo, q_hi, ...]
@@ -695,7 +694,6 @@ fn advice_push_u64div_local_procedure() {
     // stack from top [b_lo, b_hi, a_lo, a_hi] (divisor on top)
     let input_stack = stack![b_lo, b_hi, a_lo, a_hi];
     let test = build_test!(source, &input_stack);
-    // Handler uses extend_stack_for_adv_push which reverses for proper ordering.
     // Advice stack (top-to-bottom): [q_hi, q_lo, r_hi, r_lo]
     // First adv_push adv_push: pops q_hi then q_lo → [q_lo, q_hi, ...]
     // Second adv_push adv_push: pops r_hi then r_lo → [r_lo, r_hi, q_lo, q_hi, ...]
@@ -728,7 +726,6 @@ fn advice_push_u64div_conditional_execution() {
     // After eq (1==1 → true): [b_lo=4, b_hi=0, a_lo=8, a_hi=0]
     // Input array (top to bottom): [1, 1, 4, 0, 8, 0]
     let test = build_test!(&source, &[1, 1, 4, 0, 8, 0]);
-    // Handler uses extend_stack_for_adv_push which reverses for proper ordering.
     // Advice stack (top-to-bottom): [q_hi, q_lo, r_hi, r_lo]
     // First adv_push adv_push: pops q_hi then q_lo → [q_lo, q_hi, ...]
     // Second adv_push adv_push: pops r_hi then r_lo → [r_lo, r_hi, q_lo, q_hi, ...]

--- a/crates/lib/core/tests/mem/mod.rs
+++ b/crates/lib/core/tests/mem/mod.rs
@@ -4,7 +4,7 @@ use miden_processor::{
     trace::RowIndex,
 };
 use miden_utils_testing::{
-    AdviceStackBuilder, build_expected_hash, build_expected_perm, felt_slice_to_ints,
+    AdviceStack, build_expected_hash, build_expected_perm, felt_slice_to_ints,
 };
 
 #[test]
@@ -320,11 +320,8 @@ fn test_pipe_preimage_to_memory() {
 
     let operand_stack = &[];
     let data: &[u64] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-    let mut builder = AdviceStackBuilder::new();
-    builder.push_word(build_expected_hash(data).into());
-    builder.push_u64_slice(data);
-    let advice_stack = builder.build_vec_u64();
-    build_test!(three_words, operand_stack, &advice_stack).expect_stack_and_memory(
+    let advice_stack = advice_stack_from_hash_and_data(build_expected_hash(data).into(), data);
+    build_test!(three_words, operand_stack, advice_stack).expect_stack_and_memory(
         &[1012],
         mem_addr,
         data,
@@ -349,11 +346,8 @@ fn test_pipe_preimage_to_memory_invalid_preimage() {
     let data: &[u64] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
     let mut corrupted_hash = build_expected_hash(data);
     corrupted_hash[0] += Felt::ONE; // corrupt the expected hash
-    let mut builder = AdviceStackBuilder::new();
-    builder.push_word(corrupted_hash.into());
-    builder.push_u64_slice(data);
-    let advice_stack = builder.build_vec_u64();
-    let res = build_test!(three_words, operand_stack, &advice_stack).execute();
+    let advice_stack = advice_stack_from_hash_and_data(corrupted_hash.into(), data);
+    let res = build_test!(three_words, operand_stack, advice_stack).execute();
     assert!(res.is_err());
 }
 
@@ -376,11 +370,8 @@ fn test_pipe_double_words_preimage_to_memory() {
 
     let operand_stack = &[];
     let data: &[u64] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
-    let mut builder = AdviceStackBuilder::new();
-    builder.push_word(build_expected_hash(data).into());
-    builder.push_u64_slice(data);
-    let advice_stack = builder.build_vec_u64();
-    build_test!(four_words, operand_stack, &advice_stack).expect_stack_and_memory(
+    let advice_stack = advice_stack_from_hash_and_data(build_expected_hash(data).into(), data);
+    build_test!(four_words, operand_stack, advice_stack).expect_stack_and_memory(
         &[mem_addr + (4u64 * 4u64)],
         mem_addr as u32,
         data,
@@ -405,11 +396,8 @@ fn test_pipe_double_words_preimage_to_memory_invalid_preimage() {
     let data: &[u64] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
     let mut corrupted_hash = build_expected_hash(data);
     corrupted_hash[0] += Felt::ONE; // corrupt the expected hash
-    let mut builder = AdviceStackBuilder::new();
-    builder.push_word(corrupted_hash.into());
-    builder.push_u64_slice(data);
-    let advice_stack = builder.build_vec_u64();
-    let test = build_test!(four_words, operand_stack, &advice_stack);
+    let advice_stack = advice_stack_from_hash_and_data(corrupted_hash.into(), data);
+    let test = build_test!(four_words, operand_stack, advice_stack);
     expect_assert_error_message!(test);
 }
 
@@ -429,10 +417,14 @@ fn test_pipe_double_words_preimage_to_memory_invalid_count() {
 
     let operand_stack = &[];
     let data: &[u64] = &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-    let mut builder = AdviceStackBuilder::new();
-    builder.push_word(build_expected_hash(data).into());
-    builder.push_u64_slice(data);
-    let advice_stack = builder.build_vec_u64();
-    let test = build_test!(three_words, operand_stack, &advice_stack);
+    let advice_stack = advice_stack_from_hash_and_data(build_expected_hash(data).into(), data);
+    let test = build_test!(three_words, operand_stack, advice_stack);
     expect_assert_error_message!(test);
+}
+
+fn advice_stack_from_hash_and_data(hash: Word, data: &[u64]) -> AdviceStack {
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_word(hash);
+    advice_stack.push_elements(data.iter().map(|&value| Felt::new_unchecked(value)));
+    advice_stack
 }

--- a/crates/lib/core/tests/mem/mod.rs
+++ b/crates/lib/core/tests/mem/mod.rs
@@ -424,7 +424,7 @@ fn test_pipe_double_words_preimage_to_memory_invalid_count() {
 
 fn advice_stack_from_hash_and_data(hash: Word, data: &[u64]) -> AdviceStack {
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_word(hash);
-    advice_stack.push_elements(data.iter().map(|&value| Felt::new_unchecked(value)));
+    advice_stack.append_word(hash);
+    advice_stack.append_elements(data.iter().map(|&value| Felt::new_unchecked(value)));
     advice_stack
 }

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -38,7 +38,7 @@ use miden_mast_package::{Package, debug_info::PackageDebugInfo};
 use miden_processor::trace::build_trace;
 pub use miden_processor::{
     ContextId, ExecutionError, ProcessorState,
-    advice::{AdviceInputs, AdviceProvider, AdviceStackBuilder},
+    advice::{AdviceInputs, AdviceProvider, AdviceStack, AdviceStackBuilder},
     trace::ExecutionTrace,
 };
 use miden_processor::{
@@ -71,9 +71,9 @@ pub mod rand;
 pub mod recursive_verifier;
 
 mod test_builders;
-
 #[cfg(all(feature = "arbitrary", not(target_family = "wasm")))]
 pub use proptest;
+pub use test_builders::{IntoAdviceStackInput, advice_stack_from};
 
 pub fn module_source(path: impl AsRef<Path>, source: impl ToString) -> String {
     let source = source.to_string();

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -38,7 +38,7 @@ use miden_mast_package::{Package, debug_info::PackageDebugInfo};
 use miden_processor::trace::build_trace;
 pub use miden_processor::{
     ContextId, ExecutionError, ProcessorState,
-    advice::{AdviceInputs, AdviceProvider, AdviceStack, AdviceStackBuilder},
+    advice::{AdviceInputs, AdviceProvider, AdviceStack},
     trace::ExecutionTrace,
 };
 use miden_processor::{

--- a/crates/test-utils/src/test_builders.rs
+++ b/crates/test-utils/src/test_builders.rs
@@ -1,3 +1,79 @@
+// HELPERS
+// ================================================================================================
+
+use miden_core::field::QuotientMap;
+
+/// Converts macro advice stack inputs into the typed advice stack representation.
+pub trait IntoAdviceStackInput {
+    fn into_advice_stack_input(self)
+    -> Result<crate::AdviceStack, miden_core::program::InputError>;
+}
+
+impl IntoAdviceStackInput for crate::AdviceStack {
+    fn into_advice_stack_input(
+        self,
+    ) -> Result<crate::AdviceStack, miden_core::program::InputError> {
+        Ok(self)
+    }
+}
+
+impl IntoAdviceStackInput for ::alloc::vec::Vec<u64> {
+    fn into_advice_stack_input(
+        self,
+    ) -> Result<crate::AdviceStack, miden_core::program::InputError> {
+        advice_stack_from_ints(self)
+    }
+}
+
+impl IntoAdviceStackInput for &[u64] {
+    fn into_advice_stack_input(
+        self,
+    ) -> Result<crate::AdviceStack, miden_core::program::InputError> {
+        advice_stack_from_ints(self.iter().copied())
+    }
+}
+
+impl<const N: usize> IntoAdviceStackInput for [u64; N] {
+    fn into_advice_stack_input(
+        self,
+    ) -> Result<crate::AdviceStack, miden_core::program::InputError> {
+        advice_stack_from_ints(self)
+    }
+}
+
+impl<T> IntoAdviceStackInput for &T
+where
+    T: Clone + IntoAdviceStackInput,
+{
+    fn into_advice_stack_input(
+        self,
+    ) -> Result<crate::AdviceStack, miden_core::program::InputError> {
+        self.clone().into_advice_stack_input()
+    }
+}
+
+pub fn advice_stack_from<I>(stack: I) -> Result<crate::AdviceStack, miden_core::program::InputError>
+where
+    I: IntoAdviceStackInput,
+{
+    stack.into_advice_stack_input()
+}
+
+fn advice_stack_from_ints<I>(iter: I) -> Result<crate::AdviceStack, miden_core::program::InputError>
+where
+    I: IntoIterator<Item = u64>,
+{
+    let stack = iter
+        .into_iter()
+        .map(|value| {
+            crate::Felt::from_canonical_checked(value)
+                .ok_or(miden_core::program::InputError::InvalidStackElement(value))
+        })
+        .collect::<Result<::alloc::vec::Vec<_>, _>>()?;
+
+    Ok(stack.into())
+}
+
 // MACROS TO BUILD TESTS
 // ================================================================================================
 
@@ -167,11 +243,10 @@ macro_rules! build_test_by_mode {
 
         let stack_inputs: ::alloc::vec::Vec<u64> = $stack_inputs.to_vec();
         let stack_inputs = $crate::stack_inputs_from_ints(stack_inputs);
-        let stack_values: ::alloc::vec::Vec<u64> = $advice_stack.to_vec();
+        let advice_stack = $crate::advice_stack_from(&$advice_stack).unwrap();
         let store = $crate::crypto::MerkleStore::new();
         let advice_inputs = $crate::AdviceInputs::default()
-            .with_stack_values(stack_values)
-            .unwrap()
+            .with_advice_stack(advice_stack)
             .with_merkle_store(store);
         let name = format!("test{}", line!());
         let source_manager = ::alloc::sync::Arc::new($crate::DefaultSourceManager::default());
@@ -200,10 +275,9 @@ macro_rules! build_test_by_mode {
 
         let stack_inputs: Vec<u64> = $stack_inputs.to_vec();
         let stack_inputs = $crate::stack_inputs_from_ints(stack_inputs);
-        let stack_values: Vec<u64> = $advice_stack.to_vec();
+        let advice_stack = $crate::advice_stack_from(&$advice_stack).unwrap();
         let advice_inputs = $crate::AdviceInputs::default()
-            .with_stack_values(stack_values)
-            .unwrap()
+            .with_advice_stack(advice_stack)
             .with_merkle_store($advice_merkle_store);
         let name = format!("test{}", line!());
         let source_manager = ::alloc::sync::Arc::new($crate::DefaultSourceManager::default());
@@ -233,10 +307,9 @@ macro_rules! build_test_by_mode {
 
         let stack_inputs: Vec<u64> = $stack_inputs.to_vec();
         let stack_inputs = $crate::stack_inputs_from_ints(stack_inputs);
-        let stack_values: Vec<u64> = $advice_stack.to_vec();
+        let advice_stack = $crate::advice_stack_from(&$advice_stack).unwrap();
         let advice_inputs = $crate::AdviceInputs::default()
-            .with_stack_values(stack_values)
-            .unwrap()
+            .with_advice_stack(advice_stack)
             .with_merkle_store($advice_merkle_store)
             .with_map($advice_map);
         let name = format!("test{}", line!());
@@ -255,4 +328,32 @@ macro_rules! build_test_by_mode {
             add_modules: ::alloc::vec::Vec::default(),
         }
     }};
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::advice_stack_from;
+    use crate::{AdviceStack, Felt};
+
+    #[test]
+    fn advice_stack_from_accepts_integer_slices() {
+        let stack = advice_stack_from([1, 2, 3]).unwrap();
+
+        assert_eq!(
+            stack.into_elements(),
+            vec![Felt::new_unchecked(1), Felt::new_unchecked(2), Felt::new_unchecked(3)]
+        );
+    }
+
+    #[test]
+    fn advice_stack_from_accepts_typed_advice_stack() {
+        let mut stack = AdviceStack::new();
+        stack.push_element(Felt::new_unchecked(7));
+
+        let converted = advice_stack_from(stack).unwrap();
+
+        assert_eq!(converted.into_elements(), vec![Felt::new_unchecked(7)]);
+    }
 }

--- a/crates/test-utils/src/test_builders.rs
+++ b/crates/test-utils/src/test_builders.rs
@@ -1,8 +1,6 @@
 // HELPERS
 // ================================================================================================
 
-use miden_core::field::QuotientMap;
-
 /// Converts macro advice stack inputs into the typed advice stack representation.
 pub trait IntoAdviceStackInput {
     fn into_advice_stack_input(self)
@@ -63,15 +61,7 @@ fn advice_stack_from_ints<I>(iter: I) -> Result<crate::AdviceStack, miden_core::
 where
     I: IntoIterator<Item = u64>,
 {
-    let stack = iter
-        .into_iter()
-        .map(|value| {
-            crate::Felt::from_canonical_checked(value)
-                .ok_or(miden_core::program::InputError::InvalidStackElement(value))
-        })
-        .collect::<Result<::alloc::vec::Vec<_>, _>>()?;
-
-    Ok(stack.into())
+    crate::AdviceStack::try_from_values(iter)
 }
 
 // MACROS TO BUILD TESTS

--- a/crates/test-utils/src/test_builders.rs
+++ b/crates/test-utils/src/test_builders.rs
@@ -340,7 +340,7 @@ mod tests {
     #[test]
     fn advice_stack_from_accepts_typed_advice_stack() {
         let mut stack = AdviceStack::new();
-        stack.push_element(Felt::new_unchecked(7));
+        stack.append_element(Felt::new_unchecked(7));
 
         let converted = advice_stack_from(stack).unwrap();
 

--- a/miden-vm/src/internal.rs
+++ b/miden-vm/src/internal.rs
@@ -14,7 +14,7 @@ pub use tracing::{Level, event, instrument};
 
 use crate::{
     StackInputs, Word, ZERO,
-    advice::AdviceInputs,
+    advice::{AdviceInputs, AdviceStack},
     crypto::merkle::{MerkleStore, MerkleTree, NodeIndex, PartialMerkleTree, SimpleSmt},
 };
 
@@ -112,7 +112,8 @@ impl InputFile {
         let stack = self
             .parse_advice_stack()
             .map_err(|e| format!("failed to parse advice provider: {e}"))?;
-        advice_inputs = advice_inputs.with_stack_values(stack).map_err(|e| e.to_string())?;
+        let stack = AdviceStack::try_from_values(stack).map_err(|e| e.to_string())?;
+        advice_inputs = advice_inputs.with_advice_stack(stack);
 
         if let Some(map) = self
             .parse_advice_map()

--- a/miden-vm/tests/integration/operations/io_ops/adv_ops.rs
+++ b/miden-vm/tests/integration/operations/io_ops/adv_ops.rs
@@ -1,5 +1,5 @@
 use miden_core::{
-    Felt, advice::AdviceStackBuilder, chiplets::hasher::apply_permutation, utils::ToElements,
+    Felt, advice::AdviceStack, chiplets::hasher::apply_permutation, utils::ToElements,
 };
 use miden_processor::{ExecutionError, advice::AdviceError};
 use miden_utils_testing::expect_exec_error_matches;
@@ -18,16 +18,14 @@ fn adv_push() {
 
 #[test]
 fn adv_push_repeat() {
-    // AdviceStackBuilder handles the reversal required by sequential adv_push.
-    let mut builder = AdviceStackBuilder::new();
-    builder.push_for_adv_push(&[
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_for_adv_push(&[
         Felt::new_unchecked(1),
         Felt::new_unchecked(2),
         Felt::new_unchecked(3),
         Felt::new_unchecked(4),
     ]);
-    let advice_stack = builder.build_vec_u64();
-    let test = build_op_test!("repeat.4 adv_push end", &[], &advice_stack);
+    let test = build_op_test!("repeat.4 adv_push end", &[], advice_stack);
     test.expect_stack(&[1, 2, 3, 4]);
 }
 

--- a/miden-vm/tests/integration/operations/io_ops/adv_ops.rs
+++ b/miden-vm/tests/integration/operations/io_ops/adv_ops.rs
@@ -19,7 +19,7 @@ fn adv_push() {
 #[test]
 fn adv_push_repeat() {
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_for_adv_push(&[
+    advice_stack.append_for_adv_push(&[
         Felt::new_unchecked(1),
         Felt::new_unchecked(2),
         Felt::new_unchecked(3),

--- a/precompiles/benches/precompiles_bench/input_generation.rs
+++ b/precompiles/benches/precompiles_bench/input_generation.rs
@@ -1,6 +1,6 @@
 use miden_core::{
     Felt, Word,
-    advice::{AdviceInputs, AdviceStackBuilder},
+    advice::{AdviceInputs, AdviceStack},
 };
 use miden_core_lib::dsa::ecdsa_k256_keccak;
 use miden_crypto::dsa::ecdsa_k256_keccak::SigningKey;
@@ -25,7 +25,7 @@ impl Default for PrecompileWorkload {
 }
 
 pub(crate) fn generate_advice_inputs(workload: PrecompileWorkload) -> AdviceInputs {
-    let mut builder = AdviceStackBuilder::new();
+    let mut advice_stack = AdviceStack::new();
     let mut rng = ChaCha20Rng::from_seed([0xd3; 32]);
 
     for i in 0..workload.ecdsas {
@@ -38,14 +38,13 @@ pub(crate) fn generate_advice_inputs(workload: PrecompileWorkload) -> AdviceInpu
             "generated ECDSA fixture must verify before passing it to MASM",
         );
 
-        builder.push_word(message);
-        builder.push_word(ecdsa_k256_keccak::public_key_commitment(&pk));
-        builder.push_for_adv_pipe(&ecdsa_k256_keccak::encode_signature(&pk, &signature));
+        advice_stack.push_word(message);
+        advice_stack.push_word(ecdsa_k256_keccak::public_key_commitment(&pk));
+        advice_stack.push_for_adv_pipe(&ecdsa_k256_keccak::encode_signature(&pk, &signature));
     }
 
-    let advice = builder.into_elements();
-    assert_eq!(advice.len(), workload.ecdsas * 40, "unexpected ECDSA advice length");
-    AdviceInputs::default().with_stack(advice)
+    assert_eq!(advice_stack.len(), workload.ecdsas * 40, "unexpected ECDSA advice length");
+    AdviceInputs::default().with_advice_stack(advice_stack)
 }
 
 fn ecdsa_message(index: u64) -> Word {

--- a/precompiles/benches/precompiles_bench/input_generation.rs
+++ b/precompiles/benches/precompiles_bench/input_generation.rs
@@ -38,9 +38,9 @@ pub(crate) fn generate_advice_inputs(workload: PrecompileWorkload) -> AdviceInpu
             "generated ECDSA fixture must verify before passing it to MASM",
         );
 
-        advice_stack.push_word(message);
-        advice_stack.push_word(ecdsa_k256_keccak::public_key_commitment(&pk));
-        advice_stack.push_for_adv_pipe(&ecdsa_k256_keccak::encode_signature(&pk, &signature));
+        advice_stack.append_word(message);
+        advice_stack.append_word(ecdsa_k256_keccak::public_key_commitment(&pk));
+        advice_stack.append_for_adv_pipe(&ecdsa_k256_keccak::encode_signature(&pk, &signature));
     }
 
     assert_eq!(advice_stack.len(), workload.ecdsas * 40, "unexpected ECDSA advice length");

--- a/processor/src/execution/operations/io_ops/tests.rs
+++ b/processor/src/execution/operations/io_ops/tests.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 
 use miden_core::{
     Felt, Word, ZERO,
+    advice::AdviceStack,
     program::{MIN_STACK_DEPTH, StackInputs},
 };
 
@@ -21,8 +22,9 @@ use crate::{
 #[test]
 fn test_op_advpop() {
     // popping from the advice stack should push the value onto the operand stack
-    let advice_stack: Vec<u64> = vec![3];
-    let advice_inputs = AdviceInputs::default().with_stack_values(advice_stack).unwrap();
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_element(Felt::new_unchecked(3));
+    let advice_inputs = AdviceInputs::default().with_advice_stack(advice_stack);
     let mut processor = FastProcessor::new(StackInputs::default())
         .with_advice(advice_inputs)
         .expect("advice inputs should fit advice map limits");
@@ -43,11 +45,19 @@ fn test_op_advpop() {
 #[test]
 fn test_op_advpopw() {
     // popping a word from the advice stack should overwrite top 4 elements of the operand stack
-    // Advice stack: with_stack_values([3, 4, 5, 6]) puts 3 at front (top when popping).
-    // pop_stack_word() pops: 3, 4, 5, 6 -> Word([3, 4, 5, 6])
+    // pop_stack_word() consumes Word([3, 4, 5, 6])
     // word[0]=3 goes to stack position 0 (top), so result is [3, 4, 5, 6, 1].
-    let advice_stack: Vec<u64> = vec![3, 4, 5, 6];
-    let advice_inputs = AdviceInputs::default().with_stack_values(advice_stack).unwrap();
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_word(
+        [
+            Felt::new_unchecked(3),
+            Felt::new_unchecked(4),
+            Felt::new_unchecked(5),
+            Felt::new_unchecked(6),
+        ]
+        .into(),
+    );
+    let advice_inputs = AdviceInputs::default().with_advice_stack(advice_stack);
     let mut processor = FastProcessor::new(StackInputs::default())
         .with_advice(advice_inputs)
         .expect("advice inputs should fit advice map limits");
@@ -390,10 +400,23 @@ fn test_op_mstore() {
 #[test]
 fn test_op_pipe() {
     // push words onto the advice stack
-    // with_stack_values([30, 29, ..., 23]) puts 30 at front (first to pop).
-    // pop_stack_dword pops: 30, 29, 28, 27 -> words[0], then 26, 25, 24, 23 -> words[1]
-    let advice_stack: Vec<u64> = vec![30, 29, 28, 27, 26, 25, 24, 23];
-    let advice_inputs = AdviceInputs::default().with_stack_values(advice_stack).unwrap();
+    let advice_word1: Word = [
+        Felt::new_unchecked(30),
+        Felt::new_unchecked(29),
+        Felt::new_unchecked(28),
+        Felt::new_unchecked(27),
+    ]
+    .into();
+    let advice_word2: Word = [
+        Felt::new_unchecked(26),
+        Felt::new_unchecked(25),
+        Felt::new_unchecked(24),
+        Felt::new_unchecked(23),
+    ]
+    .into();
+    let mut advice_stack = AdviceStack::new();
+    advice_stack.push_dword([advice_word1, advice_word2]);
+    let advice_inputs = AdviceInputs::default().with_advice_stack(advice_stack);
     let mut processor = FastProcessor::new(StackInputs::default())
         .with_advice(advice_inputs)
         .expect("advice inputs should fit advice map limits");

--- a/processor/src/execution/operations/io_ops/tests.rs
+++ b/processor/src/execution/operations/io_ops/tests.rs
@@ -23,7 +23,7 @@ use crate::{
 fn test_op_advpop() {
     // popping from the advice stack should push the value onto the operand stack
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_element(Felt::new_unchecked(3));
+    advice_stack.append_element(Felt::new_unchecked(3));
     let advice_inputs = AdviceInputs::default().with_advice_stack(advice_stack);
     let mut processor = FastProcessor::new(StackInputs::default())
         .with_advice(advice_inputs)
@@ -48,7 +48,7 @@ fn test_op_advpopw() {
     // pop_stack_word() consumes Word([3, 4, 5, 6])
     // word[0]=3 goes to stack position 0 (top), so result is [3, 4, 5, 6, 1].
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_word(
+    advice_stack.append_word(
         [
             Felt::new_unchecked(3),
             Felt::new_unchecked(4),
@@ -415,7 +415,7 @@ fn test_op_pipe() {
     ]
     .into();
     let mut advice_stack = AdviceStack::new();
-    advice_stack.push_dword([advice_word1, advice_word2]);
+    advice_stack.append_dword([advice_word1, advice_word2]);
     let advice_inputs = AdviceInputs::default().with_advice_stack(advice_stack);
     let mut processor = FastProcessor::new(StackInputs::default())
         .with_advice(advice_inputs)

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -1,11 +1,8 @@
-use alloc::{
-    collections::{BTreeSet, VecDeque},
-    vec::Vec,
-};
+use alloc::{collections::BTreeSet, vec::Vec};
 
 use miden_core::{
     Felt, WORD_SIZE, Word,
-    advice::{AdviceInputs, AdviceMap},
+    advice::{AdviceInputs, AdviceMap, AdviceStack},
     crypto::{
         hash::Poseidon2,
         merkle::{InnerNodeInfo, MerkleError, MerklePath, MerkleStore, NodeIndex},
@@ -95,7 +92,7 @@ impl MerkleStoreBudget for MerkleStore {
 ///    the store.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AdviceProvider {
-    stack: VecDeque<Felt>,
+    stack: AdviceStack,
     map: AdviceMap,
     map_element_count: usize,
     max_map_value_size: usize,
@@ -118,7 +115,7 @@ impl AdviceProvider {
     pub fn new(inputs: AdviceInputs, options: &ExecutionOptions) -> Result<Self, AdviceError> {
         let AdviceInputs { stack, map, store } = inputs;
         let mut provider = Self::empty(options);
-        provider.extend_stack(stack)?;
+        provider.extend_advice_stack(stack.into())?;
         provider.extend_merkle_store(store.inner_nodes())?;
         provider.extend_map(&map)?;
         Ok(provider)
@@ -128,7 +125,7 @@ impl AdviceProvider {
         let store = MerkleStore::default();
         let merkle_store_node_count = store.num_internal_nodes();
         Self {
-            stack: VecDeque::new(),
+            stack: AdviceStack::new(),
             map: AdviceMap::default(),
             map_element_count: 0,
             max_map_value_size: options.max_adv_map_value_size(),
@@ -185,8 +182,8 @@ impl AdviceProvider {
 
     fn apply_mutation(&mut self, mutation: AdviceMutation) -> Result<(), AdviceError> {
         match mutation {
-            AdviceMutation::ExtendStack { values } => {
-                self.extend_stack(values)?;
+            AdviceMutation::ExtendStack { stack } => {
+                self.extend_advice_stack(stack)?;
             },
             AdviceMutation::ExtendMap { other } => {
                 self.extend_map(&other)?;
@@ -235,7 +232,7 @@ impl AdviceProvider {
     /// # Errors
     /// Returns an error if the advice stack is empty.
     fn pop_stack(&mut self) -> Result<Felt, AdviceError> {
-        self.stack.pop_front().ok_or(AdviceError::StackReadFailed)
+        self.stack.consume_element().ok_or(AdviceError::StackReadFailed)
     }
 
     /// Pops a word (4 elements) from the advice stack and returns it.
@@ -246,16 +243,7 @@ impl AdviceProvider {
     /// # Errors
     /// Returns an error if the advice stack does not contain a full word.
     fn pop_stack_word(&mut self) -> Result<Word, AdviceError> {
-        if self.stack.len() < 4 {
-            return Err(AdviceError::StackReadFailed);
-        }
-
-        let w0 = self.stack.pop_front().expect("checked len");
-        let w1 = self.stack.pop_front().expect("checked len");
-        let w2 = self.stack.pop_front().expect("checked len");
-        let w3 = self.stack.pop_front().expect("checked len");
-
-        Ok(Word::new([w0, w1, w2, w3]))
+        self.stack.consume_word().ok_or(AdviceError::StackReadFailed)
     }
 
     /// Pops a double word (8 elements) from the advice stack and returns them.
@@ -267,10 +255,7 @@ impl AdviceProvider {
     /// # Errors
     /// Returns an error if the advice stack does not contain two words.
     fn pop_stack_dword(&mut self) -> Result<[Word; 2], AdviceError> {
-        let word0 = self.pop_stack_word()?;
-        let word1 = self.pop_stack_word()?;
-
-        Ok([word0, word1])
+        self.stack.consume_dword().ok_or(AdviceError::StackReadFailed)
     }
 
     /// Checks that pushing `count` elements would not exceed the advice stack size limit.
@@ -292,16 +277,14 @@ impl AdviceProvider {
     /// Pushes a single value onto the advice stack.
     pub fn push_stack(&mut self, value: Felt) -> Result<(), AdviceError> {
         self.check_stack_capacity(1)?;
-        self.stack.push_front(value);
+        self.stack.prepend_element(value);
         Ok(())
     }
 
     /// Pushes a word (4 elements) onto the stack.
     pub fn push_stack_word(&mut self, word: &Word) -> Result<(), AdviceError> {
         self.check_stack_capacity(4)?;
-        for &value in word.iter().rev() {
-            self.stack.push_front(value);
-        }
+        self.stack.prepend_word(*word);
         Ok(())
     }
 
@@ -355,21 +338,18 @@ impl AdviceProvider {
             })?;
         self.check_stack_capacity(total_push)?;
 
+        let mut stack = AdviceStack::new();
+        if include_len {
+            stack.push_element(Felt::new_unchecked(values.len() as u64));
+        }
+        stack.push_elements(values.iter().copied());
+
         // if pad_to was provided (not equal 0), push some zeros to the advice stack so that the
         // final (padded) elements list length will be the next multiple of pad_to
         for _ in 0..num_pad_elements {
-            self.stack.push_front(Felt::default());
+            stack.push_element(Felt::default());
         }
-
-        // Treat map values as already canonical sequences of FELTs.
-        // The advice stack is LIFO; extend in reverse so that the first element of `values`
-        // becomes the first element returned by a subsequent `adv_push`.
-        for &value in values.iter().rev() {
-            self.stack.push_front(value);
-        }
-        if include_len {
-            self.stack.push_front(Felt::new_unchecked(values.len() as u64));
-        }
+        self.stack.prepend_stack(stack);
         Ok(())
     }
 
@@ -383,11 +363,15 @@ impl AdviceProvider {
     where
         I: IntoIterator<Item = Felt>,
     {
-        let values: Vec<Felt> = iter.into_iter().collect();
-        self.check_stack_capacity(values.len())?;
-        for value in values.into_iter().rev() {
-            self.stack.push_front(value);
-        }
+        let mut stack = AdviceStack::new();
+        stack.push_elements(iter);
+        self.extend_advice_stack(stack)
+    }
+
+    /// Extends the stack with typed advice stack values.
+    pub fn extend_advice_stack(&mut self, stack: AdviceStack) -> Result<(), AdviceError> {
+        self.check_stack_capacity(stack.len())?;
+        self.stack.prepend_stack(stack);
         Ok(())
     }
 
@@ -701,7 +685,7 @@ impl AdviceProvider {
 
     /// Extends the contents of this instance with the contents of an `AdviceInputs`.
     pub fn extend_from_inputs(&mut self, inputs: &AdviceInputs) -> Result<(), AdviceError> {
-        self.extend_stack(inputs.stack.iter().cloned())?;
+        self.extend_advice_stack(inputs.advice_stack())?;
         self.extend_merkle_store(inputs.store.inner_nodes())?;
         self.extend_map(&inputs.map)
     }
@@ -710,7 +694,7 @@ impl AdviceProvider {
     ///
     /// The returned stack vector is ordered from top (index 0) to bottom.
     pub fn into_parts(self) -> (Vec<Felt>, AdviceMap, MerkleStore) {
-        (self.stack.into_iter().collect(), self.map, self.store)
+        (self.stack.into_elements(), self.map, self.store)
     }
 }
 
@@ -764,7 +748,7 @@ mod tests {
     use super::AdviceProvider;
     use crate::{
         AdviceInputs, ExecutionOptions, Felt, Word,
-        advice::{AdviceError, AdviceMap},
+        advice::{AdviceError, AdviceMap, AdviceMutation, AdviceStack},
         crypto::merkle::{MerkleStore, MerkleTree},
     };
 
@@ -808,6 +792,33 @@ mod tests {
 
         assert_eq!(provider_a, provider_b);
         assert_eq!(provider_a.fingerprint(), provider_b.fingerprint());
+    }
+
+    #[test]
+    fn typed_advice_stack_mutation_prepends_values() {
+        let mut initial_stack = AdviceStack::new();
+        initial_stack.push_elements([Felt::new_unchecked(3), Felt::new_unchecked(4)]);
+        let mut mutation_stack = AdviceStack::new();
+        mutation_stack.push_elements([Felt::new_unchecked(1), Felt::new_unchecked(2)]);
+        let mut provider = AdviceProvider::new(
+            AdviceInputs::default().with_advice_stack(initial_stack),
+            &Default::default(),
+        )
+        .unwrap();
+
+        provider
+            .apply_mutations([AdviceMutation::extend_advice_stack(mutation_stack)])
+            .unwrap();
+
+        assert_eq!(
+            provider.stack(),
+            vec![
+                Felt::new_unchecked(1),
+                Felt::new_unchecked(2),
+                Felt::new_unchecked(3),
+                Felt::new_unchecked(4)
+            ]
+        );
     }
 
     #[test]

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -113,9 +113,9 @@ impl AdviceProvider {
     ///
     /// The advice map limits in `options` are enforced while loading the initial advice inputs.
     pub fn new(inputs: AdviceInputs, options: &ExecutionOptions) -> Result<Self, AdviceError> {
-        let AdviceInputs { stack, map, store } = inputs;
+        let (stack, map, store) = inputs.into_parts();
         let mut provider = Self::empty(options);
-        provider.extend_advice_stack(stack.into())?;
+        provider.extend_advice_stack(stack)?;
         provider.extend_merkle_store(store.inner_nodes())?;
         provider.extend_map(&map)?;
         Ok(provider)
@@ -356,16 +356,6 @@ impl AdviceProvider {
     /// Returns the current stack as a vector ordered from top (index 0) to bottom.
     pub fn stack(&self) -> Vec<Felt> {
         self.stack.iter().copied().collect()
-    }
-
-    /// Extends the stack with the given elements.
-    pub fn extend_stack<I>(&mut self, iter: I) -> Result<(), AdviceError>
-    where
-        I: IntoIterator<Item = Felt>,
-    {
-        let mut stack = AdviceStack::new();
-        stack.push_elements(iter);
-        self.extend_advice_stack(stack)
     }
 
     /// Extends the stack with typed advice stack values.

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -277,7 +277,7 @@ impl AdviceProvider {
     /// Pushes a single value onto the advice stack.
     pub fn push_stack(&mut self, value: Felt) -> Result<(), AdviceError> {
         self.check_stack_capacity(1)?;
-        self.stack.prepend_element(value);
+        self.stack.push_element(value);
         Ok(())
     }
 
@@ -340,14 +340,14 @@ impl AdviceProvider {
 
         let mut stack = AdviceStack::new();
         if include_len {
-            stack.push_element(Felt::new_unchecked(values.len() as u64));
+            stack.append_element(Felt::new_unchecked(values.len() as u64));
         }
-        stack.push_elements(values.iter().copied());
+        stack.append_elements(values.iter().copied());
 
         // if pad_to was provided (not equal 0), push some zeros to the advice stack so that the
         // final (padded) elements list length will be the next multiple of pad_to
         for _ in 0..num_pad_elements {
-            stack.push_element(Felt::default());
+            stack.append_element(Felt::default());
         }
         self.stack.prepend_stack(stack);
         Ok(())
@@ -787,9 +787,9 @@ mod tests {
     #[test]
     fn typed_advice_stack_mutation_prepends_values() {
         let mut initial_stack = AdviceStack::new();
-        initial_stack.push_elements([Felt::new_unchecked(3), Felt::new_unchecked(4)]);
+        initial_stack.append_elements([Felt::new_unchecked(3), Felt::new_unchecked(4)]);
         let mut mutation_stack = AdviceStack::new();
-        mutation_stack.push_elements([Felt::new_unchecked(1), Felt::new_unchecked(2)]);
+        mutation_stack.append_elements([Felt::new_unchecked(1), Felt::new_unchecked(2)]);
         let mut provider = AdviceProvider::new(
             AdviceInputs::default().with_advice_stack(initial_stack),
             &Default::default(),

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -2,7 +2,7 @@ use alloc::{sync::Arc, vec::Vec};
 use core::future::Future;
 
 use miden_core::{
-    Felt, Word,
+    Word,
     advice::{AdviceMap, AdviceStack},
     crypto::merkle::InnerNodeInfo,
     events::{EventId, EventName},
@@ -35,12 +35,6 @@ pub enum AdviceMutation {
 }
 
 impl AdviceMutation {
-    pub fn extend_stack(iter: impl IntoIterator<Item = Felt>) -> Self {
-        let mut stack = AdviceStack::new();
-        stack.push_elements(iter);
-        Self::extend_advice_stack(stack)
-    }
-
     pub fn extend_advice_stack(stack: AdviceStack) -> Self {
         Self::ExtendStack { stack }
     }

--- a/processor/src/host/mod.rs
+++ b/processor/src/host/mod.rs
@@ -3,7 +3,7 @@ use core::future::Future;
 
 use miden_core::{
     Felt, Word,
-    advice::AdviceMap,
+    advice::{AdviceMap, AdviceStack},
     crypto::merkle::InnerNodeInfo,
     events::{EventId, EventName},
 };
@@ -29,14 +29,20 @@ pub use mast_forest_store::{LoadedMastForest, MastForestStore, MemMastForestStor
 /// Any possible way an event can modify the advice provider.
 #[derive(Debug, PartialEq, Eq)]
 pub enum AdviceMutation {
-    ExtendStack { values: Vec<Felt> },
+    ExtendStack { stack: AdviceStack },
     ExtendMap { other: AdviceMap },
     ExtendMerkleStore { infos: Vec<InnerNodeInfo> },
 }
 
 impl AdviceMutation {
     pub fn extend_stack(iter: impl IntoIterator<Item = Felt>) -> Self {
-        Self::ExtendStack { values: Vec::from_iter(iter) }
+        let mut stack = AdviceStack::new();
+        stack.push_elements(iter);
+        Self::extend_advice_stack(stack)
+    }
+
+    pub fn extend_advice_stack(stack: AdviceStack) -> Self {
+        Self::ExtendStack { stack }
     }
 
     pub fn extend_map(other: AdviceMap) -> Self {

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -75,7 +75,7 @@ pub use miden_core::{
 pub use trace::{TraceBuildInputs, TraceGenerationContext};
 
 pub mod advice {
-    pub use miden_core::advice::{AdviceInputs, AdviceMap, AdviceStack, AdviceStackBuilder};
+    pub use miden_core::advice::{AdviceInputs, AdviceMap, AdviceStack};
 
     pub use super::host::{
         AdviceMutation,

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -75,7 +75,7 @@ pub use miden_core::{
 pub use trace::{TraceBuildInputs, TraceGenerationContext};
 
 pub mod advice {
-    pub use miden_core::advice::{AdviceInputs, AdviceMap, AdviceStackBuilder};
+    pub use miden_core::advice::{AdviceInputs, AdviceMap, AdviceStack, AdviceStackBuilder};
 
     pub use super::host::{
         AdviceMutation,

--- a/processor/tests/advice_public_api.rs
+++ b/processor/tests/advice_public_api.rs
@@ -1,0 +1,15 @@
+use miden_processor::{
+    Felt,
+    advice::{AdviceInputs, AdviceStack},
+};
+
+#[test]
+fn advice_stack_is_available_through_processor_advice_facade() {
+    let mut stack = AdviceStack::new();
+    let value = Felt::new_unchecked(1);
+    stack.push_element(value);
+
+    let advice_inputs = AdviceInputs::default().with_advice_stack(stack);
+
+    assert_eq!(advice_inputs.advice_stack().into_elements(), vec![value]);
+}

--- a/processor/tests/advice_public_api.rs
+++ b/processor/tests/advice_public_api.rs
@@ -7,7 +7,7 @@ use miden_processor::{
 fn advice_stack_is_available_through_processor_advice_facade() {
     let mut stack = AdviceStack::new();
     let value = Felt::new_unchecked(1);
-    stack.push_element(value);
+    stack.append_element(value);
 
     let advice_inputs = AdviceInputs::default().with_advice_stack(stack);
 


### PR DESCRIPTION
This PR adds a public `AdviceStack` type. It stores advice values in the same top first order that the VM consumes.

`AdviceInputs` can now accept and return an `AdviceStack`.

`AdviceProvider` now stores its live stack as an `AdviceStack`. `AdviceMutation` can also carry an `AdviceStack`

Core handlers and key tests now build advice with typed calls such as push_word, push_dword, and push_for_adv_pipe. This removes local reversal rules from places where order must be clear.

Closes #2557 

The old `stack`field and the old `extend_stack` helper are removed only in the last commit. Question for @Al-Kindi-0 : should we make `push_for_adv_push` deprecated?