### PR TITLE
fix: Split core and precompiles into separate MASM packages

### DIFF
--- a/.github/workflows/workspace-dry-run.yml
+++ b/.github/workflows/workspace-dry-run.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Build core.masp
+      - name: Build MASM packages
         run: |
           make packages
 

--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -198,21 +198,24 @@ jobs:
            miden-vm-${{ matrix.target }} \
            miden-format-${{ matrix.target }} \
            miden-registry-${{ matrix.target }}
-      # Since the core.masp package is triplet independent, we only build it once.
-      - name: Build core.masp
+      # Since the MASM packages are triplet independent, we only build them once.
+      - name: Build MASM packages
         if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
         run: |
           make packages
-      - name: Prepare artifact
+      - name: Prepare MASM package artifacts
         if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
         run: |
           mv target/packages/miden-core.masp core.masp
-      - name: Attest core.masp
+          mv target/packages/miden-precompiles.masp precompiles.masp
+      - name: Attest MASM packages
         if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: core.masp
-      - name: Upload core.masp
+          subject-path: |
+            core.masp
+            precompiles.masp
+      - name: Upload MASM packages
         if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
         env:
           RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
@@ -221,7 +224,7 @@ jobs:
           set -euo pipefail
           # Reruns are safe after partial artifact upload: --clobber replaces
           # existing draft assets instead of failing on "already exists".
-          gh release upload --clobber "${RELEASE_TAG}" core.masp
+          gh release upload --clobber "${RELEASE_TAG}" core.masp precompiles.masp
 
   publish:
     name: publish workspace crates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.28.1 (Unreleased)
