### PR TITLE
fix: bump midenc-hir-type for serde 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ miden-core-lib          = { path = "./crates/lib/core", version = "0.29", defaul
 miden-serde-utils       = { path = "./crates/serde-utils", version = "0.29", default-features = false }
 miden-stark-transcript  = { path = "./crates/stark-transcript", version = "0.29", default-features = false }
 miden-stateful-hasher   = { path = "./crates/stateful-hasher", version = "0.29", default-features = false }
-midenc-hir-type         = { path = "./crates/midenc-hir-type", version = "0.9.1", default-features = false }
+midenc-hir-type         = { path = "./crates/midenc-hir-type", version = "0.10", default-features = false }
 miden-utils-core-derive = { path = "./crates/utils-core-derive", version = "0.29", default-features = false }
 miden-utils-diagnostics = { path = "./crates/utils-diagnostics", version = "0.29", default-features = false }
 miden-utils-indexing    = { path = "./crates/utils-indexing", version = "0.29", default-features = false }

--- a/crates/midenc-hir-type/Cargo.toml
+++ b/crates/midenc-hir-type/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-type"
 description = "Type system and utilities for Miden HIR"
-version = "0.9.1"
+version = "0.10.0"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",


### PR DESCRIPTION
## Workspace dry-runs fail

midenc-hir-type 0.9.1 was published with a dependency on miden-serde-utils 0.28. Workspace builds on next masked that dependency because the local *path* crate inherited miden-serde-utils 0.29.

_Release dry-runs_ exclude the published 0.9.1 crate and resolve it from crates.io. That gives miden-mast-package incompatible 0.28 and 0.29 serialization trait identities.

## THis PR

This bumps midenc-hir-type to 0.10.0 so release verification stages a crate built against miden-serde-utils 0.29. The minor bump reflects the public serialization trait change.