### PR TITLE
Limit unsafe code in debug info serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,6 +1533,7 @@ dependencies = [
  "serde_json",
  "serde_spanned",
  "thiserror",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1632,6 +1633,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,6 +118,7 @@ tracing         = { version = "0.1", default-features = false, features = ["attr
 tracing-subscriber = { version = "0.3" }
 trybuild        = { version = "1.0" }
 windows-sys     = { version = "0.61.2" }
+zerocopy        = { version = "0.8", default-features = false, features = ["derive"] }
 
 loom = "0.7"
 miette = { package = "miden-miette", version = "8.0", default-features = false }

--- a/crates/debug-types/Cargo.toml
+++ b/crates/debug-types/Cargo.toml
@@ -46,6 +46,7 @@ proptest = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_spanned = { version = "1.0", optional = true, default-features = false }
 thiserror.workspace = true
+zerocopy.workspace = true
 
 [dev-dependencies]
 miden-test-serde-macros.workspace = true

--- a/crates/debug-types/src/source_file.rs
+++ b/crates/debug-types/src/source_file.rs
@@ -786,7 +786,21 @@ fn compute_line_starts(text: &str, text_offset: Option<u32>) -> Vec<ByteIndex> {
 // ================================================================================================
 
 /// An index representing the offset in bytes from the start of a source file
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Default,
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::IntoBytes,
+    zerocopy::KnownLayout,
+)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
 #[cfg_attr(all(feature = "arbitrary", test), miden_test_serde_macros::serde_test)]
@@ -954,7 +968,21 @@ macro_rules! declare_dual_number_and_index_type {
 
     ($index_name:ident, $number_name:ident, $description:literal) => {
         #[doc = concat!("A zero-indexed ", $description, " number")]
-        #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[derive(
+            Default,
+            Debug,
+            Copy,
+            Clone,
+            PartialEq,
+            Eq,
+            PartialOrd,
+            Ord,
+            Hash,
+            zerocopy::FromBytes,
+            zerocopy::Immutable,
+            zerocopy::IntoBytes,
+            zerocopy::KnownLayout,
+        )]
         #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
         #[cfg_attr(feature = "serde", serde(transparent))]
         #[cfg_attr(all(feature = "arbitrary", test), miden_test_serde_macros::serde_test)]

--- a/crates/mast-package/Cargo.toml
+++ b/crates/mast-package/Cargo.toml
@@ -38,6 +38,7 @@ hashbrown = "0.17"
 rustc-hash = { version = "2.1", default-features = false }
 serde = { workspace = true, optional = true }
 thiserror.workspace = true
+zerocopy.workspace = true
 
 [dev-dependencies]
 miden-assembly-syntax = { workspace = true, features = ["arbitrary"] }

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -791,7 +791,7 @@ mod tests {
     use core::cell::Cell;
 
     use miden_assembly_syntax::ast::DebugVarLocation;
-    use miden_core::Word;
+    use miden_core::{Felt, Word};
     use miden_debug_types::{ByteIndex, ColumnNumber, LineNumber, Location, Uri};
 
     use super::*;
@@ -1099,6 +1099,45 @@ mod tests {
         let debug_info = *builder.build();
         let result = roundtrip_debug_info(&debug_info);
         assert_eq!(result.functions(), debug_info.functions());
+    }
+
+    #[test]
+    fn debug_function_v2_wire_bytes_are_stable() {
+        const EXPECTED_ROW: [u8; size_of::<WireDebugFunctionInfo>()] = [
+            1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0,
+            0, 0, 0, 1, 0, 0, 0, 7, 0, 0, 0, 1, 0, 0, 0, 9, 0, 0, 0, 1, 0, 0, 0, 11, 0, 0, 0, 13,
+            0, 0, 0, 15, 0, 0, 0, 17, 0, 0, 0, 19, 0, 0, 0,
+        ];
+
+        let function = DebugFunctionInfo {
+            mast_root: Word::new([
+                Felt::new(1).unwrap(),
+                Felt::new(2).unwrap(),
+                Felt::new(3).unwrap(),
+                Felt::new(4).unwrap(),
+            ]),
+            source_node: Some(DebugSourceNodeId::from(7)).into(),
+            type_idx: Some(DebugTypeIdx::from(9)).into(),
+            linkage_name_idx: Some(DebugStringIdx::from(11)).into(),
+            name_idx: DebugStringIdx::from(13),
+            file_idx: DebugFileIdx::from(15),
+            line: LineIndex::from(17),
+            column: ColumnIndex::from(19),
+        };
+        let mut builder = PackageDebugInfoBuilder::default();
+        builder.add_function(function);
+        let debug_info = builder.build();
+
+        let bytes = debug_info.to_bytes();
+        assert_eq!(bytes[0], 2);
+        assert!(
+            bytes.windows(EXPECTED_ROW.len()).any(|window| window == EXPECTED_ROW),
+            "serialized debug info did not contain the expected function row",
+        );
+
+        let decoded =
+            PackageDebugInfo::read_from(&mut miden_core::serde::SliceReader::new(&bytes)).unwrap();
+        assert_eq!(decoded.functions(), [function]);
     }
 
     #[test]

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -23,6 +23,8 @@ use super::{
     DebugTypeIdx, DebugTypeInfo, DebugVariantInfo, PackageDebugInfo,
 };
 
+/// Base alignment for copied payloads. The assertions below ensure that this is sufficient for
+/// every row type decoded directly from the payload.
 const POD_BUFFER_ALIGNMENT: usize = align_of::<u64>();
 
 const _: () = {
@@ -34,6 +36,8 @@ const _: () = {
     assert!(align_of::<DebugSourceAsmOp>() <= POD_BUFFER_ALIGNMENT);
 };
 
+/// Wire form of an optional index. Byte arrays make little-endian encoding explicit, while keeping
+/// invalid discriminants representable for later validation.
 #[repr(C)]
 #[derive(Clone, Copy, zerocopy::FromBytes, Immutable, IntoBytes, KnownLayout)]
 struct WireOptionU32 {
@@ -58,6 +62,8 @@ impl WireOptionU32 {
     }
 }
 
+/// Wire form of [`DebugFunctionInfo`]. The domain type cannot be decoded from arbitrary bytes
+/// because its field elements must be validated before constructing a [`Word`].
 #[repr(C, align(8))]
 #[derive(Clone, Copy, zerocopy::FromBytes, Immutable, IntoBytes, KnownLayout)]
 struct WireDebugFunctionInfo {
@@ -74,7 +80,9 @@ struct WireDebugFunctionInfo {
 // PACKAGE DEBUG INFO SERIALIZATION
 // ================================================================================================
 
-/// Fixed-size tables use `zerocopy`-certified POD rows. The function table uses an explicit POD
+/// Fixed-size tables are padded to their row alignment and written as `zerocopy`-certified rows.
+/// Deserialization copies each payload into an aligned allocation because the padding preserves row
+/// alignment only when measured from an aligned payload base. The function table uses an explicit
 /// wire row because its field elements require validation before constructing domain values.
 #[cfg(target_endian = "little")]
 impl Serializable for PackageDebugInfo {
@@ -208,8 +216,8 @@ impl Deserializable for PackageDebugInfo {
 // DEBUG SOURCE NODE SERIALIZATION
 // ================================================================================================
 
-/// Fixed-size child and assembly-op rows use the same explicit POD wire representation as
-/// [PackageDebugInfo].
+/// Fixed-size child and assembly-op tables use the same certified row format as
+/// [`PackageDebugInfo`].
 #[cfg(target_endian = "little")]
 impl Serializable for DebugSourceNode {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
@@ -628,7 +636,8 @@ impl AlignedBytes {
         let Some(ptr) = self.ptr else {
             return &[];
         };
-        // SAFETY: the allocation remains owned by `self` for the returned borrow.
+        // SAFETY: `ptr` was allocated with `self.layout`, every byte was initialized by the copy in
+        // `copy_from_slice`, and the allocation remains owned by `self` for the returned borrow.
         unsafe { core::slice::from_raw_parts(ptr.as_ptr(), self.layout.size()) }
     }
 }

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -17,10 +17,10 @@ use miden_utils_indexing::IndexVec;
 use zerocopy::{Immutable, IntoBytes, KnownLayout};
 
 use super::{
-    DEBUG_INFO_VERSION, DebugErrorMessage, DebugFieldInfo, DebugFileInfo, DebugFunctionIdx,
-    DebugFunctionInfo, DebugLoc, DebugLocIdx, DebugPrimitiveType, DebugSourceAsmOp,
-    DebugSourceInlineCall, DebugSourceNode, DebugSourceNodeId, DebugSourceVar, DebugStringIdx,
-    DebugTypeIdx, DebugTypeInfo, DebugVariantInfo, PackageDebugInfo,
+    DEBUG_INFO_VERSION, DebugErrorMessage, DebugFieldInfo, DebugFileIdx, DebugFileInfo,
+    DebugFunctionIdx, DebugFunctionInfo, DebugLoc, DebugLocIdx, DebugPrimitiveType,
+    DebugSourceAsmOp, DebugSourceInlineCall, DebugSourceNode, DebugSourceNodeId, DebugSourceVar,
+    DebugStringIdx, DebugTypeIdx, DebugTypeInfo, DebugVariantInfo, OptionalIndex, PackageDebugInfo,
 };
 
 /// Base alignment for copied payloads. The assertions below ensure that this is sufficient for
@@ -36,45 +36,19 @@ const _: () = {
     assert!(align_of::<DebugSourceAsmOp>() <= POD_BUFFER_ALIGNMENT);
 };
 
-/// Wire form of an optional index. Byte arrays make little-endian encoding explicit, while keeping
-/// invalid discriminants representable for later validation.
-#[repr(C)]
-#[derive(Clone, Copy, zerocopy::FromBytes, Immutable, IntoBytes, KnownLayout)]
-struct WireOptionU32 {
-    discriminant: [u8; 4],
-    payload: [u8; 4],
-}
-
-impl WireOptionU32 {
-    fn from_option<T: miden_utils_indexing::Idx>(value: super::OptionC<T>) -> Self {
-        let (discriminant, payload) = value.into_raw_parts();
-        Self {
-            discriminant: discriminant.to_le_bytes(),
-            payload: payload.to_le_bytes(),
-        }
-    }
-
-    fn into_option<T: miden_utils_indexing::Idx>(self) -> super::OptionC<T> {
-        super::OptionC::from_raw_parts(
-            u32::from_le_bytes(self.discriminant),
-            u32::from_le_bytes(self.payload),
-        )
-    }
-}
-
 /// Wire form of [`DebugFunctionInfo`]. The domain type cannot be decoded from arbitrary bytes
 /// because its field elements must be validated before constructing a [`Word`].
 #[repr(C, align(8))]
 #[derive(Clone, Copy, zerocopy::FromBytes, Immutable, IntoBytes, KnownLayout)]
 struct WireDebugFunctionInfo {
-    mast_root: [[u8; 8]; 4],
-    source_node: WireOptionU32,
-    type_idx: WireOptionU32,
-    linkage_name_idx: WireOptionU32,
-    name_idx: [u8; 4],
-    file_idx: [u8; 4],
-    line: [u8; 4],
-    column: [u8; 4],
+    mast_root: [u64; 4],
+    source_node: OptionalIndex<DebugSourceNodeId>,
+    type_idx: OptionalIndex<DebugTypeIdx>,
+    linkage_name_idx: OptionalIndex<DebugStringIdx>,
+    name_idx: DebugStringIdx,
+    file_idx: DebugFileIdx,
+    line: LineIndex,
+    column: ColumnIndex,
 }
 
 // PACKAGE DEBUG INFO SERIALIZATION
@@ -103,17 +77,16 @@ impl Serializable for PackageDebugInfo {
         pad_to_align::<WireDebugFunctionInfo>(&mut output);
         write_pod_rows(
             self.functions().iter().map(|row| {
-                let mast_root =
-                    row.mast_root.into_elements().map(|felt| felt.as_canonical_u64().to_le_bytes());
+                let mast_root = row.mast_root.into_elements().map(|felt| felt.as_canonical_u64());
                 WireDebugFunctionInfo {
                     mast_root,
-                    source_node: WireOptionU32::from_option(row.source_node),
-                    type_idx: WireOptionU32::from_option(row.type_idx),
-                    linkage_name_idx: WireOptionU32::from_option(row.linkage_name_idx),
-                    name_idx: u32::from(row.name_idx).to_le_bytes(),
-                    file_idx: u32::from(row.file_idx).to_le_bytes(),
-                    line: row.line.to_u32().to_le_bytes(),
-                    column: row.column.to_u32().to_le_bytes(),
+                    source_node: row.source_node,
+                    type_idx: row.type_idx,
+                    linkage_name_idx: row.linkage_name_idx,
+                    name_idx: row.name_idx,
+                    file_idx: row.file_idx,
+                    line: row.line,
+                    column: row.column,
                 }
             }),
             &mut output,
@@ -172,13 +145,13 @@ impl Deserializable for PackageDebugInfo {
                         read_wire_felt(row.mast_root[2])?,
                         read_wire_felt(row.mast_root[3])?,
                     ]),
-                    source_node: row.source_node.into_option(),
-                    type_idx: row.type_idx.into_option(),
-                    linkage_name_idx: row.linkage_name_idx.into_option(),
-                    name_idx: u32::from_le_bytes(row.name_idx).into(),
-                    file_idx: u32::from_le_bytes(row.file_idx).into(),
-                    line: LineIndex::from(u32::from_le_bytes(row.line)),
-                    column: ColumnIndex::from(u32::from_le_bytes(row.column)),
+                    source_node: row.source_node,
+                    type_idx: row.type_idx,
+                    linkage_name_idx: row.linkage_name_idx,
+                    name_idx: row.name_idx,
+                    file_idx: row.file_idx,
+                    line: row.line,
+                    column: row.column,
                 })
             },
         )?;
@@ -788,8 +761,8 @@ where
     target.write_bytes(rows.as_bytes());
 }
 
-fn read_wire_felt(bytes: [u8; 8]) -> Result<Felt, DeserializationError> {
-    Felt::new(u64::from_le_bytes(bytes)).map_err(|err| {
+fn read_wire_felt(value: u64) -> Result<Felt, DeserializationError> {
+    Felt::new(value).map_err(|err| {
         DeserializationError::InvalidValue(alloc::format!(
             "invalid field element in debug function MAST root: {err}"
         ))

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -5,13 +5,16 @@ use core::{alloc::Layout, ptr::NonNull};
 
 use miden_assembly_syntax::ast::DebugVarLocation;
 use miden_core::{
+    Felt, Word,
     mast::MastNodeId,
     serde::{
         ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
         read_bounded_len,
     },
 };
+use miden_debug_types::{ColumnIndex, LineIndex};
 use miden_utils_indexing::IndexVec;
+use zerocopy::{Immutable, IntoBytes, KnownLayout};
 
 use super::{
     DEBUG_INFO_VERSION, DebugErrorMessage, DebugFieldInfo, DebugFileInfo, DebugFunctionIdx,
@@ -20,90 +23,101 @@ use super::{
     DebugTypeIdx, DebugTypeInfo, DebugVariantInfo, PackageDebugInfo,
 };
 
-/// The minimum alignment required for buffers containing directly decoded debug-info rows.
-const DEBUG_INFO_BUFFER_ALIGNMENT: usize = max_alignment(
-    max_alignment(
-        max_alignment(align_of::<DebugFileInfo>(), align_of::<DebugLoc>()),
-        max_alignment(align_of::<DebugFunctionInfo>(), align_of::<DebugSourceNodeId>()),
-    ),
-    max_alignment(align_of::<DebugErrorMessage>(), align_of::<DebugSourceAsmOp>()),
-);
-
-const fn max_alignment(lhs: usize, rhs: usize) -> usize {
-    if lhs > rhs { lhs } else { rhs }
-}
+const POD_BUFFER_ALIGNMENT: usize = align_of::<u64>();
 
 const _: () = {
-    assert!(DEBUG_INFO_BUFFER_ALIGNMENT.is_power_of_two());
-    assert!(DEBUG_INFO_BUFFER_ALIGNMENT >= align_of::<DebugFileInfo>());
-    assert!(DEBUG_INFO_BUFFER_ALIGNMENT >= align_of::<DebugLoc>());
-    assert!(DEBUG_INFO_BUFFER_ALIGNMENT >= align_of::<DebugFunctionInfo>());
-    assert!(DEBUG_INFO_BUFFER_ALIGNMENT >= align_of::<DebugSourceNodeId>());
-    assert!(DEBUG_INFO_BUFFER_ALIGNMENT >= align_of::<DebugErrorMessage>());
-    assert!(DEBUG_INFO_BUFFER_ALIGNMENT >= align_of::<DebugSourceAsmOp>());
+    assert!(align_of::<DebugFileInfo>() <= POD_BUFFER_ALIGNMENT);
+    assert!(align_of::<DebugLoc>() <= POD_BUFFER_ALIGNMENT);
+    assert!(align_of::<WireDebugFunctionInfo>() <= POD_BUFFER_ALIGNMENT);
+    assert!(align_of::<DebugSourceNodeId>() <= POD_BUFFER_ALIGNMENT);
+    assert!(align_of::<DebugErrorMessage>() <= POD_BUFFER_ALIGNMENT);
+    assert!(align_of::<DebugSourceAsmOp>() <= POD_BUFFER_ALIGNMENT);
 };
+
+#[repr(C)]
+#[derive(Clone, Copy, zerocopy::FromBytes, Immutable, IntoBytes, KnownLayout)]
+struct WireOptionU32 {
+    discriminant: [u8; 4],
+    payload: [u8; 4],
+}
+
+impl WireOptionU32 {
+    fn from_option<T: miden_utils_indexing::Idx>(value: super::OptionC<T>) -> Self {
+        let (discriminant, payload) = value.into_raw_parts();
+        Self {
+            discriminant: discriminant.to_le_bytes(),
+            payload: payload.to_le_bytes(),
+        }
+    }
+
+    fn into_option<T: miden_utils_indexing::Idx>(self) -> super::OptionC<T> {
+        super::OptionC::from_raw_parts(
+            u32::from_le_bytes(self.discriminant),
+            u32::from_le_bytes(self.payload),
+        )
+    }
+}
+
+#[repr(C, align(8))]
+#[derive(Clone, Copy, zerocopy::FromBytes, Immutable, IntoBytes, KnownLayout)]
+struct WireDebugFunctionInfo {
+    mast_root: [[u8; 8]; 4],
+    source_node: WireOptionU32,
+    type_idx: WireOptionU32,
+    linkage_name_idx: WireOptionU32,
+    name_idx: [u8; 4],
+    file_idx: [u8; 4],
+    line: [u8; 4],
+    column: [u8; 4],
+}
 
 // PACKAGE DEBUG INFO SERIALIZATION
 // ================================================================================================
 
-/// [PackageDebugInfo] is a very rich and information-dense structure, and so we need to use a few
-/// unsafe tricks in order to keep the (de)serialization performance within a reasonable bound).
-/// Most notably, we attempt to (de)serialize entire rows/tables of data to/from memory directly to
-/// the output buffer without invoking per-element (de)serializers. This allows us to avoid a
-/// significant amount of overhead, but the tradeoff is that it is much more fragile and highly
-/// unsafe - we mitigate this by imposing specific restrictions on types which can be serialized
-/// this way (primarily, the type must be `Copy`).
-///
-/// In order to ensure we can deserialize the data using the same process (copying data out of the
-/// buffer into memory directly), we ensure that the output data is padded in such a way that when
-/// extracted to an aligned buffer in memory, we are guaranteed to be able to directly reference
-/// the encoded rows as a slice of the desired type, and uphold the requirements Rust imposes on
-/// references.
+/// Fixed-size tables use `zerocopy`-certified POD rows. The function table uses an explicit POD
+/// wire row because its field elements require validation before constructing domain values.
 #[cfg(target_endian = "little")]
 impl Serializable for PackageDebugInfo {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        // We serialize to a temporary buffer in memory with a starting size of 16k
-        //
-        // This allows us to emit padding bytes to keep specific parts of the serialized data
-        // aligned according to the required minimum alignment requirements of that data so that
-        // we can construct direct references to it during deserialization.
         let mut output = Vec::<u8>::with_capacity(16 * 1024);
 
         self.strings.write_into(&mut output);
 
         output.write_u32(self.files().len().try_into().unwrap());
-        pad_to_align::<DebugFileInfo>(&mut output);
-        unsafe {
-            copy_slice_memory_to_output(self.files().as_slice(), &mut output);
-        }
+        write_pod_slice(self.files().as_slice(), &mut output);
 
         output.write_u32(self.locations().len().try_into().unwrap());
-        pad_to_align::<DebugLoc>(&mut output);
-        unsafe {
-            copy_slice_memory_to_output(self.locations().as_slice(), &mut output);
-        }
+        write_pod_slice(self.locations().as_slice(), &mut output);
 
         self.types.write_into(&mut output);
 
         output.write_u32(self.functions().len().try_into().unwrap());
-        pad_to_align::<DebugFunctionInfo>(&mut output);
-        unsafe {
-            copy_slice_memory_to_output(self.functions(), &mut output);
-        }
+        pad_to_align::<WireDebugFunctionInfo>(&mut output);
+        write_pod_rows(
+            self.functions().iter().map(|row| {
+                let mast_root =
+                    row.mast_root.into_elements().map(|felt| felt.as_canonical_u64().to_le_bytes());
+                WireDebugFunctionInfo {
+                    mast_root,
+                    source_node: WireOptionU32::from_option(row.source_node),
+                    type_idx: WireOptionU32::from_option(row.type_idx),
+                    linkage_name_idx: WireOptionU32::from_option(row.linkage_name_idx),
+                    name_idx: u32::from(row.name_idx).to_le_bytes(),
+                    file_idx: u32::from(row.file_idx).to_le_bytes(),
+                    line: row.line.to_u32().to_le_bytes(),
+                    column: row.column.to_u32().to_le_bytes(),
+                }
+            }),
+            &mut output,
+        );
 
         self.nodes.write_into(&mut output);
 
         output.write_u32(self.roots().len().try_into().unwrap());
-        pad_to_align::<DebugSourceNodeId>(&mut output);
-        unsafe {
-            copy_slice_memory_to_output(self.roots(), &mut output);
-        }
+        write_pod_slice(self.roots(), &mut output);
 
         output.write_u32(self.error_messages().len().try_into().unwrap());
-        pad_to_align::<DebugErrorMessage>(&mut output);
-        unsafe {
-            copy_slice_memory_to_output(self.error_messages(), &mut output);
-        }
+        write_pod_slice(self.error_messages(), &mut output);
 
         target.write_u8(self.version());
         target.write_usize(output.len());
@@ -121,43 +135,54 @@ impl Deserializable for PackageDebugInfo {
             )));
         }
 
-        // Read the serialized data into a temporary allocation specifically aligned so that we
-        // can construct references directly into it for certain rows/tables. It is not safe to do
-        // so unless we guarantee the alignment of the entire buffer, because our padding bytes
-        // are emitted based relative to the start of the buffer.
         let data_len = read_bounded_len(source, "package debug info", 1)?;
         let data = source.read_slice(data_len)?;
-        // Copy the data to an allocation whose base alignment satisfies every row type decoded
-        // directly from this buffer. The owner retains the allocation layout so it can deallocate
-        // the buffer with the same layout later.
-        let data = AlignedBytes::copy_from_slice(data, DEBUG_INFO_BUFFER_ALIGNMENT)?;
-
-        let mut source = AlignedSliceReader::new(data.as_slice());
+        let aligned = AlignedBytes::copy_from_slice(data, POD_BUFFER_ALIGNMENT)?;
+        let mut source = PodSliceReader::new(aligned.as_slice());
 
         let strings =
             IndexVec::read_from_bounded_with(&mut source, "debug_info strings", 1, read_string)?;
 
         let files_len = source.read_u32()?;
-        let files = source.read_aligned_slice_of::<DebugFileInfo>(files_len as usize)?.to_vec();
+        let files = source.read_pod_rows::<DebugFileInfo>(files_len as usize, "debug files")?;
 
         let locations_len = source.read_u32()?;
-        let locations = source.read_aligned_slice_of::<DebugLoc>(locations_len as usize)?.to_vec();
+        let locations =
+            source.read_pod_rows::<DebugLoc>(locations_len as usize, "debug locations")?;
 
         let types = IndexVec::read_from_bounded(&mut source, "debug_info types")?;
 
         let functions_len = source.read_u32()?;
-        let functions = source
-            .read_aligned_slice_of::<DebugFunctionInfo>(functions_len as usize)?
-            .to_vec();
+        let functions = source.read_pod_rows_with::<WireDebugFunctionInfo, _, _>(
+            functions_len as usize,
+            "debug functions",
+            |row| {
+                Ok(DebugFunctionInfo {
+                    mast_root: Word::new([
+                        read_wire_felt(row.mast_root[0])?,
+                        read_wire_felt(row.mast_root[1])?,
+                        read_wire_felt(row.mast_root[2])?,
+                        read_wire_felt(row.mast_root[3])?,
+                    ]),
+                    source_node: row.source_node.into_option(),
+                    type_idx: row.type_idx.into_option(),
+                    linkage_name_idx: row.linkage_name_idx.into_option(),
+                    name_idx: u32::from_le_bytes(row.name_idx).into(),
+                    file_idx: u32::from_le_bytes(row.file_idx).into(),
+                    line: LineIndex::from(u32::from_le_bytes(row.line)),
+                    column: ColumnIndex::from(u32::from_le_bytes(row.column)),
+                })
+            },
+        )?;
 
         let nodes = IndexVec::read_from_bounded(&mut source, "debug_info nodes")?;
 
         let roots_len = source.read_u32()? as usize;
-        let roots = source.read_aligned_slice_of::<DebugSourceNodeId>(roots_len)?.to_vec();
+        let roots = source.read_pod_rows::<DebugSourceNodeId>(roots_len, "debug source roots")?;
 
         let error_messages_len = source.read_u32()? as usize;
-        let error_messages =
-            source.read_aligned_slice_of::<DebugErrorMessage>(error_messages_len)?.to_vec();
+        let error_messages = source
+            .read_pod_rows::<DebugErrorMessage>(error_messages_len, "debug error messages")?;
 
         let remaining_len = source.remaining_len();
         if remaining_len != 0 {
@@ -183,20 +208,11 @@ impl Deserializable for PackageDebugInfo {
 // DEBUG SOURCE NODE SERIALIZATION
 // ================================================================================================
 
-/// We use the same techniques with [DebugSourceNode] as [PackageDebugInfo] itself, as it is a
-/// complex record in the debug info, the largest, and contains multiple sub-tables of data linked
-/// to the node.
-///
-/// See the doc on the `Serializable` impl of `PackageDebugInfo` for details
+/// Fixed-size child and assembly-op rows use the same explicit POD wire representation as
+/// [PackageDebugInfo].
 #[cfg(target_endian = "little")]
 impl Serializable for DebugSourceNode {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        // We serialize to a temporary buffer in memory with sufficient minimum capacity to hold
-        // a single DebugSourceNode.
-        //
-        // This allows us to emit padding bytes to keep specific parts of the serialized data
-        // aligned according to the required minimum alignment requirements of that data so that
-        // we can construct direct references to it during deserialization.
         let mut output = Vec::<u8>::with_capacity(
             size_of::<DebugSourceNode>()
                 + (self.asm_ops.len() * size_of::<DebugSourceAsmOp>())
@@ -207,19 +223,13 @@ impl Serializable for DebugSourceNode {
         output.write_u32(self.exec_node.into());
 
         output.write_u32(self.children.len().try_into().unwrap());
-        pad_to_align::<DebugSourceNodeId>(&mut output);
-        unsafe {
-            copy_slice_memory_to_output(self.children.as_slice(), &mut output);
-        }
+        write_pod_slice(self.children.as_slice(), &mut output);
 
         output.write_u32(self.op_start);
         output.write_u32(self.op_end);
 
         output.write_u32(self.asm_ops.len().try_into().unwrap());
-        pad_to_align::<DebugSourceAsmOp>(&mut output);
-        unsafe {
-            copy_slice_memory_to_output(self.asm_ops.as_slice(), &mut output);
-        }
+        write_pod_slice(self.asm_ops.as_slice(), &mut output);
 
         self.debug_vars.write_into(&mut output);
         self.inline_calls.write_into(&mut output);
@@ -232,28 +242,23 @@ impl Serializable for DebugSourceNode {
 #[cfg(target_endian = "little")]
 impl Deserializable for DebugSourceNode {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        // Read the serialized data into a temporary allocation specifically aligned so that we
-        // can construct references directly into it for certain rows/tables. It is not safe to do
-        // so unless we guarantee the alignment of the entire buffer, because our padding bytes
-        // are emitted based relative to the start of the buffer.
         let data_len = read_bounded_len(source, "debug source node", 1)?;
         let data = source.read_slice(data_len)?;
-        // Keep the same base-alignment guarantee as the package-level buffer so every directly
-        // decoded row remains aligned even if new row types are shared between the two payloads.
-        let data = AlignedBytes::copy_from_slice(data, DEBUG_INFO_BUFFER_ALIGNMENT)?;
-
-        let mut source = AlignedSliceReader::new(data.as_slice());
+        let aligned = AlignedBytes::copy_from_slice(data, POD_BUFFER_ALIGNMENT)?;
+        let mut source = PodSliceReader::new(aligned.as_slice());
 
         let exec_node = MastNodeId::new_unchecked(source.read_u32()?);
 
         let children_len = source.read_u32()? as usize;
-        let children = source.read_aligned_slice_of::<DebugSourceNodeId>(children_len)?.to_vec();
+        let children =
+            source.read_pod_rows::<DebugSourceNodeId>(children_len, "debug source children")?;
 
         let op_start = source.read_u32()?;
         let op_end = source.read_u32()?;
 
         let asm_ops_len = source.read_u32()? as usize;
-        let asm_ops = source.read_aligned_slice_of::<DebugSourceAsmOp>(asm_ops_len)?.to_vec();
+        let asm_ops =
+            source.read_pod_rows::<DebugSourceAsmOp>(asm_ops_len, "debug assembly operations")?;
 
         let debug_vars = Vec::read_from(&mut source)?;
         let inline_calls = Vec::read_from(&mut source)?;
@@ -589,7 +594,7 @@ impl Deserializable for DebugFileInfo {
 // HELPER FUNCTIONS
 // ================================================================================================
 
-/// An owned byte buffer whose allocation layout is preserved until deallocation.
+/// Owns a byte allocation with the alignment required by the certified POD row types.
 struct AlignedBytes {
     ptr: Option<NonNull<u8>>,
     layout: Layout,
@@ -599,27 +604,23 @@ impl AlignedBytes {
     fn copy_from_slice(source: &[u8], alignment: usize) -> Result<Self, DeserializationError> {
         let layout = Layout::from_size_align(source.len(), alignment).map_err(|_| {
             DeserializationError::InvalidValue(format!(
-                "debug info payload size {} is too large: unable to allocate aligned buffer of sufficient size",
+                "debug info payload size {} is too large",
                 source.len()
             ))
         })?;
-
         if source.is_empty() {
             return Ok(Self { ptr: None, layout });
         }
 
-        // SAFETY: `layout` has non-zero size in this branch and was constructed successfully above.
+        // SAFETY: `layout` is non-zero and valid in this branch.
         let ptr = unsafe { alloc::alloc::alloc(layout) };
         let Some(ptr) = NonNull::new(ptr) else {
             alloc::alloc::handle_alloc_error(layout)
         };
-        // SAFETY: `ptr` points to a newly allocated block of `source.len()` bytes and therefore
-        // does not overlap `source`. Both pointers are valid for reads/writes of
-        // `source.len()` bytes.
+        // SAFETY: `ptr` owns `source.len()` writable bytes and does not overlap `source`.
         unsafe {
             ptr.as_ptr().copy_from_nonoverlapping(source.as_ptr(), source.len());
         }
-
         Ok(Self { ptr: Some(ptr), layout })
     }
 
@@ -627,8 +628,7 @@ impl AlignedBytes {
         let Some(ptr) = self.ptr else {
             return &[];
         };
-        // SAFETY: `ptr` was allocated for `layout` and remains owned by `self`, so it is valid for
-        // reads of `layout.size()` bytes for the lifetime of this borrow.
+        // SAFETY: the allocation remains owned by `self` for the returned borrow.
         unsafe { core::slice::from_raw_parts(ptr.as_ptr(), self.layout.size()) }
     }
 }
@@ -636,8 +636,7 @@ impl AlignedBytes {
 impl Drop for AlignedBytes {
     fn drop(&mut self) {
         if let Some(ptr) = self.ptr {
-            // SAFETY: `ptr` was allocated with this exact layout in `copy_from_slice`, has not been
-            // deallocated, and is never present for the zero-sized layout.
+            // SAFETY: `ptr` was allocated with this exact layout and has not been freed.
             unsafe {
                 alloc::alloc::dealloc(ptr.as_ptr(), self.layout);
             }
@@ -645,46 +644,64 @@ impl Drop for AlignedBytes {
     }
 }
 
-struct AlignedSliceReader<'a> {
+struct PodSliceReader<'a> {
     source: &'a [u8],
     pos: usize,
 }
 
-impl<'a> AlignedSliceReader<'a> {
-    /// Creates a new slice reader from the specified slice.
+impl<'a> PodSliceReader<'a> {
     fn new(source: &'a [u8]) -> Self {
-        AlignedSliceReader { source, pos: 0 }
+        Self { source, pos: 0 }
     }
 
     fn remaining_len(&self) -> usize {
         self.source.len() - self.pos
     }
 
-    fn read_aligned_slice_of<T>(&mut self, len: usize) -> Result<&[T], DeserializationError> {
+    fn read_pod_rows<T>(&mut self, len: usize, label: &str) -> Result<Vec<T>, DeserializationError>
+    where
+        T: Copy + zerocopy::FromBytes + Immutable + KnownLayout,
+    {
         self.skip_alignment_padding::<T>()?;
         let byte_len = len.checked_mul(size_of::<T>()).ok_or_else(|| {
             DeserializationError::InvalidValue(alloc::format!(
-                "aligned slice count {len} overflows element size {}",
+                "{label} row count {len} overflows row size {}",
                 size_of::<T>()
             ))
         })?;
-        if len == 0 {
-            return Ok(&[]);
-        }
         let bytes = self.read_slice(byte_len)?;
-        let ptr = bytes.as_ptr().cast::<T>();
-        if !ptr.is_aligned() {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "aligned slice at byte offset {} does not satisfy alignment {}",
-                self.pos - byte_len,
-                align_of::<T>(),
-            )));
-        }
-        // SAFETY: The byte range was bounds-checked above, starts at an address aligned for `T`,
-        // and spans exactly `len * size_of::<T>()` bytes. The high-throughput wire format
-        // separately requires callers to use row types whose encoded bytes are valid values
-        // of `T`.
-        Ok(unsafe { core::slice::from_raw_parts(ptr, len) })
+        let rows: &[T] = <[T] as zerocopy::FromBytes>::ref_from_bytes(bytes).map_err(|_| {
+            DeserializationError::InvalidValue(alloc::format!(
+                "{label} bytes do not form aligned POD rows"
+            ))
+        })?;
+        Ok(rows.to_vec())
+    }
+
+    fn read_pod_rows_with<T, U, F>(
+        &mut self,
+        len: usize,
+        label: &str,
+        map: F,
+    ) -> Result<Vec<U>, DeserializationError>
+    where
+        T: Copy + zerocopy::FromBytes + Immutable + KnownLayout,
+        F: FnMut(T) -> Result<U, DeserializationError>,
+    {
+        self.skip_alignment_padding::<T>()?;
+        let byte_len = len.checked_mul(size_of::<T>()).ok_or_else(|| {
+            DeserializationError::InvalidValue(alloc::format!(
+                "{label} row count {len} overflows row size {}",
+                size_of::<T>()
+            ))
+        })?;
+        let bytes = self.read_slice(byte_len)?;
+        let rows: &[T] = <[T] as zerocopy::FromBytes>::ref_from_bytes(bytes).map_err(|_| {
+            DeserializationError::InvalidValue(alloc::format!(
+                "{label} bytes do not form aligned POD rows"
+            ))
+        })?;
+        rows.iter().copied().map(map).collect()
     }
 
     fn skip_alignment_padding<T>(&mut self) -> Result<(), DeserializationError> {
@@ -698,10 +715,11 @@ impl<'a> AlignedSliceReader<'a> {
     }
 }
 
-impl ByteReader for AlignedSliceReader<'_> {
+impl ByteReader for PodSliceReader<'_> {
     fn max_alloc(&self, element_size: usize) -> usize {
-        (self.source.len() - self.pos).checked_div(element_size).unwrap_or(usize::MAX)
+        self.remaining_len().checked_div(element_size).unwrap_or(usize::MAX)
     }
+
     fn read_u8(&mut self) -> Result<u8, DeserializationError> {
         self.check_eor(1)?;
         let result = self.source[self.pos];
@@ -744,26 +762,29 @@ impl ByteReader for AlignedSliceReader<'_> {
 
 fn pad_to_align<T>(output: &mut Vec<u8>) {
     let padding_required = output.len().next_multiple_of(align_of::<T>()) - output.len();
-    for _ in 0..padding_required {
-        output.write_u8(0);
-    }
+    output.resize(output.len() + padding_required, 0);
 }
 
-unsafe fn copy_slice_memory_to_output<T: Copy>(slice: &[T], output: &mut Vec<u8>) {
-    unsafe {
-        let ptr = slice.as_ptr() as *const u8;
-        let slice_layout = Layout::array::<T>(slice.len()).unwrap();
-        let range = slice.as_ptr_range();
-        let actual_size = range.end.byte_offset_from_unsigned(range.start);
-        let layout_size = slice_layout.size();
-        assert!(
-            actual_size >= layout_size,
-            "expected layout of slice of len {} ({layout_size} bytes) to be <= {actual_size} bytes",
-            slice.len()
-        );
-        let bytes = core::slice::from_raw_parts(ptr, actual_size);
-        output.write_bytes(bytes);
-    }
+fn write_pod_slice<T: IntoBytes + Immutable>(slice: &[T], target: &mut Vec<u8>) {
+    pad_to_align::<T>(target);
+    target.write_bytes(slice.as_bytes());
+}
+
+fn write_pod_rows<T, I>(rows: I, target: &mut Vec<u8>)
+where
+    T: IntoBytes + Immutable,
+    I: IntoIterator<Item = T>,
+{
+    let rows: Vec<T> = rows.into_iter().collect();
+    target.write_bytes(rows.as_bytes());
+}
+
+fn read_wire_felt(bytes: [u8; 8]) -> Result<Felt, DeserializationError> {
+    Felt::new(u64::from_le_bytes(bytes)).map_err(|err| {
+        DeserializationError::InvalidValue(alloc::format!(
+            "invalid field element in debug function MAST root: {err}"
+        ))
+    })
 }
 
 fn read_string<R: ByteReader>(source: &mut R) -> Result<Arc<str>, DeserializationError> {
@@ -865,46 +886,31 @@ mod tests {
     }
 
     #[test]
-    fn aligned_bytes_preserves_contents_and_required_alignment() {
-        let payload = [1, 2, 3, 4, 5];
-        let data = AlignedBytes::copy_from_slice(&payload, DEBUG_INFO_BUFFER_ALIGNMENT).unwrap();
-
-        assert_eq!(data.as_slice(), payload);
-        assert_eq!(data.as_slice().as_ptr().addr() % DEBUG_INFO_BUFFER_ALIGNMENT, 0);
-    }
-
-    #[test]
-    fn aligned_bytes_handles_empty_payload() {
-        let data = AlignedBytes::copy_from_slice(&[], DEBUG_INFO_BUFFER_ALIGNMENT).unwrap();
-
-        assert!(data.ptr.is_none());
-        assert!(data.as_slice().is_empty());
-        assert_eq!(data.layout.size(), 0);
-        assert_eq!(data.layout.align(), DEBUG_INFO_BUFFER_ALIGNMENT);
-    }
-
-    #[test]
-    fn aligned_slice_reader_rejects_byte_length_overflow() {
-        let mut reader = AlignedSliceReader::new(&[]);
-        let error = reader.read_aligned_slice_of::<u64>(usize::MAX).unwrap_err();
+    fn pod_row_reader_rejects_byte_length_overflow() {
+        let mut reader = PodSliceReader::new(&[]);
+        let result = reader.read_pod_rows::<DebugErrorMessage>(usize::MAX, "test error messages");
+        let error = result.unwrap_err();
 
         let DeserializationError::InvalidValue(message) = error else {
             panic!("expected InvalidValue error");
         };
-        assert!(message.contains("overflows element size"));
+        assert!(message.contains("overflows row size"));
     }
 
     #[test]
-    fn aligned_slice_reader_supports_maximum_row_alignment() {
-        let bytes = [0u8; size_of::<DebugErrorMessage>()];
-        let data = AlignedBytes::copy_from_slice(&bytes, DEBUG_INFO_BUFFER_ALIGNMENT).unwrap();
-        let mut reader = AlignedSliceReader::new(data.as_slice());
+    fn pod_row_reader_decodes_certified_rows() {
+        let expected = DebugErrorMessage::new(42, DebugStringIdx::from(7));
+        let mut aligned = [0_u64; 2];
+        aligned.as_mut_bytes()[..size_of::<DebugErrorMessage>()]
+            .copy_from_slice(expected.as_bytes());
+        let mut reader = PodSliceReader::new(aligned.as_bytes());
+        let decoded = reader.read_pod_rows::<DebugErrorMessage>(1, "test error messages").unwrap();
 
-        assert_eq!(reader.read_aligned_slice_of::<DebugErrorMessage>(1).unwrap().len(), 1);
+        assert_eq!(decoded, [expected]);
     }
 
     #[test]
-    fn debug_variant_min_serialized_size_is_accepted_by_aligned_reader() {
+    fn debug_variant_min_serialized_size_is_accepted_by_slice_reader() {
         let variant = DebugVariantInfo {
             name_idx: DebugStringIdx::from(0),
             type_idx: None,
@@ -916,7 +922,7 @@ mod tests {
 
         assert_eq!(bytes.len(), DebugVariantInfo::min_serialized_size());
 
-        let mut reader = AlignedSliceReader::new(&bytes);
+        let mut reader = miden_core::serde::SliceReader::new(&bytes);
         let mut variants = reader.read_many_iter::<DebugVariantInfo>(1).unwrap();
         assert_eq!(variants.next().unwrap().unwrap(), variant);
         assert!(variants.next().is_none());

--- a/crates/mast-package/src/debug_info/types.rs
+++ b/crates/mast-package/src/debug_info/types.rs
@@ -62,7 +62,7 @@ pub enum DebugInfoTableRemapError {
     InvalidOptionField {
         context: &'static str,
         #[source]
-        err: InvalidOptionCError,
+        err: InvalidOptionalIndexError,
     },
     /// A type row refers to a string that is not present in the source string table.
     #[error(
@@ -98,7 +98,7 @@ pub enum DebugInfoMergeError<Exec: Idx, Src: Idx> {
         forest_index: usize,
         context: &'static str,
         #[source]
-        err: InvalidOptionCError,
+        err: InvalidOptionalIndexError,
     },
     /// The package has source-keyed metadata rows without a source graph to define source IDs.
     #[error("debug info for forest {forest_index} has source-map rows but no source graph")]
@@ -262,19 +262,19 @@ impl SourceNodeIdMarker for DebugSourceNodeId {}
     zerocopy::IntoBytes,
     zerocopy::KnownLayout,
 )]
-pub struct OptionC<T: Idx> {
+pub struct OptionalIndex<T: Idx> {
     raw: [u32; 2],
     marker: PhantomData<fn() -> T>,
 }
 
-impl<T: Idx> Default for OptionC<T> {
+impl<T: Idx> Default for OptionalIndex<T> {
     #[inline(always)]
     fn default() -> Self {
         Self::none()
     }
 }
 
-impl<T: Idx> OptionC<T> {
+impl<T: Idx> OptionalIndex<T> {
     fn none() -> Self {
         Self { raw: [0, 0], marker: PhantomData }
     }
@@ -307,25 +307,14 @@ impl<T: Idx> OptionC<T> {
     /// Convert this value into an [`Option<T>`] without panicking if the underlying discriminant
     /// is out of range.
     #[inline(always)]
-    pub fn try_into_option(self) -> Result<Option<T>, InvalidOptionCError> {
+    pub fn try_into_option(self) -> Result<Option<T>, InvalidOptionalIndexError> {
         self.try_into()
-    }
-
-    pub(super) fn from_raw_parts(discriminant: u32, payload: u32) -> Self {
-        Self {
-            raw: [discriminant, payload],
-            marker: PhantomData,
-        }
-    }
-
-    pub(super) fn into_raw_parts(self) -> (u32, u32) {
-        (self.raw[0], self.raw[1])
     }
 }
 
-impl<T: Idx> Eq for OptionC<T> {}
+impl<T: Idx> Eq for OptionalIndex<T> {}
 
-impl<T: Idx> PartialEq for OptionC<T> {
+impl<T: Idx> PartialEq for OptionalIndex<T> {
     fn eq(&self, other: &Self) -> bool {
         match (self.raw[0], other.raw[0]) {
             (0, 0) => true,
@@ -336,7 +325,7 @@ impl<T: Idx> PartialEq for OptionC<T> {
     }
 }
 
-impl<T: Idx> core::fmt::Debug for OptionC<T> {
+impl<T: Idx> core::fmt::Debug for OptionalIndex<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self.raw[0] {
             0 => write!(f, "None"),
@@ -346,7 +335,7 @@ impl<T: Idx> core::fmt::Debug for OptionC<T> {
     }
 }
 
-impl<T: Idx> From<Option<T>> for OptionC<T> {
+impl<T: Idx> From<Option<T>> for OptionalIndex<T> {
     fn from(value: Option<T>) -> Self {
         match value {
             Some(t) => Self::some(t),
@@ -357,15 +346,15 @@ impl<T: Idx> From<Option<T>> for OptionC<T> {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("invalid optional value - discriminant tag of {0} is invalid (expected 0 or 1)")]
-pub struct InvalidOptionCError(u32);
+pub struct InvalidOptionalIndexError(u32);
 
-impl<T: Idx> TryFrom<OptionC<T>> for Option<T> {
-    type Error = InvalidOptionCError;
-    fn try_from(value: OptionC<T>) -> Result<Self, Self::Error> {
+impl<T: Idx> TryFrom<OptionalIndex<T>> for Option<T> {
+    type Error = InvalidOptionalIndexError;
+    fn try_from(value: OptionalIndex<T>) -> Result<Self, Self::Error> {
         match value.raw[0] {
             0 => Ok(None),
             1 => Ok(Some(T::from(value.raw[1]))),
-            invalid => Err(InvalidOptionCError(invalid)),
+            invalid => Err(InvalidOptionalIndexError(invalid)),
         }
     }
 }
@@ -503,7 +492,7 @@ pub struct DebugSourceAsmOp {
     /// Operation index local to the reduced execution node.
     pub op_idx: u32,
     /// Source location index in the locations table
-    pub location_idx: OptionC<DebugLocIdx>,
+    pub location_idx: OptionalIndex<DebugLocIdx>,
     /// Assembly context name index in the strings table
     pub context_name_idx: DebugStringIdx,
     /// Assembly operation text index in the strings table
@@ -1192,11 +1181,11 @@ pub struct FunctionInfo<N: Idx> {
     /// This links the debug info to the compiled code if `source_node` is unknown
     pub mast_root: Word,
     /// The source occurrance this function is linked to, if known
-    pub source_node: OptionC<N>,
+    pub source_node: OptionalIndex<N>,
     /// Type signature of this function (index into type table, optional)
-    pub type_idx: OptionC<DebugTypeIdx>,
+    pub type_idx: OptionalIndex<DebugTypeIdx>,
     /// Linkage name / mangled name (index into string table, optional)
-    pub linkage_name_idx: OptionC<DebugStringIdx>,
+    pub linkage_name_idx: OptionalIndex<DebugStringIdx>,
     /// Name of the function (index into string table)
     pub name_idx: DebugStringIdx,
     /// File containing this function (index into file table)
@@ -1228,24 +1217,24 @@ impl<N: Idx> FunctionInfo<N> {
         Self {
             source_node: source_node.into(),
             name_idx,
-            linkage_name_idx: OptionC::none(),
+            linkage_name_idx: OptionalIndex::none(),
             file_idx,
             line: line.to_index(),
             column: column.to_index(),
-            type_idx: OptionC::none(),
+            type_idx: OptionalIndex::none(),
             mast_root,
         }
     }
 
     /// Sets the linkage name.
     pub fn with_linkage_name(mut self, linkage_name_idx: DebugStringIdx) -> Self {
-        self.linkage_name_idx = OptionC::some(linkage_name_idx);
+        self.linkage_name_idx = OptionalIndex::some(linkage_name_idx);
         self
     }
 
     /// Sets the type index.
     pub fn with_type(mut self, type_idx: DebugTypeIdx) -> Self {
-        self.type_idx = OptionC::some(type_idx);
+        self.type_idx = OptionalIndex::some(type_idx);
         self
     }
 }
@@ -1603,17 +1592,17 @@ mod tests {
     #[test]
     fn merge_tables_into_rejects_invalid_function_options_before_mutating_target() {
         let (mut invalid_type, function_idx) = debug_info_builder_with_function();
-        invalid_type.debug_info_mut().functions[function_idx].type_idx = OptionC::invalid(2);
+        invalid_type.debug_info_mut().functions[function_idx].type_idx = OptionalIndex::invalid(2);
         let invalid_type = invalid_type.build();
 
         let (mut invalid_linkage, function_idx) = debug_info_builder_with_function();
         invalid_linkage.debug_info_mut().functions[function_idx].linkage_name_idx =
-            OptionC::invalid(3);
+            OptionalIndex::invalid(3);
         let invalid_linkage = invalid_linkage.build();
 
         for (source, expected_context, expected_err) in [
-            (invalid_type, "debug function type", InvalidOptionCError(2)),
-            (invalid_linkage, "debug function linkage name", InvalidOptionCError(3)),
+            (invalid_type, "debug function type", InvalidOptionalIndexError(2)),
+            (invalid_linkage, "debug function linkage name", InvalidOptionalIndexError(3)),
         ] {
             let mut target = PackageDebugInfoBuilder::default();
             target.add_string("existing target string");
@@ -1646,7 +1635,7 @@ mod tests {
     #[test]
     fn merge_source_debug_rejects_invalid_function_source_option() {
         let (mut source, function_idx) = debug_info_builder_with_function();
-        source.debug_info_mut().functions[function_idx].source_node = OptionC::invalid(4);
+        source.debug_info_mut().functions[function_idx].source_node = OptionalIndex::invalid(4);
         let source = source.build();
 
         let error = PackageDebugInfo::merge_source_debug(
@@ -1660,7 +1649,7 @@ mod tests {
             DebugInfoMergeError::InvalidOptionField {
                 forest_index: 0,
                 context: "debug function source node",
-                err: InvalidOptionCError(4),
+                err: InvalidOptionalIndexError(4),
             },
         );
     }
@@ -1685,7 +1674,7 @@ mod tests {
         let context_name_idx = source.add_string("context");
         let op_name_idx = source.add_string("add");
         let mut asm_op = DebugSourceAsmOp::new(0, None, context_name_idx, op_name_idx, 1);
-        asm_op.location_idx = OptionC::invalid(5);
+        asm_op.location_idx = OptionalIndex::invalid(5);
         let mut node = source_node(block, Vec::new(), 0, 1);
         node.asm_ops.push(asm_op);
         source.add_node(node).unwrap();
@@ -1699,7 +1688,7 @@ mod tests {
             DebugInfoMergeError::InvalidOptionField {
                 forest_index: 0,
                 context: "debug source assembly op location",
-                err: InvalidOptionCError(5),
+                err: InvalidOptionalIndexError(5),
             },
         );
     }

--- a/crates/mast-package/src/debug_info/types.rs
+++ b/crates/mast-package/src/debug_info/types.rs
@@ -16,7 +16,7 @@
 //! variable inspection, stepping, and call stack visualization.
 
 use alloc::{sync::Arc, vec::Vec};
-use core::{mem::MaybeUninit, num::NonZeroU32};
+use core::{marker::PhantomData, num::NonZeroU32};
 
 use miden_assembly_syntax::ast::{DebugVarInfo, DebugVarLocation, TypeExpr, types::Type};
 use miden_core::{Word, mast::MastNodeId, operations::AssemblyOp};
@@ -177,6 +177,9 @@ pub enum DebugInfoMergeError<Exec: Idx, Src: Idx> {
 }
 
 newtype_id!(
+    #[derive(
+        zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes, zerocopy::KnownLayout,
+    )]
     /// A strongly-typed index into the strings table of [`PackageDebugInfo`].
     ///
     /// This prevents accidental misuse of raw `u32` indices (e.g., using a string index
@@ -185,6 +188,9 @@ newtype_id!(
 );
 
 newtype_id!(
+    #[derive(
+        zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes, zerocopy::KnownLayout,
+    )]
     /// A strongly-typed index into the type table of [`PackageDebugInfo`].
     ///
     /// This prevents accidental misuse of raw `u32` indices (e.g., using a string index
@@ -193,6 +199,9 @@ newtype_id!(
 );
 
 newtype_id!(
+    #[derive(
+        zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes, zerocopy::KnownLayout,
+    )]
     /// A strongly-typed index into the sources table of [`PackageDebugInfo`].
     ///
     /// This prevents accidental misuse of raw `u32` indices (e.g., using a string index
@@ -201,6 +210,9 @@ newtype_id!(
 );
 
 newtype_id!(
+    #[derive(
+        zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes, zerocopy::KnownLayout,
+    )]
     /// A strongly-typed index into the functions table of [`PackageDebugInfo`].
     ///
     /// This prevents accidental misuse of raw `u32` indices (e.g., using a string index
@@ -209,6 +221,9 @@ newtype_id!(
 );
 
 newtype_id!(
+    #[derive(
+        zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes, zerocopy::KnownLayout,
+    )]
     /// A strongly-typed index into the locations table of [`PackageDebugInfo`].
     ///
     /// This prevents accidental misuse of raw `u32` indices (e.g., using a string index
@@ -217,6 +232,9 @@ newtype_id!(
 );
 
 newtype_id!(
+    #[derive(
+        zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes, zerocopy::KnownLayout,
+    )]
     /// A strongly-typed index into the assembly source nodes table of [`PackageDebugInfo`].
     ///
     /// This prevents accidental misuse of raw `u32` indices (e.g., using a string index
@@ -234,50 +252,44 @@ impl SourceNodeIdMarker for DebugSourceNodeId {}
 /// A custom `Option<T>` type that has a stable memory layout
 ///
 /// This type is meant to be converted to/from an `Option<T>` for actual use
-#[repr(C)]
-pub struct OptionC<T> {
-    discriminant: u32,
-    payload: MaybeUninit<T>,
+#[repr(transparent)]
+#[derive(
+    Copy,
+    Clone,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::IntoBytes,
+    zerocopy::KnownLayout,
+)]
+pub struct OptionC<T: Idx> {
+    raw: [u32; 2],
+    marker: PhantomData<fn() -> T>,
 }
 
-impl<T> Default for OptionC<T> {
+impl<T: Idx> Default for OptionC<T> {
     #[inline(always)]
     fn default() -> Self {
         Self::none()
     }
 }
 
-impl<T> OptionC<T> {
-    const fn none() -> Self {
+impl<T: Idx> OptionC<T> {
+    fn none() -> Self {
+        Self { raw: [0, 0], marker: PhantomData }
+    }
+
+    fn some(value: T) -> Self {
         Self {
-            discriminant: 0,
-            payload: MaybeUninit::zeroed(),
+            raw: [1, value.into()],
+            marker: PhantomData,
         }
     }
 
-    const fn some(value: T) -> Self {
+    #[cfg(test)]
+    fn invalid(discriminant: u32) -> Self {
         Self {
-            discriminant: 1,
-            payload: MaybeUninit::new(value),
-        }
-    }
-
-    const fn invalid(discriminant: u32) -> Self {
-        Self {
-            discriminant,
-            payload: MaybeUninit::zeroed(),
-        }
-    }
-
-    /// Get an [`Option<&T>`] from this value.
-    ///
-    /// NOTE: This function will panic if the discriminant tag is invalid, you must use
-    /// `try_into_option` to obtain a non-panicking equivalent.
-    pub fn as_ref(&self) -> Option<&T> {
-        match self.discriminant {
-            0 => None,
-            1 => Some(unsafe { self.payload() }),
-            _ => panic!("attempted to unwrap invalid {}", core::any::type_name::<Self>()),
+            raw: [discriminant, 0],
+            marker: PhantomData,
         }
     }
 
@@ -298,54 +310,42 @@ impl<T> OptionC<T> {
         self.try_into()
     }
 
-    /// Get a reference to the payload value of this option.
-    ///
-    /// This function will panic if:
-    ///
-    /// * The discriminant tag is invalid
-    /// * The discriminant is `None`
-    unsafe fn payload(&self) -> &T {
-        assert_eq!(self.discriminant, 1, "attempted to access payload of None/Invalid variant");
-        unsafe { MaybeUninit::assume_init_ref(&self.payload) }
-    }
-}
-
-impl<T: Copy> Copy for OptionC<T> {}
-
-impl<T: Clone> Clone for OptionC<T> {
-    fn clone(&self) -> Self {
-        match self.discriminant {
-            0 => Self::none(),
-            1 => Self::some(unsafe { self.payload() }.clone()),
-            invalid => Self::invalid(invalid),
+    pub(super) fn from_raw_parts(discriminant: u32, payload: u32) -> Self {
+        Self {
+            raw: [discriminant, payload],
+            marker: PhantomData,
         }
     }
+
+    pub(super) fn into_raw_parts(self) -> (u32, u32) {
+        (self.raw[0], self.raw[1])
+    }
 }
 
-impl<T: Eq> Eq for OptionC<T> {}
+impl<T: Idx> Eq for OptionC<T> {}
 
-impl<T: PartialEq> PartialEq for OptionC<T> {
+impl<T: Idx> PartialEq for OptionC<T> {
     fn eq(&self, other: &Self) -> bool {
-        match (self.discriminant, other.discriminant) {
+        match (self.raw[0], other.raw[0]) {
             (0, 0) => true,
             (1, 0) | (0, 1) => false,
-            (1, 1) => unsafe { self.payload().eq(other.payload()) },
+            (1, 1) => self.raw[1] == other.raw[1],
             (invalid1, invalid2) => invalid1 == invalid2,
         }
     }
 }
 
-impl<T: core::fmt::Debug> core::fmt::Debug for OptionC<T> {
+impl<T: Idx> core::fmt::Debug for OptionC<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self.discriminant {
+        match self.raw[0] {
             0 => write!(f, "None"),
-            1 => f.debug_tuple("Some").field(unsafe { self.payload() }).finish(),
+            1 => f.debug_tuple("Some").field(&T::from(self.raw[1])).finish(),
             invalid => write!(f, "Invalid(discriminant={invalid})"),
         }
     }
 }
 
-impl<T: Copy> From<Option<T>> for OptionC<T> {
+impl<T: Idx> From<Option<T>> for OptionC<T> {
     fn from(value: Option<T>) -> Self {
         match value {
             Some(t) => Self::some(t),
@@ -358,12 +358,12 @@ impl<T: Copy> From<Option<T>> for OptionC<T> {
 #[error("invalid optional value - discriminant tag of {0} is invalid (expected 0 or 1)")]
 pub struct InvalidOptionCError(u32);
 
-impl<T> TryFrom<OptionC<T>> for Option<T> {
+impl<T: Idx> TryFrom<OptionC<T>> for Option<T> {
     type Error = InvalidOptionCError;
     fn try_from(value: OptionC<T>) -> Result<Self, Self::Error> {
-        match value.discriminant {
+        match value.raw[0] {
             0 => Ok(None),
-            1 => Ok(Some(unsafe { MaybeUninit::assume_init(value.payload) })),
+            1 => Ok(Some(T::from(value.raw[1]))),
             invalid => Err(InvalidOptionCError(invalid)),
         }
     }
@@ -373,7 +373,20 @@ impl<T> TryFrom<OptionC<T>> for Option<T> {
 // ================================================================================================
 
 /// Trusted package-owned debug information decoded from well-known debug sections.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::IntoBytes,
+    zerocopy::KnownLayout,
+)]
 #[repr(C)]
 pub struct DebugLoc {
     pub file_idx: DebugFileIdx,
@@ -473,7 +486,17 @@ impl<Exec: Idx, Src: Idx> SourceNode<Exec, Src> {
 }
 
 /// Assembly operation metadata keyed by a source/debug MAST occurrence.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::IntoBytes,
+    zerocopy::KnownLayout,
+)]
 #[repr(C)]
 pub struct DebugSourceAsmOp {
     /// Operation index local to the reduced execution node.
@@ -559,7 +582,17 @@ pub struct DebugSourceInlineCall {
 // ================================================================================================
 
 /// Assertion error message keyed by its runtime error code.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::IntoBytes,
+    zerocopy::KnownLayout,
+)]
 #[repr(C)]
 pub struct DebugErrorMessage {
     /// Runtime error code emitted by the assembled assertion operation.
@@ -1084,7 +1117,17 @@ fn checked_align_up_usize(value: usize, alignment: usize) -> Option<usize> {
 /// When `directory_idx` is set, `path_idx` would be a relative path; otherwise `path_idx`
 /// is expected to be absolute. This would allow sharing common directory prefixes across
 /// multiple files.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(
+    Debug,
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::IntoBytes,
+    zerocopy::KnownLayout,
+)]
 #[repr(C)]
 pub struct DebugFileInfo {
     /// Full path to the source file (index into string table).

--- a/crates/mast-package/src/debug_info/types.rs
+++ b/crates/mast-package/src/debug_info/types.rs
@@ -249,9 +249,10 @@ impl SourceNodeIdMarker for DebugSourceNodeId {}
 // STABLE OPTION TYPE
 // ================================================================================================
 
-/// A custom `Option<T>` type that has a stable memory layout
+/// An optional index with a stable, fully initialized memory layout.
 ///
-/// This type is meant to be converted to/from an `Option<T>` for actual use
+/// The first `u32` is the discriminant: zero means `None`, one means `Some`, and other values are
+/// invalid. The second `u32` holds the index payload and is initialized for every discriminant.
 #[repr(transparent)]
 #[derive(
     Copy,

--- a/crates/mast-package/src/package/error.rs
+++ b/crates/mast-package/src/package/error.rs
@@ -3,7 +3,7 @@ use alloc::string::String;
 use miden_core::serde::DeserializationError;
 
 use super::section::SectionId;
-use crate::debug_info::InvalidOptionCError;
+use crate::debug_info::InvalidOptionalIndexError;
 
 /// Errors raised while stripping package-owned debug information.
 #[derive(Debug, thiserror::Error)]
@@ -48,7 +48,7 @@ pub enum PackageDebugInfoError {
     #[error("invalid optional field discriminant for {context}: {err}")]
     InvalidOptionField {
         #[source]
-        err: InvalidOptionCError,
+        err: InvalidOptionalIndexError,
         context: String,
     },
 }

--- a/miden-core-fuzz/Cargo.lock
+++ b/miden-core-fuzz/Cargo.lock
@@ -864,6 +864,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "thiserror",
+ "zerocopy",
 ]
 
 [[package]]
@@ -944,6 +945,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "thiserror",
+ "zerocopy",
 ]
 
 [[package]]


### PR DESCRIPTION
PR #3398 casts fixed debug info tables between bytes and Rust rows. The casts accept any `Copy` type. `Copy` does not ensure that every byte pattern is valid or that every byte may be read, so each row needs a manual safety check.

The shared string table and fast decoding from #3398 are unchanged. Simple rows now derive `zerocopy::FromBytes`, `IntoBytes`, `Immutable`, and `KnownLayout`. `DebugFunctionInfo` uses a separate wire row because its field elements need validation. `OptionC` stores two initialized `u32` values instead of a `MaybeUninit<T>` payload. The four remaining unsafe operations only manage the aligned byte allocation.

Unsafe code occurrences in `debug_info/serialization.rs` and `debug_info/types.rs` fall from 20 to 4.

`OptionC` was added by #3398. In this branch, it is limited to `Idx` types and `as_ref` is removed. All current uses are index values, and `miden-protocol` does not call `as_ref`.

The roundtrip tests pass. A deterministic debug info fixture also has the same serialized bytes on #3398 and this branch.

We measured `PackageDebugInfo::read_from_bytes` and `Package::debug_info()`. The second measurement matches the benchmark in the #3398 summary. The patches and full command are in the [benchmark gist](https://gist.github.com/huitseeker/a361a9e5e8e6848db8d26a254179366e).

```bash
MIDEN_DEBUG_INFO_BENCH_SECONDS=15 \
  cargo bench --profile optimized \
  --bench deserialize_core_lib_debug_info -- --noplot
```

| Revision | `read_from_bytes` | `Package::debug_info()` |
| --- | ---: | ---: |
| `main` at `f7d8549000` | 17.924 ms | 18.406 ms |
| PR #3398 at `962d427284` | 0.521 ms | 1.475 ms |
| This change at `d029cf4336` | 0.532 ms | 1.472 ms |

On `Package::debug_info()`, #3398 and this change are both about 92% faster than
`main`. The central estimate for this change was 0.2% lower than #3398. Its
`read_from_bytes` estimate was 2.2% higher.

The speedup from #3398 remains without the broad raw memory casts. This result
does not tell us how much of that speedup comes from string interning.