### PR TITLE
fix(mast-package): dedupe dependencies in PackageManifest Arbitrary impl

### DIFF
--- a/crates/mast-package/src/package/manifest.rs
+++ b/crates/mast-package/src/package/manifest.rs
@@ -55,6 +55,10 @@ pub struct PackageManifest {
     pub(super) modules: BTreeMap<Arc<Path>, PackageModule>,
     /// The libraries (packages) linked against by this package, which must be provided when
     /// executing the program.
+    #[cfg_attr(
+        any(test, feature = "arbitrary"),
+        proptest(strategy = "arbitrary_dependencies()")
+    )]
     pub(super) dependencies: Vec<Dependency>,
     /// The (optional) entrypoint function for this package, if it is executable
     #[cfg_attr(any(test, feature = "arbitrary"), proptest(value = "None"))]
@@ -671,6 +675,19 @@ impl fmt::Debug for TypeExport {
             .field("ty", ty)
             .finish()
     }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+fn arbitrary_dependencies() -> impl Strategy<Value = Vec<Dependency>> {
+    proptest::collection::vec(any::<Dependency>(), 0..10).prop_filter(
+        "package dependencies must have unique ids",
+        |dependencies| {
+            use alloc::collections::BTreeSet;
+
+            let mut seen = BTreeSet::new();
+            dependencies.iter().all(|dependency| seen.insert(dependency.id().clone()))
+        },
+    )
 }
 
 fn normalize_export(export: &mut PackageExport) -> Result<(), ManifestValidationError> {


### PR DESCRIPTION
## Describe your changes

The issue encountered in #3436 was in `PackageManifest`'s dependencies.
`Vec<Dependency>` field used the default derived `Arbitrary` strategy (an unconstrained `Vec<Dependency>`), independent of the exports field's dedicated dedup strategy.
Proptest could occasionally generate two `Dependency` entries with the same `PackageId`.
  
closes #3436 

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md`
