### PR TITLE
Validate and retain DebugInfo from untrusted packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,7 @@
 
 #### Changes
 
-- Validated and retained `DebugInfo` when reading untrusted packages, with bounds and safe handling for hostile data ([#3460](https://github.com/0xMiden/miden-vm/pull/3460)).
+- Validated and retained `DebugInfo` when reading untrusted packages, with bounded decoding for hostile data and an explicit unmetered decoder for analysis ([#3460](https://github.com/0xMiden/miden-vm/pull/3460)).
 
 ## v0.28.0 (2026-08-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@
 - [BREAKING] Split the synthetic core MASM package into separate `miden-core` and `miden-precompiles` packages, leaving the bare `miden` namespace available for sibling packages such as `miden-protocol` ([#3459](https://github.com/0xMiden/miden-vm/pull/3459)).
 - Moved the `miden-precompiles` and `miden-precompiles-prover` crate sources from the repository root into `crates/`, aligning them with the rest of the workspace layout ([#3462](https://github.com/0xMiden/miden-vm/pull/3462)).
 
+#### Changes
+
+- Validated and retained `DebugInfo` when reading untrusted packages, with bounds and safe handling for hostile data ([#3460](https://github.com/0xMiden/miden-vm/pull/3460)).
+
 ## v0.28.0 (2026-08-01)
 
 #### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,6 +2429,7 @@ dependencies = [
 name = "miden-mast-package"
 version = "0.30.0"
 dependencies = [
+ "codspeed-criterion-compat",
  "hashbrown 0.17.1",
  "log",
  "miden-assembly-syntax",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,7 +2431,6 @@ version = "0.30.0"
 dependencies = [
  "codspeed-criterion-compat",
  "hashbrown 0.17.1",
- "log",
  "miden-assembly-syntax",
  "miden-core",
  "miden-debug-types",

--- a/crates/mast-package/Cargo.toml
+++ b/crates/mast-package/Cargo.toml
@@ -36,7 +36,6 @@ miden-utils-indexing.workspace = true
 
 # External dependencies
 hashbrown.workspace = true
-log.workspace = true
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 rustc-hash = { version = "2.1", default-features = false }

--- a/crates/mast-package/Cargo.toml
+++ b/crates/mast-package/Cargo.toml
@@ -17,6 +17,10 @@ edition.workspace = true
 bench = false
 doctest = false
 
+[[bench]]
+name = "package_deserialization"
+harness = false
+
 [features]
 default = ["std"]
 arbitrary = ["std", "dep:proptest", "dep:proptest-derive", "miden-assembly-syntax/arbitrary", "miden-core/arbitrary"]
@@ -41,6 +45,7 @@ thiserror.workspace = true
 zerocopy.workspace = true
 
 [dev-dependencies]
+codspeed-criterion-compat.workspace = true
 miden-assembly-syntax = { workspace = true, features = ["arbitrary"] }
 miden-core = { workspace = true, features = ["arbitrary"] }
 miden-test-serde-macros.workspace = true

--- a/crates/mast-package/benches/package_deserialization.rs
+++ b/crates/mast-package/benches/package_deserialization.rs
@@ -1,0 +1,124 @@
+use std::{hint::black_box, sync::Arc, time::Duration};
+
+use codspeed_criterion_compat as criterion;
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use miden_assembly_syntax::{
+    ast::{
+        Path as AstPath, PathBuf,
+        types::{CallConv, FunctionType, StructType, Type, TypeRepr},
+    },
+    semver::Version,
+};
+use miden_core::{
+    mast::{BasicBlockNodeBuilder, DenseMastForestBuilder, MastNodeExt},
+    operations::Operation,
+    serde::{Deserializable, Serializable},
+};
+use miden_mast_package::{
+    Package, PackageExport, PackageId, ProcedureExport, Section, SectionId, TargetType,
+    debug_info::{DebugSourceAsmOp, DebugSourceNode, PackageDebugInfoBuilder},
+};
+
+fn absolute_path(name: &str) -> Arc<AstPath> {
+    let path = PathBuf::new(name).expect("benchmark path should be valid");
+    let path = path.as_path().to_absolute().unwrap().into_owned();
+    Arc::from(path.into_boxed_path())
+}
+
+fn package_bytes(with_debug_info: bool) -> Vec<u8> {
+    let mut forest_builder = DenseMastForestBuilder::new();
+    let node_id = forest_builder
+        .push_node(BasicBlockNodeBuilder::new(vec![Operation::Add; 128]))
+        .expect("benchmark basic block should be valid");
+    forest_builder.mark_root(node_id);
+    let (forest, remapping) = forest_builder.build_with_id_map().expect("forest should build");
+    let node_id = remapping.get(node_id).expect("benchmark root should be retained");
+
+    let struct_type = StructType::new_with_repr(
+        TypeRepr::align(8),
+        core::iter::repeat_with(|| Type::Felt).take(16),
+    );
+    let signature = FunctionType::new(CallConv::Fast, [Type::from(struct_type)], [Type::Felt]);
+    let export = ProcedureExport::new(
+        absolute_path("bench::deserialize"),
+        Some(node_id),
+        forest[node_id].digest(),
+        Some(signature),
+    );
+    let mut package = Package::create(
+        PackageId::from("benchmark_pkg"),
+        Version::new(0, 0, 0),
+        TargetType::Library,
+        Arc::new(forest),
+        vec![PackageExport::Procedure(export)],
+        None,
+    )
+    .expect("benchmark package should be valid");
+
+    if with_debug_info {
+        let mut debug_info = PackageDebugInfoBuilder::default();
+        let context_name = debug_info.add_string("bench::deserialize");
+        let op_names = (0..128)
+            .map(|index| debug_info.add_string(format!("operation_{index}")))
+            .collect::<Vec<_>>();
+        let source_node = debug_info
+            .add_node(DebugSourceNode {
+                exec_node: node_id,
+                children: Vec::new(),
+                op_start: 0,
+                op_end: 128,
+                asm_ops: op_names
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, op_name)| {
+                        DebugSourceAsmOp::new(index as u32, None, context_name, op_name, 1)
+                    })
+                    .collect(),
+                debug_vars: Vec::new(),
+                inline_calls: Vec::new(),
+            })
+            .expect("benchmark debug node should be valid");
+        debug_info.add_root(source_node);
+        package
+            .sections
+            .push(Section::new(SectionId::DEBUG_INFO, debug_info.build().to_bytes()));
+    }
+
+    package.to_bytes()
+}
+
+fn package_deserialization(c: &mut Criterion) {
+    let without_debug_info = package_bytes(false);
+    let with_debug_info = package_bytes(true);
+    let mut group = c.benchmark_group("package_deserialization");
+    group.warm_up_time(Duration::from_secs(2));
+    group.measurement_time(Duration::from_secs(5));
+    group.sample_size(100);
+
+    group.throughput(Throughput::Bytes(without_debug_info.len() as u64));
+    group.bench_function("untrusted_without_debug_info", |bench| {
+        bench.iter(|| Package::read_from_bytes(black_box(&without_debug_info)).unwrap())
+    });
+    group.bench_function("trusted_without_debug_info", |bench| {
+        bench.iter(|| Package::read_from_bytes_trusted(black_box(&without_debug_info)).unwrap())
+    });
+
+    group.throughput(Throughput::Bytes(with_debug_info.len() as u64));
+    group.bench_function("untrusted_with_debug_info", |bench| {
+        bench.iter(|| Package::read_from_bytes(black_box(&with_debug_info)).unwrap())
+    });
+    group.bench_function("trusted_with_debug_info", |bench| {
+        bench.iter(|| Package::read_from_bytes_trusted(black_box(&with_debug_info)).unwrap())
+    });
+    group.bench_function("trusted_with_debug_info_and_decode", |bench| {
+        bench.iter(|| {
+            let package = Package::read_from_bytes_trusted(black_box(&with_debug_info)).unwrap();
+            black_box(package.debug_info().unwrap())
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, package_deserialization);
+criterion_main!(benches);

--- a/crates/mast-package/benches/package_deserialization.rs
+++ b/crates/mast-package/benches/package_deserialization.rs
@@ -1,7 +1,7 @@
 use std::{hint::black_box, sync::Arc, time::Duration};
 
 use codspeed_criterion_compat as criterion;
-use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use miden_assembly_syntax::{
     ast::{
         Path as AstPath, PathBuf,
@@ -10,13 +10,16 @@ use miden_assembly_syntax::{
     semver::Version,
 };
 use miden_core::{
-    mast::{BasicBlockNodeBuilder, DenseMastForestBuilder, MastNodeExt},
+    mast::{BasicBlockNodeBuilder, DenseMastForestBuilder, MastNodeExt, MastNodeId},
     operations::Operation,
     serde::{Deserializable, Serializable},
 };
 use miden_mast_package::{
     Package, PackageExport, PackageId, ProcedureExport, Section, SectionId, TargetType,
-    debug_info::{DebugSourceAsmOp, DebugSourceNode, PackageDebugInfoBuilder},
+    debug_info::{
+        DebugSourceAsmOp, DebugSourceNode, DebugSourceNodeId, PackageDebugInfo,
+        PackageDebugInfoBuilder,
+    },
 };
 
 fn absolute_path(name: &str) -> Arc<AstPath> {
@@ -120,5 +123,58 @@ fn package_deserialization(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, package_deserialization);
+fn debug_info_with_asm_ops(row_count: usize) -> (Box<PackageDebugInfo>, DebugSourceNodeId) {
+    let mut debug_info = PackageDebugInfoBuilder::default();
+    let context_name = debug_info.add_string("bench::lookup");
+    let op_name = debug_info.add_string("operation");
+    let source_node = debug_info
+        .add_node(DebugSourceNode {
+            exec_node: MastNodeId::new_unchecked(0),
+            children: Vec::new(),
+            op_start: 0,
+            op_end: row_count as u32,
+            asm_ops: (0..row_count)
+                .map(|index| DebugSourceAsmOp::new(index as u32, None, context_name, op_name, 1))
+                .collect(),
+            debug_vars: Vec::new(),
+            inline_calls: Vec::new(),
+        })
+        .expect("benchmark debug node should be valid");
+    debug_info.add_root(source_node);
+    (debug_info.build(), source_node)
+}
+
+fn debug_assembly_lookup(c: &mut Criterion) {
+    let mut group = c.benchmark_group("debug_assembly_lookup");
+    group.warm_up_time(Duration::from_secs(2));
+    group.measurement_time(Duration::from_secs(5));
+    group.sample_size(100);
+
+    for row_count in [16, 1_024, 65_536] {
+        let (debug_info, source_node) = debug_info_with_asm_ops(row_count);
+
+        group.bench_with_input(
+            BenchmarkId::new("linear_scan_control", row_count),
+            &row_count,
+            |bench, _| {
+                bench.iter(|| {
+                    debug_info.source_node(black_box(source_node)).and_then(|node| {
+                        node.asm_ops.iter().rfind(|row| row.op_idx <= black_box(0))
+                    })
+                })
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("public_binary_lookup", row_count),
+            &row_count,
+            |bench, _| {
+                bench.iter(|| debug_info.asm_op_for_operation(black_box(source_node), black_box(0)))
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, package_deserialization, debug_assembly_lookup);
 criterion_main!(benches);

--- a/crates/mast-package/src/debug_info/builder.rs
+++ b/crates/mast-package/src/debug_info/builder.rs
@@ -397,9 +397,10 @@ impl<Exec: Idx, Src: Idx> DebugInfoBuilder<Exec, Src> {
 
 impl<Exec: Idx, Src: Idx> DebugInfoBuilder<Exec, Src> {
     /// Add `node` to the set of sources nodes in the debug info source graph
-    pub fn add_node(&mut self, node: SourceNode<Exec, Src>) -> Result<Src, IndexedVecError> {
+    pub fn add_node(&mut self, mut node: SourceNode<Exec, Src>) -> Result<Src, IndexedVecError> {
         assert!(node.op_end >= node.op_start);
         assert!(node.children.iter().copied().all(|n| self.debug_info.source_node(n).is_some()));
+        node.asm_ops.sort_unstable_by_key(|row| row.op_idx);
         self.debug_info.nodes.push(node)
     }
 

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -26,6 +26,12 @@ type FxHashSet<K> = hashbrown::HashSet<K, rustc_hash::FxBuildHasher>;
 
 pub const DEBUG_INFO_VERSION: u8 = 2;
 
+/// Maximum encoded payload size accepted for package-owned debug information.
+///
+/// Decoding temporarily retains the encoded section, an aligned copy, and decoded table storage,
+/// so this cap bounds peak memory before any package-level validation can run.
+pub const MAX_DEBUG_INFO_PAYLOAD_SIZE: usize = 16 * 1024 * 1024;
+
 // PACKAGE DEBUG INFO
 // ================================================================================================
 

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -468,14 +468,12 @@ impl<Exec: Idx, Src: Idx> DebugInfo<Exec, Src> {
 
     /// Returns the first assembly operation row for `source_node`, if present.
     pub fn first_asm_op_for_source_node(&self, source_node: Src) -> Option<&DebugSourceAsmOp> {
-        self.asm_ops_for_source_node(source_node).min_by_key(|row| row.op_idx)
+        self.source_node(source_node).and_then(|node| node.asm_ops.first())
     }
 
     /// Returns the assembly operation row for `source_node` at or before `op_idx`, if present.
     pub fn asm_op_for_operation(&self, source_node: Src, op_idx: u32) -> Option<&DebugSourceAsmOp> {
-        self.asm_ops_for_source_node(source_node)
-            .filter(|row| row.op_idx <= op_idx)
-            .max_by_key(|row| row.op_idx)
+        self.source_node(source_node).and_then(|node| node.asm_op_for_operation(op_idx))
     }
 
     /// Returns debug variable rows for a source/debug occurrence.

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -44,7 +44,12 @@ pub const MAX_DEBUG_INFO_TYPE_ROWS: usize = 1_000_000;
 // PACKAGE DEBUG INFO
 // ================================================================================================
 
-/// Trusted package-owned debug information decoded from well-known debug sections.
+/// Package-owned debug information decoded from the well-known debug section.
+///
+/// [`PackageDebugInfo::read_from`] and [`PackageDebugInfo::read_from_bytes`] apply fixed resource
+/// limits for potentially adversarial input. Tools that deliberately accept the resource cost of
+/// larger debug information can use [`PackageDebugInfo::read_from_unmetered`] or
+/// [`PackageDebugInfo::read_from_bytes_unmetered`].
 #[cfg_attr(
     all(feature = "arbitrary", test),
     miden_test_serde_macros::serde_test(binary_serde(true), serde_test(false))

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -307,7 +307,9 @@ impl<Exec: Idx, Src: Idx> DebugInfo<Exec, Src> {
             let new_path_idx = if let Some(new_path_idx) = remapped_paths.get(&old_path_idx) {
                 *new_path_idx
             } else {
-                let path = self.strings[old_path_idx].clone();
+                let Some(path) = self.strings.get(old_path_idx).cloned() else {
+                    continue;
+                };
                 let new_path_idx = match trimmer(path.as_ref()) {
                     None => old_path_idx,
                     Some(new_path) => match string_indices.entry(new_path.clone()) {

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -32,6 +32,9 @@ pub const DEBUG_INFO_VERSION: u8 = 2;
 /// so this cap bounds peak memory before any package-level validation can run.
 pub const MAX_DEBUG_INFO_PAYLOAD_SIZE: usize = 16 * 1024 * 1024;
 
+/// Maximum number of rows accepted in the variable-width debug string table.
+pub const MAX_DEBUG_INFO_STRING_ROWS: usize = 100_000;
+
 /// Maximum number of rows accepted in the variable-width debug type table.
 pub const MAX_DEBUG_INFO_TYPE_ROWS: usize = 1_000_000;
 

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -364,7 +364,7 @@ impl<Exec: Idx, Src: Idx> DebugInfo<Exec, Src> {
         self.error_messages
             .iter()
             .find(|row| row.err_code == err_code)
-            .map(|row| self.strings[row.message].clone())
+            .and_then(|row| self.strings.get(row.message).cloned())
     }
 
     /// Returns source/debug occurrence nodes.

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -35,6 +35,9 @@ pub const MAX_DEBUG_INFO_PAYLOAD_SIZE: usize = 16 * 1024 * 1024;
 /// Maximum number of rows accepted in the variable-width debug string table.
 pub const MAX_DEBUG_INFO_STRING_ROWS: usize = 100_000;
 
+/// Maximum encoded byte length accepted for one debug string.
+pub const MAX_DEBUG_INFO_STRING_SIZE: usize = 4 * 1024;
+
 /// Maximum number of rows accepted in the variable-width debug type table.
 pub const MAX_DEBUG_INFO_TYPE_ROWS: usize = 1_000_000;
 

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -400,7 +400,7 @@ impl<Exec: Idx, Src: Idx> DebugInfo<Exec, Src> {
         exec_node: Exec,
     ) -> impl Iterator<Item = (Src, &SourceNode<Exec, Src>)> {
         self.roots.iter().copied().filter_map(move |source_node_id| {
-            let source_node = &self.nodes[source_node_id];
+            let source_node = self.nodes.get(source_node_id)?;
             if source_node.exec_node == exec_node {
                 Some((source_node_id, source_node))
             } else {

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -32,6 +32,9 @@ pub const DEBUG_INFO_VERSION: u8 = 2;
 /// so this cap bounds peak memory before any package-level validation can run.
 pub const MAX_DEBUG_INFO_PAYLOAD_SIZE: usize = 16 * 1024 * 1024;
 
+/// Maximum number of rows accepted in the variable-width debug type table.
+pub const MAX_DEBUG_INFO_TYPE_ROWS: usize = 1_000_000;
+
 // PACKAGE DEBUG INFO
 // ================================================================================================
 

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -347,8 +347,8 @@ impl<Exec: Idx, Src: Idx> DebugInfo<Exec, Src> {
     /// Returns the deduplicated source locations referenced by assembly operation rows.
     pub fn get_location(&self, idx: DebugLocIdx) -> Option<Location> {
         let DebugLoc { file_idx, start, end } = self.locations.get(idx)?;
-        let file = &self.files[*file_idx];
-        let uri = self.strings[file.path_idx].clone();
+        let file = self.files.get(*file_idx)?;
+        let uri = self.strings.get(file.path_idx).cloned()?;
         Some(Location {
             uri: Uri::from(uri),
             start: *start,

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -46,7 +46,8 @@ pub const MAX_DEBUG_INFO_TYPE_ROWS: usize = 1_000_000;
 
 /// Package-owned debug information decoded from the well-known debug section.
 ///
-/// [`PackageDebugInfo::read_from`] and [`PackageDebugInfo::read_from_bytes`] apply fixed resource
+/// The [`miden_core::serde::Deserializable::read_from`] and
+/// [`miden_core::serde::Deserializable::read_from_bytes`] implementations apply fixed resource
 /// limits for potentially adversarial input. Tools that deliberately accept the resource cost of
 /// larger debug information can use [`PackageDebugInfo::read_from_unmetered`] or
 /// [`PackageDebugInfo::read_from_bytes_unmetered`].

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -21,7 +21,7 @@ use super::{
     DebugFunctionIdx, DebugFunctionInfo, DebugLoc, DebugLocIdx, DebugPrimitiveType,
     DebugSourceAsmOp, DebugSourceInlineCall, DebugSourceNode, DebugSourceNodeId, DebugSourceVar,
     DebugStringIdx, DebugTypeIdx, DebugTypeInfo, DebugVariantInfo, MAX_DEBUG_INFO_PAYLOAD_SIZE,
-    OptionalIndex, PackageDebugInfo,
+    MAX_DEBUG_INFO_TYPE_ROWS, OptionalIndex, PackageDebugInfo,
 };
 
 /// Base alignment for copied payloads. The assertions below ensure that this is sufficient for
@@ -137,7 +137,18 @@ impl Deserializable for PackageDebugInfo {
         let locations =
             source.read_pod_rows::<DebugLoc>(locations_len as usize, "debug locations")?;
 
-        let types = IndexVec::read_from_bounded(&mut source, "debug_info types")?;
+        let types_len = read_bounded_len(
+            &mut source,
+            "debug_info types",
+            DebugTypeInfo::min_serialized_size(),
+        )?;
+        if types_len > MAX_DEBUG_INFO_TYPE_ROWS {
+            return Err(DeserializationError::InvalidValue(format!(
+                "debug_info types count {types_len} exceeds limit {MAX_DEBUG_INFO_TYPE_ROWS}"
+            )));
+        }
+        let types = source.read_many_iter(types_len)?.collect::<Result<Vec<DebugTypeInfo>, _>>()?;
+        let types = IndexVec::try_from(types).expect("limited debug type count fits in u32");
 
         let functions_len = source.read_u32()?;
         let functions = source.read_pod_rows_with::<WireDebugFunctionInfo, _, _>(

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -267,6 +267,12 @@ impl Deserializable for DebugSourceNode {
         let asm_ops_len = source.read_u32()? as usize;
         let asm_ops =
             source.read_pod_rows::<DebugSourceAsmOp>(asm_ops_len, "debug assembly operations")?;
+        if let Some(rows) = asm_ops.windows(2).find(|rows| rows[0].op_idx >= rows[1].op_idx) {
+            return Err(DeserializationError::InvalidValue(format!(
+                "debug assembly operation indices are not strictly increasing at {} and {}",
+                rows[0].op_idx, rows[1].op_idx,
+            )));
+        }
 
         let debug_vars = Vec::read_from(&mut source)?;
         let inline_calls = Vec::read_from(&mut source)?;

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -134,23 +134,25 @@ impl Serializable for PackageDebugInfo {
 
 #[cfg(target_endian = "little")]
 impl PackageDebugInfo {
-    /// Deserializes package debug information without the fixed resource limits used for untrusted
-    /// input.
+    /// Reads package debug information without the fixed resource limits enforced by
+    /// [`Self::read_from`].
     ///
-    /// This is intended for analysis and troubleshooting when the caller explicitly accepts the
-    /// allocation cost of the encoded data. It still validates lengths against the reader's
-    /// remaining input and allocation budget, and performs all normal wire-format validity checks.
-    /// Callers can supply a budgeted reader if they need a custom resource limit.
+    /// Use this for data from a trusted producer or in analysis tooling where the caller accepts
+    /// its memory and processing costs. This method still checks the wire format and honors the
+    /// reader's remaining input and allocation budget. Use [`Self::read_from`] for potentially
+    /// adversarial input with the standard fixed limits.
     pub fn read_from_unmetered<R: ByteReader>(
         source: &mut R,
     ) -> Result<Self, DeserializationError> {
         Self::read_from_with_limits(source, PackageDebugInfoDecodeLimits::UNMETERED)
     }
 
-    /// Deserializes package debug information from `bytes` without the fixed resource limits used
-    /// for untrusted input.
+    /// Reads package debug information from `bytes` without the fixed resource limits enforced by
+    /// [`Self::read_from_bytes`].
     ///
-    /// See [`Self::read_from_unmetered`].
+    /// Use this only when the caller accepts the memory and processing costs of the encoded data.
+    /// The wire-format checks described by [`Self::read_from_unmetered`] still apply. Use
+    /// [`Self::read_from_bytes`] for potentially adversarial input with the standard fixed limits.
     pub fn read_from_bytes_unmetered(bytes: &[u8]) -> Result<Self, DeserializationError> {
         Self::read_from_unmetered(&mut miden_core::serde::SliceReader::new(bytes))
     }
@@ -274,8 +276,24 @@ impl PackageDebugInfo {
 
 #[cfg(target_endian = "little")]
 impl Deserializable for PackageDebugInfo {
+    /// Reads package debug information using fixed resource limits for potentially adversarial
+    /// input.
+    ///
+    /// The limits cap the encoded payload, string table, individual strings, and type table. This
+    /// method also performs the normal wire-format checks. Use [`Self::read_from_unmetered`] only
+    /// when the data may exceed those limits and the caller accepts its resource costs.
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         Self::read_from_with_limits(source, PackageDebugInfoDecodeLimits::BOUNDED)
+    }
+
+    /// Reads package debug information from `bytes` using fixed resource limits for potentially
+    /// adversarial input.
+    ///
+    /// This is the byte-slice counterpart to [`Self::read_from`]. Use
+    /// [`Self::read_from_bytes_unmetered`] only when the data may exceed the standard limits and
+    /// the caller accepts its resource costs.
+    fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
+        Self::read_from(&mut miden_core::serde::SliceReader::new(bytes))
     }
 }
 

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -21,7 +21,8 @@ use super::{
     DebugFunctionIdx, DebugFunctionInfo, DebugLoc, DebugLocIdx, DebugPrimitiveType,
     DebugSourceAsmOp, DebugSourceInlineCall, DebugSourceNode, DebugSourceNodeId, DebugSourceVar,
     DebugStringIdx, DebugTypeIdx, DebugTypeInfo, DebugVariantInfo, MAX_DEBUG_INFO_PAYLOAD_SIZE,
-    MAX_DEBUG_INFO_STRING_ROWS, MAX_DEBUG_INFO_TYPE_ROWS, OptionalIndex, PackageDebugInfo,
+    MAX_DEBUG_INFO_STRING_ROWS, MAX_DEBUG_INFO_STRING_SIZE, MAX_DEBUG_INFO_TYPE_ROWS,
+    OptionalIndex, PackageDebugInfo,
 };
 
 /// Base alignment for copied payloads. The assertions below ensure that this is sufficient for
@@ -797,6 +798,11 @@ fn read_wire_felt(value: u64) -> Result<Felt, DeserializationError> {
 
 fn read_string<R: ByteReader>(source: &mut R) -> Result<Arc<str>, DeserializationError> {
     let len = read_bounded_len(source, "debug string bytes", 1)?;
+    if len > MAX_DEBUG_INFO_STRING_SIZE {
+        return Err(DeserializationError::InvalidValue(alloc::format!(
+            "debug string size {len} exceeds limit {MAX_DEBUG_INFO_STRING_SIZE}"
+        )));
+    }
     let bytes = source.read_slice(len)?;
     let s = core::str::from_utf8(bytes).map_err(|err| {
         DeserializationError::InvalidValue(alloc::format!("invalid utf-8 in string: {err}"))

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -21,7 +21,7 @@ use super::{
     DebugFunctionIdx, DebugFunctionInfo, DebugLoc, DebugLocIdx, DebugPrimitiveType,
     DebugSourceAsmOp, DebugSourceInlineCall, DebugSourceNode, DebugSourceNodeId, DebugSourceVar,
     DebugStringIdx, DebugTypeIdx, DebugTypeInfo, DebugVariantInfo, MAX_DEBUG_INFO_PAYLOAD_SIZE,
-    MAX_DEBUG_INFO_TYPE_ROWS, OptionalIndex, PackageDebugInfo,
+    MAX_DEBUG_INFO_STRING_ROWS, MAX_DEBUG_INFO_TYPE_ROWS, OptionalIndex, PackageDebugInfo,
 };
 
 /// Base alignment for copied payloads. The assertions below ensure that this is sufficient for
@@ -127,8 +127,17 @@ impl Deserializable for PackageDebugInfo {
         let aligned = AlignedBytes::copy_from_slice(data, POD_BUFFER_ALIGNMENT)?;
         let mut source = PodSliceReader::new(aligned.as_slice());
 
-        let strings =
-            IndexVec::read_from_bounded_with(&mut source, "debug_info strings", 1, read_string)?;
+        let strings_len = read_bounded_len(&mut source, "debug_info strings", 1)?;
+        if strings_len > MAX_DEBUG_INFO_STRING_ROWS {
+            return Err(DeserializationError::InvalidValue(format!(
+                "debug_info strings count {strings_len} exceeds limit {MAX_DEBUG_INFO_STRING_ROWS}"
+            )));
+        }
+        let mut strings = Vec::new();
+        for _ in 0..strings_len {
+            strings.push(read_string(&mut source)?);
+        }
+        let strings = IndexVec::try_from(strings).expect("limited debug string count fits in u32");
 
         let files_len = source.read_u32()?;
         let files = source.read_pod_rows::<DebugFileInfo>(files_len as usize, "debug files")?;

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -53,6 +53,30 @@ struct WireDebugFunctionInfo {
     column: ColumnIndex,
 }
 
+#[derive(Clone, Copy)]
+struct PackageDebugInfoDecodeLimits {
+    payload_size: usize,
+    string_rows: usize,
+    string_size: usize,
+    type_rows: usize,
+}
+
+impl PackageDebugInfoDecodeLimits {
+    const BOUNDED: Self = Self {
+        payload_size: MAX_DEBUG_INFO_PAYLOAD_SIZE,
+        string_rows: MAX_DEBUG_INFO_STRING_ROWS,
+        string_size: MAX_DEBUG_INFO_STRING_SIZE,
+        type_rows: MAX_DEBUG_INFO_TYPE_ROWS,
+    };
+
+    const UNMETERED: Self = Self {
+        payload_size: usize::MAX,
+        string_rows: usize::MAX,
+        string_size: usize::MAX,
+        type_rows: usize::MAX,
+    };
+}
+
 // PACKAGE DEBUG INFO SERIALIZATION
 // ================================================================================================
 
@@ -109,8 +133,32 @@ impl Serializable for PackageDebugInfo {
 }
 
 #[cfg(target_endian = "little")]
-impl Deserializable for PackageDebugInfo {
-    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+impl PackageDebugInfo {
+    /// Deserializes package debug information without the fixed resource limits used for untrusted
+    /// input.
+    ///
+    /// This is intended for analysis and troubleshooting when the caller explicitly accepts the
+    /// allocation cost of the encoded data. It still validates lengths against the reader's
+    /// remaining input and allocation budget, and performs all normal wire-format validity checks.
+    /// Callers can supply a budgeted reader if they need a custom resource limit.
+    pub fn read_from_unmetered<R: ByteReader>(
+        source: &mut R,
+    ) -> Result<Self, DeserializationError> {
+        Self::read_from_with_limits(source, PackageDebugInfoDecodeLimits::UNMETERED)
+    }
+
+    /// Deserializes package debug information from `bytes` without the fixed resource limits used
+    /// for untrusted input.
+    ///
+    /// See [`Self::read_from_unmetered`].
+    pub fn read_from_bytes_unmetered(bytes: &[u8]) -> Result<Self, DeserializationError> {
+        Self::read_from_unmetered(&mut miden_core::serde::SliceReader::new(bytes))
+    }
+
+    fn read_from_with_limits<R: ByteReader>(
+        source: &mut R,
+        limits: PackageDebugInfoDecodeLimits,
+    ) -> Result<Self, DeserializationError> {
         let version = source.read_u8()?;
         if version != DEBUG_INFO_VERSION {
             return Err(DeserializationError::InvalidValue(format!(
@@ -119,9 +167,10 @@ impl Deserializable for PackageDebugInfo {
         }
 
         let data_len = read_bounded_len(source, "package debug info", 1)?;
-        if data_len > MAX_DEBUG_INFO_PAYLOAD_SIZE {
+        if data_len > limits.payload_size {
             return Err(DeserializationError::InvalidValue(format!(
-                "package debug info payload size {data_len} exceeds limit {MAX_DEBUG_INFO_PAYLOAD_SIZE}"
+                "package debug info payload size {data_len} exceeds limit {}",
+                limits.payload_size,
             )));
         }
         let data = source.read_slice(data_len)?;
@@ -129,16 +178,21 @@ impl Deserializable for PackageDebugInfo {
         let mut source = PodSliceReader::new(aligned.as_slice());
 
         let strings_len = read_bounded_len(&mut source, "debug_info strings", 1)?;
-        if strings_len > MAX_DEBUG_INFO_STRING_ROWS {
+        if strings_len > limits.string_rows {
             return Err(DeserializationError::InvalidValue(format!(
-                "debug_info strings count {strings_len} exceeds limit {MAX_DEBUG_INFO_STRING_ROWS}"
+                "debug_info strings count {strings_len} exceeds limit {}",
+                limits.string_rows,
             )));
         }
         let mut strings = Vec::new();
         for _ in 0..strings_len {
-            strings.push(read_string(&mut source)?);
+            strings.push(read_string(&mut source, limits.string_size)?);
         }
-        let strings = IndexVec::try_from(strings).expect("limited debug string count fits in u32");
+        let strings = IndexVec::try_from(strings).map_err(|_| {
+            DeserializationError::InvalidValue(
+                "debug_info strings count exceeds the u32 index range".into(),
+            )
+        })?;
 
         let files_len = source.read_u32()?;
         let files = source.read_pod_rows::<DebugFileInfo>(files_len as usize, "debug files")?;
@@ -152,13 +206,18 @@ impl Deserializable for PackageDebugInfo {
             "debug_info types",
             DebugTypeInfo::min_serialized_size(),
         )?;
-        if types_len > MAX_DEBUG_INFO_TYPE_ROWS {
+        if types_len > limits.type_rows {
             return Err(DeserializationError::InvalidValue(format!(
-                "debug_info types count {types_len} exceeds limit {MAX_DEBUG_INFO_TYPE_ROWS}"
+                "debug_info types count {types_len} exceeds limit {}",
+                limits.type_rows,
             )));
         }
         let types = source.read_many_iter(types_len)?.collect::<Result<Vec<DebugTypeInfo>, _>>()?;
-        let types = IndexVec::try_from(types).expect("limited debug type count fits in u32");
+        let types = IndexVec::try_from(types).map_err(|_| {
+            DeserializationError::InvalidValue(
+                "debug_info types count exceeds the u32 index range".into(),
+            )
+        })?;
 
         let functions_len = source.read_u32()?;
         let functions = source.read_pod_rows_with::<WireDebugFunctionInfo, _, _>(
@@ -210,6 +269,13 @@ impl Deserializable for PackageDebugInfo {
             roots,
             error_messages,
         })
+    }
+}
+
+#[cfg(target_endian = "little")]
+impl Deserializable for PackageDebugInfo {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        Self::read_from_with_limits(source, PackageDebugInfoDecodeLimits::BOUNDED)
     }
 }
 
@@ -802,11 +868,14 @@ fn read_wire_felt(value: u64) -> Result<Felt, DeserializationError> {
     })
 }
 
-fn read_string<R: ByteReader>(source: &mut R) -> Result<Arc<str>, DeserializationError> {
+fn read_string<R: ByteReader>(
+    source: &mut R,
+    max_size: usize,
+) -> Result<Arc<str>, DeserializationError> {
     let len = read_bounded_len(source, "debug string bytes", 1)?;
-    if len > MAX_DEBUG_INFO_STRING_SIZE {
+    if len > max_size {
         return Err(DeserializationError::InvalidValue(alloc::format!(
-            "debug string size {len} exceeds limit {MAX_DEBUG_INFO_STRING_SIZE}"
+            "debug string size {len} exceeds limit {max_size}"
         )));
     }
     let bytes = source.read_slice(len)?;
@@ -1462,9 +1531,36 @@ mod tests {
         assert!(message.contains("package debug info"));
         assert!(message.contains("exceeds budget"));
 
+        let mut reader = FixedBudgetReader::new(&bytes, 1);
+        let error = PackageDebugInfo::read_from_unmetered(&mut reader).unwrap_err();
+        let DeserializationError::InvalidValue(message) = error else {
+            panic!("expected InvalidValue error");
+        };
+        assert!(message.contains("package debug info"));
+        assert!(message.contains("exceeds budget"));
+
         let mut reader = FixedBudgetReader::new(&bytes, bytes.len());
         let result = PackageDebugInfo::read_from(&mut reader).unwrap();
         assert!(result.nodes().is_empty());
+    }
+
+    #[test]
+    fn unmetered_package_debug_info_decode_ignores_fixed_limits() {
+        let oversized_string = "x".repeat(MAX_DEBUG_INFO_STRING_SIZE + 1);
+        let mut builder = PackageDebugInfoBuilder::default();
+        builder.add_string(oversized_string.clone());
+        let bytes = builder.build().to_bytes();
+
+        let error = PackageDebugInfo::read_from_bytes(&bytes).unwrap_err();
+        let DeserializationError::InvalidValue(message) = error else {
+            panic!("expected InvalidValue error");
+        };
+        assert!(message.contains("debug string size"));
+        assert!(message.contains("exceeds limit"));
+
+        let decoded = PackageDebugInfo::read_from_bytes_unmetered(&bytes).unwrap();
+        assert_eq!(decoded.strings().len(), 1);
+        assert_eq!(decoded.strings()[DebugStringIdx::from(0)].as_ref(), oversized_string);
     }
 
     #[test]

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -20,7 +20,8 @@ use super::{
     DEBUG_INFO_VERSION, DebugErrorMessage, DebugFieldInfo, DebugFileIdx, DebugFileInfo,
     DebugFunctionIdx, DebugFunctionInfo, DebugLoc, DebugLocIdx, DebugPrimitiveType,
     DebugSourceAsmOp, DebugSourceInlineCall, DebugSourceNode, DebugSourceNodeId, DebugSourceVar,
-    DebugStringIdx, DebugTypeIdx, DebugTypeInfo, DebugVariantInfo, OptionalIndex, PackageDebugInfo,
+    DebugStringIdx, DebugTypeIdx, DebugTypeInfo, DebugVariantInfo, MAX_DEBUG_INFO_PAYLOAD_SIZE,
+    OptionalIndex, PackageDebugInfo,
 };
 
 /// Base alignment for copied payloads. The assertions below ensure that this is sufficient for
@@ -117,6 +118,11 @@ impl Deserializable for PackageDebugInfo {
         }
 
         let data_len = read_bounded_len(source, "package debug info", 1)?;
+        if data_len > MAX_DEBUG_INFO_PAYLOAD_SIZE {
+            return Err(DeserializationError::InvalidValue(format!(
+                "package debug info payload size {data_len} exceeds limit {MAX_DEBUG_INFO_PAYLOAD_SIZE}"
+            )));
+        }
         let data = source.read_slice(data_len)?;
         let aligned = AlignedBytes::copy_from_slice(data, POD_BUFFER_ALIGNMENT)?;
         let mut source = PodSliceReader::new(aligned.as_slice());

--- a/crates/mast-package/src/debug_info/types.rs
+++ b/crates/mast-package/src/debug_info/types.rs
@@ -431,10 +431,8 @@ pub struct SourceNode<Exec: Idx, Src: Idx> {
 
 impl<Exec: Idx, Src: Idx> SourceNode<Exec, Src> {
     pub fn asm_op_for_operation(&self, op_idx: u32) -> Option<&DebugSourceAsmOp> {
-        self.asm_ops
-            .iter()
-            .filter(|row| row.op_idx <= op_idx)
-            .max_by_key(|row| row.op_idx)
+        let insertion_index = self.asm_ops.partition_point(|row| row.op_idx <= op_idx);
+        insertion_index.checked_sub(1).and_then(|index| self.asm_ops.get(index))
     }
 
     pub fn debug_vars_for_operation(

--- a/crates/mast-package/src/debug_info/types.rs
+++ b/crates/mast-package/src/debug_info/types.rs
@@ -529,11 +529,15 @@ impl DebugSourceAsmOp {
         }
     }
 
-    pub fn to_assembly_op(&self, debug_info: &PackageDebugInfo) -> AssemblyOp {
-        let location = self.location_idx.into_option().and_then(|loc| debug_info.get_location(loc));
-        let context_name = debug_info[self.context_name_idx].clone();
-        let op = debug_info[self.op_name_idx].clone();
-        AssemblyOp::new(location, context_name, self.num_cycles, op)
+    pub fn to_assembly_op(&self, debug_info: &PackageDebugInfo) -> Option<AssemblyOp> {
+        let location = self
+            .location_idx
+            .try_into_option()
+            .ok()?
+            .and_then(|loc| debug_info.get_location(loc));
+        let context_name = debug_info.get_string(self.context_name_idx)?;
+        let op = debug_info.get_string(self.op_name_idx)?;
+        Some(AssemblyOp::new(location, context_name, self.num_cycles, op))
     }
 }
 

--- a/crates/mast-package/src/debug_info/types.rs
+++ b/crates/mast-package/src/debug_info/types.rs
@@ -450,14 +450,14 @@ impl<Exec: Idx, Src: Idx> SourceNode<Exec, Src> {
         debug_info: &DebugInfo<Exec, Src>,
     ) -> impl Iterator<Item = DebugVarInfo> {
         let mut type_cache = FxHashMap::<DebugTypeIdx, (Type, Option<Arc<TypeExpr>>)>::default();
-        self.debug_vars_for_operation(op_idx).map(move |source_var| {
-            let name = debug_info[source_var.name_idx].clone();
+        self.debug_vars_for_operation(op_idx).filter_map(move |source_var| {
+            let name = debug_info.get_string(source_var.name_idx)?;
             let mut info = DebugVarInfo::new(name, source_var.value_location.clone());
             if let Some(arg_idx) = source_var.arg_idx {
                 info.set_arg_index(arg_idx.get())
             }
             if let Some(loc) = source_var.location_idx {
-                info.set_location(debug_info.get_location(loc).unwrap())
+                info.set_location(debug_info.get_location(loc)?)
             }
             if let Some(tid) = source_var.type_id {
                 if let Some((ty, declared_ty)) = type_cache.get(&tid) {
@@ -470,7 +470,7 @@ impl<Exec: Idx, Src: Idx> SourceNode<Exec, Src> {
                     info.set_ty(ty, declared_type);
                 }
             }
-            info
+            Some(info)
         })
     }
 }

--- a/crates/mast-package/src/package/error.rs
+++ b/crates/mast-package/src/package/error.rs
@@ -21,9 +21,9 @@ pub enum PackageDebugInfoError {
     #[error("package debug sections are present but are not trusted")]
     /// Package debug sections are present on a package that does not trust them.
     ///
-    /// Normal untrusted deserialization discards package-owned debug sections before returning a
+    /// Normal untrusted deserialization validates package-owned debug sections before returning a
     /// package. This error protects callers from manually constructed packages, or future
-    /// deserialization paths, that retain debug sections without marking them trusted.
+    /// deserialization paths, that retain debug sections without validating or trusting them.
     UntrustedSections,
     #[error("package contains multiple '{id}' debug sections")]
     DuplicateSection {

--- a/crates/mast-package/src/package/error.rs
+++ b/crates/mast-package/src/package/error.rs
@@ -45,6 +45,8 @@ pub enum PackageDebugInfoError {
     },
     #[error("invalid package debug info: {message}")]
     InvalidReference { message: String },
+    #[error("invalid package debug info value: {message}")]
+    InvalidValue { message: String },
     #[error("invalid optional field discriminant for {context}: {err}")]
     InvalidOptionField {
         #[source]

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -899,6 +899,15 @@ impl Package {
             })?;
         }
         for (location_index, location) in debug_info.locations().iter().enumerate() {
+            if location.start.to_usize() > location.end.to_usize() {
+                return Err(PackageDebugInfoError::InvalidValue {
+                    message: format!(
+                        "debug source location {location_index} starts at byte {} after ending at byte {}",
+                        location.start.to_usize(),
+                        location.end.to_usize(),
+                    ),
+                });
+            }
             if debug_info.get_file(location.file_idx).is_none() {
                 return Err(PackageDebugInfoError::InvalidReference {
                     message: format!(

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -711,6 +711,16 @@ impl Package {
                     });
                 }
             }
+            if let Some(rows) =
+                source_node.asm_ops.windows(2).find(|rows| rows[0].op_idx >= rows[1].op_idx)
+            {
+                return Err(PackageDebugInfoError::InvalidValue {
+                    message: format!(
+                        "debug source node {source_id:?} assembly operation indices are not strictly increasing at {} and {}",
+                        rows[0].op_idx, rows[1].op_idx,
+                    ),
+                });
+            }
             for row in source_node.asm_ops.iter() {
                 self.validate_source_map_row(source_id, source_node, row.op_idx, "assembly op")?;
                 self.validate_string_index(row.context_name_idx, debug_info, || {

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -360,6 +360,11 @@ impl Package {
     /// Normal package readers validate debug sections before returning. Explicit trusted readers
     /// and in-process construction may defer validation until this method is called.
     ///
+    /// Decoding uses the fixed resource limits of [`PackageDebugInfo::read_from`]. Analysis tools
+    /// that intentionally accept larger debug information can locate [`SectionId::DEBUG_INFO`] in
+    /// [`Package::sections`] and call [`PackageDebugInfo::read_from_bytes_unmetered`] on its data.
+    /// That alternative does not perform this method's package-level reference validation.
+    ///
     /// This does not read legacy debug metadata from the embedded [`MastForest`].
     pub fn debug_info(&self) -> Result<Option<PackageDebugInfo>, PackageDebugInfoError> {
         if !self.debug_sections_trusted && self.sections.iter().any(|section| section.id.is_debug())

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -636,6 +636,7 @@ impl Package {
         &self,
         debug_info: &PackageDebugInfo,
     ) -> Result<(), PackageDebugInfoError> {
+        self.validate_debug_strings(debug_info)?;
         self.validate_debug_sources(debug_info)?;
         self.validate_debug_types(debug_info)?;
         self.validate_debug_functions(debug_info)?;
@@ -802,6 +803,20 @@ impl Package {
             }
         }
 
+        Ok(())
+    }
+
+    fn validate_debug_strings(
+        &self,
+        debug_info: &PackageDebugInfo,
+    ) -> Result<(), PackageDebugInfoError> {
+        for (string_index, string) in debug_info.strings().iter().enumerate() {
+            if string.chars().any(char::is_control) {
+                return Err(PackageDebugInfoError::InvalidValue {
+                    message: format!("debug string {string_index} contains a control character"),
+                });
+            }
+        }
         Ok(())
     }
 

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -97,10 +97,9 @@ pub struct Package {
     pub sections: Vec<Section>,
     /// Whether package-owned debug sections may be decoded as trusted debug info.
     ///
-    /// Normal package deserialization validates the embedded MAST forest, warns on package debug
-    /// sections, and discards those sections as untrusted metadata. Trusted local/cache readers
-    /// and in-process package construction preserve package debug sections and expose them through
-    /// [`Package::debug_info`].
+    /// Normal package deserialization validates both the embedded MAST forest and package debug
+    /// sections before marking them trusted. Trusted local/cache readers and in-process package
+    /// construction may defer debug validation until [`Package::debug_info`] is called.
     debug_sections_trusted: bool,
 }
 
@@ -209,7 +208,9 @@ impl Package {
     /// package if one is present.
     pub fn strip_debug_info(&mut self) -> Result<(), PackageStripError> {
         for section in self.sections.iter_mut().filter(|section| section.id == SectionId::KERNEL) {
-            let mut kernel_package = Self::read_from_bytes(section.data.as_ref())
+            // Debug metadata is about to be removed, so validate the nested MAST while deferring
+            // debug validation that could otherwise prevent stripping malformed metadata.
+            let mut kernel_package = Self::read_from_bytes_trusted(section.data.as_ref())
                 .map_err(|source| PackageStripError::DecodeEmbeddedKernel { source })?;
             kernel_package.strip_debug_info()?;
             section.data = Cow::Owned(kernel_package.to_bytes());
@@ -354,13 +355,10 @@ impl Package {
         Ok(Some(kernel_dependency))
     }
 
-    /// Decodes trusted package-owned debug sections, if any are present.
+    /// Decodes validated or trusted package-owned debug sections, if any are present.
     ///
-    /// Package debug sections are trusted only for packages constructed in-process or read via the
-    /// trusted same-domain readers such as [`Self::read_from_trusted`],
-    /// [`Self::read_from_bytes_trusted`], [`Self::read_from_unchecked`], and
-    /// [`Self::read_from_bytes_unchecked`]. Normal untrusted readers discard debug sections before
-    /// returning the package.
+    /// Normal package readers validate debug sections before returning. Explicit trusted readers
+    /// and in-process construction may defer validation until this method is called.
     ///
     /// This does not read legacy debug metadata from the embedded [`MastForest`].
     pub fn debug_info(&self) -> Result<Option<PackageDebugInfo>, PackageDebugInfoError> {
@@ -711,18 +709,18 @@ impl Package {
                     });
                 }
             }
-            if let Some(rows) =
-                source_node.asm_ops.windows(2).find(|rows| rows[0].op_idx >= rows[1].op_idx)
+            if let (Some(first), Some(last)) =
+                (source_node.asm_ops.first(), source_node.asm_ops.last())
+                && (first.op_idx < source_node.op_start || last.op_idx >= source_node.op_end)
             {
-                return Err(PackageDebugInfoError::InvalidValue {
+                return Err(PackageDebugInfoError::InvalidReference {
                     message: format!(
-                        "debug source node {source_id:?} assembly operation indices are not strictly increasing at {} and {}",
-                        rows[0].op_idx, rows[1].op_idx,
+                        "assembly op rows for source node {source_id:?} span operation indices {}..={}, outside source range {}..{}",
+                        first.op_idx, last.op_idx, source_node.op_start, source_node.op_end,
                     ),
                 });
             }
             for row in source_node.asm_ops.iter() {
-                self.validate_source_map_row(source_id, source_node, row.op_idx, "assembly op")?;
                 self.validate_string_index(row.context_name_idx, debug_info, || {
                     format!("debug source node {source_id:?} assembly op context name")
                 })?;
@@ -1217,19 +1215,15 @@ impl Package {
             )));
         }
 
-        if self.debug_sections_trusted {
-            Self::read_from_bytes_trusted(section.data.as_ref())
-        } else {
-            Self::read_from_bytes(section.data.as_ref())
-        }
-        .map(Box::new)
-        .map(Some)
-        .map_err(|error| {
-            Report::msg(format!(
-                "failed to decode embedded kernel package for '{}': {error}",
-                self.name
-            ))
-        })
+        Self::read_from_bytes(section.data.as_ref())
+            .map(Box::new)
+            .map(Some)
+            .map_err(|error| {
+                Report::msg(format!(
+                    "failed to decode embedded kernel package for '{}': {error}",
+                    self.name
+                ))
+            })
     }
 
     fn validate_embedded_kernel_dependency(&self, kernel_package: &Self) -> Result<(), Report> {
@@ -2095,7 +2089,7 @@ mod tests {
     }
 
     #[test]
-    fn untrusted_embedded_kernel_decode_discards_nested_debug_info() {
+    fn untrusted_embedded_kernel_decode_preserves_validated_nested_debug_info() {
         let kernel =
             build_debug_package("kernel", TargetType::Kernel, "kernel::boot", "kernel_ctx");
         assert!(kernel.debug_info().unwrap().is_some());
@@ -2129,10 +2123,13 @@ mod tests {
             .expect("embedded kernel should decode")
             .expect("kernel should be present");
         assert!(
-            !untrusted_kernel.sections.iter().any(|section| section.id.is_debug()),
-            "untrusted embedded-kernel decode should discard nested debug sections"
+            untrusted_kernel
+                .sections
+                .iter()
+                .any(|section| section.id == SectionId::DEBUG_INFO),
+            "untrusted embedded-kernel decode should retain validated nested debug sections"
         );
-        assert!(untrusted_kernel.debug_info().unwrap().is_none());
+        assert!(untrusted_kernel.debug_info().unwrap().is_some());
     }
 
     #[test]

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -634,7 +634,6 @@ impl Package {
         &self,
         debug_info: &PackageDebugInfo,
     ) -> Result<(), PackageDebugInfoError> {
-        self.validate_debug_strings(debug_info)?;
         self.validate_debug_sources(debug_info)?;
         self.validate_debug_types(debug_info)?;
         self.validate_debug_functions(debug_info)?;
@@ -811,20 +810,6 @@ impl Package {
             }
         }
 
-        Ok(())
-    }
-
-    fn validate_debug_strings(
-        &self,
-        debug_info: &PackageDebugInfo,
-    ) -> Result<(), PackageDebugInfoError> {
-        for (string_index, string) in debug_info.strings().iter().enumerate() {
-            if string.chars().any(char::is_control) {
-                return Err(PackageDebugInfoError::InvalidValue {
-                    message: format!("debug string {string_index} contains a control character"),
-                });
-            }
-        }
         Ok(())
     }
 

--- a/crates/mast-package/src/package/mod.rs
+++ b/crates/mast-package/src/package/mod.rs
@@ -360,10 +360,11 @@ impl Package {
     /// Normal package readers validate debug sections before returning. Explicit trusted readers
     /// and in-process construction may defer validation until this method is called.
     ///
-    /// Decoding uses the fixed resource limits of [`PackageDebugInfo::read_from`]. Analysis tools
-    /// that intentionally accept larger debug information can locate [`SectionId::DEBUG_INFO`] in
-    /// [`Package::sections`] and call [`PackageDebugInfo::read_from_bytes_unmetered`] on its data.
-    /// That alternative does not perform this method's package-level reference validation.
+    /// Decoding uses the fixed resource limits of [`Deserializable::read_from`]. Analysis tools
+    /// that intentionally accept larger debug information can locate [`SectionId::DEBUG_INFO`]
+    /// in [`Package::sections`] and call [`PackageDebugInfo::read_from_bytes_unmetered`] on its
+    /// data. That alternative does not perform this method's package-level reference
+    /// validation.
     ///
     /// This does not read legacy debug metadata from the embedded [`MastForest`].
     pub fn debug_info(&self) -> Result<Option<PackageDebugInfo>, PackageDebugInfoError> {

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -14,6 +14,7 @@ use miden_core::{
     serde::Serializable,
 };
 use miden_debug_types::{ByteIndex, Uri};
+use zerocopy::IntoBytes;
 
 use super::{PackageId, TargetType};
 use crate::{
@@ -61,7 +62,9 @@ fn build_package(signature: Option<FunctionType>) -> Package {
     .expect("seed package should be valid")
 }
 
-fn build_package_with_debug_info(signature: Option<FunctionType>) -> (Package, Vec<u8>) {
+fn build_package_with_debug_info(
+    signature: Option<FunctionType>,
+) -> (Package, Vec<u8>, DebugSourceAsmOp) {
     let mut package = build_package(signature);
     let exec_node = *package.mast.procedure_roots().first().expect("seed package has a root");
 
@@ -69,18 +72,19 @@ fn build_package_with_debug_info(signature: Option<FunctionType>) -> (Package, V
     let context_name = debug_info.add_string("seed::test");
     let op_name = debug_info.add_string("add");
     let file_idx = debug_info.add_file(Uri::new("file:///seed/source.masm"), Some([0xa5; 32]));
-    debug_info.add_location_info(crate::debug_info::DebugLoc {
+    let location_idx = debug_info.add_location_info(crate::debug_info::DebugLoc {
         file_idx,
         start: ByteIndex::new(0),
         end: ByteIndex::new(1),
     });
+    let asm_op = DebugSourceAsmOp::new(0, Some(location_idx), context_name, op_name, 1);
     let source_node = debug_info
         .add_node(DebugSourceNode {
             exec_node,
             children: Vec::new(),
             op_start: 0,
             op_end: 1,
-            asm_ops: vec![DebugSourceAsmOp::new(0, None, context_name, op_name, 1)],
+            asm_ops: vec![asm_op],
             debug_vars: Vec::new(),
             inline_calls: Vec::new(),
         })
@@ -93,14 +97,14 @@ fn build_package_with_debug_info(signature: Option<FunctionType>) -> (Package, V
         .sections
         .push(Section::new(SectionId::DEBUG_INFO, debug_info_bytes.clone()));
 
-    (package, debug_info_bytes)
+    (package, debug_info_bytes, asm_op)
 }
 
 fn build_packages_with_invalid_struct_types() -> Vec<(&'static str, Vec<u8>)> {
     let struct_type = StructType::new_with_repr(TypeRepr::align(8), [Type::Felt]);
     let signature = FunctionType::new(CallConv::Fast, [Type::from(struct_type)], []);
     let signature_bytes = signature.to_bytes();
-    let (package, _) = build_package_with_debug_info(Some(signature));
+    let (package, ..) = build_package_with_debug_info(Some(signature));
     let package_bytes = package.to_bytes();
 
     let signature_offset = package_bytes
@@ -141,7 +145,7 @@ fn build_packages_with_invalid_struct_types() -> Vec<(&'static str, Vec<u8>)> {
             .expect("seed enum should be valid");
     let signature = FunctionType::new(CallConv::Fast, [Type::Enum(Arc::new(enum_type))], []);
     let signature_bytes = signature.to_bytes();
-    let (package, _) = build_package_with_debug_info(Some(signature));
+    let (package, ..) = build_package_with_debug_info(Some(signature));
     let mut package_bytes = package.to_bytes();
     let signature_offset = package_bytes
         .windows(signature_bytes.len())
@@ -184,7 +188,7 @@ fn generate_fuzz_seeds() {
         &package_with_signature.to_bytes(),
     );
 
-    let (package_with_debug_info, debug_info_bytes) = build_package_with_debug_info(None);
+    let (package_with_debug_info, debug_info_bytes, asm_op) = build_package_with_debug_info(None);
     write_seed("debug_info", "valid_debug_info.bin", &debug_info_bytes);
     write_seed("debug_info", "package_with_debug_info.bin", &package_with_debug_info.to_bytes());
     write_seed(
@@ -262,6 +266,44 @@ fn generate_fuzz_seeds() {
         "package_semantic_deserialize",
         "package_with_dangling_source_root.bin",
         &dangling_root_package,
+    );
+
+    let asm_op_offset = debug_info_bytes
+        .windows(asm_op.as_bytes().len())
+        .position(|window| window == asm_op.as_bytes())
+        .expect("seed debug info should contain its assembly operation")
+        + 4;
+    let mut invalid_asm_location_debug_info = debug_info_bytes.clone();
+    invalid_asm_location_debug_info[asm_op_offset..asm_op_offset + 4]
+        .copy_from_slice(&2u32.to_le_bytes());
+    write_seed(
+        "debug_info",
+        "invalid_assembly_location_option.bin",
+        &invalid_asm_location_debug_info,
+    );
+
+    let mut invalid_asm_location_package = package_with_debug_info.to_bytes();
+    let asm_op_offset = invalid_asm_location_package
+        .windows(asm_op.as_bytes().len())
+        .position(|window| window == asm_op.as_bytes())
+        .expect("seed package should contain its debug assembly operation")
+        + 4;
+    invalid_asm_location_package[asm_op_offset..asm_op_offset + 4]
+        .copy_from_slice(&2u32.to_le_bytes());
+    write_seed(
+        "debug_info",
+        "package_with_invalid_assembly_location_option.bin",
+        &invalid_asm_location_package,
+    );
+    write_seed(
+        "package_deserialize",
+        "package_with_invalid_assembly_location_option.bin",
+        &invalid_asm_location_package,
+    );
+    write_seed(
+        "package_semantic_deserialize",
+        "package_with_invalid_assembly_location_option.bin",
+        &invalid_asm_location_package,
     );
 
     let mut dangling_error_debug_info = debug_info_bytes;

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -309,6 +309,14 @@ fn generate_fuzz_seeds() {
         .copy_from_slice(&2u32.to_le_bytes());
     write_seed("debug_info", "package_with_inverted_location.bin", &inverted_location_package);
 
+    let mut control_character_package = package_with_debug_info.to_bytes();
+    let error_message_offset = control_character_package
+        .windows(b"seed error".len())
+        .position(|window| window == b"seed error")
+        .expect("seed package should contain its debug error message");
+    control_character_package[error_message_offset] = b'\n';
+    write_seed("debug_info", "package_with_control_character.bin", &control_character_package);
+
     let file_path_offset = debug_info_bytes
         .windows(file_checksum.len())
         .position(|window| window == file_checksum)

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -284,11 +284,15 @@ fn generate_fuzz_seeds() {
         "invalid_assembly_location_option.bin",
         &invalid_asm_location_debug_info,
     );
-    for (name, field_offset) in [
-        ("dangling_assembly_context_string.bin", 12),
-        ("dangling_assembly_op_string.bin", 16),
+    for (name, field_offset, expected) in [
+        ("dangling_assembly_context_string.bin", 12, 0u32),
+        ("dangling_assembly_op_string.bin", 16, 1u32),
     ] {
         let mut bytes = debug_info_bytes.clone();
+        assert_eq!(
+            &bytes[asm_op_offset + field_offset..asm_op_offset + field_offset + 4],
+            &expected.to_le_bytes(),
+        );
         bytes[asm_op_offset + field_offset..asm_op_offset + field_offset + 4]
             .copy_from_slice(&u32::MAX.to_le_bytes());
         write_seed("debug_info", name, &bytes);
@@ -320,11 +324,15 @@ fn generate_fuzz_seeds() {
         "package_with_invalid_assembly_location_option.bin",
         &invalid_asm_location_package,
     );
-    for (name, field_offset) in [
-        ("package_with_dangling_assembly_context_string.bin", 12),
-        ("package_with_dangling_assembly_op_string.bin", 16),
+    for (name, field_offset, expected) in [
+        ("package_with_dangling_assembly_context_string.bin", 12, 0u32),
+        ("package_with_dangling_assembly_op_string.bin", 16, 1u32),
     ] {
         let mut bytes = package_with_debug_info.to_bytes();
+        assert_eq!(
+            &bytes[asm_op_offset + field_offset..asm_op_offset + field_offset + 4],
+            &expected.to_le_bytes(),
+        );
         bytes[asm_op_offset + field_offset..asm_op_offset + field_offset + 4]
             .copy_from_slice(&u32::MAX.to_le_bytes());
         write_seed("debug_info", name, &bytes);

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -11,7 +11,7 @@ use miden_assembly_syntax::{
 use miden_core::{
     mast::{BasicBlockNodeBuilder, DenseMastForestBuilder, MastForest, MastNodeExt, MastNodeId},
     operations::Operation,
-    serde::Serializable,
+    serde::{ByteReader, ByteWriter, Serializable, SliceReader},
 };
 use miden_debug_types::{ByteIndex, Uri};
 use zerocopy::IntoBytes;
@@ -20,8 +20,8 @@ use super::{PackageId, TargetType};
 use crate::{
     Package, PackageExport, ProcedureExport, Section, SectionId,
     debug_info::{
-        DebugSourceAsmOp, DebugSourceNode, DebugSourceVar, DebugTypeInfo, MAX_DEBUG_INFO_TYPE_ROWS,
-        PackageDebugInfoBuilder,
+        DebugSourceAsmOp, DebugSourceNode, DebugSourceVar, DebugTypeInfo,
+        MAX_DEBUG_INFO_STRING_ROWS, MAX_DEBUG_INFO_TYPE_ROWS, PackageDebugInfoBuilder,
     },
 };
 
@@ -246,6 +246,24 @@ fn generate_fuzz_seeds() {
     let (package_with_debug_info, debug_info_bytes, asm_op, debug_var) =
         build_package_with_debug_info(None);
     write_seed("debug_info", "valid_debug_info.bin", &debug_info_bytes);
+    let empty_debug_info = PackageDebugInfoBuilder::default().build().to_bytes();
+    let mut empty_reader = SliceReader::new(&empty_debug_info);
+    assert_eq!(empty_reader.read_u8().unwrap(), crate::debug_info::DEBUG_INFO_VERSION);
+    let empty_payload_len = empty_reader.read_usize().unwrap();
+    let empty_payload_offset = 1 + empty_payload_len.to_bytes().len();
+    let mut oversized_string_payload = empty_debug_info[empty_payload_offset..].to_vec();
+    let oversized_string_rows = MAX_DEBUG_INFO_STRING_ROWS + 6;
+    let oversized_string_count = oversized_string_rows.to_bytes();
+    oversized_string_payload.splice(0..1, oversized_string_count.iter().copied());
+    oversized_string_payload.splice(
+        oversized_string_count.len()..oversized_string_count.len(),
+        0usize.to_bytes().repeat(oversized_string_rows),
+    );
+    let mut oversized_string_table = Vec::new();
+    oversized_string_table.write_u8(crate::debug_info::DEBUG_INFO_VERSION);
+    oversized_string_table.write_usize(oversized_string_payload.len());
+    oversized_string_table.write_bytes(&oversized_string_payload);
+    write_seed("debug_info", "oversized_debug_string_table.bin", &oversized_string_table);
     let mut oversized_debug_info = PackageDebugInfoBuilder::default();
     oversized_debug_info.add_string("x".repeat(16 * 1024 * 1024));
     write_seed(

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -201,11 +201,17 @@ fn build_packages_with_invalid_struct_types() -> Vec<(&'static str, Vec<u8>)> {
         .position(|window| window == [18, 3, 15])
         .expect("seed signature should contain its single-Felt array")
         + 1;
+    let mut overflowing_package_bytes = package_bytes.clone();
     package_bytes.splice(
         signature_offset + array_len_offset..signature_offset + array_len_offset + 1,
         (u32::MAX as usize).to_bytes(),
     );
     packages.push(("oversized_struct_field.bin", package_bytes));
+    overflowing_package_bytes.splice(
+        signature_offset + array_len_offset..signature_offset + array_len_offset + 1,
+        usize::MAX.to_bytes(),
+    );
+    packages.push(("overflowing_struct_field.bin", overflowing_package_bytes));
 
     packages
 }

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -4,7 +4,7 @@ use std::{fs, path::Path, println};
 use miden_assembly_syntax::{
     ast::{
         Path as AstPath, PathBuf,
-        types::{CallConv, FunctionType, StructType, Type, TypeRepr},
+        types::{CallConv, EnumType, FunctionType, StructType, Type, TypeRepr, Variant},
     },
     semver::Version,
 };
@@ -88,7 +88,7 @@ fn build_package_with_debug_info(signature: Option<FunctionType>) -> (Package, V
     (package, debug_info_bytes)
 }
 
-fn build_packages_with_invalid_struct_alignments() -> [(&'static str, Vec<u8>); 2] {
+fn build_packages_with_invalid_struct_types() -> Vec<(&'static str, Vec<u8>)> {
     let struct_type = StructType::new_with_repr(TypeRepr::align(8), [Type::Felt]);
     let signature = FunctionType::new(CallConv::Fast, [Type::from(struct_type)], []);
     let signature_bytes = signature.to_bytes();
@@ -104,18 +104,52 @@ fn build_packages_with_invalid_struct_alignments() -> [(&'static str, Vec<u8>); 
         .position(|window| window == [17, 0, 1, 8, 0])
         .expect("seed signature should contain the aligned struct type");
     let repr_offset = signature_offset + repr_offset + 2;
+    let field_type_offset = signature_offset
+        + signature_bytes
+            .windows(8)
+            .position(|window| window == [17, 0, 1, 8, 0, 1, 0, 15])
+            .expect("seed signature should contain the struct field type")
+        + 7;
 
     let mut non_power_of_two = package_bytes.clone();
     non_power_of_two[repr_offset + 1..repr_offset + 3].copy_from_slice(&3u16.to_le_bytes());
 
-    let mut zero_packed = package_bytes;
+    let mut zero_packed = package_bytes.clone();
     zero_packed[repr_offset] = 2;
     zero_packed[repr_offset + 1..repr_offset + 3].copy_from_slice(&0u16.to_le_bytes());
 
-    [
+    let mut list_field = package_bytes;
+    list_field[field_type_offset] = 19;
+    list_field.insert(field_type_offset + 1, 15);
+
+    let mut packages = vec![
         ("non_power_of_two_struct_align.bin", non_power_of_two),
         ("zero_packed_struct_align.bin", zero_packed),
-    ]
+        ("list_struct_field.bin", list_field),
+    ];
+
+    let enum_type =
+        EnumType::new(Arc::from("E"), Type::U8, [Variant::new(Arc::from("V"), Type::Felt, None)])
+            .expect("seed enum should be valid");
+    let signature = FunctionType::new(CallConv::Fast, [Type::Enum(Arc::new(enum_type))], []);
+    let signature_bytes = signature.to_bytes();
+    let (package, _) = build_package_with_debug_info(Some(signature));
+    let mut package_bytes = package.to_bytes();
+    let signature_offset = package_bytes
+        .windows(signature_bytes.len())
+        .position(|window| window == signature_bytes)
+        .expect("seed package should contain its enum procedure signature");
+    let variant_type_offset = signature_offset
+        + signature_bytes
+            .windows(4)
+            .position(|window| window == [b'V', 1, 15, 0])
+            .expect("seed signature should contain the enum variant type")
+        + 2;
+    package_bytes[variant_type_offset] = 19;
+    package_bytes.insert(variant_type_offset + 1, 15);
+    packages.push(("list_enum_variant.bin", package_bytes));
+
+    packages
 }
 
 #[test]
@@ -156,7 +190,7 @@ fn generate_fuzz_seeds() {
         &package_with_debug_info.to_bytes(),
     );
 
-    for (name, bytes) in build_packages_with_invalid_struct_alignments() {
+    for (name, bytes) in build_packages_with_invalid_struct_types() {
         write_seed("debug_info", name, &bytes);
         write_seed("package_deserialize", name, &bytes);
         write_seed("package_semantic_deserialize", name, &bytes);

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -271,24 +271,39 @@ fn generate_fuzz_seeds() {
     let asm_op_offset = debug_info_bytes
         .windows(asm_op.as_bytes().len())
         .position(|window| window == asm_op.as_bytes())
-        .expect("seed debug info should contain its assembly operation")
-        + 4;
+        .expect("seed debug info should contain its assembly operation");
     let mut invalid_asm_location_debug_info = debug_info_bytes.clone();
-    invalid_asm_location_debug_info[asm_op_offset..asm_op_offset + 4]
+    assert_eq!(
+        &invalid_asm_location_debug_info[asm_op_offset + 4..asm_op_offset + 8],
+        &1u32.to_le_bytes(),
+    );
+    invalid_asm_location_debug_info[asm_op_offset + 4..asm_op_offset + 8]
         .copy_from_slice(&2u32.to_le_bytes());
     write_seed(
         "debug_info",
         "invalid_assembly_location_option.bin",
         &invalid_asm_location_debug_info,
     );
+    for (name, field_offset) in [
+        ("dangling_assembly_context_string.bin", 12),
+        ("dangling_assembly_op_string.bin", 16),
+    ] {
+        let mut bytes = debug_info_bytes.clone();
+        bytes[asm_op_offset + field_offset..asm_op_offset + field_offset + 4]
+            .copy_from_slice(&u32::MAX.to_le_bytes());
+        write_seed("debug_info", name, &bytes);
+    }
 
     let mut invalid_asm_location_package = package_with_debug_info.to_bytes();
     let asm_op_offset = invalid_asm_location_package
         .windows(asm_op.as_bytes().len())
         .position(|window| window == asm_op.as_bytes())
-        .expect("seed package should contain its debug assembly operation")
-        + 4;
-    invalid_asm_location_package[asm_op_offset..asm_op_offset + 4]
+        .expect("seed package should contain its debug assembly operation");
+    assert_eq!(
+        &invalid_asm_location_package[asm_op_offset + 4..asm_op_offset + 8],
+        &1u32.to_le_bytes(),
+    );
+    invalid_asm_location_package[asm_op_offset + 4..asm_op_offset + 8]
         .copy_from_slice(&2u32.to_le_bytes());
     write_seed(
         "debug_info",
@@ -305,6 +320,17 @@ fn generate_fuzz_seeds() {
         "package_with_invalid_assembly_location_option.bin",
         &invalid_asm_location_package,
     );
+    for (name, field_offset) in [
+        ("package_with_dangling_assembly_context_string.bin", 12),
+        ("package_with_dangling_assembly_op_string.bin", 16),
+    ] {
+        let mut bytes = package_with_debug_info.to_bytes();
+        bytes[asm_op_offset + field_offset..asm_op_offset + field_offset + 4]
+            .copy_from_slice(&u32::MAX.to_le_bytes());
+        write_seed("debug_info", name, &bytes);
+        write_seed("package_deserialize", name, &bytes);
+        write_seed("package_semantic_deserialize", name, &bytes);
+    }
 
     let mut dangling_error_debug_info = debug_info_bytes;
     let error_message_offset = dangling_error_debug_info

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -13,6 +13,7 @@ use miden_core::{
     operations::Operation,
     serde::Serializable,
 };
+use miden_debug_types::Uri;
 
 use super::{PackageId, TargetType};
 use crate::{
@@ -67,6 +68,7 @@ fn build_package_with_debug_info(signature: Option<FunctionType>) -> (Package, V
     let mut debug_info = PackageDebugInfoBuilder::default();
     let context_name = debug_info.add_string("seed::test");
     let op_name = debug_info.add_string("add");
+    debug_info.add_file(Uri::new("file:///seed/source.masm"), Some([0xa5; 32]));
     let source_node = debug_info
         .add_node(DebugSourceNode {
             exec_node,
@@ -189,6 +191,41 @@ fn generate_fuzz_seeds() {
         "package_semantic_deserialize",
         "package_with_debug_info.bin",
         &package_with_debug_info.to_bytes(),
+    );
+
+    let file_checksum = [0xa5; 32];
+    let file_path_offset = debug_info_bytes
+        .windows(file_checksum.len())
+        .position(|window| window == file_checksum)
+        .expect("seed debug info should contain its file checksum")
+        - 4;
+    let mut dangling_file_debug_info = debug_info_bytes.clone();
+    dangling_file_debug_info[file_path_offset..file_path_offset + 4]
+        .copy_from_slice(&u32::MAX.to_le_bytes());
+    write_seed("debug_info", "dangling_file_path_string.bin", &dangling_file_debug_info);
+
+    let mut dangling_file_package = package_with_debug_info.to_bytes();
+    let file_path_offset = dangling_file_package
+        .windows(file_checksum.len())
+        .position(|window| window == file_checksum)
+        .expect("seed package should contain its debug file checksum")
+        - 4;
+    dangling_file_package[file_path_offset..file_path_offset + 4]
+        .copy_from_slice(&u32::MAX.to_le_bytes());
+    write_seed(
+        "debug_info",
+        "package_with_dangling_file_path_string.bin",
+        &dangling_file_package,
+    );
+    write_seed(
+        "package_deserialize",
+        "package_with_dangling_file_path_string.bin",
+        &dangling_file_package,
+    );
+    write_seed(
+        "package_semantic_deserialize",
+        "package_with_dangling_file_path_string.bin",
+        &dangling_file_package,
     );
 
     let mut dangling_error_debug_info = debug_info_bytes;

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -19,7 +19,10 @@ use zerocopy::IntoBytes;
 use super::{PackageId, TargetType};
 use crate::{
     Package, PackageExport, ProcedureExport, Section, SectionId,
-    debug_info::{DebugSourceAsmOp, DebugSourceNode, DebugSourceVar, PackageDebugInfoBuilder},
+    debug_info::{
+        DebugSourceAsmOp, DebugSourceNode, DebugSourceVar, DebugTypeInfo, MAX_DEBUG_INFO_TYPE_ROWS,
+        PackageDebugInfoBuilder,
+    },
 };
 
 fn build_forest() -> (MastForest, MastNodeId) {
@@ -249,6 +252,15 @@ fn generate_fuzz_seeds() {
         "debug_info",
         "oversized_debug_info.bin",
         &oversized_debug_info.build().to_bytes(),
+    );
+    let mut oversized_type_table = PackageDebugInfoBuilder::default();
+    for _ in 0..=MAX_DEBUG_INFO_TYPE_ROWS {
+        oversized_type_table.push_type(DebugTypeInfo::Unknown);
+    }
+    write_seed(
+        "debug_info",
+        "oversized_debug_type_table.bin",
+        &oversized_type_table.build().to_bytes(),
     );
     write_seed("debug_info", "package_with_debug_info.bin", &package_with_debug_info.to_bytes());
     write_seed(

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -4,7 +4,7 @@ use std::{fs, path::Path, println};
 use miden_assembly_syntax::{
     ast::{
         Path as AstPath, PathBuf,
-        types::{CallConv, FunctionType, Type},
+        types::{CallConv, FunctionType, StructType, Type, TypeRepr},
     },
     semver::Version,
 };
@@ -60,8 +60,8 @@ fn build_package(signature: Option<FunctionType>) -> Package {
     .expect("seed package should be valid")
 }
 
-fn build_package_with_debug_info() -> (Package, Vec<u8>) {
-    let mut package = build_package(None);
+fn build_package_with_debug_info(signature: Option<FunctionType>) -> (Package, Vec<u8>) {
+    let mut package = build_package(signature);
     let exec_node = *package.mast.procedure_roots().first().expect("seed package has a root");
 
     let mut debug_info = PackageDebugInfoBuilder::default();
@@ -88,6 +88,36 @@ fn build_package_with_debug_info() -> (Package, Vec<u8>) {
     (package, debug_info_bytes)
 }
 
+fn build_packages_with_invalid_struct_alignments() -> [(&'static str, Vec<u8>); 2] {
+    let struct_type = StructType::new_with_repr(TypeRepr::align(8), [Type::Felt]);
+    let signature = FunctionType::new(CallConv::Fast, [Type::from(struct_type)], []);
+    let signature_bytes = signature.to_bytes();
+    let (package, _) = build_package_with_debug_info(Some(signature));
+    let package_bytes = package.to_bytes();
+
+    let signature_offset = package_bytes
+        .windows(signature_bytes.len())
+        .position(|window| window == signature_bytes)
+        .expect("seed package should contain its procedure signature");
+    let repr_offset = signature_bytes
+        .windows(5)
+        .position(|window| window == [17, 0, 1, 8, 0])
+        .expect("seed signature should contain the aligned struct type");
+    let repr_offset = signature_offset + repr_offset + 2;
+
+    let mut non_power_of_two = package_bytes.clone();
+    non_power_of_two[repr_offset + 1..repr_offset + 3].copy_from_slice(&3u16.to_le_bytes());
+
+    let mut zero_packed = package_bytes;
+    zero_packed[repr_offset] = 2;
+    zero_packed[repr_offset + 1..repr_offset + 3].copy_from_slice(&0u16.to_le_bytes());
+
+    [
+        ("non_power_of_two_struct_align.bin", non_power_of_two),
+        ("zero_packed_struct_align.bin", zero_packed),
+    ]
+}
+
 #[test]
 #[ignore = "run manually to generate fuzz seeds"]
 fn generate_fuzz_seeds() {
@@ -112,7 +142,7 @@ fn generate_fuzz_seeds() {
         &package_with_signature.to_bytes(),
     );
 
-    let (package_with_debug_info, debug_info_bytes) = build_package_with_debug_info();
+    let (package_with_debug_info, debug_info_bytes) = build_package_with_debug_info(None);
     write_seed("debug_info", "valid_debug_info.bin", &debug_info_bytes);
     write_seed("debug_info", "package_with_debug_info.bin", &package_with_debug_info.to_bytes());
     write_seed(
@@ -125,6 +155,12 @@ fn generate_fuzz_seeds() {
         "package_with_debug_info.bin",
         &package_with_debug_info.to_bytes(),
     );
+
+    for (name, bytes) in build_packages_with_invalid_struct_alignments() {
+        write_seed("debug_info", name, &bytes);
+        write_seed("package_deserialize", name, &bytes);
+        write_seed("package_semantic_deserialize", name, &bytes);
+    }
 
     println!("\nSeed corpus generated in ../../tools/miden-core-fuzz/corpus");
 }

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -3,7 +3,7 @@ use std::{fs, path::Path, println};
 
 use miden_assembly_syntax::{
     ast::{
-        Path as AstPath, PathBuf,
+        DebugVarLocation, Path as AstPath, PathBuf,
         types::{CallConv, EnumType, FunctionType, StructType, Type, TypeRepr, Variant},
     },
     semver::Version,
@@ -19,7 +19,7 @@ use zerocopy::IntoBytes;
 use super::{PackageId, TargetType};
 use crate::{
     Package, PackageExport, ProcedureExport, Section, SectionId,
-    debug_info::{DebugSourceAsmOp, DebugSourceNode, PackageDebugInfoBuilder},
+    debug_info::{DebugSourceAsmOp, DebugSourceNode, DebugSourceVar, PackageDebugInfoBuilder},
 };
 
 fn build_forest() -> (MastForest, MastNodeId) {
@@ -64,13 +64,14 @@ fn build_package(signature: Option<FunctionType>) -> Package {
 
 fn build_package_with_debug_info(
     signature: Option<FunctionType>,
-) -> (Package, Vec<u8>, DebugSourceAsmOp) {
+) -> (Package, Vec<u8>, DebugSourceAsmOp, DebugSourceVar) {
     let mut package = build_package(signature);
     let exec_node = *package.mast.procedure_roots().first().expect("seed package has a root");
 
     let mut debug_info = PackageDebugInfoBuilder::default();
     let context_name = debug_info.add_string("seed::test");
     let op_name = debug_info.add_string("add");
+    let var_name = debug_info.add_string("seed_var");
     let file_idx = debug_info.add_file(Uri::new("file:///seed/source.masm"), Some([0xa5; 32]));
     let location_idx = debug_info.add_location_info(crate::debug_info::DebugLoc {
         file_idx,
@@ -78,6 +79,14 @@ fn build_package_with_debug_info(
         end: ByteIndex::new(1),
     });
     let asm_op = DebugSourceAsmOp::new(0, Some(location_idx), context_name, op_name, 1);
+    let debug_var = DebugSourceVar {
+        op_idx: 0,
+        name_idx: var_name,
+        type_id: None,
+        arg_idx: None,
+        location_idx: Some(location_idx),
+        value_location: DebugVarLocation::Stack(0),
+    };
     let source_node = debug_info
         .add_node(DebugSourceNode {
             exec_node,
@@ -85,7 +94,7 @@ fn build_package_with_debug_info(
             op_start: 0,
             op_end: 1,
             asm_ops: vec![asm_op],
-            debug_vars: Vec::new(),
+            debug_vars: vec![debug_var.clone()],
             inline_calls: Vec::new(),
         })
         .expect("seed debug info has one source node");
@@ -97,7 +106,7 @@ fn build_package_with_debug_info(
         .sections
         .push(Section::new(SectionId::DEBUG_INFO, debug_info_bytes.clone()));
 
-    (package, debug_info_bytes, asm_op)
+    (package, debug_info_bytes, asm_op, debug_var)
 }
 
 fn build_packages_with_invalid_struct_types() -> Vec<(&'static str, Vec<u8>)> {
@@ -205,7 +214,8 @@ fn generate_fuzz_seeds() {
         &package_with_signature.to_bytes(),
     );
 
-    let (package_with_debug_info, debug_info_bytes, asm_op) = build_package_with_debug_info(None);
+    let (package_with_debug_info, debug_info_bytes, asm_op, debug_var) =
+        build_package_with_debug_info(None);
     write_seed("debug_info", "valid_debug_info.bin", &debug_info_bytes);
     write_seed("debug_info", "package_with_debug_info.bin", &package_with_debug_info.to_bytes());
     write_seed(
@@ -255,22 +265,33 @@ fn generate_fuzz_seeds() {
     );
 
     let error_code = 0x0123_4567_89ab_cdef_u64.to_le_bytes();
-    let root_offset = debug_info_bytes
+    let error_code_offset = debug_info_bytes
         .windows(error_code.len())
         .position(|window| window == error_code)
-        .expect("seed debug info should contain its error code")
-        - 12;
+        .expect("seed debug info should contain its error code");
+    let mut root_section = [0u8; 12];
+    root_section[..4].copy_from_slice(&1u32.to_le_bytes());
+    root_section[8..].copy_from_slice(&1u32.to_le_bytes());
+    let root_offset = debug_info_bytes[..error_code_offset]
+        .windows(root_section.len())
+        .rposition(|window| window == root_section)
+        .expect("seed debug info should contain one root before one error message")
+        + 4;
     let mut dangling_root_debug_info = debug_info_bytes.clone();
     assert_eq!(&dangling_root_debug_info[root_offset..root_offset + 4], &0u32.to_le_bytes());
     dangling_root_debug_info[root_offset..root_offset + 4].copy_from_slice(&u32::MAX.to_le_bytes());
     write_seed("debug_info", "dangling_source_root.bin", &dangling_root_debug_info);
 
     let mut dangling_root_package = package_with_debug_info.to_bytes();
-    let root_offset = dangling_root_package
+    let error_code_offset = dangling_root_package
         .windows(error_code.len())
         .position(|window| window == error_code)
-        .expect("seed package should contain its debug error code")
-        - 12;
+        .expect("seed package should contain its debug error code");
+    let root_offset = dangling_root_package[..error_code_offset]
+        .windows(root_section.len())
+        .rposition(|window| window == root_section)
+        .expect("seed package should contain one debug root before one error message")
+        + 4;
     assert_eq!(&dangling_root_package[root_offset..root_offset + 4], &0u32.to_le_bytes());
     dangling_root_package[root_offset..root_offset + 4].copy_from_slice(&u32::MAX.to_le_bytes());
     write_seed("debug_info", "package_with_dangling_source_root.bin", &dangling_root_package);
@@ -351,6 +372,46 @@ fn generate_fuzz_seeds() {
             &expected.to_le_bytes(),
         );
         bytes[asm_op_offset + field_offset..asm_op_offset + field_offset + 4]
+            .copy_from_slice(&u32::MAX.to_le_bytes());
+        write_seed("debug_info", name, &bytes);
+        write_seed("package_deserialize", name, &bytes);
+        write_seed("package_semantic_deserialize", name, &bytes);
+    }
+
+    let debug_var_bytes = debug_var.to_bytes();
+    let debug_var_offset = debug_info_bytes
+        .windows(debug_var_bytes.len())
+        .position(|window| window == debug_var_bytes)
+        .expect("seed debug info should contain its debug variable");
+    for (name, field_offset, expected) in [
+        ("dangling_debug_var_name.bin", 4, 2u32),
+        ("dangling_debug_var_location.bin", 14, 0u32),
+    ] {
+        let mut bytes = debug_info_bytes.clone();
+        assert_eq!(
+            &bytes[debug_var_offset + field_offset..debug_var_offset + field_offset + 4],
+            &expected.to_le_bytes(),
+        );
+        bytes[debug_var_offset + field_offset..debug_var_offset + field_offset + 4]
+            .copy_from_slice(&u32::MAX.to_le_bytes());
+        write_seed("debug_info", name, &bytes);
+    }
+
+    let debug_var_offset = package_with_debug_info
+        .to_bytes()
+        .windows(debug_var_bytes.len())
+        .position(|window| window == debug_var_bytes)
+        .expect("seed package should contain its debug variable");
+    for (name, field_offset, expected) in [
+        ("package_with_dangling_debug_var_name.bin", 4, 2u32),
+        ("package_with_dangling_debug_var_location.bin", 14, 0u32),
+    ] {
+        let mut bytes = package_with_debug_info.to_bytes();
+        assert_eq!(
+            &bytes[debug_var_offset + field_offset..debug_var_offset + field_offset + 4],
+            &expected.to_le_bytes(),
+        );
+        bytes[debug_var_offset + field_offset..debug_var_offset + field_offset + 4]
             .copy_from_slice(&u32::MAX.to_le_bytes());
         write_seed("debug_info", name, &bytes);
         write_seed("package_deserialize", name, &bytes);

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -21,7 +21,8 @@ use crate::{
     Package, PackageExport, ProcedureExport, Section, SectionId,
     debug_info::{
         DebugSourceAsmOp, DebugSourceNode, DebugSourceVar, DebugTypeInfo,
-        MAX_DEBUG_INFO_STRING_ROWS, MAX_DEBUG_INFO_TYPE_ROWS, PackageDebugInfoBuilder,
+        MAX_DEBUG_INFO_STRING_ROWS, MAX_DEBUG_INFO_STRING_SIZE, MAX_DEBUG_INFO_TYPE_ROWS,
+        PackageDebugInfoBuilder,
     },
 };
 
@@ -68,6 +69,13 @@ fn build_package(signature: Option<FunctionType>) -> Package {
 fn build_package_with_debug_info(
     signature: Option<FunctionType>,
 ) -> (Package, Vec<u8>, DebugSourceAsmOp, DebugSourceVar) {
+    build_package_with_debug_error(signature, Arc::from("seed error"))
+}
+
+fn build_package_with_debug_error(
+    signature: Option<FunctionType>,
+    error_message: Arc<str>,
+) -> (Package, Vec<u8>, DebugSourceAsmOp, DebugSourceVar) {
     let mut package = build_package(signature);
     let exec_node = *package.mast.procedure_roots().first().expect("seed package has a root");
 
@@ -102,7 +110,7 @@ fn build_package_with_debug_info(
         })
         .expect("seed debug info has one source node");
     debug_info.add_root(source_node);
-    debug_info.add_error_message(0x0123_4567_89ab_cdef, Arc::from("seed error"));
+    debug_info.add_error_message(0x0123_4567_89ab_cdef, error_message);
 
     let debug_info_bytes = debug_info.build().to_bytes();
     package
@@ -316,6 +324,14 @@ fn generate_fuzz_seeds() {
         .expect("seed package should contain its debug error message");
     control_character_package[error_message_offset] = b'\n';
     write_seed("debug_info", "package_with_control_character.bin", &control_character_package);
+
+    let oversized_string: Arc<str> = "x".repeat(MAX_DEBUG_INFO_STRING_SIZE + 1).into();
+    let (oversized_string_package, ..) = build_package_with_debug_error(None, oversized_string);
+    write_seed(
+        "debug_info",
+        "package_with_oversized_string.bin",
+        &oversized_string_package.to_bytes(),
+    );
 
     let file_path_offset = debug_info_bytes
         .windows(file_checksum.len())

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -243,6 +243,13 @@ fn generate_fuzz_seeds() {
     let (package_with_debug_info, debug_info_bytes, asm_op, debug_var) =
         build_package_with_debug_info(None);
     write_seed("debug_info", "valid_debug_info.bin", &debug_info_bytes);
+    let mut oversized_debug_info = PackageDebugInfoBuilder::default();
+    oversized_debug_info.add_string("x".repeat(16 * 1024 * 1024));
+    write_seed(
+        "debug_info",
+        "oversized_debug_info.bin",
+        &oversized_debug_info.build().to_bytes(),
+    );
     write_seed("debug_info", "package_with_debug_info.bin", &package_with_debug_info.to_bytes());
     write_seed(
         "package_deserialize",

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -15,7 +15,10 @@ use miden_core::{
 };
 
 use super::{PackageId, TargetType};
-use crate::{Package, PackageExport, ProcedureExport};
+use crate::{
+    Package, PackageExport, ProcedureExport, Section, SectionId,
+    debug_info::{DebugSourceAsmOp, DebugSourceNode, PackageDebugInfoBuilder},
+};
 
 fn build_forest() -> (MastForest, MastNodeId) {
     let mut builder = DenseMastForestBuilder::new();
@@ -57,6 +60,34 @@ fn build_package(signature: Option<FunctionType>) -> Package {
     .expect("seed package should be valid")
 }
 
+fn build_package_with_debug_info() -> (Package, Vec<u8>) {
+    let mut package = build_package(None);
+    let exec_node = *package.mast.procedure_roots().first().expect("seed package has a root");
+
+    let mut debug_info = PackageDebugInfoBuilder::default();
+    let context_name = debug_info.add_string("seed::test");
+    let op_name = debug_info.add_string("add");
+    let source_node = debug_info
+        .add_node(DebugSourceNode {
+            exec_node,
+            children: Vec::new(),
+            op_start: 0,
+            op_end: 1,
+            asm_ops: vec![DebugSourceAsmOp::new(0, None, context_name, op_name, 1)],
+            debug_vars: Vec::new(),
+            inline_calls: Vec::new(),
+        })
+        .expect("seed debug info has one source node");
+    debug_info.add_root(source_node);
+
+    let debug_info_bytes = debug_info.build().to_bytes();
+    package
+        .sections
+        .push(Section::new(SectionId::DEBUG_INFO, debug_info_bytes.clone()));
+
+    (package, debug_info_bytes)
+}
+
 #[test]
 #[ignore = "run manually to generate fuzz seeds"]
 fn generate_fuzz_seeds() {
@@ -79,6 +110,20 @@ fn generate_fuzz_seeds() {
         "package_deserialize",
         "package_with_signature.bin",
         &package_with_signature.to_bytes(),
+    );
+
+    let (package_with_debug_info, debug_info_bytes) = build_package_with_debug_info();
+    write_seed("debug_info", "valid_debug_info.bin", &debug_info_bytes);
+    write_seed("debug_info", "package_with_debug_info.bin", &package_with_debug_info.to_bytes());
+    write_seed(
+        "package_deserialize",
+        "package_with_debug_info.bin",
+        &package_with_debug_info.to_bytes(),
+    );
+    write_seed(
+        "package_semantic_deserialize",
+        "package_with_debug_info.bin",
+        &package_with_debug_info.to_bytes(),
     );
 
     println!("\nSeed corpus generated in ../../tools/miden-core-fuzz/corpus");

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -293,6 +293,22 @@ fn generate_fuzz_seeds() {
     );
 
     let file_checksum = [0xa5; 32];
+    let location_pattern = [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0];
+    let mut inverted_location_package = package_with_debug_info.to_bytes();
+    let checksum_offset = inverted_location_package
+        .windows(file_checksum.len())
+        .position(|window| window == file_checksum)
+        .expect("seed package should contain its debug file checksum");
+    let location_offset = checksum_offset
+        + file_checksum.len()
+        + inverted_location_package[checksum_offset + file_checksum.len()..]
+            .windows(location_pattern.len())
+            .position(|window| window == location_pattern)
+            .expect("seed package should contain its debug location");
+    inverted_location_package[location_offset + 4..location_offset + 8]
+        .copy_from_slice(&2u32.to_le_bytes());
+    write_seed("debug_info", "package_with_inverted_location.bin", &inverted_location_package);
+
     let file_path_offset = debug_info_bytes
         .windows(file_checksum.len())
         .position(|window| window == file_checksum)

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -1,4 +1,4 @@
-use alloc::{sync::Arc, vec, vec::Vec};
+use alloc::{string::ToString, sync::Arc, vec, vec::Vec};
 use std::{fs, path::Path, println};
 
 use miden_assembly_syntax::{
@@ -11,7 +11,7 @@ use miden_assembly_syntax::{
 use miden_core::{
     mast::{BasicBlockNodeBuilder, DenseMastForestBuilder, MastForest, MastNodeExt, MastNodeId},
     operations::Operation,
-    serde::{ByteReader, ByteWriter, Serializable, SliceReader},
+    serde::{ByteReader, ByteWriter, Deserializable, Serializable, SliceReader},
 };
 use miden_debug_types::{ByteIndex, Uri};
 use zerocopy::IntoBytes;
@@ -22,7 +22,7 @@ use crate::{
     debug_info::{
         DebugSourceAsmOp, DebugSourceNode, DebugSourceVar, DebugTypeInfo,
         MAX_DEBUG_INFO_STRING_ROWS, MAX_DEBUG_INFO_STRING_SIZE, MAX_DEBUG_INFO_TYPE_ROWS,
-        PackageDebugInfoBuilder,
+        PackageDebugInfo, PackageDebugInfoBuilder,
     },
 };
 
@@ -260,35 +260,52 @@ fn generate_fuzz_seeds() {
     assert_eq!(empty_reader.read_u8().unwrap(), crate::debug_info::DEBUG_INFO_VERSION);
     let empty_payload_len = empty_reader.read_usize().unwrap();
     let empty_payload_offset = 1 + empty_payload_len.to_bytes().len();
-    let mut oversized_string_payload = empty_debug_info[empty_payload_offset..].to_vec();
-    let oversized_string_rows = MAX_DEBUG_INFO_STRING_ROWS + 6;
-    let oversized_string_count = oversized_string_rows.to_bytes();
-    oversized_string_payload.splice(0..1, oversized_string_count.iter().copied());
-    oversized_string_payload.splice(
-        oversized_string_count.len()..oversized_string_count.len(),
-        0usize.to_bytes().repeat(oversized_string_rows),
-    );
-    let mut oversized_string_table = Vec::new();
-    oversized_string_table.write_u8(crate::debug_info::DEBUG_INFO_VERSION);
-    oversized_string_table.write_usize(oversized_string_payload.len());
-    oversized_string_table.write_bytes(&oversized_string_payload);
-    write_seed("debug_info", "oversized_debug_string_table.bin", &oversized_string_table);
-    let mut oversized_debug_info = PackageDebugInfoBuilder::default();
-    oversized_debug_info.add_string("x".repeat(16 * 1024 * 1024));
-    write_seed(
-        "debug_info",
-        "oversized_debug_info.bin",
-        &oversized_debug_info.build().to_bytes(),
-    );
-    let mut oversized_type_table = PackageDebugInfoBuilder::default();
-    for _ in 0..=MAX_DEBUG_INFO_TYPE_ROWS {
-        oversized_type_table.push_type(DebugTypeInfo::Unknown);
+    let debug_info_with_empty_strings = |rows: usize| {
+        let mut payload = empty_debug_info[empty_payload_offset..].to_vec();
+        let encoded_rows = rows.to_bytes();
+        payload.splice(0..1, encoded_rows.iter().copied());
+        payload.splice(encoded_rows.len()..encoded_rows.len(), 0usize.to_bytes().repeat(rows));
+
+        let mut encoded = Vec::new();
+        encoded.write_u8(crate::debug_info::DEBUG_INFO_VERSION);
+        encoded.write_usize(payload.len());
+        encoded.write_bytes(&payload);
+        encoded
+    };
+    let mut max_string_table = PackageDebugInfoBuilder::default();
+    for index in 0..MAX_DEBUG_INFO_STRING_ROWS {
+        max_string_table.add_string(index.to_string());
     }
-    write_seed(
-        "debug_info",
-        "oversized_debug_type_table.bin",
-        &oversized_type_table.build().to_bytes(),
-    );
+    let max_string_table = max_string_table.build().to_bytes();
+    let decoded = PackageDebugInfo::read_from_bytes(&max_string_table).unwrap();
+    assert_eq!(decoded.strings().len(), MAX_DEBUG_INFO_STRING_ROWS);
+    write_seed("debug_info", "max_debug_string_table.bin", &max_string_table);
+    let oversized_string_table = debug_info_with_empty_strings(MAX_DEBUG_INFO_STRING_ROWS + 1);
+    assert!(PackageDebugInfo::read_from_bytes(&oversized_string_table).is_err());
+    write_seed("debug_info", "oversized_debug_string_table.bin", &oversized_string_table);
+    let mut max_sized_string = PackageDebugInfoBuilder::default();
+    max_sized_string.add_string("x".repeat(MAX_DEBUG_INFO_STRING_SIZE));
+    let max_sized_string = max_sized_string.build().to_bytes();
+    let decoded = PackageDebugInfo::read_from_bytes(&max_sized_string).unwrap();
+    assert_eq!(decoded.strings().iter().next().unwrap().len(), MAX_DEBUG_INFO_STRING_SIZE);
+    write_seed("debug_info", "max_sized_debug_string.bin", &max_sized_string);
+    let mut oversized_debug_info = PackageDebugInfoBuilder::default();
+    oversized_debug_info.add_string("x".repeat(MAX_DEBUG_INFO_STRING_SIZE + 1));
+    let oversized_debug_info = oversized_debug_info.build().to_bytes();
+    assert!(PackageDebugInfo::read_from_bytes(&oversized_debug_info).is_err());
+    write_seed("debug_info", "oversized_debug_info.bin", &oversized_debug_info);
+    let mut boundary_type_table = PackageDebugInfoBuilder::default();
+    for _ in 0..MAX_DEBUG_INFO_TYPE_ROWS {
+        boundary_type_table.push_type(DebugTypeInfo::Unknown);
+    }
+    let max_type_table = boundary_type_table.debug_info().to_bytes();
+    let decoded = PackageDebugInfo::read_from_bytes(&max_type_table).unwrap();
+    assert_eq!(decoded.types().len(), MAX_DEBUG_INFO_TYPE_ROWS);
+    write_seed("debug_info", "max_debug_type_table.bin", &max_type_table);
+    boundary_type_table.push_type(DebugTypeInfo::Unknown);
+    let oversized_type_table = boundary_type_table.build().to_bytes();
+    assert!(PackageDebugInfo::read_from_bytes(&oversized_type_table).is_err());
+    write_seed("debug_info", "oversized_debug_type_table.bin", &oversized_type_table);
     write_seed("debug_info", "package_with_debug_info.bin", &package_with_debug_info.to_bytes());
     write_seed(
         "package_deserialize",

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -318,6 +318,35 @@ fn generate_fuzz_seeds() {
         &package_with_debug_info.to_bytes(),
     );
 
+    let mut kernel_with_debug_info = package_with_debug_info.clone();
+    kernel_with_debug_info.name = PackageId::from("seed_kernel");
+    kernel_with_debug_info.kind = TargetType::Kernel;
+    let kernel_dependency = kernel_with_debug_info.to_dependency();
+    let mut package_with_nested_debug_info = build_package(None);
+    package_with_nested_debug_info
+        .manifest
+        .add_dependency(kernel_dependency.clone())
+        .expect("seed package should accept its kernel dependency");
+    package_with_nested_debug_info
+        .sections
+        .push(Section::new(SectionId::KERNEL, kernel_with_debug_info.to_bytes()));
+    let nested_package_bytes = package_with_nested_debug_info.to_bytes();
+    let admitted_nested_package = Package::read_from_bytes(&nested_package_bytes)
+        .expect("valid nested debug seed should pass outer admission");
+    let admitted_kernel = admitted_nested_package
+        .try_embedded_kernel_package()
+        .expect("valid nested debug seed should pass kernel extraction")
+        .expect("valid nested debug seed should contain a kernel");
+    assert_eq!(
+        admitted_kernel.debug_info().unwrap(),
+        kernel_with_debug_info.debug_info().unwrap()
+    );
+    write_seed(
+        "package_semantic_deserialize",
+        "package_with_nested_debug_info.bin",
+        &nested_package_bytes,
+    );
+
     let file_checksum = [0xa5; 32];
     let location_pattern = [0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0];
     let mut inverted_location_package = package_with_debug_info.to_bytes();
@@ -491,6 +520,38 @@ fn generate_fuzz_seeds() {
         "package_semantic_deserialize",
         "package_with_invalid_assembly_location_option.bin",
         &invalid_asm_location_package,
+    );
+
+    let mut invalid_nested_kernel = kernel_with_debug_info.to_bytes();
+    let nested_asm_op_offset = invalid_nested_kernel
+        .windows(asm_op.as_bytes().len())
+        .position(|window| window == asm_op.as_bytes())
+        .expect("nested seed kernel should contain its debug assembly operation");
+    assert_eq!(
+        &invalid_nested_kernel[nested_asm_op_offset + 4..nested_asm_op_offset + 8],
+        &1u32.to_le_bytes(),
+    );
+    invalid_nested_kernel[nested_asm_op_offset + 4..nested_asm_op_offset + 8]
+        .copy_from_slice(&2u32.to_le_bytes());
+    let mut package_with_invalid_nested_debug_info = build_package(None);
+    package_with_invalid_nested_debug_info
+        .manifest
+        .add_dependency(kernel_dependency)
+        .expect("seed package should accept its kernel dependency");
+    package_with_invalid_nested_debug_info
+        .sections
+        .push(Section::new(SectionId::KERNEL, invalid_nested_kernel));
+    let invalid_nested_package_bytes = package_with_invalid_nested_debug_info.to_bytes();
+    let admitted_outer = Package::read_from_bytes(&invalid_nested_package_bytes)
+        .expect("opaque hostile nested debug should not fail outer admission");
+    assert!(
+        admitted_outer.try_embedded_kernel_package().is_err(),
+        "hostile nested debug seed should fail untrusted kernel extraction"
+    );
+    write_seed(
+        "package_semantic_deserialize",
+        "package_with_invalid_nested_debug_info.bin",
+        &invalid_nested_package_bytes,
     );
     for (name, field_offset, expected) in [
         ("package_with_dangling_assembly_context_string.bin", 12, 0u32),

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -233,8 +233,36 @@ fn generate_fuzz_seeds() {
         &dangling_file_package,
     );
 
-    let mut dangling_error_debug_info = debug_info_bytes;
     let error_code = 0x0123_4567_89ab_cdef_u64.to_le_bytes();
+    let root_offset = debug_info_bytes
+        .windows(error_code.len())
+        .position(|window| window == error_code)
+        .expect("seed debug info should contain its error code")
+        - 8;
+    let mut dangling_root_debug_info = debug_info_bytes.clone();
+    dangling_root_debug_info[root_offset..root_offset + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+    write_seed("debug_info", "dangling_source_root.bin", &dangling_root_debug_info);
+
+    let mut dangling_root_package = package_with_debug_info.to_bytes();
+    let root_offset = dangling_root_package
+        .windows(error_code.len())
+        .position(|window| window == error_code)
+        .expect("seed package should contain its debug error code")
+        - 8;
+    dangling_root_package[root_offset..root_offset + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+    write_seed("debug_info", "package_with_dangling_source_root.bin", &dangling_root_package);
+    write_seed(
+        "package_deserialize",
+        "package_with_dangling_source_root.bin",
+        &dangling_root_package,
+    );
+    write_seed(
+        "package_semantic_deserialize",
+        "package_with_dangling_source_root.bin",
+        &dangling_root_package,
+    );
+
+    let mut dangling_error_debug_info = debug_info_bytes;
     let error_message_offset = dangling_error_debug_info
         .windows(error_code.len())
         .position(|window| window == error_code)

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -69,12 +69,13 @@ fn build_package(signature: Option<FunctionType>) -> Package {
 fn build_package_with_debug_info(
     signature: Option<FunctionType>,
 ) -> (Package, Vec<u8>, DebugSourceAsmOp, DebugSourceVar) {
-    build_package_with_debug_error(signature, Arc::from("seed error"))
+    build_package_with_debug_options(signature, Arc::from("seed error"), 1)
 }
 
-fn build_package_with_debug_error(
+fn build_package_with_debug_options(
     signature: Option<FunctionType>,
     error_message: Arc<str>,
+    asm_op_repetitions: usize,
 ) -> (Package, Vec<u8>, DebugSourceAsmOp, DebugSourceVar) {
     let mut package = build_package(signature);
     let exec_node = *package.mast.procedure_roots().first().expect("seed package has a root");
@@ -104,7 +105,7 @@ fn build_package_with_debug_error(
             children: Vec::new(),
             op_start: 0,
             op_end: 1,
-            asm_ops: vec![asm_op],
+            asm_ops: vec![asm_op; asm_op_repetitions],
             debug_vars: vec![debug_var.clone()],
             inline_calls: Vec::new(),
         })
@@ -326,11 +327,20 @@ fn generate_fuzz_seeds() {
     write_seed("debug_info", "package_with_control_character.bin", &control_character_package);
 
     let oversized_string: Arc<str> = "x".repeat(MAX_DEBUG_INFO_STRING_SIZE + 1).into();
-    let (oversized_string_package, ..) = build_package_with_debug_error(None, oversized_string);
+    let (oversized_string_package, ..) =
+        build_package_with_debug_options(None, oversized_string, 1);
     write_seed(
         "debug_info",
         "package_with_oversized_string.bin",
         &oversized_string_package.to_bytes(),
+    );
+
+    let (duplicate_asm_op_package, ..) =
+        build_package_with_debug_options(None, Arc::from("seed error"), 2);
+    write_seed(
+        "debug_info",
+        "package_with_duplicate_assembly_op.bin",
+        &duplicate_asm_op_package.to_bytes(),
     );
 
     let file_path_offset = debug_info_bytes

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -238,8 +238,9 @@ fn generate_fuzz_seeds() {
         .windows(error_code.len())
         .position(|window| window == error_code)
         .expect("seed debug info should contain its error code")
-        - 8;
+        - 12;
     let mut dangling_root_debug_info = debug_info_bytes.clone();
+    assert_eq!(&dangling_root_debug_info[root_offset..root_offset + 4], &0u32.to_le_bytes());
     dangling_root_debug_info[root_offset..root_offset + 4].copy_from_slice(&u32::MAX.to_le_bytes());
     write_seed("debug_info", "dangling_source_root.bin", &dangling_root_debug_info);
 
@@ -248,7 +249,8 @@ fn generate_fuzz_seeds() {
         .windows(error_code.len())
         .position(|window| window == error_code)
         .expect("seed package should contain its debug error code")
-        - 8;
+        - 12;
+    assert_eq!(&dangling_root_package[root_offset..root_offset + 4], &0u32.to_le_bytes());
     dangling_root_package[root_offset..root_offset + 4].copy_from_slice(&u32::MAX.to_le_bytes());
     write_seed("debug_info", "package_with_dangling_source_root.bin", &dangling_root_package);
     write_seed(

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -79,6 +79,7 @@ fn build_package_with_debug_info(signature: Option<FunctionType>) -> (Package, V
         })
         .expect("seed debug info has one source node");
     debug_info.add_root(source_node);
+    debug_info.add_error_message(0x0123_4567_89ab_cdef, Arc::from("seed error"));
 
     let debug_info_bytes = debug_info.build().to_bytes();
     package
@@ -188,6 +189,41 @@ fn generate_fuzz_seeds() {
         "package_semantic_deserialize",
         "package_with_debug_info.bin",
         &package_with_debug_info.to_bytes(),
+    );
+
+    let mut dangling_error_debug_info = debug_info_bytes;
+    let error_code = 0x0123_4567_89ab_cdef_u64.to_le_bytes();
+    let error_message_offset = dangling_error_debug_info
+        .windows(error_code.len())
+        .position(|window| window == error_code)
+        .expect("seed debug info should contain its error code")
+        + error_code.len();
+    dangling_error_debug_info[error_message_offset..error_message_offset + 4]
+        .copy_from_slice(&u32::MAX.to_le_bytes());
+    write_seed("debug_info", "dangling_error_message_string.bin", &dangling_error_debug_info);
+
+    let mut dangling_error_package = package_with_debug_info.to_bytes();
+    let error_message_offset = dangling_error_package
+        .windows(error_code.len())
+        .position(|window| window == error_code)
+        .expect("seed package should contain its debug error code")
+        + error_code.len();
+    dangling_error_package[error_message_offset..error_message_offset + 4]
+        .copy_from_slice(&u32::MAX.to_le_bytes());
+    write_seed(
+        "debug_info",
+        "package_with_dangling_error_message_string.bin",
+        &dangling_error_package,
+    );
+    write_seed(
+        "package_deserialize",
+        "package_with_dangling_error_message_string.bin",
+        &dangling_error_package,
+    );
+    write_seed(
+        "package_semantic_deserialize",
+        "package_with_dangling_error_message_string.bin",
+        &dangling_error_package,
     );
 
     for (name, bytes) in build_packages_with_invalid_struct_types() {

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -13,7 +13,7 @@ use miden_core::{
     operations::Operation,
     serde::Serializable,
 };
-use miden_debug_types::Uri;
+use miden_debug_types::{ByteIndex, Uri};
 
 use super::{PackageId, TargetType};
 use crate::{
@@ -68,7 +68,12 @@ fn build_package_with_debug_info(signature: Option<FunctionType>) -> (Package, V
     let mut debug_info = PackageDebugInfoBuilder::default();
     let context_name = debug_info.add_string("seed::test");
     let op_name = debug_info.add_string("add");
-    debug_info.add_file(Uri::new("file:///seed/source.masm"), Some([0xa5; 32]));
+    let file_idx = debug_info.add_file(Uri::new("file:///seed/source.masm"), Some([0xa5; 32]));
+    debug_info.add_location_info(crate::debug_info::DebugLoc {
+        file_idx,
+        start: ByteIndex::new(0),
+        end: ByteIndex::new(1),
+    });
     let source_node = debug_info
         .add_node(DebugSourceNode {
             exec_node,

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -161,6 +161,23 @@ fn build_packages_with_invalid_struct_types() -> Vec<(&'static str, Vec<u8>)> {
     package_bytes.insert(variant_type_offset + 1, 15);
     packages.push(("list_enum_variant.bin", package_bytes));
 
+    let struct_type = StructType::new([Type::Felt, Type::Felt]);
+    let signature = FunctionType::new(CallConv::Fast, [Type::from(struct_type)], []);
+    let signature_bytes = signature.to_bytes();
+    let (package, ..) = build_package_with_debug_info(Some(signature));
+    let mut package_bytes = package.to_bytes();
+    let signature_offset = package_bytes
+        .windows(signature_bytes.len())
+        .position(|window| window == signature_bytes)
+        .expect("seed package should contain its two-field struct signature");
+    let repr_offset = signature_bytes
+        .windows(8)
+        .position(|window| window == [17, 0, 0, 2, 0, 15, 0, 15])
+        .expect("seed signature should contain its default two-field struct")
+        + 2;
+    package_bytes[signature_offset + repr_offset] = 3;
+    packages.push(("multi_field_transparent_struct.bin", package_bytes));
+
     packages
 }
 

--- a/crates/mast-package/src/package/seed_gen.rs
+++ b/crates/mast-package/src/package/seed_gen.rs
@@ -4,7 +4,7 @@ use std::{fs, path::Path, println};
 use miden_assembly_syntax::{
     ast::{
         DebugVarLocation, Path as AstPath, PathBuf,
-        types::{CallConv, EnumType, FunctionType, StructType, Type, TypeRepr, Variant},
+        types::{ArrayType, CallConv, EnumType, FunctionType, StructType, Type, TypeRepr, Variant},
     },
     semver::Version,
 };
@@ -186,6 +186,26 @@ fn build_packages_with_invalid_struct_types() -> Vec<(&'static str, Vec<u8>)> {
         + 2;
     package_bytes[signature_offset + repr_offset] = 3;
     packages.push(("multi_field_transparent_struct.bin", package_bytes));
+
+    let struct_type = StructType::new([Type::from(ArrayType::new(Type::Felt, 1))]);
+    let signature = FunctionType::new(CallConv::Fast, [Type::from(struct_type)], []);
+    let signature_bytes = signature.to_bytes();
+    let (package, ..) = build_package_with_debug_info(Some(signature));
+    let mut package_bytes = package.to_bytes();
+    let signature_offset = package_bytes
+        .windows(signature_bytes.len())
+        .position(|window| window == signature_bytes)
+        .expect("seed package should contain its array-field struct signature");
+    let array_len_offset = signature_bytes
+        .windows(3)
+        .position(|window| window == [18, 3, 15])
+        .expect("seed signature should contain its single-Felt array")
+        + 1;
+    package_bytes.splice(
+        signature_offset + array_len_offset..signature_offset + array_len_offset + 1,
+        (u32::MAX as usize).to_bytes(),
+    );
+    packages.push(("oversized_struct_field.bin", package_bytes));
 
     packages
 }

--- a/crates/mast-package/src/package/serialization/mod.rs
+++ b/crates/mast-package/src/package/serialization/mod.rs
@@ -27,21 +27,21 @@
 //! - whether package-owned debug sections may be exposed to callers.
 //!
 //! [`Package::read_from`] and [`Package::read_from_bytes`] are the normal untrusted readers. They
-//! validate the embedded MAST forest and discard package-owned debug sections before returning the
+//! validate the embedded MAST forest and package-owned debug information before returning the
 //! package. Use them for bytes received across a trust boundary.
 //!
 //! [`Package::read_from_trusted`] and [`Package::read_from_bytes_trusted`] are for local
 //! files/cache entries controlled by the same trusted build or execution system. They validate the
-//! embedded MAST forest, but preserve package-owned debug sections so [`Package::debug_info`] can
-//! decode them.
+//! embedded MAST forest, but defer package-owned debug validation until [`Package::debug_info`] is
+//! called.
 //!
 //! [`Package::read_from_unchecked`] and [`Package::read_from_bytes_unchecked`] are also trusted
 //! same-domain readers, but skip MAST validation. Use them only for bytes that were already
 //! validated before being persisted by the same trusted system.
 //!
-//! Embedded kernel package bytes are stored in the opaque `kernel` custom section. Untrusted
-//! package reads may carry those bytes, but decoding the embedded kernel through the package API
-//! uses the untrusted reader and therefore strips any nested package-owned debug sections.
+//! Embedded kernel package bytes are stored in the opaque `kernel` custom section. Decoding an
+//! embedded kernel through the package API uses the untrusted reader, so nested package-owned debug
+//! information is validated and retained under the same policy.
 
 use alloc::{
     format,
@@ -139,7 +139,7 @@ impl Package {
     ) -> Result<Self, DeserializationError> {
         let header = Self::read_header_from(source)?;
         let mast_forest = Self::read_mast_forest(source, false)?;
-        Self::read_from_with_header_and_mast(source, header, mast_forest, true)
+        Self::read_from_with_header_and_mast(source, header, mast_forest, false)
     }
 
     /// Reads trusted package bytes without validating the embedded MAST forest.
@@ -159,15 +159,15 @@ impl Package {
 
     /// Reads a trusted local package while validating the embedded MAST forest.
     ///
-    /// This keeps the same structural validation as [`Package::read_from`], but allows
-    /// package-owned debug sections to be decoded as trusted metadata. Use this only for local
-    /// files or cache artifacts controlled by this process or build system. Do not use this for
-    /// inbound artifacts from an untrusted channel; use [`Package::read_from`] instead so debug
-    /// sections are discarded before the package is exposed to callers.
+    /// This keeps the same structural validation as [`Package::read_from`], but defers
+    /// package-owned debug validation until the metadata is used. Use this only for local files or
+    /// cache artifacts controlled by this process or build system. Do not use this for inbound
+    /// artifacts from an untrusted channel; use [`Package::read_from`] instead so debug sections
+    /// are validated before the package is exposed to callers.
     pub fn read_from_trusted<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let header = Self::read_header_from(source)?;
         let mast_forest = Self::read_mast_forest(source, true)?;
-        Self::read_from_with_header_and_mast(source, header, mast_forest, true)
+        Self::read_from_with_header_and_mast(source, header, mast_forest, false)
     }
 
     /// Reads trusted local package bytes while validating the embedded MAST forest.
@@ -256,7 +256,7 @@ impl Package {
         source: &mut R,
         header: PackageHeader,
         mast: Arc<MastForest>,
-        debug_sections_trusted: bool,
+        validate_debug_sections: bool,
     ) -> Result<Self, DeserializationError> {
         let PackageHeader { name, version, description, kind } = header;
 
@@ -264,13 +264,7 @@ impl Package {
         let manifest = PackageManifest::read_from_safe(source, &mast)?;
 
         // Read custom sections
-        let mut sections = Vec::<Section>::read_from(source)?;
-        if !debug_sections_trusted && sections.iter().any(|section| section.id.is_debug()) {
-            log::warn!(
-                "Package read ignored debug sections from an untrusted artifact; use Package::read_from_trusted for local cache/debug reads"
-            );
-            sections.retain(|section| !section.id.is_debug());
-        }
+        let sections = Vec::<Section>::read_from(source)?;
 
         let mut package = Self {
             name,
@@ -281,8 +275,16 @@ impl Package {
             mast,
             manifest,
             sections,
-            debug_sections_trusted,
+            debug_sections_trusted: true,
         };
+
+        if validate_debug_sections {
+            package.debug_info().map_err(|err| {
+                DeserializationError::InvalidValue(format!(
+                    "package contains invalid debug information: {err}"
+                ))
+            })?;
+        }
 
         package
             .compute_interface_digest()
@@ -300,7 +302,7 @@ impl Deserializable for Package {
         // Read MAST artifact
         let mast = Self::read_mast_forest(source, true)?;
 
-        Self::read_from_with_header_and_mast(source, header, mast, false)
+        Self::read_from_with_header_and_mast(source, header, mast, true)
     }
 
     fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {

--- a/crates/mast-package/src/package/serialization/tests.rs
+++ b/crates/mast-package/src/package/serialization/tests.rs
@@ -210,24 +210,21 @@ fn executable_package_entrypoint_roundtrips() {
 }
 
 #[test]
-fn package_checked_deserialization_discards_untrusted_debug_sections() {
+fn package_checked_deserialization_preserves_validated_debug_sections() {
     let package = build_package_with_debug_info();
     let bytes = package.to_bytes();
 
     let deserialized = Package::read_from_bytes(&bytes).unwrap();
 
-    assert!(
-        !deserialized.sections.iter().any(|section| section.id.is_debug()),
-        "untrusted package reads should discard debug sections"
-    );
-    assert!(deserialized.debug_info().unwrap().is_none());
+    assert!(deserialized.sections.iter().any(|section| section.id == SectionId::DEBUG_INFO));
+    assert!(deserialized.debug_info().unwrap().is_some());
     let debug_info_id = SectionId::DEBUG_INFO.as_str().as_bytes();
     assert!(
-        !deserialized
+        deserialized
             .to_bytes()
             .windows(debug_info_id.len())
             .any(|window| window == debug_info_id),
-        "discarded debug sections should not be reserialized"
+        "validated debug sections should be reserialized"
     );
 }
 
@@ -255,7 +252,7 @@ fn package_unchecked_deserialization_preserves_trusted_debug_sections() {
 
 #[cfg(feature = "std")]
 #[test]
-fn package_deserialize_from_file_discards_untrusted_debug_sections() {
+fn package_deserialize_from_file_preserves_validated_debug_sections() {
     let package = build_package_with_debug_info();
     let path = std::env::temp_dir().join(format!(
         "miden-package-deserialize-{}-{}.masp",
@@ -267,11 +264,8 @@ fn package_deserialize_from_file_discards_untrusted_debug_sections() {
     let deserialized = Package::deserialize_from_file(&path).unwrap();
     fs::remove_file(&path).unwrap();
 
-    assert!(
-        !deserialized.sections.iter().any(|section| section.id.is_debug()),
-        "untrusted package file reads should discard debug sections"
-    );
-    assert!(deserialized.debug_info().unwrap().is_none());
+    assert!(deserialized.sections.iter().any(|section| section.id == SectionId::DEBUG_INFO));
+    assert!(deserialized.debug_info().unwrap().is_some());
 }
 
 #[cfg(feature = "std")]

--- a/crates/midenc-hir-type/src/layout.rs
+++ b/crates/midenc-hir-type/src/layout.rs
@@ -76,6 +76,7 @@ impl Type {
             | Self::Ptr(_)
             | Self::I16
             | Self::U16
+            | Self::List(_)
             | Self::Function(_)
             | Self::Enum(_)) => {
                 let len = ty.size_in_bytes();
@@ -383,9 +384,6 @@ impl Type {
                     }
                 },
             },
-            Type::List(_) => {
-                panic!("invalid type: list has no defined representation yet, so cannot be split")
-            },
             // These types either have no size, or are 1 byte in size, so must have
             // been handled above when checking if the size of the type is <= the
             // requested split size
@@ -407,7 +405,7 @@ impl Type {
             // 64-bit integers and floats must be element-aligned
             Self::I64 | Self::U64 | Self::F64 => 4,
             // 32-bit integers and pointers must be element-aligned
-            Self::I32 | Self::U32 | Self::Ptr(_) | Self::Function(..) => 4,
+            Self::I32 | Self::U32 | Self::Ptr(_) | Self::Function(..) | Self::List(_) => 4,
             // 16-bit integers can be naturally aligned
             Self::I16 | Self::U16 => 2,
             // 8-bit integers and booleans can be naturally aligned
@@ -418,8 +416,6 @@ impl Type {
             Self::Enum(enum_ty) => enum_ty.min_alignment(),
             // Arrays use the minimum alignment of their element type
             Self::Array(array_ty) => array_ty.min_alignment(),
-            // Lists use the minimum alignment of their element type
-            Self::List(element_ty) => element_ty.min_alignment(),
         }
     }
 
@@ -444,14 +440,12 @@ impl Type {
             Self::U256 => 256,
             // Raw pointers  are 32-bits, the same size as the native integer width, u32
             Self::Ptr(_) | Self::Function(_) => 32,
+            // Lists are fat pointers containing a pointer and a length.
+            Self::List(_) => 64,
             // Packed structs have no alignment padding between fields
             Self::Struct(struct_ty) => struct_ty.size as usize * 8,
             Self::Enum(enum_ty) => enum_ty.size_in_bits(),
             Self::Array(array_ty) => array_ty.size_in_bits(),
-            Type::List(_) => panic!(
-                "invalid type: list has no defined representation yet, so its size cannot be \
-                 determined"
-            ),
         }
     }
 

--- a/crates/midenc-hir-type/src/lib.rs
+++ b/crates/midenc-hir-type/src/lib.rs
@@ -74,11 +74,9 @@ pub enum Type {
     Enum(Arc<EnumType>),
     /// A vector of fixed size
     Array(Arc<ArrayType>),
-    /// A dynamically sized list of values of the given type
+    /// A dynamically sized list of values of the given type.
     ///
-    /// NOTE: Currently this only exists to support the Wasm Canonical ABI,
-    /// but it has no defined represenation yet, so in practice cannot be
-    /// used in most places except during initial translation in the Wasm frontend.
+    /// Lists use a fat pointer layout containing a pointer and a length.
     List(Arc<Type>),
     /// A reference to a function with the given type signature
     Function(Arc<FunctionType>),

--- a/crates/midenc-hir-type/src/serialization.rs
+++ b/crates/midenc-hir-type/src/serialization.rs
@@ -311,6 +311,14 @@ impl Type {
                     }
                     fields.push(NameAndType { name, ty });
                 }
+                if repr == TypeRepr::Transparent
+                    && fields.iter().filter(|field| field.ty.size_in_bytes() != 0).count() != 1
+                {
+                    return Err(DeserializationError::InvalidValue(
+                        "invalid transparent struct: expected exactly one non-zero-sized field"
+                            .to_string(),
+                    ));
+                }
                 Type::Struct(Arc::new(StructType::from_parts(name, repr, fields)))
             },
             18 => {

--- a/crates/midenc-hir-type/src/serialization.rs
+++ b/crates/midenc-hir-type/src/serialization.rs
@@ -263,11 +263,8 @@ impl Type {
                                 "invalid type repr: alignment must be a power of two".to_string(),
                             ));
                         }
-                        let align = NonZeroU16::new(align).ok_or_else(|| {
-                            DeserializationError::InvalidValue(
-                                "invalid type repr: alignment must be a non-zero value".to_string(),
-                            )
-                        })?;
+                        let align =
+                            NonZeroU16::new(align).expect("power-of-two alignment is non-zero");
                         TypeRepr::Align(align)
                     },
                     2 => {
@@ -278,12 +275,8 @@ impl Type {
                                     .to_string(),
                             ));
                         }
-                        let align = NonZeroU16::new(align).ok_or_else(|| {
-                            DeserializationError::InvalidValue(
-                                "invalid type repr: packed alignment must be a non-zero value"
-                                    .to_string(),
-                            )
-                        })?;
+                        let align =
+                            NonZeroU16::new(align).expect("power-of-two alignment is non-zero");
                         TypeRepr::Packed(align)
                     },
                     3 => TypeRepr::Transparent,

--- a/crates/midenc-hir-type/src/serialization.rs
+++ b/crates/midenc-hir-type/src/serialization.rs
@@ -329,6 +329,31 @@ impl Type {
             18 => {
                 let arity = source.read_usize()?;
                 let ty = Type::read_from_with_depth(source, next_depth)?;
+                if ty.has_defined_layout() {
+                    let element_size = u64::try_from(ty.size_in_bits()).unwrap_or(u64::MAX);
+                    let element_align =
+                        u64::try_from(ty.min_alignment()).unwrap_or(u64::MAX).saturating_mul(8);
+                    let padded_element_size = element_size
+                        .checked_add(element_align.saturating_sub(1))
+                        .map(|size| size / element_align * element_align);
+                    let size_in_bits = match arity {
+                        0 => Some(0),
+                        1 => Some(element_size),
+                        n => padded_element_size.and_then(|padded_size| {
+                            u64::try_from(n - 1)
+                                .ok()
+                                .and_then(|n| padded_size.checked_mul(n))
+                                .and_then(|tail_size| element_size.checked_add(tail_size))
+                        }),
+                    };
+                    let size_in_bytes =
+                        size_in_bits.and_then(|size| size.checked_add(7)).map(|size| size / 8);
+                    if size_in_bytes.is_none_or(|size| size > u64::from(u32::MAX)) {
+                        return Err(DeserializationError::InvalidValue(
+                            "invalid array: size exceeds u32::MAX bytes".to_string(),
+                        ));
+                    }
+                }
                 Type::Array(Arc::new(ArrayType { ty, len: arity }))
             },
             19 => {

--- a/crates/midenc-hir-type/src/serialization.rs
+++ b/crates/midenc-hir-type/src/serialization.rs
@@ -309,6 +309,11 @@ impl Type {
                             "invalid struct field: type has no defined layout".to_string(),
                         ));
                     }
+                    if u32::try_from(ty.size_in_bytes()).is_err() {
+                        return Err(DeserializationError::InvalidValue(
+                            "invalid struct field: size exceeds u32::MAX bytes".to_string(),
+                        ));
+                    }
                     fields.push(NameAndType { name, ty });
                 }
                 if repr == TypeRepr::Transparent

--- a/crates/midenc-hir-type/src/serialization.rs
+++ b/crates/midenc-hir-type/src/serialization.rs
@@ -257,7 +257,13 @@ impl Type {
                 let repr = match source.read_u8()? {
                     0 => TypeRepr::Default,
                     1 => {
-                        let align = NonZeroU16::new(source.read_u16()?).ok_or_else(|| {
+                        let align = source.read_u16()?;
+                        if !align.is_power_of_two() {
+                            return Err(DeserializationError::InvalidValue(
+                                "invalid type repr: alignment must be a power of two".to_string(),
+                            ));
+                        }
+                        let align = NonZeroU16::new(align).ok_or_else(|| {
                             DeserializationError::InvalidValue(
                                 "invalid type repr: alignment must be a non-zero value".to_string(),
                             )
@@ -265,7 +271,14 @@ impl Type {
                         TypeRepr::Align(align)
                     },
                     2 => {
-                        let align = NonZeroU16::new(source.read_u16()?).ok_or_else(|| {
+                        let align = source.read_u16()?;
+                        if !align.is_power_of_two() {
+                            return Err(DeserializationError::InvalidValue(
+                                "invalid type repr: packed alignment must be a power of two"
+                                    .to_string(),
+                            ));
+                        }
+                        let align = NonZeroU16::new(align).ok_or_else(|| {
                             DeserializationError::InvalidValue(
                                 "invalid type repr: packed alignment must be a non-zero value"
                                     .to_string(),

--- a/crates/midenc-hir-type/src/serialization.rs
+++ b/crates/midenc-hir-type/src/serialization.rs
@@ -198,6 +198,14 @@ impl Serializable for Type {
 const MAX_TYPE_NESTING: usize = 128;
 
 impl Type {
+    fn has_defined_layout(&self) -> bool {
+        match self {
+            Self::List(_) => false,
+            Self::Array(array) => array.element_type().has_defined_layout(),
+            _ => true,
+        }
+    }
+
     /// Provides [Type] deserialization support via the miden-serde-utils serializer.
     ///
     /// This is a temporary implementation to allow type information to be serialized with
@@ -296,6 +304,11 @@ impl Type {
                         None
                     };
                     let ty = Type::read_from_with_depth(source, next_depth)?;
+                    if !ty.has_defined_layout() {
+                        return Err(DeserializationError::InvalidValue(
+                            "invalid struct field: type has no defined layout".to_string(),
+                        ));
+                    }
                     fields.push(NameAndType { name, ty });
                 }
                 Type::Struct(Arc::new(StructType::from_parts(name, repr, fields)))
@@ -324,7 +337,13 @@ impl Type {
                 for _ in 0..num_variants {
                     let name = Arc::<str>::from(String::read_from(source)?.into_boxed_str());
                     let value_ty = if source.read_bool()? {
-                        Some(Type::read_from_with_depth(source, next_depth)?)
+                        let ty = Type::read_from_with_depth(source, next_depth)?;
+                        if !ty.has_defined_layout() {
+                            return Err(DeserializationError::InvalidValue(
+                                "invalid enum variant: type has no defined layout".to_string(),
+                            ));
+                        }
+                        Some(ty)
                     } else {
                         None
                     };

--- a/crates/midenc-hir-type/src/serialization.rs
+++ b/crates/midenc-hir-type/src/serialization.rs
@@ -198,14 +198,6 @@ impl Serializable for Type {
 const MAX_TYPE_NESTING: usize = 128;
 
 impl Type {
-    fn has_defined_layout(&self) -> bool {
-        match self {
-            Self::List(_) => false,
-            Self::Array(array) => array.element_type().has_defined_layout(),
-            _ => true,
-        }
-    }
-
     /// Provides [Type] deserialization support via the miden-serde-utils serializer.
     ///
     /// This is a temporary implementation to allow type information to be serialized with
@@ -304,11 +296,6 @@ impl Type {
                         None
                     };
                     let ty = Type::read_from_with_depth(source, next_depth)?;
-                    if !ty.has_defined_layout() {
-                        return Err(DeserializationError::InvalidValue(
-                            "invalid struct field: type has no defined layout".to_string(),
-                        ));
-                    }
                     if u32::try_from(ty.size_in_bytes()).is_err() {
                         return Err(DeserializationError::InvalidValue(
                             "invalid struct field: size exceeds u32::MAX bytes".to_string(),
@@ -317,10 +304,10 @@ impl Type {
                     fields.push(NameAndType { name, ty });
                 }
                 if repr == TypeRepr::Transparent
-                    && fields.iter().filter(|field| field.ty.size_in_bytes() != 0).count() != 1
+                    && fields.iter().filter(|field| field.ty.size_in_bytes() != 0).count() > 1
                 {
                     return Err(DeserializationError::InvalidValue(
-                        "invalid transparent struct: expected exactly one non-zero-sized field"
+                        "invalid transparent struct: expected at most one non-zero-sized field"
                             .to_string(),
                     ));
                 }
@@ -329,30 +316,16 @@ impl Type {
             18 => {
                 let arity = source.read_usize()?;
                 let ty = Type::read_from_with_depth(source, next_depth)?;
-                if ty.has_defined_layout() {
-                    let element_size = u64::try_from(ty.size_in_bits()).unwrap_or(u64::MAX);
-                    let element_align =
-                        u64::try_from(ty.min_alignment()).unwrap_or(u64::MAX).saturating_mul(8);
-                    let padded_element_size = element_size
-                        .checked_add(element_align.saturating_sub(1))
-                        .map(|size| size / element_align * element_align);
-                    let size_in_bits = match arity {
-                        0 => Some(0),
-                        1 => Some(element_size),
-                        n => padded_element_size.and_then(|padded_size| {
-                            u64::try_from(n - 1)
-                                .ok()
-                                .and_then(|n| padded_size.checked_mul(n))
-                                .and_then(|tail_size| element_size.checked_add(tail_size))
-                        }),
-                    };
-                    let size_in_bytes =
-                        size_in_bits.and_then(|size| size.checked_add(7)).map(|size| size / 8);
-                    if size_in_bytes.is_none_or(|size| size > u64::from(u32::MAX)) {
-                        return Err(DeserializationError::InvalidValue(
-                            "invalid array: size exceeds u32::MAX bytes".to_string(),
-                        ));
-                    }
+                let element_size = u64::try_from(ty.size_in_bytes()).unwrap_or(u64::MAX);
+                let element_align = u64::try_from(ty.min_alignment()).unwrap_or(u64::MAX);
+                let padded_element_size = element_size.checked_next_multiple_of(element_align);
+                let size_in_bytes = padded_element_size.and_then(|padded_size| {
+                    u64::try_from(arity).ok().and_then(|arity| padded_size.checked_mul(arity))
+                });
+                if size_in_bytes.is_none_or(|size| size > u64::from(u32::MAX)) {
+                    return Err(DeserializationError::InvalidValue(
+                        "invalid array: size exceeds u32::MAX bytes".to_string(),
+                    ));
                 }
                 Type::Array(Arc::new(ArrayType { ty, len: arity }))
             },
@@ -375,13 +348,7 @@ impl Type {
                 for _ in 0..num_variants {
                     let name = Arc::<str>::from(String::read_from(source)?.into_boxed_str());
                     let value_ty = if source.read_bool()? {
-                        let ty = Type::read_from_with_depth(source, next_depth)?;
-                        if !ty.has_defined_layout() {
-                            return Err(DeserializationError::InvalidValue(
-                                "invalid enum variant: type has no defined layout".to_string(),
-                            ));
-                        }
-                        Some(ty)
+                        Some(Type::read_from_with_depth(source, next_depth)?)
                     } else {
                         None
                     };
@@ -425,7 +392,7 @@ impl Deserializable for Type {
 
 #[cfg(test)]
 mod tests {
-    use alloc::{format, vec::Vec};
+    use alloc::{format, sync::Arc, vec::Vec};
 
     use miden_serde_utils::{BudgetedReader, ByteWriter, SliceReader};
 
@@ -485,6 +452,93 @@ mod tests {
 
         let ty = Type::read_from(&mut SliceReader::new(&bytes)).unwrap();
         assert!(matches!(ty, Type::Ptr(_)));
+    }
+
+    #[test]
+    fn list_type_has_fat_pointer_layout() {
+        let ty = Type::List(Arc::new(Type::U8));
+
+        assert_eq!(ty.min_alignment(), 4);
+        assert_eq!(ty.size_in_bytes(), 8);
+    }
+
+    #[test]
+    fn struct_type_allows_zero_sized_and_list_fields() {
+        let mut bytes = Vec::new();
+        bytes.write_u8(17);
+        bytes.write_bool(false);
+        bytes.write_u8(0);
+        bytes.write_u8(2);
+        bytes.write_bool(false);
+        bytes.write_u8(1);
+        bytes.write_bool(false);
+        bytes.write_u8(19);
+        bytes.write_u8(4);
+
+        let ty = Type::read_from(&mut SliceReader::new(&bytes)).unwrap();
+        let Type::Struct(struct_ty) = ty else {
+            panic!("expected struct");
+        };
+        assert_eq!(struct_ty.fields().len(), 2);
+        assert_eq!(struct_ty.size(), 8);
+    }
+
+    #[test]
+    fn transparent_struct_allows_only_zero_sized_fields() {
+        let mut bytes = Vec::new();
+        bytes.write_u8(17);
+        bytes.write_bool(false);
+        bytes.write_u8(3);
+        bytes.write_u8(1);
+        bytes.write_bool(false);
+        bytes.write_u8(1);
+
+        let ty = Type::read_from(&mut SliceReader::new(&bytes)).unwrap();
+        let Type::Struct(struct_ty) = ty else {
+            panic!("expected struct");
+        };
+        assert_eq!(struct_ty.size(), 0);
+    }
+
+    #[test]
+    fn array_type_allows_zero_sized_elements_at_large_arity() {
+        let mut bytes = Vec::new();
+        bytes.write_u8(18);
+        bytes.write_usize(usize::MAX);
+        bytes.write_u8(1);
+
+        let ty = Type::read_from(&mut SliceReader::new(&bytes)).unwrap();
+        assert!(ty.is_zst());
+    }
+
+    #[test]
+    fn array_type_rejects_oversized_non_zero_elements() {
+        let mut bytes = Vec::new();
+        bytes.write_u8(18);
+        bytes.write_usize(usize::MAX);
+        bytes.write_u8(4);
+
+        let err = Type::read_from(&mut SliceReader::new(&bytes)).unwrap_err();
+        let DeserializationError::InvalidValue(message) = err else {
+            panic!("expected InvalidValue error");
+        };
+        assert!(message.contains("invalid array"));
+    }
+
+    #[test]
+    fn enum_type_allows_zero_sized_variant_payloads() {
+        let mut bytes = Vec::new();
+        bytes.write_u8(21);
+        write_str(&mut bytes, "E");
+        bytes.write_u8(4);
+        bytes.write_usize(1);
+        write_str(&mut bytes, "V");
+        bytes.write_bool(true);
+        bytes.write_u8(1);
+        bytes.write_bool(false);
+
+        let ty = Type::read_from(&mut SliceReader::new(&bytes)).unwrap();
+        assert!(matches!(ty, Type::Enum(_)));
     }
 
     #[test]

--- a/crates/midenc-hir-type/src/struct_type.rs
+++ b/crates/midenc-hir-type/src/struct_type.rs
@@ -211,6 +211,11 @@ impl StructType {
                         offset += field_size;
                     }
                 }
+                assert_ne!(
+                    offset, 0,
+                    "invalid transparent representation for struct: repr(transparent) requires a \
+                     non-zero sized field"
+                );
                 offset
             },
             repr => {

--- a/crates/midenc-hir-type/src/struct_type.rs
+++ b/crates/midenc-hir-type/src/struct_type.rs
@@ -211,11 +211,6 @@ impl StructType {
                         offset += field_size;
                     }
                 }
-                assert_ne!(
-                    offset, 0,
-                    "invalid transparent representation for struct: repr(transparent) requires a \
-                     non-zero sized field"
-                );
                 offset
             },
             repr => {

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -264,7 +264,7 @@ fn test_syscall_fail() {
 }
 
 #[test]
-fn untrusted_debug_stripped_child_bearing_package_executes_without_debug_info() {
+fn validated_debug_child_bearing_package_executes_with_debug_info() {
     let source_manager = Arc::new(DefaultSourceManager::default());
     let package = Assembler::new(source_manager)
         .assemble_program(
@@ -289,7 +289,7 @@ fn untrusted_debug_stripped_child_bearing_package_executes_without_debug_info() 
     assert!(package.debug_info().unwrap().is_some());
 
     let package = Package::read_from_bytes(&package.to_bytes()).unwrap();
-    assert!(package.debug_info().unwrap().is_none());
+    assert!(package.debug_info().unwrap().is_some());
 
     let program = package.unwrap_program();
     let output = FastProcessor::new(StackInputs::new(&[Felt::new_unchecked(3)]).unwrap())

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "miden-constraint-compiler",
  "miden-core",
  "miden-crypto",
+ "miden-field",
  "thiserror",
 ]
 
@@ -1042,6 +1043,7 @@ version = "0.30.0"
 dependencies = [
  "miden-core",
  "miden-crypto",
+ "ruint",
 ]
 
 [[package]]
@@ -1780,6 +1782,21 @@ dependencies = [
  "crypto-bigint",
  "hmac",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
+dependencies = [
+ "ruint-macro",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-hash"

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -742,7 +742,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "miden-constraint-compiler",
  "miden-core",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "miden-ace-codegen",
  "miden-core",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "miden-constraint-compiler"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "hashbrown",
  "itertools",

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -179,6 +179,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,6 +741,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "miden-ace-codegen"
+version = "0.29.0"
+dependencies = [
+ "miden-constraint-compiler",
+ "miden-core",
+ "miden-crypto",
+ "thiserror",
+]
+
+[[package]]
+name = "miden-air"
+version = "0.29.0"
+dependencies = [
+ "miden-ace-codegen",
+ "miden-core",
+ "miden-crypto",
+ "miden-utils-indexing",
+ "p3-field",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "miden-assembly"
 version = "0.30.0"
 dependencies = [
@@ -759,6 +807,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-constraint-compiler"
+version = "0.29.0"
+dependencies = [
+ "miden-core",
+ "miden-crypto",
+]
+
+[[package]]
 name = "miden-core"
 version = "0.30.0"
 dependencies = [
@@ -785,6 +841,7 @@ dependencies = [
  "miden-core",
  "miden-mast-package",
  "miden-package-registry",
+ "miden-processor",
  "miden-project",
  "serde_json",
  "toml",
@@ -977,6 +1034,33 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror",
+]
+
+[[package]]
+name = "miden-precompiles"
+version = "0.29.0"
+dependencies = [
+ "miden-core",
+ "miden-crypto",
+]
+
+[[package]]
+name = "miden-processor"
+version = "0.29.0"
+dependencies = [
+ "hashbrown",
+ "itertools",
+ "miden-air",
+ "miden-core",
+ "miden-debug-types",
+ "miden-mast-package",
+ "miden-precompiles",
+ "miden-utils-diagnostics",
+ "miden-utils-indexing",
+ "paste",
+ "rayon",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1627,6 +1711,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -919,7 +919,6 @@ name = "miden-mast-package"
 version = "0.30.0"
 dependencies = [
  "hashbrown",
- "log",
  "miden-assembly-syntax",
  "miden-core",
  "miden-debug-types",

--- a/tools/miden-core-fuzz/Cargo.toml
+++ b/tools/miden-core-fuzz/Cargo.toml
@@ -31,6 +31,10 @@ features = ["std"]
 path = "../../crates/mast-package"
 features = ["std"]
 
+[dependencies.miden-processor]
+path = "../../processor"
+features = ["std"]
+
 [dependencies.miden-package-registry]
 path = "../../crates/package-registry"
 features = ["std", "serde", "resolver"]

--- a/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
@@ -13,8 +13,8 @@ use miden_core::serde::{ByteReader, Deserializable, SliceReader};
 use miden_mast_package::{
     Package,
     debug_info::{
-        MAX_DEBUG_INFO_PAYLOAD_SIZE, MAX_DEBUG_INFO_STRING_ROWS, MAX_DEBUG_INFO_TYPE_ROWS,
-        PackageDebugInfo,
+        MAX_DEBUG_INFO_PAYLOAD_SIZE, MAX_DEBUG_INFO_STRING_ROWS, MAX_DEBUG_INFO_STRING_SIZE,
+        MAX_DEBUG_INFO_TYPE_ROWS, PackageDebugInfo,
     },
 };
 
@@ -82,6 +82,7 @@ fn assert_valid_package_type_alignments(package: &Package) {
 
 fn assert_valid_debug_policy(debug_info: &PackageDebugInfo) {
     for string in debug_info.strings() {
+        assert!(string.len() <= MAX_DEBUG_INFO_STRING_SIZE);
         assert!(!string.chars().any(char::is_control));
     }
     for location in debug_info.locations() {

--- a/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
@@ -88,6 +88,9 @@ fn assert_valid_debug_policy(debug_info: &PackageDebugInfo) {
     for location in debug_info.locations() {
         assert!(location.start.to_usize() <= location.end.to_usize());
     }
+    for source_node in debug_info.nodes() {
+        assert!(source_node.asm_ops.windows(2).all(|rows| rows[0].op_idx < rows[1].op_idx));
+    }
 }
 
 fuzz_target!(|data: &[u8]| {
@@ -114,6 +117,9 @@ fuzz_target!(|data: &[u8]| {
     } else if let Ok(debug_info) = debug_info {
         assert!(debug_info.strings().len() <= MAX_DEBUG_INFO_STRING_ROWS);
         assert!(debug_info.types().len() <= MAX_DEBUG_INFO_TYPE_ROWS);
+        for source_node in debug_info.nodes() {
+            assert!(source_node.asm_ops.windows(2).all(|rows| rows[0].op_idx < rows[1].op_idx));
+        }
         exercise_debug_info(&debug_info);
     }
 });

--- a/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
@@ -9,7 +9,7 @@
 
 use libfuzzer_sys::fuzz_target;
 use miden_assembly_syntax::ast::types::Type;
-use miden_core::serde::{Deserializable, SliceReader};
+use miden_core::serde::{ByteReader, Deserializable, SliceReader};
 use miden_mast_package::{
     Package,
     debug_info::{MAX_DEBUG_INFO_PAYLOAD_SIZE, PackageDebugInfo},
@@ -87,9 +87,14 @@ fuzz_target!(|data: &[u8]| {
         let _ = package.debug_info();
     }
 
+    let mut framing_reader = SliceReader::new(data);
+    let declared_payload_len = framing_reader
+        .read_u8()
+        .and_then(|_| framing_reader.read_usize())
+        .ok();
     let mut reader = SliceReader::new(data);
     let debug_info = PackageDebugInfo::read_from(&mut reader);
-    if data.len() > MAX_DEBUG_INFO_PAYLOAD_SIZE + 10 {
+    if declared_payload_len.is_some_and(|len| len > MAX_DEBUG_INFO_PAYLOAD_SIZE) {
         assert!(debug_info.is_err());
     } else if let Ok(debug_info) = debug_info {
         exercise_debug_info(&debug_info);

--- a/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
@@ -12,6 +12,29 @@ use miden_assembly_syntax::ast::types::Type;
 use miden_core::serde::{Deserializable, SliceReader};
 use miden_mast_package::{Package, debug_info::PackageDebugInfo};
 
+fn exercise_debug_info(debug_info: &PackageDebugInfo) {
+    for (index, _) in debug_info.locations().iter().enumerate() {
+        let _ = debug_info.get_location((index as u32).into());
+    }
+    for message in debug_info.error_messages() {
+        let _ = debug_info.error_message(message.err_code);
+    }
+    for node in debug_info.nodes() {
+        for asm_op in &node.asm_ops {
+            let _ = asm_op.to_assembly_op(debug_info);
+        }
+        for debug_var in &node.debug_vars {
+            let _ = node.debug_infos_for_operation(debug_var.op_idx, debug_info).count();
+        }
+    }
+
+    let _ = debug_info
+        .source_roots_for_exec_node(miden_core::mast::MastNodeId::new_unchecked(0))
+        .count();
+    let mut cloned = debug_info.clone();
+    cloned.trim_file_paths(|_| None);
+}
+
 fn assert_valid_type_alignments(ty: &Type) {
     assert!(ty.min_alignment().is_power_of_two());
 
@@ -62,5 +85,7 @@ fuzz_target!(|data: &[u8]| {
     }
 
     let mut reader = SliceReader::new(data);
-    let _ = PackageDebugInfo::read_from(&mut reader);
+    if let Ok(debug_info) = PackageDebugInfo::read_from(&mut reader) {
+        exercise_debug_info(&debug_info);
+    }
 });

--- a/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
@@ -13,7 +13,8 @@ use miden_core::serde::{ByteReader, Deserializable, SliceReader};
 use miden_mast_package::{
     Package,
     debug_info::{
-        MAX_DEBUG_INFO_PAYLOAD_SIZE, MAX_DEBUG_INFO_TYPE_ROWS, PackageDebugInfo,
+        MAX_DEBUG_INFO_PAYLOAD_SIZE, MAX_DEBUG_INFO_STRING_ROWS, MAX_DEBUG_INFO_TYPE_ROWS,
+        PackageDebugInfo,
     },
 };
 
@@ -99,6 +100,7 @@ fuzz_target!(|data: &[u8]| {
     if declared_payload_len.is_some_and(|len| len > MAX_DEBUG_INFO_PAYLOAD_SIZE) {
         assert!(debug_info.is_err());
     } else if let Ok(debug_info) = debug_info {
+        assert!(debug_info.strings().len() <= MAX_DEBUG_INFO_STRING_ROWS);
         assert!(debug_info.types().len() <= MAX_DEBUG_INFO_TYPE_ROWS);
         exercise_debug_info(&debug_info);
     }

--- a/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
@@ -81,6 +81,9 @@ fn assert_valid_package_type_alignments(package: &Package) {
 }
 
 fn assert_valid_debug_policy(debug_info: &PackageDebugInfo) {
+    for string in debug_info.strings() {
+        assert!(!string.chars().any(char::is_control));
+    }
     for location in debug_info.locations() {
         assert!(location.start.to_usize() <= location.end.to_usize());
     }

--- a/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
@@ -10,7 +10,10 @@
 use libfuzzer_sys::fuzz_target;
 use miden_assembly_syntax::ast::types::Type;
 use miden_core::serde::{Deserializable, SliceReader};
-use miden_mast_package::{Package, debug_info::PackageDebugInfo};
+use miden_mast_package::{
+    Package,
+    debug_info::{MAX_DEBUG_INFO_PAYLOAD_SIZE, PackageDebugInfo},
+};
 
 fn exercise_debug_info(debug_info: &PackageDebugInfo) {
     for (index, _) in debug_info.locations().iter().enumerate() {
@@ -85,7 +88,10 @@ fuzz_target!(|data: &[u8]| {
     }
 
     let mut reader = SliceReader::new(data);
-    if let Ok(debug_info) = PackageDebugInfo::read_from(&mut reader) {
+    let debug_info = PackageDebugInfo::read_from(&mut reader);
+    if data.len() > MAX_DEBUG_INFO_PAYLOAD_SIZE + 10 {
+        assert!(debug_info.is_err());
+    } else if let Ok(debug_info) = debug_info {
         exercise_debug_info(&debug_info);
     }
 });

--- a/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
@@ -80,6 +80,12 @@ fn assert_valid_package_type_alignments(package: &Package) {
     }
 }
 
+fn assert_valid_debug_policy(debug_info: &PackageDebugInfo) {
+    for location in debug_info.locations() {
+        assert!(location.start.to_usize() <= location.end.to_usize());
+    }
+}
+
 fuzz_target!(|data: &[u8]| {
     if let Ok(package) = Package::read_from_bytes(data) {
         assert_valid_package_type_alignments(&package);
@@ -87,7 +93,9 @@ fuzz_target!(|data: &[u8]| {
     }
     if let Ok(package) = Package::read_from_bytes_trusted(data) {
         assert_valid_package_type_alignments(&package);
-        let _ = package.debug_info();
+        if let Ok(Some(debug_info)) = package.debug_info() {
+            assert_valid_debug_policy(&debug_info);
+        }
     }
 
     let mut framing_reader = SliceReader::new(data);

--- a/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
@@ -8,14 +8,56 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
+use miden_assembly_syntax::ast::types::Type;
 use miden_core::serde::{Deserializable, SliceReader};
 use miden_mast_package::{Package, debug_info::PackageDebugInfo};
 
+fn assert_valid_type_alignments(ty: &Type) {
+    assert!(ty.min_alignment().is_power_of_two());
+
+    match ty {
+        Type::Ptr(pointer) => assert_valid_type_alignments(pointer.pointee()),
+        Type::Struct(structure) => {
+            for field in structure.fields() {
+                assert_valid_type_alignments(&field.ty);
+            }
+        },
+        Type::Enum(enumeration) => {
+            assert_valid_type_alignments(enumeration.discriminant());
+            for variant in enumeration.variants() {
+                if let Some(value) = variant.value.as_ref() {
+                    assert_valid_type_alignments(value);
+                }
+            }
+        },
+        Type::Array(array) => assert_valid_type_alignments(array.element_type()),
+        Type::List(element) => assert_valid_type_alignments(element),
+        Type::Function(function) => {
+            for ty in function.params().iter().chain(function.results()) {
+                assert_valid_type_alignments(ty);
+            }
+        },
+        _ => {},
+    }
+}
+
+fn assert_valid_package_type_alignments(package: &Package) {
+    for procedure in package.manifest.exports().filter_map(|export| export.as_procedure()) {
+        if let Some(signature) = procedure.signature.as_ref() {
+            for ty in signature.params().iter().chain(signature.results()) {
+                assert_valid_type_alignments(ty);
+            }
+        }
+    }
+}
+
 fuzz_target!(|data: &[u8]| {
     if let Ok(package) = Package::read_from_bytes(data) {
+        assert_valid_package_type_alignments(&package);
         let _ = package.debug_info();
     }
     if let Ok(package) = Package::read_from_bytes_trusted(data) {
+        assert_valid_package_type_alignments(&package);
         let _ = package.debug_info();
     }
 

--- a/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/debug_info.rs
@@ -12,7 +12,9 @@ use miden_assembly_syntax::ast::types::Type;
 use miden_core::serde::{ByteReader, Deserializable, SliceReader};
 use miden_mast_package::{
     Package,
-    debug_info::{MAX_DEBUG_INFO_PAYLOAD_SIZE, PackageDebugInfo},
+    debug_info::{
+        MAX_DEBUG_INFO_PAYLOAD_SIZE, MAX_DEBUG_INFO_TYPE_ROWS, PackageDebugInfo,
+    },
 };
 
 fn exercise_debug_info(debug_info: &PackageDebugInfo) {
@@ -97,6 +99,7 @@ fuzz_target!(|data: &[u8]| {
     if declared_payload_len.is_some_and(|len| len > MAX_DEBUG_INFO_PAYLOAD_SIZE) {
         assert!(debug_info.is_err());
     } else if let Ok(debug_info) = debug_info {
+        assert!(debug_info.types().len() <= MAX_DEBUG_INFO_TYPE_ROWS);
         exercise_debug_info(&debug_info);
     }
 });

--- a/tools/miden-core-fuzz/fuzz_targets/package_semantic_deserialize.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/package_semantic_deserialize.rs
@@ -14,7 +14,19 @@ use miden_mast_package::{Package, SectionId, TargetType, debug_info::PackageDebu
 fuzz_target!(|data: &[u8]| {
     if let Ok(package) = Package::read_from_bytes_trusted(data) {
         validate_debug_sections(&package);
-        let _ = package.debug_info();
+        match package.debug_info() {
+            Ok(Some(expected_debug_info)) => {
+                let untrusted_package = Package::read_from_bytes(data)
+                    .expect("a package with valid debug info should pass untrusted admission");
+                let actual_debug_info = untrusted_package
+                    .debug_info()
+                    .expect("admitted debug info should remain accessible")
+                    .expect("admitted debug info should remain present");
+                assert_eq!(actual_debug_info, expected_debug_info);
+            },
+            Err(_) => assert!(Package::read_from_bytes(data).is_err()),
+            Ok(None) => {},
+        }
     }
 
     let Ok(package) = Package::read_from_bytes(data) else {

--- a/tools/miden-core-fuzz/fuzz_targets/package_semantic_deserialize.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/package_semantic_deserialize.rs
@@ -58,7 +58,7 @@ fuzz_target!(|data: &[u8]| {
     }
 
     let _ = package.kernel_runtime_dependency();
-    let _ = package.try_embedded_kernel_package();
+    exercise_embedded_kernel(&package);
 
     // These conversion helpers borrow the package, despite the `try_into_*` names.
     match package.kind {
@@ -72,6 +72,48 @@ fuzz_target!(|data: &[u8]| {
         _ => (),
     }
 });
+
+fn exercise_embedded_kernel(package: &Package) {
+    let mut kernel_sections =
+        package.sections.iter().filter(|section| section.id == SectionId::KERNEL);
+    let Some(kernel_section) = kernel_sections.next() else {
+        return;
+    };
+    if kernel_sections.next().is_some() {
+        return;
+    }
+
+    let Ok(trusted_kernel) = Package::read_from_bytes_trusted(kernel_section.data.as_ref()) else {
+        return;
+    };
+
+    let expected_debug_info = match trusted_kernel.debug_info() {
+        Ok(debug_info) => debug_info,
+        Err(_) => {
+            assert!(
+                package.try_embedded_kernel_package().is_err(),
+                "nested debug info rejected on use must not pass untrusted kernel extraction"
+            );
+            return;
+        },
+    };
+
+    let Ok(Some(kernel)) = package.try_embedded_kernel_package() else {
+        return;
+    };
+    let actual_debug_info = kernel
+        .debug_info()
+        .expect("untrusted kernel extraction should leave no deferred debug validation errors");
+    assert_eq!(actual_debug_info, expected_debug_info);
+
+    let encoded = kernel.to_bytes();
+    let round_tripped = Package::read_from_bytes(&encoded)
+        .expect("an admitted embedded kernel should survive serialization and re-admission");
+    assert_eq!(
+        round_tripped.debug_info().expect("round-tripped kernel debug info should remain valid"),
+        actual_debug_info
+    );
+}
 
 fn validate_debug_sections(package: &Package) {
     for section in &package.sections {

--- a/tools/miden-core-fuzz/fuzz_targets/package_semantic_deserialize.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/package_semantic_deserialize.rs
@@ -8,7 +8,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use miden_core::serde::{Deserializable, SliceReader};
+use miden_core::serde::{Deserializable, Serializable, SliceReader};
 use miden_mast_package::{Package, SectionId, TargetType, debug_info::PackageDebugInfo};
 
 fuzz_target!(|data: &[u8]| {
@@ -34,6 +34,17 @@ fuzz_target!(|data: &[u8]| {
     };
 
     validate_debug_sections(&package);
+
+    let expected_debug_info = package
+        .debug_info()
+        .expect("untrusted admission should leave no deferred debug validation errors");
+    let encoded = package.to_bytes();
+    let round_tripped = Package::read_from_bytes(&encoded)
+        .expect("an admitted package should survive serialization and re-admission");
+    let actual_debug_info = round_tripped
+        .debug_info()
+        .expect("round-tripped debug info should remain valid");
+    assert_eq!(actual_debug_info, expected_debug_info);
 
     let _ = package.kernel_runtime_dependency();
     let _ = package.try_embedded_kernel_package();

--- a/tools/miden-core-fuzz/fuzz_targets/package_semantic_deserialize.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/package_semantic_deserialize.rs
@@ -9,7 +9,14 @@
 
 use libfuzzer_sys::fuzz_target;
 use miden_core::serde::{Deserializable, Serializable, SliceReader};
-use miden_mast_package::{Package, SectionId, TargetType, debug_info::PackageDebugInfo};
+use miden_mast_package::{
+    Package, SectionId, TargetType,
+    debug_info::{DebugSourceNodeId, PackageDebugInfo},
+};
+use miden_processor::{
+    DefaultHost, PackageSourceDebugContext,
+    operation::OperationError,
+};
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(package) = Package::read_from_bytes_trusted(data) {
@@ -46,6 +53,10 @@ fuzz_target!(|data: &[u8]| {
         .expect("round-tripped debug info should remain valid");
     assert_eq!(actual_debug_info, expected_debug_info);
 
+    if let Some(debug_info) = expected_debug_info.as_ref() {
+        exercise_execution_diagnostics(debug_info);
+    }
+
     let _ = package.kernel_runtime_dependency();
     let _ = package.try_embedded_kernel_package();
 
@@ -67,6 +78,29 @@ fn validate_debug_sections(package: &Package) {
         if section.id == SectionId::DEBUG_INFO {
             let mut reader = SliceReader::new(section.data.as_ref());
             let _ = PackageDebugInfo::read_from(&mut reader);
+        }
+    }
+}
+
+fn exercise_execution_diagnostics(debug_info: &PackageDebugInfo) {
+    let host = DefaultHost::default();
+
+    for (source_node_idx, source_node) in debug_info.nodes().iter().enumerate() {
+        let Ok(source_node_idx) = u32::try_from(source_node_idx) else {
+            break;
+        };
+        let context = PackageSourceDebugContext::new(
+            debug_info,
+            DebugSourceNodeId::from(source_node_idx),
+        );
+
+        let _ = context.assembly_location(None);
+        for asm_op in &source_node.asm_ops {
+            let _ = OperationError::DivideByZero.with_package_source_context(
+                context,
+                &host,
+                Some(asm_op.op_idx as usize),
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

`Package::read_from` and `Package::read_from_bytes` now validate `DEBUG_INFO` in untrusted `.masp` packages and keep it after validation succeeds. Invalid debug data rejects the package.

`Package::read_from_trusted` and `Package::read_from_bytes_trusted` preserve debug sections for same-domain package bytes. `Package::debug_info()` validates those sections when trusted callers ask for them.

## Security impact

- `PackageDebugInfo::read_from` caps the encoded debug payload at 16 MiB, string rows at 100,000, type rows at 1,000,000, and each string at 4 KiB.
- `Package::debug_info()` rejects bad references before callers can use them, including strings, files, locations, sources, functions, assembly records, variables, types.
- `OptionalIndex::try_into_option` rejects invalid optional-index tags and returns a decode error.
- `DebugTypeInfo` validation rejects invalid struct alignment, invalid transparent structs, layout-free aggregate members, oversized fields, and overflowing array layouts.
- `Package::validate_debug_strings` rejects control characters in paths and diagnostic text.
- `Package::validate_debug_sources` rejects inverted spans and assembly rows outside their source node. It also rejects duplicate or unordered operation indices.
- `DebugSourceMapSection` requires sorted rows and uses binary search for source lookups.
- `Package::try_embedded_kernel_package` decodes embedded kernels with `Package::read_from_bytes`, so nested debug data follows the untrusted validation path.

## Performance

Times are paired Criterion estimates against `origin/next` on the same host.

| Path | Before | After | Change |
| --- | ---: | ---: | ---: |
| Untrusted, no debug data | 6.178 us | 6.214 us | +0.33% |
| Trusted, no debug data | 6.248 us | 6.249 us | +0.02% |
| Untrusted, with debug data | 6.228 us | 14.149 us | +126.95% |
| Trusted, with debug data | 6.248 us | 6.322 us | +1.08% |
| Trusted read plus debug decode | 13.562 us | 14.105 us | +4.17% |

`Package::read_from_bytes` now decodes and validates debug data that it used to skip. The matching read-plus-decode path changed by 4.17%, below the 5% limit. The 95% interval was +3.99% to +4.37%. Packages without debug data changed by less than 0.4%.

Unblocks #3418.
