### PR TITLE
Prepare to release imported crypto crates as 0.28.2 and show package errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - [BREAKING] Add dead-node elimination in ACE DAG ([#3408](https://github.com/0xMiden/miden-vm/pull/3408)).
 - [BREAKING] Removed unused public APIs and narrowed test-only helper visibility across VM and crypto crates ([#3424](https://github.com/0xMiden/miden-vm/pull/3424)).
 - [BREAKING] Bump Plonky3 related dependencies to integrate SVE2 and WASM-SIMD128 speed-ups and include a NEON bugfix. ([#3441](https://github.com/0xMiden/miden-vm/pull/3441)).
+- Bumped the imported crypto crates to 0.28.2 after the standalone crypto repository published different 0.28.1 package contents, and raised the minimum `p3-field` version to match `num-bigint` 0.5.
 
 #### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "assert_matches",
  "blake3",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "miden-field",
  "quote",
@@ -2312,7 +2312,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "miden-field",
  "p3-air",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "criterion",
  "miden-lifted-air",
@@ -2591,7 +2591,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-bn254",
  "p3-field",

--- a/crates/crypto-derive/Cargo.toml
+++ b/crates/crypto-derive/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "miden-crypto-derive"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.28.1"
+version = "0.28.2"
 
 [lib]
 doctest    = false

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-crypto"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.28.1"
+version = "0.28.2"
 
 [[bin]]
 bench             = false

--- a/crates/field/Cargo.toml
+++ b/crates/field/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-field"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.28.1"
+version = "0.28.2"
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/lifted-air/Cargo.toml
+++ b/crates/lifted-air/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-lifted-air"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.28.1"
+version = "0.28.2"
 
 [lib]
 doctest = true

--- a/crates/lifted-stark/Cargo.toml
+++ b/crates/lifted-stark/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-lifted-stark"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.28.1"
+version = "0.28.2"
 
 [lib]
 doctest = false

--- a/crates/serde-utils/Cargo.toml
+++ b/crates/serde-utils/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-serde-utils"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.28.1"
+version = "0.28.2"
 
 [features]
 default = ["std"]

--- a/crates/stark-transcript/Cargo.toml
+++ b/crates/stark-transcript/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-stark-transcript"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.28.1"
+version = "0.28.2"
 
 [lib]
 doctest = false

--- a/crates/stateful-hasher/Cargo.toml
+++ b/crates/stateful-hasher/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-stateful-hasher"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.28.1"
+version = "0.28.2"
 
 [lib]
 doctest = false

--- a/scripts/check-package-release-plan.sh
+++ b/scripts/check-package-release-plan.sh
@@ -72,13 +72,14 @@ would_publish=()
 already_published=()
 version_errors=()
 semver_failures=()
+semver_packages=()
+semver_local_versions=()
+semver_latest_versions=()
 
 echo "Package release plan"
 echo
 
 while IFS=$'\t' read -r package local_version manifest_path; do
-    baseline_commit=""
-
     if ! is_selected_package "$package"; then
         continue
     fi
@@ -91,12 +92,16 @@ while IFS=$'\t' read -r package local_version manifest_path; do
     fi
 
     if crate_version_exists "$package" "$local_version"; then
-        if ! package_archive_matches_published "$package" "$local_version" "$workspace_root"; then
-            version_errors+=("$package v$local_version already exists on crates.io, but the local package archive differs from the published crate")
-            continue
+        if package_archive_matches_published "$package" "$local_version" "$workspace_root"; then
+            already_published+=("$package v$local_version (latest published: $latest_version)")
+        else
+            archive_status=$?
+            if [[ "$archive_status" -eq 1 ]]; then
+                version_errors+=("$package v$local_version already exists on crates.io, but the local package archive differs from the published crate")
+            else
+                version_errors+=("$package v$local_version already exists on crates.io, but the local package could not be built and compared with the published crate")
+            fi
         fi
-
-        already_published+=("$package v$local_version (latest published: $latest_version)")
         continue
     fi
 
@@ -106,14 +111,35 @@ while IFS=$'\t' read -r package local_version manifest_path; do
         continue
     fi
 
-    echo "Checking semver for $package v$local_version against published v$latest_version"
-    baseline_commit="$(baseline_commit_for "$package" "$latest_version" || true)"
-    if run_semver_check "$package" "$latest_version" "$workspace_root" "$baseline_commit"; then
-        would_publish+=("$package v$local_version (latest published: $latest_version)")
-    else
-        semver_failures+=("$package v$local_version against published v$latest_version")
-    fi
+    semver_packages+=("$package")
+    semver_local_versions+=("$local_version")
+    semver_latest_versions+=("$latest_version")
 done < <(publishable_packages)
+
+if [[ ${#version_errors[@]} -gt 0 && ${#semver_packages[@]} -gt 0 ]]; then
+    echo
+    echo "Skipping semver checks until package version errors are fixed:"
+    for ((i = 0; i < ${#semver_packages[@]}; i++)); do
+        printf '  - %s v%s against published v%s\n' \
+            "${semver_packages[$i]}" \
+            "${semver_local_versions[$i]}" \
+            "${semver_latest_versions[$i]}"
+    done
+else
+    for ((i = 0; i < ${#semver_packages[@]}; i++)); do
+        package="${semver_packages[$i]}"
+        local_version="${semver_local_versions[$i]}"
+        latest_version="${semver_latest_versions[$i]}"
+
+        echo "Checking semver for $package v$local_version against published v$latest_version"
+        baseline_commit="$(baseline_commit_for "$package" "$latest_version" || true)"
+        if run_semver_check "$package" "$latest_version" "$workspace_root" "$baseline_commit"; then
+            would_publish+=("$package v$local_version (latest published: $latest_version)")
+        else
+            semver_failures+=("$package v$local_version against published v$latest_version")
+        fi
+    done
+fi
 
 echo
 

--- a/scripts/lib/release-plan-common.sh
+++ b/scripts/lib/release-plan-common.sh
@@ -157,39 +157,65 @@ package_archive_matches_published() {
     local package="$1"
     local version="$2"
     local workspace_root="$3"
-    local package_target_dir local_archive published_archive local_dir published_dir
+    local package_target_dir package_log local_archive published_archive local_dir published_dir
+    local diff_output diff_status
 
     check_command "diff"
     check_command "tar"
 
     package_target_dir="$RELEASE_PLAN_TMPDIR/package-target/$package"
+    package_log="$RELEASE_PLAN_TMPDIR/package-logs/$package.log"
     local_archive="$package_target_dir/package/$package-$version.crate"
     published_archive="$RELEASE_PLAN_TMPDIR/published-crates/$package-$version.crate"
     local_dir="$RELEASE_PLAN_TMPDIR/package-compare/$package/local"
     published_dir="$RELEASE_PLAN_TMPDIR/package-compare/$package/published"
+    diff_output="$RELEASE_PLAN_TMPDIR/package-compare/$package/diff.txt"
 
-    mkdir -p "$(dirname "$published_archive")" "$local_dir" "$published_dir"
+    mkdir -p "$(dirname "$package_log")" "$(dirname "$published_archive")" "$local_dir" "$published_dir"
 
-    cargo package \
+    if ! cargo package \
         --manifest-path "$workspace_root/Cargo.toml" \
         --package "$package" \
         --locked \
         --allow-dirty \
         --no-verify \
-        --target-dir "$package_target_dir" >/dev/null
+        --target-dir "$package_target_dir" >"$package_log" 2>&1; then
+        echo "ERROR: failed to package $package v$version for comparison with crates.io:" >&2
+        sed 's/^/  /' "$package_log" >&2
+        return 2
+    fi
 
     if [[ ! -f "$local_archive" ]]; then
         echo "ERROR: cargo package did not create $local_archive" >&2
-        exit 1
+        return 2
     fi
 
     download_published_crate "$package" "$version" "$published_archive"
 
-    tar -xzf "$local_archive" -C "$local_dir"
-    tar -xzf "$published_archive" -C "$published_dir"
+    if ! tar -xzf "$local_archive" -C "$local_dir"; then
+        echo "ERROR: could not extract local archive for $package v$version" >&2
+        return 2
+    fi
+    if ! tar -xzf "$published_archive" -C "$published_dir"; then
+        echo "ERROR: could not extract published archive for $package v$version" >&2
+        return 2
+    fi
 
     find "$local_dir" "$published_dir" -name .cargo_vcs_info.json -delete
-    diff -qr "$local_dir" "$published_dir" >/dev/null
+    if diff -qr "$local_dir" "$published_dir" >"$diff_output"; then
+        return 0
+    else
+        diff_status=$?
+    fi
+
+    if [[ "$diff_status" -ne 1 ]]; then
+        echo "ERROR: could not compare local and published archives for $package v$version" >&2
+        return 2
+    fi
+
+    echo "Package archive differences for $package v$version:" >&2
+    sed 's/^/  /' "$diff_output" >&2
+    return 1
 }
 
 version_cmp() {
@@ -248,7 +274,7 @@ package_has_library_target() {
           | $m.packages[]
           | select(.name == $package and (.id as $id | $m.workspace_members | index($id)))
           | .targets[]
-          | select(.kind | index("lib"))
+          | select(.kind | index("lib") or index("rlib"))
         ' >/dev/null
 }
 
@@ -261,7 +287,7 @@ package_rustdoc_name() {
           | $m.packages[]
           | select(.name == $package and (.id as $id | $m.workspace_members | index($id)))
           | .targets[]
-          | select(.kind | index("lib"))
+          | select(.kind | index("lib") or index("rlib"))
           | .name
           | gsub("-"; "_")
         ' |

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "blake3",
  "cc",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-air",
  "p3-challenger",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-field",
  "p3-symmetric",

--- a/tools/miden-crypto-fuzz/Cargo.lock
+++ b/tools/miden-crypto-fuzz/Cargo.lock
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "blake3",
  "cc",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "quote",
  "syn",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-air",
  "p3-challenger",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-field",
  "p3-symmetric",

--- a/tools/miden-serde-utils-fuzz/Cargo.lock
+++ b/tools/miden-serde-utils-fuzz/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -34,9 +34,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -46,30 +46,29 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
  "getrandom",
  "libc",
@@ -77,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -102,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -119,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -147,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "p3-challenger"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272b2cfdcd3cf1affeab292aa7888ed7e4c156e0d5ffc19612c86553941db178"
+checksum = "84d5d5e1ecf2c80b09b48ce870e8abd08b643454101c5dc9d0fd71bfbd78224d"
 dependencies = [
  "p3-field",
  "p3-maybe-rayon",
@@ -161,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "p3-dft"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc420990b39aa4cdb78ac248d5defe97f760c1056aeceb160dcf3e62baf4eb7"
+checksum = "4321a952da2721ecd85ca593ea189798dfb4e439a2cc1378ce1442091880f173"
 dependencies = [
  "itertools",
  "p3-field",
@@ -176,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "p3-field"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab37408c6c964e7e18c2305a15e31bc784aa20eb82eb513b4850aaa13ee445d3"
+checksum = "53db75d38e04fc255826f388eca9d05976733dc9754aa3db411bc9ea1a37c1a0"
 dependencies = [
  "itertools",
  "num-bigint",
@@ -192,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "p3-goldilocks"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf8c89d8e833f93c488bd207786cd2d525a9f93de7f00363bca5652c88110a4"
+checksum = "d03b3f31080df31be723b876709246f8f1e532e1c5b82efb5281d705c8304c63"
 dependencies = [
  "num-bigint",
  "p3-challenger",
@@ -208,13 +207,14 @@ dependencies = [
  "paste",
  "rand",
  "serde",
+ "spin",
 ]
 
 [[package]]
 name = "p3-matrix"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c5e32dd61fa6341f8ce7abe2a97e9c3f8a93d9ea17bf4f675a2f6c987b658e"
+checksum = "473eb920c446a6f4536e0d3528fbdca2a23c0e24e1d0d7767452e6d385dd335c"
 dependencies = [
  "itertools",
  "p3-field",
@@ -227,15 +227,15 @@ dependencies = [
 
 [[package]]
 name = "p3-maybe-rayon"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c17330c94d04221bafe310d2c13afedd9d26bb57a63ec088b68b6cfe64b357"
+checksum = "e6fddfd435f96394769414cf5590b77058aa506659bf20d6592e9d1989e04440"
 
 [[package]]
 name = "p3-mds"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ea6f54d4436d44f14841f78238b79199b83ea983a4a2fa3c4d16202f28f119"
+checksum = "551ba0ab2cccd89f85a99450224898aff224e323bbf61f777ba6344f0896ef10"
 dependencies = [
  "p3-dft",
  "p3-field",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "p3-monty-31"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d3acd0d5f0ba2e8a1c903e80c92e778368b68c2e551a6c30fc3982a4be023e"
+checksum = "871f635f7340cd0868b17e43e0c98fefdafdaed90469d0725caf6d8372a2a47c"
 dependencies = [
  "itertools",
  "num-bigint",
@@ -270,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon1"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cccfe593f85f87681f885c32f1447ea7afe12b3c9b11b4149c4534edacacb51"
+checksum = "8d0d304e9a1f29c0d66534aa84e69528e2118351fdce08dcf5898af4e0fecc32"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "p3-poseidon2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d28bb6596f38c493d7a590e3b7d30eae86cbcfc325fb44f652ec3540933bcaa0"
+checksum = "43eb8a73a26d14becaed1c67c3e8a047e4311d7909b402383c82ca9643ba17c6"
 dependencies = [
  "p3-field",
  "p3-mds",
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "p3-symmetric"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284db1f284c4007eeb65cef4656426c93192af9bd9703b7f3afbf7faab274500"
+checksum = "2015ea80cad969b6aabf27a04884286fe1354393b166d968ee0d80a95126b2a4"
 dependencies = [
  "itertools",
  "p3-field",
@@ -307,12 +307,11 @@ dependencies = [
 
 [[package]]
 name = "p3-util"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f241f0faa735a03b1af8c923b4728a9fac5e4a26e573a087656c354a784dfcae"
+checksum = "6c5466fc40e6df89d3b291a2eff16b33e68e8571207790370137ec18090aadab"
 dependencies = [
  "serde",
- "transpose",
 ]
 
 [[package]]
@@ -329,27 +328,27 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -374,9 +373,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -384,22 +383,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -410,24 +409,29 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "spin"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5231412d905519dca6a5deb0327d407be68d6c941feec004533401d3a0a715"
+checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
-name = "strength_reduce"
-version = "0.2.4"
+name = "syn"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -453,7 +457,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -463,32 +467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 
 [[package]]
-name = "transpose"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
-dependencies = [
- "num-integer",
- "strength_reduce",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"


### PR DESCRIPTION
PR #3366 moved eight crypto crates into this repo at version 0.28.1. The crypto repo then changed `num-bigint` to 0.5 in `91c38b0`. It published its crates as 0.28.1 in `bcdc585` and later refreshed the serde fuzz lockfile in `3f7063d`. PR #3441 brought most of the dependency update into this repo, but the local 0.28.1 packages still differ from the files on crates.io.

[The gate failed while rebuilding `miden-crypto` 0.28.1 for comparison](https://github.com/0xMiden/miden-vm/actions/runs/30613635210/job/91101771149). Cargo selected the published `miden-field` 0.28.1, which does not have the `arbitrary` feature used by the local crate. All eight 0.28.1 versions are already published, so the corrected packages need version 0.28.2.

This PR brings the remaining crypto changes into miden-vm. It raises all eight imported crates to 0.28.2. It also updates the three fuzz lockfiles.

The package gate now checks versions and archives _before_ running semver checks. It prints Cargo package errors and the files that differ between archives. It also checks `rlib` crates such as `miden-field`.

The full release plan passes with `cargo-semver-checks`. `make check-fuzz` also passes. A replay of the 0.28.1 failure now prints the dependency error and the final summary.
