### PR TITLE
fix(lifted-stark): restore public fixture constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 
 #### Fixes
 
+- Restored public `miden-lifted-stark` testing constants to preserve compatibility with version 0.28.1.
 - [BREAKING] Bound MMR peak commitments to the leaf count by hashing `[num_leaves, 0, 0, 0] || padded_peaks`, and updated the core library `mmr::pack`/`mmr::unpack` procedures to use the same preimage ([#3388](https://github.com/0xMiden/miden-vm/pull/3388)).
 - Documented the program-entrypoint locals invariant on `Procedure::set_num_locals` and now assert it at that AST mutation site, so setting locals on an executable module's `begin`..`end` block panics at the producer boundary. The existing assembler assertion is retained as a backstop for entrypoints built directly via `Procedure::new` ([#3382](https://github.com/0xMiden/miden-vm/pull/3382)).
 - Validated `SectionId` on deserialization: `Section::read_from()` now rejects invalid identifiers and the `serde` path delegates to `FromStr`, keeping both readers on the same invariant ([#3277](https://github.com/0xMiden/miden-vm/pull/3277)).

--- a/crates/lifted-stark/src/testing/airs/keccak.rs
+++ b/crates/lifted-stark/src/testing/airs/keccak.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use miden_lifted_air::{Air, BaseAir, LiftedAir, LiftedAirBuilder};
 use p3_field::{Field, PrimeField64};
-use p3_keccak_air::{KeccakAir, NUM_KECCAK_COLS};
+use p3_keccak_air::{KeccakAir, NUM_KECCAK_COLS, NUM_ROUNDS};
 use p3_matrix::{Matrix, dense::RowMajorMatrix};
 
 /// [`KeccakAir`] adapted for the lifted STARK prover.
@@ -61,3 +61,6 @@ impl<F: PrimeField64, EF: Field> LiftedAir<F, EF> for LiftedKeccakAir {
 pub fn generate_keccak_trace<F: PrimeField64>(inputs: Vec<[u64; 25]>) -> RowMajorMatrix<F> {
     p3_keccak_air::generate_trace_rows(inputs, 0)
 }
+
+/// The number of trace rows per Keccak-f permutation (24 rounds).
+pub const ROWS_PER_HASH: usize = NUM_ROUNDS;

--- a/crates/lifted-stark/src/testing/airs/miden.rs
+++ b/crates/lifted-stark/src/testing/airs/miden.rs
@@ -11,6 +11,21 @@ use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::{Matrix, dense::RowMajorMatrix};
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Main trace width for the first (shorter) trace.
+pub const TRACE1_WIDTH: usize = 51;
+/// Main trace width for the second (taller) trace.
+pub const TRACE2_WIDTH: usize = 20;
+/// Log₂ height of the first trace (2^18 = 262144 rows).
+pub const TRACE1_LOG_HEIGHT: u8 = 18;
+/// Log₂ height of the second trace (2^19 = 524288 rows).
+pub const TRACE2_LOG_HEIGHT: u8 = 19;
+/// Number of extension-field auxiliary columns.
+pub const NUM_AUX_COLS: usize = 8;
+
+// ---------------------------------------------------------------------------
 // AIR definition
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This follows https://github.com/0xMiden/miden-vm/pull/3428 and #3424 and #3442. It reverts some semver breaking changes from #3424 so that the next release of crypto can be 0.28.2 and not 0.29.0, so that the node gets access to the APIs they have been pining for since https://github.com/0xMiden/crypto/pull/1057.