### PR TITLE
Restore StorageUpdates API compatibility and reduce benchmark noise

### DIFF
--- a/.github/workflows/blake3-nonregression.yml
+++ b/.github/workflows/blake3-nonregression.yml
@@ -474,7 +474,7 @@ jobs:
           git worktree remove --force "${WORKTREE_DIR}/current" || true
           rm -rf "${RUN_ROOT}"
 
-      - name: Fail on regression
+      - name: Report possible regression
         if: steps.compare.outputs.regression == 'true'
         env:
           PROGRAM_DELTA_PCT: ${{ steps.compare.outputs.program_delta_pct }}
@@ -482,66 +482,4 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "Blake3 benchmark regressions over threshold: ${REGRESSION_METRICS}"
-          echo "Primary metric delta: ${PROGRAM_DELTA_PCT}%"
-          exit 1
-
-  comment:
-    name: Comment on pushed commit
-    runs-on: ubuntu-latest
-    needs:
-      - benchmark
-    if: always() && github.event_name == 'push' && needs.benchmark.outputs.regression == 'true' && needs.benchmark.outputs.current_sha != '' && needs.benchmark.outputs.summary != ''
-    permissions:
-      contents: write
-    steps:
-      - name: Create or update commit comment
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-        env:
-          CURRENT_SHA: ${{ needs.benchmark.outputs.current_sha }}
-          MARKER: "<!-- blake3-1to1-nonregression -->"
-          BODY: ${{ needs.benchmark.outputs.summary }}
-        with:
-          script: |
-            const body = [
-              process.env.MARKER,
-              process.env.BODY,
-              '',
-              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-            ].join('\n');
-
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const commitSha = process.env.CURRENT_SHA;
-            const marker = process.env.MARKER;
-
-            const comments = await github.paginate(
-              github.rest.repos.listCommentsForCommit,
-              {
-                owner,
-                repo,
-                commit_sha: commitSha,
-                per_page: 100,
-              },
-            );
-
-            const existing = comments.find(comment =>
-              comment.user?.type === 'Bot' && comment.body?.includes(marker)
-            );
-
-            if (existing) {
-              await github.rest.repos.updateCommitComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-              return;
-            }
-
-            await github.rest.repos.createCommitComment({
-              owner,
-              repo,
-              commit_sha: commitSha,
-              body,
-            });
+          echo "::warning title=Advisory Blake3 benchmark result::One or more metrics crossed the configured threshold: ${REGRESSION_METRICS}. The primary metric changed by ${PROGRAM_DELTA_PCT}%. This result is report-only because the benchmark has shown high run-to-run variance. Review the job summary and artifacts, then reproduce the result before treating it as a regression."

--- a/.github/workflows/synthetic-tx-nonregression.yml
+++ b/.github/workflows/synthetic-tx-nonregression.yml
@@ -71,12 +71,12 @@ jobs:
       contents: read
     outputs:
       summary: ${{ steps.summary.outputs.summary }}
-      regression: ${{ steps.compare.outputs.regression }}
-      status: ${{ steps.compare.outputs.status }}
+      regression: ${{ steps.verdict.outputs.regression }}
+      status: ${{ steps.verdict.outputs.status }}
       baseline_sha: ${{ steps.compare.outputs.baseline_sha }}
       current_sha: ${{ steps.compare.outputs.current_sha }}
-      max_delta_metric: ${{ steps.compare.outputs.max_delta_metric }}
-      max_delta_pct: ${{ steps.compare.outputs.max_delta_pct }}
+      max_delta_metric: ${{ steps.verdict.outputs.max_delta_metric }}
+      max_delta_pct: ${{ steps.verdict.outputs.max_delta_pct }}
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -372,6 +372,124 @@ jobs:
             --min-regression-ms "${MIN_DELTA_MS}" \
             --github-output "${GITHUB_OUTPUT}"
 