+
+#### Fixes
+
+- [BREAKING] Split the synthetic core MASM package into separate `miden-core` and `miden-precompiles` packages, leaving the bare `miden` namespace available for sibling packages such as `miden-protocol` ([#3459](https://github.com/0xMiden/miden-vm/pull/3459)).
+
 ## v0.28.0 (2026-08-01)
 
 #### Features

--- a/crates/lib/core/README.md
+++ b/crates/lib/core/README.md
@@ -9,9 +9,10 @@ The goals of Miden core library are:
 
 The second goal can be achieved because calls to procedures in the core library can always be serialized as 32 bytes, regardless of how large the procedure is.
 
-`CoreLibrary` also bundles precompile-backed verification support used internally by core wrappers,
-so users do not need any separate precompile-package wiring for standard Miden programs. Users
-should call the stable facades under `miden::core::*`.
+`CoreLibrary` provides separate `miden-core` and `miden-precompiles` MASM packages. Keeping their
+`miden::core` and `miden::precompiles` namespaces in separate packages leaves the parent `miden`
+namespace available to other packages. Use `CoreLibrary::packages()` when both packages should be
+linked, and call the stable facades under `miden::core::*`.
 
 Generated core-library MASM can be inspected locally:
 

--- a/crates/lib/core/build.rs
+++ b/crates/lib/core/build.rs
@@ -19,7 +19,7 @@ const ASM_DIR_PATH: &str = "asm";
 const PRECOMPILES_ASM_DIR_PATH: &str = "precompiles/asm";
 const ASL_DIR_PATH: &str = "assets";
 const DOC_DIR_PATH: &str = "docs";
-const AGGREGATE_ASM_DIR: &str = "aggregate-masm";
+const BUILD_PROJECTS_DIR: &str = "masm-projects";
 
 // MARKDOWN RENDERER
 // ================================================================================================
@@ -198,35 +198,38 @@ fn reexport_target_docs(
 // PRE-PROCESSING
 // ================================================================================================
 
-fn prepare_aggregate_project(
+fn prepare_project(
     build_dir: &Path,
-    core_asm_dir: &Path,
-    precompiles_asm_dir: &Path,
+    project_name: &str,
+    namespace: &str,
+    source_dir: &Path,
+    dependencies: &str,
 ) -> Result<PathBuf, Report> {
-    let aggregate_dir = build_dir.join(AGGREGATE_ASM_DIR);
-    match fs::remove_dir_all(&aggregate_dir) {
+    let project_dir = build_dir.join(BUILD_PROJECTS_DIR).join(project_name);
+    match fs::remove_dir_all(&project_dir) {
         Ok(()) => {},
         Err(err) if err.kind() == io::ErrorKind::NotFound => {},
         Err(err) => {
             return Err(Report::msg(format!(
-                "failed to clear aggregate MASM directory `{}`: {err}",
-                aggregate_dir.display()
+                "failed to clear MASM project directory `{}`: {err}",
+                project_dir.display()
             )));
         },
     }
 
-    fs::create_dir_all(&aggregate_dir).into_diagnostic()?;
+    fs::create_dir_all(&project_dir).into_diagnostic()?;
     fs::write(
-        aggregate_dir.join("miden-project.toml"),
+        project_dir.join("miden-project.toml"),
         format!(
             r#"[package]
-name = "miden-core"
+name = "{project_name}"
 version = "{}"
 
 [lib]
-namespace = "miden"
+namespace = "{namespace}"
 path = "mod.masm"
 
+{dependencies}
 [profile.release]
 # Always produce debug information, as it can be stripped later by the VM
 debug = true
@@ -237,15 +240,10 @@ trim_paths = true
         ),
     )
     .into_diagnostic()?;
-    fs::write(aggregate_dir.join("mod.masm"), "pub mod core\npub mod precompiles\n")
-        .into_diagnostic()?;
 
-    copy_masm_tree(core_asm_dir, &aggregate_dir.join("core"))?;
-    copy_masm_tree(precompiles_asm_dir, &aggregate_dir.join("precompiles"))?;
-    miden_core_lib_codegen::masm::write_math_masm(aggregate_dir.join("precompiles"))
-        .map_err(Report::msg)?;
+    copy_masm_tree(source_dir, &project_dir)?;
 
-    Ok(aggregate_dir)
+    Ok(project_dir)
 }
 
 fn copy_masm_tree(source_dir: &Path, target_dir: &Path) -> Result<(), Report> {
@@ -269,10 +267,11 @@ fn copy_masm_tree(source_dir: &Path, target_dir: &Path) -> Result<(), Report> {
     Ok(())
 }
 
-/// Read and parse the aggregate core/precompiles sources into a package, serializing it into the
-/// `assets` folder as the `miden-core` package.
+/// Assemble the core and precompiles sources as separate packages and serialize both into the
+/// `assets` folder.
 fn main() -> Result<(), Report> {
     use miden_assembly::diagnostics::reporting::ReportHandlerOpts;
+    use miden_package_registry::PackageCache;
 
     // re-build the `[OUT_DIR]/assets/core.masp` file iff core-library MASM sources,
     // generated core-library MASM, or the builder changed:
@@ -293,23 +292,45 @@ fn main() -> Result<(), Report> {
     // Enable debug tracing to stderr via the MIDEN_LOG environment variable, if present
     env_logger::Builder::from_env("MIDEN_LOG").format_timestamp(None).init();
 
-    // Build the aggregate core library package.
+    // Build the precompiles package first so that the core package can resolve its dynamic
+    // dependency against the exact embedded artifact.
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let asm_dir = Path::new(manifest_dir).join(ASM_DIR_PATH);
     let precompiles_asm_dir = Path::new(manifest_dir).join(PRECOMPILES_ASM_DIR_PATH);
     let build_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let aggregate_dir = prepare_aggregate_project(&build_dir, &asm_dir, &precompiles_asm_dir)?;
+    let precompiles_project = prepare_project(
+        &build_dir,
+        "miden-precompiles",
+        "miden::precompiles",
+        &precompiles_asm_dir,
+        "",
+    )?;
+    miden_core_lib_codegen::masm::write_math_masm(&precompiles_project).map_err(Report::msg)?;
 
     let assembler = Assembler::default();
     let mut registry = miden_package_registry::InMemoryPackageRegistry::default();
-    let mut project_assembler =
-        assembler.for_project_at_path(aggregate_dir.join("miden-project.toml"), &mut registry)?;
+    let mut project_assembler = assembler
+        .clone()
+        .for_project_at_path(precompiles_project.join("miden-project.toml"), &mut registry)?;
+    let precompiles_package =
+        project_assembler.assemble(miden_assembly::ProjectTargetSelector::Library, "release")?;
+    precompiles_package
+        .write_masp_file(build_dir.join(ASL_DIR_PATH))
+        .into_diagnostic()?;
+    registry.cache_package(precompiles_package).into_diagnostic()?;
 
-    let package =
+    let core_dependencies = format!(
+        "[dependencies]\nmiden-precompiles = {{ version = \"{}\", linkage = \"dynamic\" }}\n",
+        env!("CARGO_PKG_VERSION")
+    );
+    let core_project =
+        prepare_project(&build_dir, "miden-core", "miden::core", &asm_dir, &core_dependencies)?;
+    let mut project_assembler =
+        assembler.for_project_at_path(core_project.join("miden-project.toml"), &mut registry)?;
+    let core_package =
         project_assembler.assemble(miden_assembly::ProjectTargetSelector::Library, "release")?;
 
-    // write the masp output
-    package.write_masp_file(build_dir.join(ASL_DIR_PATH)).into_diagnostic()?;
+    core_package.write_masp_file(build_dir.join(ASL_DIR_PATH)).into_diagnostic()?;
 
     // Generate documentation
     if env::var("MIDEN_BUILD_LIB_DOCS").is_ok() {

--- a/crates/lib/core/codegen/src/templates/curve.masm.tpl
+++ b/crates/lib/core/codegen/src/templates/curve.masm.tpl
@@ -4,7 +4,6 @@
 
 use miden::precompiles
 use miden::precompiles::fields::{{BASE_FIELD_MODULE}}
-use miden::core::word
 
 # {{TITLE}} CURVE PRECOMPILE SUPPORT WRAPPERS
 # ================================================================================================
@@ -302,7 +301,7 @@ pub proc is_eq
     # => [RHS_DIGEST, LHS_VALUE_DIGEST, ...]
     exec.eval_digest
     # => [RHS_VALUE_DIGEST, LHS_VALUE_DIGEST, ...]
-    exec.word::eq
+    exec.precompiles::word_eq
     # => [is_equal, ...]
 end
 
@@ -314,7 +313,7 @@ pub proc is_eq_digest
     # => [EXPR_DIGEST, TARGET_DIGEST, ...]
     exec.eval_digest
     # => [VALUE_DIGEST, TARGET_DIGEST, ...]
-    exec.word::eq
+    exec.precompiles::word_eq
     # => [is_equal, ...]
 end
 
@@ -352,7 +351,7 @@ pub proc assert_not_identity
     # => [VALUE_DIGEST, ...]
     push.IDENTITY_DIGEST
     # => [IDENTITY_DIGEST, VALUE_DIGEST, ...]
-    exec.word::eq
+    exec.precompiles::word_eq
     # => [is_identity, ...]
     assertz
 end

--- a/crates/lib/core/codegen/src/templates/uint.masm.tpl
+++ b/crates/lib/core/codegen/src/templates/uint.masm.tpl
@@ -3,7 +3,6 @@
 # Regenerate with: {{REGENERATE_COMMAND}}
 
 use miden::precompiles
-use miden::core::word
 
 # {{TITLE}} {{DOMAIN_KIND}} PRECOMPILE SUPPORT WRAPPERS
 # ================================================================================================
@@ -164,12 +163,12 @@ pub proc is_eq
     # Compare the two {{VALUE_KIND}} values one word at a time, consuming each compared pair.
     movupw.2
     # => [LHS_LO, RHS_LO, RHS_HI, LHS_HI, ...]
-    exec.word::eq
+    exec.precompiles::word_eq
     # => [lo_equal, RHS_HI, LHS_HI, ...]
 
     movdn.8
     # => [RHS_HI, LHS_HI, lo_equal, ...]
-    exec.word::eq
+    exec.precompiles::word_eq
     # => [hi_equal, lo_equal, ...]
     and
     # => [is_equal, ...]
@@ -256,7 +255,7 @@ pub proc is_eq_digest
     exec.precompiles::log_deferred
     # => [VALUE_DIGEST, TARGET_DIGEST, ...]
 
-    exec.word::eq
+    exec.precompiles::word_eq
     # => [is_equal, ...]
 end
 

--- a/crates/lib/core/precompiles/asm/mod.masm
+++ b/crates/lib/core/precompiles/asm/mod.masm
@@ -11,12 +11,35 @@ pub mod u256
 # Framework data tag used for generic CHUNKS nodes: Tag::CHUNKS = [2, 0, 0, 0].
 const CHUNKS_TAG = [2, 0, 0, 0]
 
+#! Returns whether two words are equal, consuming both words.
+#!
+#! This helper keeps generated precompile modules independent of `miden-core`. Importing
+#! `miden::core::word::eq` here would create a dependency cycle because `miden-core` dynamically
+#! depends on `miden-precompiles`.
+#!
+#! Inputs:  [RHS, LHS]
+#! Outputs: [is_equal]
+#!
+#! Where:
+#! - RHS is the first word to compare.
+#! - LHS is the second word to compare.
+#! - is_equal is one if the words are equal, and zero otherwise.
+#!
+#! Invocation: exec
+pub proc word_eq
+    movup.4 eq swap
+    movup.4 eq and swap
+    movup.3 eq and
+    movdn.2 eq and
+end
+
 # ===== DEFERRED-DAG HELPERS =======================================================================
 #
 # NOTE: `register_value`, `register_mem`, and `log_deferred` are adapted from `miden::core::sys`
 # (crates/lib/core/asm/sys/mod.masm) so the internal `miden::precompiles` support namespace can be
-# assembled inside the aggregate core package. They should be deduplicated against a single shared
-# source once the precompile proof-model migration settles.
+# assembled without depending on `miden-core`. This keeps the package dependency one-way because
+# `miden-core` depends on `miden-precompiles`. These helpers should be deduplicated against a single
+# shared source once the precompile proof-model migration settles.
 #
 # `register_value` / `register_mem` bind their registration inputs by deriving the node digest with
 # VM instructions from the exact same tag and payload. There is intentionally no `evaluate` proc

--- a/crates/lib/core/src/bin/generate-package.rs
+++ b/crates/lib/core/src/bin/generate-package.rs
@@ -8,11 +8,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         .map(PathBuf::from)
         .expect("expected the output path as the first argument");
 
-    if let Some(parent) = output_path.parent() {
-        fs::create_dir_all(parent)?;
-    }
+    let output_dir = output_path.parent().expect("output path must have a parent directory");
+    fs::create_dir_all(output_dir)?;
     fs::write(&output_path, CoreLibrary::SERIALIZED)?;
+    let precompiles_output_path = output_dir.join("miden-precompiles.masp");
+    fs::write(&precompiles_output_path, CoreLibrary::PRECOMPILES_SERIALIZED)?;
 
     println!("wrote miden-core.masp to {}", output_path.display());
+    println!("wrote miden-precompiles.masp to {}", precompiles_output_path.display());
     Ok(())
 }

--- a/crates/lib/core/src/lib.rs
+++ b/crates/lib/core/src/lib.rs
@@ -43,11 +43,10 @@ use crate::handlers::{
 
 /// The Miden core library, providing a set of optimized procedures for Miden programs.
 ///
-/// This library wraps a [`Package`] containing highly-optimized and battle-tested implementations
-/// of commonly-used primitives. When the core library is dynamically linked during assembly time,
-/// procedures can be called from any Miden program and are serialized as 32 bytes, reducing the
-/// amount of code that needs to be shared between parties for proving and verifying program
-/// execution.
+/// This library wraps the `miden-core` [`Package`] and its `miden-precompiles` runtime dependency.
+/// When the core library is dynamically linked during assembly time, procedures can be called from
+/// any Miden program and are serialized as 32 bytes, reducing the amount of code that needs to be
+/// shared between parties for proving and verifying program execution.
 ///
 /// # Contents
 ///
@@ -71,9 +70,10 @@ use crate::handlers::{
 /// use miden_core_lib::CoreLibrary;
 ///
 /// let core_lib = CoreLibrary::default();
-/// let assembler = Assembler::new(source_manager)
-///     .with_package(core_lib.package(), Linkage::Dynamic)
-///     .unwrap();
+/// let mut assembler = Assembler::new(source_manager);
+/// for package in core_lib.packages() {
+///     assembler.link_package(package, Linkage::Dynamic).unwrap();
+/// }
 /// ```
 ///
 /// For program execution, you'll also need to register the event handlers:
@@ -91,18 +91,22 @@ use crate::handlers::{
 ///
 /// [`Package`]: miden_mast_package::Package
 #[derive(Clone)]
-pub struct CoreLibrary(Arc<Package>);
+pub struct CoreLibrary {
+    core_package: Arc<Package>,
+    precompiles_package: Arc<Package>,
+    mast_forest: Arc<MastForest>,
+}
 
 impl AsRef<Package> for CoreLibrary {
     fn as_ref(&self) -> &Package {
-        &self.0
+        &self.core_package
     }
 }
 
 impl From<&CoreLibrary> for HostLibrary {
     fn from(core_lib: &CoreLibrary) -> Self {
         Self {
-            mast_forest: core_lib.mast_forest().clone(),
+            mast_forest: Arc::clone(core_lib.mast_forest()),
             package_debug_info: Ok(None),
             handlers: core_lib.handlers(),
         }
@@ -114,14 +118,29 @@ impl CoreLibrary {
     pub const SERIALIZED: &'static [u8] =
         include_bytes!(concat!(env!("OUT_DIR"), "/assets/miden-core.masp"));
 
-    /// Returns a reference to the [MastForest] underlying the Miden core library.
+    /// Serialized representation of the `miden-precompiles` package used by the core library.
+    pub const PRECOMPILES_SERIALIZED: &'static [u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/assets/miden-precompiles.masp"));
+
+    /// Returns a reference to the merged [MastForest] used to execute the core library and its
+    /// precompiles dependency.
     pub fn mast_forest(&self) -> &Arc<MastForest> {
-        self.0.mast_forest()
+        &self.mast_forest
     }
 
-    /// Returns a reference to the underlying [`Arc<Package>`].
+    /// Returns the `miden-core` package.
     pub fn package(&self) -> Arc<Package> {
-        self.0.clone()
+        Arc::clone(&self.core_package)
+    }
+
+    /// Returns the `miden-precompiles` package required by `miden-core`.
+    pub fn precompiles_package(&self) -> Arc<Package> {
+        Arc::clone(&self.precompiles_package)
+    }
+
+    /// Returns the core package followed by its precompiles dependency.
+    pub fn packages(&self) -> [Arc<Package>; 2] {
+        [self.package(), self.precompiles_package()]
     }
 
     /// Returns the MAST root of `sys::vm::verify_vm_proof` — the verifier identity under
@@ -132,7 +151,7 @@ impl CoreLibrary {
     /// in-VM with `procref` — a procedure's root is intrinsic to its own MAST — so the two sides
     /// agree without a shared constant; consumers key their proof fetches by this root.
     pub fn recursive_verifier_root(&self) -> Word {
-        self.0
+        self.core_package
             .get_procedure_root_by_path("::miden::core::sys::vm::verify_vm_proof")
             .expect("verify_vm_proof is exported from the core library")
     }
@@ -167,9 +186,25 @@ impl CoreLibrary {
 impl Default for CoreLibrary {
     fn default() -> Self {
         static CORELIB: LazyLock<CoreLibrary> = LazyLock::new(|| {
-            let contents = Package::read_from_bytes_trusted(CoreLibrary::SERIALIZED)
-                .expect("failed to read core package!");
-            CoreLibrary(Arc::new(contents))
+            let core_package = Arc::new(
+                Package::read_from_bytes_trusted(CoreLibrary::SERIALIZED)
+                    .expect("failed to read core package!"),
+            );
+            let precompiles_package = Arc::new(
+                Package::read_from_bytes_trusted(CoreLibrary::PRECOMPILES_SERIALIZED)
+                    .expect("failed to read precompiles package!"),
+            );
+            let (mast_forest, _) = MastForest::merge([
+                core_package.mast_forest().as_ref(),
+                precompiles_package.mast_forest().as_ref(),
+            ])
+            .expect("failed to merge core and precompiles MAST forests");
+
+            CoreLibrary {
+                core_package,
+                precompiles_package,
+                mast_forest: Arc::new(mast_forest),
+            }
         });
         CORELIB.clone()
     }
@@ -185,22 +220,24 @@ mod tests {
     #[test]
     fn core_package_version_matches_crate_version() {
         let core_lib = CoreLibrary::default();
-        let package = core_lib.package();
         let crate_version = env!("CARGO_PKG_VERSION")
             .parse::<miden_mast_package::Version>()
             .expect("crate version should be a valid package version");
 
-        assert_eq!(
-            &package.version, &crate_version,
-            "embedded core package version should track the miden-core-lib crate version",
-        );
+        for package in core_lib.packages() {
+            assert_eq!(
+                &package.version, &crate_version,
+                "embedded package {} should track the miden-core-lib crate version",
+                package.name,
+            );
+        }
     }
 
     #[test]
     fn test_compile() {
         let core_lib = CoreLibrary::default();
         let exists = core_lib
-            .0
+            .core_package
             .get_procedure_root_by_path("::miden::core::math::u64::overflowing_add")
             .is_some();
 

--- a/crates/lib/core/tests/crypto/dsa.rs
+++ b/crates/lib/core/tests/crypto/dsa.rs
@@ -19,7 +19,8 @@ use miden_processor::{
 use miden_utils_testing::crypto::Poseidon2;
 use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 
-const VERIFY_EXPECTED_CYCLES: u64 = 1_453;
+// Core invokes the separately packaged precompile wrappers through dynamic MAST calls.
+const VERIFY_EXPECTED_CYCLES: u64 = 1_587;
 const VERIFY_EXPECTED_WIRE_ENTRIES: usize = 36;
 const VERIFY_EXPECTED_WIRE_BYTES: usize = 2_455;
 

--- a/crates/lib/core/tests/crypto/hashes.rs
+++ b/crates/lib/core/tests/crypto/hashes.rs
@@ -81,9 +81,10 @@ fn core_hash_wrapper_cycle_baselines() {
     let short = b"core hash compatibility";
 
     let mut mismatches = Vec::new();
+    // Core invokes the separately packaged precompile wrappers through dynamic MAST calls.
     for (name, source, expected) in [
-        ("core_keccak_hash", cycle_fixed_hash_source("keccak256", &input), 212),
-        ("core_keccak_merge", cycle_merge_source("keccak256", &left, &right), 232),
+        ("core_keccak_hash", cycle_fixed_hash_source("keccak256", &input), 221),
+        ("core_keccak_merge", cycle_merge_source("keccak256", &left, &right), 238),
         ("core_keccak_hash_bytes_short", cycle_hash_bytes_source("keccak256", short), 248),
     ] {
         let output =

--- a/crates/lib/core/tests/main.rs
+++ b/crates/lib/core/tests/main.rs
@@ -8,6 +8,7 @@ macro_rules! build_test {
         let source = $source;
         miden_utils_testing::build_test_by_mode!(false, source $(, $tail)*)
             .with_library(core_lib.package())
+            .with_library(core_lib.precompiles_package())
             .with_event_handlers(core_lib.handlers())
     }}
 }
@@ -20,6 +21,7 @@ macro_rules! build_debug_test {
         let source = $source;
         miden_utils_testing::build_test_by_mode!(true, source $(, $tail)*)
             .with_library(core_lib.package())
+            .with_library(core_lib.precompiles_package())
             .with_event_handlers(core_lib.handlers())
     }}
 }
@@ -122,19 +124,21 @@ fn core_library_exports_crypto_wrappers() {
 }
 
 #[test]
-fn core_library_package_exports_core_and_internal_precompiles() {
+fn core_and_precompiles_are_separate_packages() {
+    use miden_assembly::Path;
     use miden_core_lib::CoreLibrary;
 
     let core_lib = CoreLibrary::default();
-    let package = core_lib.package();
+    let core_package = core_lib.package();
+    let precompiles_package = core_lib.precompiles_package();
 
     for path in [
         "::miden::core::math::u64::overflowing_add",
         "::miden::core::crypto::hashes::sha256::hash",
     ] {
         assert!(
-            package.get_procedure_root_by_path(path).is_some(),
-            "{path} must be exported by aggregate corelib",
+            core_package.get_procedure_root_by_path(path).is_some(),
+            "{path} must be exported by miden-core",
         );
     }
 
@@ -143,10 +147,59 @@ fn core_library_package_exports_core_and_internal_precompiles() {
         "::miden::precompiles::hashes::keccak256::hash_bytes_mem",
     ] {
         assert!(
-            package.get_procedure_root_by_path(path).is_some(),
-            "{path} must be bundled in aggregate corelib for internal wrapper tests",
+            core_package.get_procedure_root_by_path(path).is_none(),
+            "{path} must not be exported by miden-core",
+        );
+        assert!(
+            precompiles_package.get_procedure_root_by_path(path).is_some(),
+            "{path} must be exported by miden-precompiles",
         );
     }
+
+    for package in [&core_package, &precompiles_package] {
+        assert!(
+            package.manifest.get_module(Path::new("::miden")).is_none(),
+            "package {} must not declare the bare miden namespace",
+            package.name,
+        );
+    }
+
+    let dependencies = core_package.manifest.dependencies().collect::<Vec<_>>();
+    assert_eq!(dependencies.len(), 1, "miden-core must have one MASM package dependency");
+    assert_eq!(dependencies[0].name, precompiles_package.name);
+    assert_eq!(dependencies[0].version, precompiles_package.version);
+    assert_eq!(dependencies[0].digest, precompiles_package.digest());
+}
+
+#[test]
+fn core_packages_do_not_block_sibling_miden_namespaces() {
+    use std::sync::Arc;
+
+    use miden_assembly::{
+        Assembler, DefaultSourceManager, Linkage,
+        ast::{Module, ModuleKind},
+    };
+    use miden_core_lib::CoreLibrary;
+
+    let source_manager = Arc::new(DefaultSourceManager::default());
+    let protocol_utils = Module::parser(Some(ModuleKind::Library))
+        .parse_str(
+            None,
+            "namespace miden::protocol_utils\npub proc identity push.0 drop end",
+            source_manager.clone(),
+        )
+        .expect("protocol utility module should parse");
+
+    let mut assembler = Assembler::new(source_manager);
+    for package in CoreLibrary::default().packages() {
+        assembler
+            .link_package(package, Linkage::Dynamic)
+            .expect("official Miden packages should link");
+    }
+
+    assembler
+        .assemble_library("miden-protocol-utils", protocol_utils, None::<Box<Module>>)
+        .expect("official packages must not claim the parent of miden::protocol_utils");
 }
 
 #[test]
@@ -156,7 +209,7 @@ fn precompile_semantic_api_is_available_from_precompiles_crate() {
 }
 
 #[test]
-fn core_library_links_precompile_wrappers_without_precompiles_library() {
+fn core_library_links_precompile_wrappers_with_separate_precompiles_package() {
     use miden_assembly::{Assembler, Linkage};
     use miden_core_lib::CoreLibrary;
 
@@ -167,9 +220,14 @@ fn core_library_links_precompile_wrappers_without_precompiles_library() {
         "dropw dropw ",
         "end",
     );
-    Assembler::default()
-        .with_package(CoreLibrary::default().package(), Linkage::Dynamic)
-        .expect("failed to link core library")
+    let core_lib = CoreLibrary::default();
+    let mut assembler = Assembler::default();
+    for package in core_lib.packages() {
+        assembler
+            .link_package(package, Linkage::Dynamic)
+            .expect("failed to link core library package");
+    }
+    assembler
         .assemble_program("core_links_precompile_wrappers", source)
         .expect("failed to assemble program against core precompile wrappers");
 }

--- a/crates/lib/core/tests/precompiles/helpers.rs
+++ b/crates/lib/core/tests/precompiles/helpers.rs
@@ -34,9 +34,13 @@ pub fn run_precompile_program_with_stack(
 ) -> Result<ExecutionOutput, ExecutionError> {
     let stack_inputs = StackInputs::new(stack).expect("invalid precompile test stack inputs");
     let core_lib = CoreLibrary::default();
-    let program = Assembler::default()
-        .with_package(core_lib.package(), Linkage::Dynamic)
-        .expect("failed to link core library")
+    let mut assembler = Assembler::default();
+    for package in core_lib.packages() {
+        assembler
+            .link_package(package, Linkage::Dynamic)
+            .expect("failed to link core library package");
+    }
+    let program = assembler
         .assemble_program("precompile_test", source)
         .expect("failed to assemble precompile test program")
         .unwrap_program();

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -43,6 +43,7 @@ else
         "miden-vm-aarch64-apple-darwin"
         "miden-vm-x86_64-unknown-linux-gnu"
         "core.masp"
+        "precompiles.masp"
     )
 
     missing=0


### PR DESCRIPTION
PR #3222 combined the core and precompile MASM sources into one synthetic package rooted at `::miden`. That root declared only `core` and `precompiles`, so the linker treated every other `miden::*` source module as an undeclared child. In particular, `miden-protocol` could no longer assemble `miden::protocol_utils` after linking `miden-core`. 

This change restores the intended package boundary: `miden-core` owns `miden::core`, while `miden-precompiles` owns `miden::precompiles`, and core records a dynamic dependency on precompiles. 

Separating the artifacts shows the existing reverse dependency which motivated the bundle: generated precompile wrappers imported `miden::core::word`, while core calls precompiles. Precompiles now owns a consuming word equality helper, keeping the package dependency one-way. 