### PR TITLE
ci: preserve baseline Blake3 benchmark harness

### DIFF
--- a/.github/workflows/blake3-nonregression.yml
+++ b/.github/workflows/blake3-nonregression.yml
@@ -327,25 +327,28 @@ jobs:
           git worktree add --detach "${WORKTREE_DIR}/baseline" "${BASELINE_SHA}"
           git worktree add --detach "${WORKTREE_DIR}/current" "${CURRENT_SHA}"
 
-      - name: Install current Blake3 benchmark harness
+      - name: Install missing Blake3 benchmark harness
         env:
           WORKTREE_DIR: ${{ steps.dirs.outputs.worktree_dir }}
         shell: bash
         run: |
           set -euo pipefail
 
-          install_harness() {
+          install_harness_if_missing() {
             local target="$1"
-            mkdir -p "${target}/benches"
-            rm -rf "${target}/benches/blake3-bench"
-            cp -R "${GITHUB_WORKSPACE}/benches/blake3-bench" "${target}/benches/blake3-bench"
+            # Keep the ref's harness because it may target a different public API.
+            if [[ ! -f "${target}/benches/blake3-bench/Cargo.toml" ]]; then
+              mkdir -p "${target}/benches"
+              cp -R "${GITHUB_WORKSPACE}/benches/blake3-bench" "${target}/benches/blake3-bench"
+            fi
+
             if ! grep -q '"benches/blake3-bench"' "${target}/Cargo.toml"; then
               perl -0pi -e 's/members = \[\n/members = [\n    "benches\/blake3-bench",\n/' "${target}/Cargo.toml"
             fi
           }
 
-          install_harness "${WORKTREE_DIR}/baseline"
-          install_harness "${WORKTREE_DIR}/current"
+          install_harness_if_missing "${WORKTREE_DIR}/baseline"
+          install_harness_if_missing "${WORKTREE_DIR}/current"
 
       - name: Run baseline benchmark
         env:


### PR DESCRIPTION
## Describe your changes

Preserve each benchmark ref's existing Blake3 harness, and install the current harness only when the selected ref predates it. This prevents the non-regression workflow from compiling a baseline against a harness written for a newer public API.

This fixes the deterministic baseline build failure in https://github.com/0xMiden/miden-vm/actions/runs/30693565170. The harness difference between d02eb7adc and 752e8dea7 is limited to the untimed proof-validation call; the measured benchmark paths are unchanged.

## Validation

- Simulated the install step with baseline d02eb7adc and current 752e8dea7 and confirmed both harnesses were preserved.
- Confirmed the fallback installs the harness for a ref that predates it.
- Ran cargo check -p miden-vm-blake3-bench --lib against both refs.
- Parsed the workflow YAML and checked the staged diff.

## Checklist before requesting a review

- Branch created from next.
- Commit message and style follow repository conventions.
- No changelog entry: this only fixes CI benchmark setup.