+      - name: Confirm possible regression in reverse order
+        if: steps.compare.outputs.regression == 'true'
+        env:
+          GITHUB_WORKSPACE_PATH: ${{ github.workspace }}
+          WORKTREE_DIR: ${{ steps.dirs.outputs.worktree_dir }}
+          ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
+          RAYON_THREADS: ${{ steps.refs.outputs.rayon_threads }}
+          SAMPLE_SIZE: ${{ steps.refs.outputs.sample_size }}
+          MEASUREMENT_TIME_SECS: ${{ steps.refs.outputs.measurement_time_secs }}
+          WARM_UP_TIME_SECS: ${{ steps.refs.outputs.warm_up_time_secs }}
+          BENCH_AXES: ${{ steps.refs.outputs.bench_axes }}
+          SCENARIO_FILTER: ${{ steps.refs.outputs.scenario_filter }}
+          BASELINE_SHA: ${{ steps.refs.outputs.baseline_sha }}
+          CURRENT_SHA: ${{ steps.refs.outputs.current_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 "${GITHUB_WORKSPACE_PATH}/scripts/synthetic_tx_nonregression.py" run \
+            --repo-root "${WORKTREE_DIR}/current" \
+            --output-dir "${ARTIFACT_DIR}/confirmation/current" \
+            --rayon-num-threads "${RAYON_THREADS}" \
+            --sample-size "${SAMPLE_SIZE}" \
+            --measurement-time-secs "${MEASUREMENT_TIME_SECS}" \
+            --warm-up-time-secs "${WARM_UP_TIME_SECS}" \
+            --bench-axes "${BENCH_AXES}" \
+            --scenario-filter "${SCENARIO_FILTER}" \
+            --git-ref "${CURRENT_SHA}"
+          python3 "${GITHUB_WORKSPACE_PATH}/scripts/synthetic_tx_nonregression.py" run \
+            --repo-root "${WORKTREE_DIR}/baseline" \
+            --output-dir "${ARTIFACT_DIR}/confirmation/baseline" \
+            --rayon-num-threads "${RAYON_THREADS}" \
+            --sample-size "${SAMPLE_SIZE}" \
+            --measurement-time-secs "${MEASUREMENT_TIME_SECS}" \
+            --warm-up-time-secs "${WARM_UP_TIME_SECS}" \
+            --bench-axes "${BENCH_AXES}" \
+            --scenario-filter "${SCENARIO_FILTER}" \
+            --git-ref "${BASELINE_SHA}"
+
+      - name: Compare confirmation results
+        if: steps.compare.outputs.regression == 'true'
+        id: confirmation
+        env:
+          GITHUB_WORKSPACE_PATH: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
+          THRESHOLD_PCT: ${{ steps.refs.outputs.threshold_pct }}
+          MIN_DELTA_MS: ${{ steps.refs.outputs.min_delta_ms }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 "${GITHUB_WORKSPACE_PATH}/scripts/synthetic_tx_nonregression.py" compare \
+            --baseline "${ARTIFACT_DIR}/confirmation/baseline/result.json" \
+            --current "${ARTIFACT_DIR}/confirmation/current/result.json" \
+            --summary-out "${ARTIFACT_DIR}/confirmation/summary.md" \
+            --json-out "${ARTIFACT_DIR}/confirmation/comparison.json" \
+            --threshold-pct "${THRESHOLD_PCT}" \
+            --min-regression-ms "${MIN_DELTA_MS}" \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Determine regression verdict
+        if: always() && steps.compare.outcome == 'success'
+        id: verdict
+        env:
+          ARTIFACT_DIR: ${{ steps.dirs.outputs.artifact_dir }}
+          INITIAL_REGRESSION: ${{ steps.compare.outputs.regression }}
+          INITIAL_MAX_DELTA_METRIC: ${{ steps.compare.outputs.max_delta_metric }}
+          INITIAL_MAX_DELTA_PCT: ${{ steps.compare.outputs.max_delta_pct }}
+          CONFIRMATION_REGRESSION: ${{ steps.confirmation.outputs.regression }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${INITIAL_REGRESSION}" == "true" && "${CONFIRMATION_REGRESSION}" == "true" ]]; then
+            confirmed_metric="$(
+              jq -r --slurp '
+                (.[0].regression_rows | map(.name)) as $initial_names
+                | .[1].regression_rows
+                | map(select(.name as $name | $initial_names | index($name)))
+                | sort_by(.delta_pct)
+                | last
+                | .name // empty
+              ' \
+                "${ARTIFACT_DIR}/comparison.json" \
+                "${ARTIFACT_DIR}/confirmation/comparison.json"
+            )"
+          else
+            confirmed_metric=""
+          fi
+
+          if [[ -n "${confirmed_metric}" ]]; then
+            initial_delta_pct="$(
+              jq -r --arg name "${confirmed_metric}" \
+                '.regression_rows[] | select(.name == $name) | .delta_pct' \
+                "${ARTIFACT_DIR}/comparison.json"
+            )"
+            confirmation_delta_pct="$(
+              jq -r --arg name "${confirmed_metric}" \
+                '.regression_rows[] | select(.name == $name) | .delta_pct' \
+                "${ARTIFACT_DIR}/confirmation/comparison.json"
+            )"
+            {
+              echo "regression=true"
+              echo "status=regression"
+              echo "max_delta_metric=${confirmed_metric}"
+              echo "max_delta_pct=${confirmation_delta_pct}"
+              echo "initial_delta_pct=${initial_delta_pct}"
+              echo "confirmation_delta_pct=${confirmation_delta_pct}"
+            } >> "${GITHUB_OUTPUT}"
+          else
+            {
+              echo "regression=false"
+              echo "status=ok"
+              echo "max_delta_metric=${INITIAL_MAX_DELTA_METRIC}"
+              echo "max_delta_pct=${INITIAL_MAX_DELTA_PCT}"
+            } >> "${GITHUB_OUTPUT}"
+            if [[ "${INITIAL_REGRESSION}" == "true" ]]; then
+              echo "::warning title=Unconfirmed synthetic benchmark result::The initial comparison crossed the configured regression threshold, but no metric crossed it in both the initial and reverse-order runs. The workflow will not fail for an unconfirmed result."
+            fi
+          fi
+
       - name: Publish job summary
         if: always()
         env:
@@ -381,6 +499,16 @@ jobs:
           set -euo pipefail
           if [[ -f "${ARTIFACT_DIR}/summary.md" ]]; then
             cat "${ARTIFACT_DIR}/summary.md" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+          if [[ -f "${ARTIFACT_DIR}/confirmation/summary.md" ]]; then
+            {
+              echo
+              echo "---"
+              echo
+              echo "## Reverse-order confirmation"
+              echo
+              cat "${ARTIFACT_DIR}/confirmation/summary.md"
+            } >> "${GITHUB_STEP_SUMMARY}"
           fi
 
       - name: Expose summary for downstream jobs
@@ -397,6 +525,14 @@ jobs:
           {
             echo "summary<<EOF"
             cat "${ARTIFACT_DIR}/summary.md"
+            if [[ -f "${ARTIFACT_DIR}/confirmation/summary.md" ]]; then
+              echo
+              echo "---"
+              echo
+              echo "## Reverse-order confirmation"
+              echo
+              cat "${ARTIFACT_DIR}/confirmation/summary.md"
+            fi
             echo "EOF"
           } >> "${GITHUB_OUTPUT}"
 
@@ -420,15 +556,16 @@ jobs:
           git worktree remove --force "${WORKTREE_DIR}/current" || true
           rm -rf "${RUN_ROOT}"
 
-      - name: Fail on regression
-        if: steps.compare.outputs.regression == 'true'
+      - name: Fail on confirmed regression
+        if: steps.verdict.outputs.regression == 'true'
         env:
-          MAX_DELTA_METRIC: ${{ steps.compare.outputs.max_delta_metric }}
-          MAX_DELTA_PCT: ${{ steps.compare.outputs.max_delta_pct }}
+          CONFIRMED_METRIC: ${{ steps.verdict.outputs.max_delta_metric }}
+          INITIAL_DELTA_PCT: ${{ steps.verdict.outputs.initial_delta_pct }}
+          CONFIRMATION_DELTA_PCT: ${{ steps.verdict.outputs.confirmation_delta_pct }}
         shell: bash
         run: |
           set -euo pipefail
-          echo "synthetic transaction kernel benchmark ${MAX_DELTA_METRIC} regressed by ${MAX_DELTA_PCT}%"
+          echo "::error title=Confirmed synthetic transaction regression::${CONFIRMED_METRIC} exceeded the configured threshold in both comparisons: ${INITIAL_DELTA_PCT}% initially and ${CONFIRMATION_DELTA_PCT}% in the reverse-order confirmation. Review both reports and artifacts before accepting the change."
           exit 1
 
   comment:

--- a/crates/crypto/src/merkle/smt/large/storage/updates.rs
+++ b/crates/crypto/src/merkle/smt/large/storage/updates.rs
@@ -144,6 +144,16 @@ impl StorageUpdates {
         self.leaf_updates.is_empty() && self.subtree_updates.is_empty()
     }
 
+    /// Returns the number of leaf updates in this batch.
+    pub fn leaf_update_count(&self) -> usize {
+        self.leaf_updates.len()
+    }
+
+    /// Returns the number of subtree updates in this batch.
+    pub fn subtree_update_count(&self) -> usize {
+        self.subtree_updates.len()
+    }
+
     /// Returns a reference to the leaf updates map.
     pub fn leaf_updates(&self) -> &Map<u64, Option<SmtLeaf>> {
         &self.leaf_updates
@@ -162,6 +172,36 @@ impl StorageUpdates {
     /// Returns the entry count delta.
     pub fn entry_count_delta(&self) -> isize {
         self.entry_count_delta
+    }
+
+    /// Sets the leaf count delta.
+    pub fn set_leaf_count_delta(&mut self, delta: isize) {
+        self.leaf_count_delta = delta;
+    }
+
+    /// Sets the entry count delta.
+    pub fn set_entry_count_delta(&mut self, delta: isize) {
+        self.entry_count_delta = delta;
+    }
+
+    /// Adjusts the leaf count delta by the specified amount.
+    pub fn adjust_leaf_count_delta(&mut self, adjustment: isize) {
+        self.leaf_count_delta += adjustment;
+    }
+
+    /// Adjusts the entry count delta by the specified amount.
+    pub fn adjust_entry_count_delta(&mut self, adjustment: isize) {
+        self.entry_count_delta += adjustment;
+    }
+
+    /// Consumes this StorageUpdates and returns the leaf updates map.
+    pub fn into_leaf_updates(self) -> Map<u64, Option<SmtLeaf>> {
+        self.leaf_updates
+    }
+
+    /// Consumes this StorageUpdates and returns the subtree updates vector.
+    pub fn into_subtree_updates(self) -> Vec<SubtreeUpdate> {
+        self.subtree_updates
     }
 
     /// Consumes this `StorageUpdates` and returns its owned parts as a [`StorageUpdateParts`].


### PR DESCRIPTION
PR #3424 removed (unused!) public `StorageUpdates` methods _usable_ by existing users. This restores them so miden-crypto 0.28.1 remains compatible with 0.28.0 (that way the next release of `miden-crypto` doesn't have to be 0.29)

The Blake3 benchmark now reports possible regressions without failing CI or posting commit comments (it's too noisy).

The synthetic transaction benchmark repeats a possible regression with the run order reversed. It fails only when the same metric crosses the limit twice. The error includes both results.

