### PR TITLE
feat: AdviceInputs constructors and ProgramExecutor trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Added `AdviceInputs::new` constructor and `From<AdviceMap>` impl, complementing the existing builder-style accessors for assembling advice inputs from their parts.
 
+#### Changes
+
+- [BREAKING] Removed the free `execute()` and `execute_sync()` functions from `miden-vm`/`miden-processor`. Use `FastProcessor::new_with_options(...)` followed by `execute()`/`execute_sync()` instead ([#3538](https://github.com/0xMiden/miden-vm/issues/3538)).
+
 ## v0.29.0 (2026-08-04)
 
 #### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@
 - [BREAKING] Reduced the precompile STARK relation from 12 AIRs to 10 by merging the chunk/node/sponge and EC point/group stores ([#3464](https://github.com/0xMiden/miden-vm/pull/3464)).
 #### Features
 
-- Added `AdviceInputs::new` constructor and `From<AdviceMap>` impl, complementing the existing builder-style accessors for assembling advice inputs from their parts.
-- Added the `ProgramExecutor` trait to `miden-processor`, with `FastProcessor` as the default implementation, so alternative execution engines can be plugged in without changing the surrounding executor wiring ([#3538](https://github.com/0xMiden/miden-vm/issues/3538)).
+- Added `AdviceInputs::new` constructor and `From<AdviceMap>` impl, complementing the existing builder-style accessors for assembling advice inputs from their parts ([#3540](https://github.com/0xMiden/miden-vm/pull/3540)).
+- Added the `ProgramExecutor` trait to `miden-processor`, with `FastProcessor` as the default implementation, so alternative execution engines can be plugged in without changing the surrounding executor wiring ([#3540](https://github.com/0xMiden/miden-vm/pull/3540)).
 
 #### Changes
 
-- [BREAKING] Removed the free `execute()` and `execute_sync()` functions from `miden-vm`/`miden-processor`. Use `FastProcessor::new_with_options(...)` followed by `execute()`/`execute_sync()` instead ([#3538](https://github.com/0xMiden/miden-vm/issues/3538)).
+- [BREAKING] Removed the free `execute()` and `execute_sync()` functions from `miden-vm`/`miden-processor`. Use `FastProcessor::new_with_options(...)` followed by `execute()`/`execute_sync()` instead ([#3540](https://github.com/0xMiden/miden-vm/pull/3540)).
 
 ## v0.29.0 (2026-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 #### Changes
 
 - [BREAKING] Reduced the precompile STARK relation from 12 AIRs to 10 by merging the chunk/node/sponge and EC point/group stores ([#3464](https://github.com/0xMiden/miden-vm/pull/3464)).
+#### Features
+
+- Added `AdviceInputs::new` constructor and `From<AdviceMap>` impl, complementing the existing builder-style accessors for assembling advice inputs from their parts.
 
 ## v0.29.0 (2026-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Features
 
 - Added `AdviceInputs::new` constructor and `From<AdviceMap>` impl, complementing the existing builder-style accessors for assembling advice inputs from their parts.
+- Added the `ProgramExecutor` trait to `miden-processor`, with `FastProcessor` as the default implementation, so alternative execution engines can be plugged in without changing the surrounding executor wiring ([#3538](https://github.com/0xMiden/miden-vm/issues/3538)).
 
 #### Changes
 

--- a/core/src/advice/mod.rs
+++ b/core/src/advice/mod.rs
@@ -37,6 +37,11 @@ impl AdviceInputs {
     // CONSTRUCTORS
     // --------------------------------------------------------------------------------------------
 
+    /// Creates a new advice inputs container from the provided stack, map, and Merkle store.
+    pub fn new(advice_stack: AdviceStack, map: AdviceMap, store: MerkleStore) -> Self {
+        Self { advice_stack, map, store }
+    }
+
     /// Replaces the advice stack with the provided typed stack.
     pub fn with_advice_stack(mut self, stack: AdviceStack) -> Self {
         self.advice_stack = stack;
@@ -79,6 +84,16 @@ impl AdviceInputs {
     }
 }
 
+impl From<AdviceMap> for AdviceInputs {
+    fn from(map: AdviceMap) -> Self {
+        Self {
+            advice_stack: AdviceStack::default(),
+            map,
+            store: MerkleStore::default(),
+        }
+    }
+}
+
 impl Serializable for AdviceInputs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         let Self { advice_stack, map, store } = self;
@@ -105,9 +120,10 @@ impl Deserializable for AdviceInputs {
 mod tests {
     use alloc::vec::Vec;
 
-    use super::{AdviceInputs, AdviceStack};
+    use super::{AdviceInputs, AdviceMap, AdviceStack};
     use crate::{
         Felt, Word,
+        crypto::merkle::MerkleStore,
         serde::{Deserializable, Serializable},
     };
 
@@ -134,6 +150,30 @@ mod tests {
         let advice2 = AdviceInputs::read_from_bytes(&bytes).unwrap();
 
         assert_eq!(advice1, advice2);
+    }
+
+    #[test]
+    fn advice_inputs_new_assembles_parts() {
+        let stack = AdviceStack::try_from_values([1, 2, 3]).unwrap();
+        let map = AdviceMap::from_iter([(Word::default(), vec![Felt::new_unchecked(7)])]);
+        let store = MerkleStore::default();
+
+        let advice = AdviceInputs::new(stack.clone(), map.clone(), store.clone());
+
+        assert_eq!(advice.advice_stack(), stack);
+        assert_eq!(advice.map, map);
+        assert_eq!(advice.store, store);
+    }
+
+    #[test]
+    fn advice_inputs_from_advice_map_defaults_other_parts() {
+        let map = AdviceMap::from_iter([(Word::default(), vec![Felt::new_unchecked(7)])]);
+
+        let advice = AdviceInputs::from(map.clone());
+
+        assert_eq!(advice.advice_stack(), AdviceStack::default());
+        assert_eq!(advice.map, map);
+        assert_eq!(advice.store, MerkleStore::default());
     }
 
     #[test]

--- a/core/src/advice/mod.rs
+++ b/core/src/advice/mod.rs
@@ -28,9 +28,9 @@ pub use stack::AdviceStack;
 ///    with Merkle trees.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AdviceInputs {
-    advice_stack: AdviceStack,
-    pub map: AdviceMap,
-    pub store: MerkleStore,
+    stack: AdviceStack,
+    map: AdviceMap,
+    store: MerkleStore,
 }
 
 impl AdviceInputs {
@@ -38,19 +38,29 @@ impl AdviceInputs {
     // --------------------------------------------------------------------------------------------
 
     /// Creates a new advice inputs container from the provided stack, map, and Merkle store.
-    pub fn new(advice_stack: AdviceStack, map: AdviceMap, store: MerkleStore) -> Self {
-        Self { advice_stack, map, store }
+    pub fn new(stack: AdviceStack, map: AdviceMap, store: MerkleStore) -> Self {
+        Self { stack, map, store }
     }
 
-    /// Replaces the advice stack with the provided typed stack.
-    pub fn with_advice_stack(mut self, stack: AdviceStack) -> Self {
-        self.advice_stack = stack;
+    /// Replaces the stack with the provided typed stack.
+    pub fn with_stack(mut self, stack: AdviceStack) -> Self {
+        self.stack = stack;
         self
     }
 
-    /// Returns the advice stack as a typed stack.
-    pub fn advice_stack(&self) -> AdviceStack {
-        self.advice_stack.clone()
+    /// Returns the advice stack.
+    pub fn stack(&self) -> AdviceStack {
+        self.stack.clone()
+    }
+
+    /// Returns the advice map.
+    pub fn map(&self) -> &AdviceMap {
+        &self.map
+    }
+
+    /// Returns the Merkle store.
+    pub fn store(&self) -> &MerkleStore {
+        &self.store
     }
 
     /// Extends the map of values with the given argument, replacing previously inserted items.
@@ -73,21 +83,21 @@ impl AdviceInputs {
 
     /// Extends the contents of this instance with the contents of the other instance.
     pub fn extend(&mut self, other: Self) {
-        self.advice_stack.append_elements(other.advice_stack.into_elements());
+        self.stack.append_elements(other.stack.into_elements());
         self.map.extend(other.map);
         self.store.extend(other.store.inner_nodes());
     }
 
     /// Consumes this instance and returns its parts.
     pub fn into_parts(self) -> (AdviceStack, AdviceMap, MerkleStore) {
-        (self.advice_stack, self.map, self.store)
+        (self.stack, self.map, self.store)
     }
 }
 
 impl From<AdviceMap> for AdviceInputs {
     fn from(map: AdviceMap) -> Self {
         Self {
-            advice_stack: AdviceStack::default(),
+            stack: AdviceStack::default(),
             map,
             store: MerkleStore::default(),
         }
@@ -96,8 +106,8 @@ impl From<AdviceMap> for AdviceInputs {
 
 impl Serializable for AdviceInputs {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
-        let Self { advice_stack, map, store } = self;
-        let stack: Vec<Felt> = advice_stack.iter().copied().collect();
+        let Self { stack, map, store } = self;
+        let stack: Vec<Felt> = stack.iter().copied().collect();
         stack.write_into(target);
         map.write_into(target);
         store.write_into(target);
@@ -109,7 +119,7 @@ impl Deserializable for AdviceInputs {
         let stack = Vec::<Felt>::read_from(source)?;
         let map = AdviceMap::read_from(source)?;
         let store = MerkleStore::read_from(source)?;
-        Ok(Self { advice_stack: stack.into(), map, store })
+        Ok(Self { stack: stack.into(), map, store })
     }
 }
 
@@ -134,18 +144,18 @@ mod tests {
 
         assert_eq!(advice1, advice2);
 
-        let advice1 = AdviceInputs::default()
-            .with_advice_stack(AdviceStack::try_from_values([1, 2, 3]).unwrap());
-        let advice2 = AdviceInputs::default()
-            .with_advice_stack(AdviceStack::try_from_values([1, 2, 3]).unwrap());
+        let advice1 =
+            AdviceInputs::default().with_stack(AdviceStack::try_from_values([1, 2, 3]).unwrap());
+        let advice2 =
+            AdviceInputs::default().with_stack(AdviceStack::try_from_values([1, 2, 3]).unwrap());
 
         assert_eq!(advice1, advice2);
     }
 
     #[test]
     fn test_advice_inputs_serialization() {
-        let advice1 = AdviceInputs::default()
-            .with_advice_stack(AdviceStack::try_from_values([1, 2, 3]).unwrap());
+        let advice1 =
+            AdviceInputs::default().with_stack(AdviceStack::try_from_values([1, 2, 3]).unwrap());
         let bytes = advice1.to_bytes();
         let advice2 = AdviceInputs::read_from_bytes(&bytes).unwrap();
 
@@ -160,7 +170,7 @@ mod tests {
 
         let advice = AdviceInputs::new(stack.clone(), map.clone(), store.clone());
 
-        assert_eq!(advice.advice_stack(), stack);
+        assert_eq!(advice.stack(), stack);
         assert_eq!(advice.map, map);
         assert_eq!(advice.store, store);
     }
@@ -171,7 +181,7 @@ mod tests {
 
         let advice = AdviceInputs::from(map.clone());
 
-        assert_eq!(advice.advice_stack(), AdviceStack::default());
+        assert_eq!(advice.stack(), AdviceStack::default());
         assert_eq!(advice.map, map);
         assert_eq!(advice.store, MerkleStore::default());
     }
@@ -190,9 +200,9 @@ mod tests {
             .into(),
         );
 
-        let advice = AdviceInputs::default().with_advice_stack(stack.clone());
+        let advice = AdviceInputs::default().with_stack(stack.clone());
 
-        assert_eq!(advice.advice_stack(), stack);
+        assert_eq!(advice.stack(), stack);
     }
 
     #[test]

--- a/crates/lib/core/tests/crypto/dsa.rs
+++ b/crates/lib/core/tests/crypto/dsa.rs
@@ -348,7 +348,7 @@ fn run_core_program_with_advice(
     advice_stack.append_elements(advice.iter().copied());
     let processor = FastProcessor::new_with_options(
         StackInputs::default(),
-        AdviceInputs::default().with_advice_stack(advice_stack),
+        AdviceInputs::default().with_stack(advice_stack),
         ExecutionOptions::default(),
     )
     .expect("processor construction");

--- a/crates/lib/core/tests/debug.rs
+++ b/crates/lib/core/tests/debug.rs
@@ -419,7 +419,7 @@ fn print_mem_rejects_full_range() {
 fn print_adv_stack_all_outputs_advice_stack() {
     let mut stack = AdviceStack::new();
     stack.append_elements([Felt::new_unchecked(7), Felt::new_unchecked(8), Felt::new_unchecked(9)]);
-    let advice = AdviceInputs::default().with_advice_stack(stack);
+    let advice = AdviceInputs::default().with_stack(stack);
     let source = "
     use miden::core::debug
     begin
@@ -443,7 +443,7 @@ fn print_adv_stack_outputs_range() {
         Felt::new_unchecked(9),
         Felt::new_unchecked(10),
     ]);
-    let advice = AdviceInputs::default().with_advice_stack(stack);
+    let advice = AdviceInputs::default().with_stack(stack);
     let source = "
     use miden::core::debug
     begin
@@ -583,7 +583,7 @@ fn debug_handlers_compose_with_default_core_handlers() {
     ";
     let mut stack = AdviceStack::new();
     stack.append_element(Felt::new_unchecked(7));
-    let advice = AdviceInputs::default().with_advice_stack(stack);
+    let advice = AdviceInputs::default().with_stack(stack);
 
     let core_lib = CoreLibrary::default();
     let assembler = Assembler::default()

--- a/crates/lib/core/tests/debug.rs
+++ b/crates/lib/core/tests/debug.rs
@@ -20,15 +20,27 @@ use miden_core_lib::{
     },
 };
 use miden_processor::{
-    DefaultHost, ExecutionError, ExecutionOptions, ExecutionOutput, HostLibrary, MemoryError,
-    StackInputs,
+    DefaultHost, ExecutionError, ExecutionOptions, ExecutionOutput, FastProcessor, HostLibrary,
+    MemoryError, Program, StackInputs, SyncHost,
     advice::{AdviceInputs, AdviceStack},
     event::{EventHandler, EventName},
-    execute_sync,
 };
 
 // HARNESS
 // ================================================================================================
+
+/// Runs `program` against `host`, constructing a [`FastProcessor`] the way production callers do.
+fn execute_sync(
+    program: &Program,
+    stack_inputs: StackInputs,
+    advice_inputs: AdviceInputs,
+    host: &mut impl SyncHost,
+    options: ExecutionOptions,
+) -> Result<ExecutionOutput, ExecutionError> {
+    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, options)
+        .expect("failed to construct FastProcessor");
+    processor.execute_sync(program, host)
+}
 
 /// A [`fmt::Write`] that appends into a shared, thread-safe string buffer.
 #[derive(Clone)]

--- a/crates/precompiles/benches/precompiles_bench/input_generation.rs
+++ b/crates/precompiles/benches/precompiles_bench/input_generation.rs
@@ -44,7 +44,7 @@ pub(crate) fn generate_advice_inputs(workload: PrecompileWorkload) -> AdviceInpu
     }
 
     assert_eq!(advice_stack.len(), workload.ecdsas * 40, "unexpected ECDSA advice length");
-    AdviceInputs::default().with_advice_stack(advice_stack)
+    AdviceInputs::default().with_stack(advice_stack)
 }
 
 fn ecdsa_message(index: u64) -> Word {

--- a/crates/test-utils/src/test_builders.rs
+++ b/crates/test-utils/src/test_builders.rs
@@ -237,7 +237,7 @@ macro_rules! build_test_by_mode {
         let advice_stack = $crate::advice_stack_from(&$advice_stack).unwrap();
         let store = $crate::crypto::MerkleStore::new();
         let advice_inputs = $crate::AdviceInputs::default()
-            .with_advice_stack(advice_stack)
+            .with_stack(advice_stack)
             .with_merkle_store(store);
         let name = format!("test{}", line!());
         let source_manager = ::alloc::sync::Arc::new($crate::DefaultSourceManager::default());
@@ -269,7 +269,7 @@ macro_rules! build_test_by_mode {
         let stack_inputs = $crate::stack_inputs_from_ints(stack_inputs);
         let advice_stack = $crate::advice_stack_from(&$advice_stack).unwrap();
         let advice_inputs = $crate::AdviceInputs::default()
-            .with_advice_stack(advice_stack)
+            .with_stack(advice_stack)
             .with_merkle_store($advice_merkle_store);
         let name = format!("test{}", line!());
         let source_manager = ::alloc::sync::Arc::new($crate::DefaultSourceManager::default());
@@ -302,7 +302,7 @@ macro_rules! build_test_by_mode {
         let stack_inputs = $crate::stack_inputs_from_ints(stack_inputs);
         let advice_stack = $crate::advice_stack_from(&$advice_stack).unwrap();
         let advice_inputs = $crate::AdviceInputs::default()
-            .with_advice_stack(advice_stack)
+            .with_stack(advice_stack)
             .with_merkle_store($advice_merkle_store)
             .with_map($advice_map);
         let name = format!("test{}", line!());

--- a/miden-vm/README.md
+++ b/miden-vm/README.md
@@ -56,7 +56,7 @@ For example:
 ```rust
 use miden_vm::{
     advice::AdviceInputs,
-    Assembler, execute_sync, ExecutionOptions, DefaultHost, StackInputs
+    Assembler, DefaultHost, ExecutionOptions, FastProcessor, StackInputs
 };
 
 // instantiate the assembler
@@ -81,8 +81,12 @@ let mut host = DefaultHost::default();
 let exec_options = ExecutionOptions::default();
 
 // execute the program with no inputs
-let output =
-    execute_sync(&program.unwrap_program(), stack_inputs, advice_inputs.clone(), &mut host, exec_options).unwrap();
+let output = FastProcessor::new_with_options(
+    stack_inputs, advice_inputs.clone(), exec_options
+)
+    .unwrap()
+    .execute_sync(&program.unwrap_program(), &mut host)
+    .unwrap();
 ```
 
 ### Proving program execution

--- a/miden-vm/README.md
+++ b/miden-vm/README.md
@@ -22,7 +22,7 @@ Currently, there are 3 ways to get values onto the stack:
 
 1. You can use `push` instruction to push values onto the stack. These values become a part of the program itself, and, therefore, cannot be changed between program executions. You can think of them as constants.
 2. The stack can be initialized to some set of values at the beginning of the program. These inputs are public and must be shared with the verifier for them to verify a proof of the correct execution of a Miden program. At most 16 values could be provided for the stack initialization, attempts to provide more than 16 values will cause an error.
-3. The program may request nondeterministic advice inputs from the prover. These inputs are secret inputs. This means that the prover does not need to share them with the verifier. There are three types of advice inputs: (1) a single advice stack which can contain any number of elements; (2) a key-mapped element lists which can be pushed onto the advice stack; (3) a Merkle store, which is used to provide nondeterministic inputs for instructions which work with Merkle trees. There are no restrictions on the number of advice inputs a program can request.
+3. The program may request nondeterministic advice inputs from the prover. These inputs are secret inputs. This means that the prover does not need to share them with the verifier. Advice can come from a stack, a map of element lists, or a Merkle store used by instructions that work with Merkle trees. There are no restrictions on the number of advice inputs a program can request.
 
 The stack is provided to Miden VM via `StackInputs` struct. These are public inputs of the execution, and should also be provided to the verifier. The secret inputs for the program are provided via the `Host` interface. The default implementation of the host relies on in-memory advice provider (`AdviceProvider`) that can be commonly used for operations that won't require persistence.
 
@@ -39,11 +39,11 @@ Miden crate exposes several functions which can be used to execute programs, gen
 To execute a program on Miden VM, you can use `execute()`. The sync `execute_sync()` variant is
 also available for sync callers. These functions take the following arguments:
 
-- `program: &Program` - a reference to a Miden program to be executed.
-- `stack_inputs: StackInputs` - a set of public inputs with which to execute the program.
-- `advice_inputs: AdviceInputs` - the private inputs used to build the advice provider; use `AdviceInputs::default()` when no private inputs are needed.
-- `host` - an instance of `Host` for `execute()` or `SyncHost` for `execute_sync()`, used to supply non-deterministic inputs to the VM and receive messages from the VM.
-- `options: ExecutionOptions` - a set of options for executing the specified program (e.g., max allowed number of cycles).
+- `program: &Program` is a reference to the Miden program.
+- `stack_inputs: StackInputs` contains the public inputs.
+- `advice_inputs: AdviceInputs` contains the private inputs used to build the advice provider. Use `AdviceInputs::default()` when no private inputs are needed.
+- `host` is a `Host` for `execute()` or a `SyncHost` for `execute_sync()`. It supplies nondeterministic inputs to the VM and receives messages from it.
+- `options: ExecutionOptions` controls execution settings such as the maximum cycle count.
 
 The function returns a `Result<ExecutionOutput, ExecutionError>` which will contain the final stack
 state and other execution outputs if the execution was successful, or an error if the execution
@@ -82,11 +82,13 @@ let exec_options = ExecutionOptions::default();
 
 // execute the program with no inputs
 let output = FastProcessor::new_with_options(
-    stack_inputs, advice_inputs.clone(), exec_options
+    stack_inputs,
+    advice_inputs.clone(),
+    exec_options,
 )
-    .unwrap()
-    .execute_sync(&program.unwrap_program(), &mut host)
-    .unwrap();
+.unwrap()
+.execute_sync(&program.unwrap_program(), &mut host)
+.unwrap();
 ```
 
 ### Proving program execution
@@ -95,17 +97,17 @@ To execute a program on Miden VM and generate a proof that the program was execu
 can use the `prove_sync()` function. The async `prove()` variant is also available for async
 callers. `prove_sync()` takes the following arguments:
 
-- `program: &Program` - a reference to a Miden program to be executed.
-- `stack_inputs: StackInputs` - a set of public inputs with which to execute the program.
-- `advice_inputs: AdviceInputs` - the initial nondeterministic inputs available to the VM.
-- `host: Host` - an instance of a `Host` which can be used to supply non-deterministic inputs to the VM and receive messages from the VM.
-- `execution_options: ExecutionOptions` - VM execution parameters such as cycle limits and trace fragmentation.
-- `options: ProvingOptions` - proof-generation parameters. The default options target 96-bit security level.
+- `program: &Program` is a reference to the Miden program.
+- `stack_inputs: StackInputs` contains the public inputs.
+- `advice_inputs: AdviceInputs` contains the initial nondeterministic inputs available to the VM.
+- `host: Host` supplies nondeterministic inputs to the VM and receives messages from it.
+- `execution_options: ExecutionOptions` controls VM execution parameters such as cycle limits and trace fragmentation.
+- `options: ProvingOptions` controls proof generation. The default targets a 96-bit security level.
 
 If the program is executed successfully, the function returns a tuple with 2 elements:
 
-- `outputs: StackOutputs` - the outputs generated by the program.
-- `proof: ExecutionProof` - proof of program execution. `ExecutionProof` can be easily serialized and deserialized using `to_bytes()` and `from_bytes()` functions respectively.
+- `outputs: StackOutputs` contains the outputs generated by the program.
+- `proof: ExecutionProof` proves program execution. It can be serialized and deserialized with `to_bytes()` and `from_bytes()`.
 
 #### Proof generation example
 
@@ -146,8 +148,8 @@ assert_eq!(8, outputs.first().unwrap().as_canonical_u64());
 
 To verify program execution, use `Verifier::new().verify(...)`. The verifier takes the following parameters:
 
-- `proof: ExecutionProof` - the proof generated during program execution.
-- `claim: ExecutionClaim` - the claimed program information, stack inputs, and stack outputs.
+- `proof: ExecutionProof` is the proof generated during program execution.
+- `claim: ExecutionClaim` contains the claimed program information, stack inputs, and stack outputs.
 
 Stack inputs are expected to be ordered as if they would be pushed onto the stack one by one. Thus, their expected order on the stack will be the reverse of the order in which they are provided, and the last value in the `stack_inputs` is expected to be the value at the top of the stack.
 
@@ -157,7 +159,7 @@ The verifier returns `Result<u32, VerificationError>` which will be `Ok(security
 
 > If a program with the provided hash is executed against some secret inputs and the provided public inputs, it will produce the provided outputs.
 
-Notice how the verifier needs to know only the hash of the program - not what the actual program was.
+The verifier needs only the program hash. It does not need the program itself.
 
 #### Proof verification example
 
@@ -229,7 +231,7 @@ let program = assembler.assemble_program("prg", &source).unwrap();
 let mut host = DefaultHost::default();
 
 // initialize the stack with values 0 and 1
-let stack_inputs = StackInputs::try_from_ints([1, 0]).unwrap();
+let stack_inputs = StackInputs::new(&[1_u32.into(), 0_u32.into()]).unwrap();
 
 // execute the program
 let (outputs, proof) = miden_vm::prove_sync(
@@ -249,7 +251,7 @@ let stack = outputs.get_num_elements(1);
 assert_eq!(12586269025, stack[0].as_canonical_u64());
 ```
 
-Above, we used public inputs to initialize the stack rather than using `push` operations. This makes the program a bit simpler, and also allows us to run the program from arbitrary starting points without changing program hash.
+Above, we used public inputs to initialize the stack. This keeps the program simpler and lets us run it from arbitrary starting points without changing its hash.
 
 ## CLI interface
 
@@ -299,12 +301,12 @@ Once the executable has been compiled, you can run Miden VM like so:
 
 Currently, Miden VM can be executed with the following subcommands:
 
-- `run` - this will execute a Miden assembly program and output the result, but will not generate a proof of execution.
-- `prove` - this will execute a Miden assembly program, and will also generate a STARK proof of execution.
-- `verify` - this will verify a previously generated proof of execution for a given program.
-- `compile` - this will compile a Miden assembly program and outputs stats about the compilation process.
-- `debug` - this will instantiate a CLI debugger against the specified Miden assembly program and inputs.
-- `analyze` - this will run a Miden assembly program against specific inputs and will output stats about its execution.
+- `run` executes a Miden assembly program and outputs the result without generating a proof.
+- `prove` executes a Miden assembly program and generates a STARK proof.
+- `verify` verifies a previously generated proof for a given program.
+- `compile` compiles a Miden assembly program and reports compilation statistics.
+- `debug` starts a CLI debugger for the specified Miden assembly program and inputs.
+- `analyze` runs a Miden assembly program against specific inputs and reports execution statistics.
 
 All of the above subcommands require various parameters to be provided. To get more detailed help on what is needed for a given subcommand, you can run the following:
 
@@ -332,10 +334,10 @@ This will run the example code to completion and will output the top element rem
 
 Miden VM can be compiled with the following features:
 
-- `std` - enabled by default and relies on the Rust standard library.
-- `concurrent` - implies `std` and also enables multi-threaded proof generation.
-- `executable` - required for building Miden VM binary as described above. Implies `std`.
-- `metal` - enables [Metal](<https://en.wikipedia.org/wiki/Metal_(API)>)-based acceleration of proof generation (for recursive proofs) on supported platforms (e.g., Apple silicon).
+- `std` is enabled by default and relies on the Rust standard library.
+- `concurrent` implies `std` and enables multithreaded proof generation.
+- `executable` is required for building the Miden VM binary as described above. It implies `std`.
+- `metal` enables [Metal](<https://en.wikipedia.org/wiki/Metal_(API)>)-based acceleration of proof generation for recursive proofs on supported platforms such as Apple silicon.
 - `no_std` does not rely on the Rust standard library and enables compilation to WebAssembly.
   - Only the `wasm32-unknown-unknown` and `wasm32-wasip1` targets are officially supported.
 

--- a/miden-vm/src/internal.rs
+++ b/miden-vm/src/internal.rs
@@ -113,7 +113,7 @@ impl InputFile {
             .parse_advice_stack()
             .map_err(|e| format!("failed to parse advice provider: {e}"))?;
         let stack = AdviceStack::try_from_values(stack).map_err(|e| e.to_string())?;
-        advice_inputs = advice_inputs.with_advice_stack(stack);
+        advice_inputs = advice_inputs.with_stack(stack);
 
         if let Some(map) = self
             .parse_advice_map()

--- a/miden-vm/src/lib.rs
+++ b/miden-vm/src/lib.rs
@@ -13,13 +13,11 @@ pub use miden_core::{
     program::ExecutionClaim,
     proof::{DeferredProof, ExecutionProof, HashFunction, StarkProof},
 };
-#[cfg(not(target_family = "wasm"))]
-pub use miden_processor::execute_sync;
 pub use miden_processor::{
     BaseHost, DefaultHost, ExecutionError, ExecutionOptions, ExecutionOutput, FastProcessor,
     FutureMaybeSend, Host, KernelDescriptor, Program, ProgramInfo, StackInputs, SyncHost,
-    TraceBuildInputs, TraceGenerationContext, ZERO, advice, crypto, execute, field,
-    operation::Operation, serde, trace, trace::ExecutionTrace, utils,
+    TraceBuildInputs, TraceGenerationContext, ZERO, advice, crypto, field, operation::Operation,
+    serde, trace, trace::ExecutionTrace, utils,
 };
 pub use miden_prover::{InputError, ProvingOptions, StackOutputs, TraceProvingInputs, Word, prove};
 #[cfg(not(target_family = "wasm"))]

--- a/miden-vm/tests/integration/exec.rs
+++ b/miden-vm/tests/integration/exec.rs
@@ -4,7 +4,7 @@ use core::assert_matches;
 use miden_assembly::{Assembler, DefaultSourceManager};
 use miden_core::{ONE, Word, advice::AdviceMap, program::Program};
 use miden_processor::{
-    ExecutionOptions, StackInputs,
+    ExecutionOptions, FastProcessor, StackInputs,
     advice::{AdviceError, AdviceInputs},
     mast::MastForest,
 };
@@ -25,16 +25,17 @@ fn advice_map_loaded_before_execution() {
         .unwrap()
         .unwrap_program();
 
-    // Test `miden_processor::execute_sync` fails if no advice map provided with the program
+    // Test `FastProcessor::execute_sync` fails if no advice map provided with the program
     let mut host =
         DefaultHost::default().with_source_manager(Arc::new(DefaultSourceManager::default()));
-    match miden_processor::execute_sync(
-        &program_without_advice_map,
+    match FastProcessor::new_with_options(
         StackInputs::default(),
         AdviceInputs::default(),
-        &mut host,
         ExecutionOptions::default(),
-    ) {
+    )
+    .expect("failed to construct FastProcessor")
+    .execute_sync(&program_without_advice_map, &mut host)
+    {
         Ok(_) => panic!("Expected error"),
         Err(e) => {
             assert_matches!(
@@ -47,7 +48,7 @@ fn advice_map_loaded_before_execution() {
         },
     }
 
-    // Test `miden_processor::execute_sync` works if advice map provided with the program
+    // Test `FastProcessor::execute_sync` works if advice map provided with the program
     let mast_forest: MastForest = (**program_without_advice_map.mast_forest()).clone();
 
     let key = Word::new([ONE, ONE, ONE, ONE]);
@@ -58,12 +59,12 @@ fn advice_map_loaded_before_execution() {
         Program::new(mast_forest.into(), program_without_advice_map.entrypoint());
 
     let mut host = DefaultHost::default();
-    miden_processor::execute_sync(
-        &program_with_advice_map,
+    FastProcessor::new_with_options(
         StackInputs::default(),
         AdviceInputs::default(),
-        &mut host,
         ExecutionOptions::default(),
     )
+    .expect("failed to construct FastProcessor")
+    .execute_sync(&program_with_advice_map, &mut host)
     .unwrap();
 }

--- a/miden-vm/tests/integration/operations/decorators/advice.rs
+++ b/miden-vm/tests/integration/operations/decorators/advice.rs
@@ -1,6 +1,6 @@
 use miden_assembly::Assembler;
 use miden_core::Felt;
-use miden_processor::{ExecutionOptions, StackInputs, advice::AdviceInputs};
+use miden_processor::{ExecutionOptions, FastProcessor, StackInputs, advice::AdviceInputs};
 use miden_prover::Word;
 use miden_utils_testing::{build_test, crypto::MerkleStore};
 
@@ -489,12 +489,8 @@ fn run_insert_mem_with_max_size(
     let mut host = super::TestHost::default();
     let options = ExecutionOptions::default().with_max_adv_map_value_size(max_adv_map_value_size);
 
-    miden_processor::execute_sync(
-        &program,
-        StackInputs::default(),
-        AdviceInputs::default(),
-        &mut host,
-        options,
-    )?;
+    FastProcessor::new_with_options(StackInputs::default(), AdviceInputs::default(), options)
+        .map_err(miden_processor::ExecutionError::advice_error_no_context)?
+        .execute_sync(&program, &mut host)?;
     Ok(())
 }

--- a/miden-vm/tests/integration/operations/decorators/events.rs
+++ b/miden-vm/tests/integration/operations/decorators/events.rs
@@ -1,5 +1,7 @@
 use miden_assembly::Assembler;
-use miden_processor::{ExecutionOptions, Program, StackInputs, advice::AdviceInputs};
+use miden_processor::{
+    ExecutionOptions, FastProcessor, Program, StackInputs, advice::AdviceInputs,
+};
 
 use super::TestHost;
 
@@ -22,13 +24,13 @@ fn test_event_handling() {
         .unwrap()
         .unwrap_program();
     let mut host = TestHost::default();
-    miden_processor::execute_sync(
-        &program,
+    FastProcessor::new_with_options(
         StackInputs::default(),
         AdviceInputs::default(),
-        &mut host,
         ExecutionOptions::default(),
     )
+    .expect("failed to construct FastProcessor")
+    .execute_sync(&program, &mut host)
     .unwrap();
 
     // make sure events were handled correctly

--- a/miden-vm/tests/integration/operations/decorators/trace_events.rs
+++ b/miden-vm/tests/integration/operations/decorators/trace_events.rs
@@ -141,13 +141,13 @@ fn test_trace_event_from_stack() {
         .unwrap_program();
 
     let mut host = TestHost::default();
-    let output = miden_processor::execute_sync(
-        &program,
+    let output = FastProcessor::new_with_options(
         StackInputs::new(&[Felt::from_u32(1000)]).unwrap(),
         AdviceInputs::default(),
-        &mut host,
         ExecutionOptions::default(),
     )
+    .unwrap()
+    .execute_sync(&program, &mut host)
     .unwrap();
 
     assert_eq!(host.trace_handler, vec![1000]);
@@ -176,13 +176,13 @@ fn test_trace_event_manual_emit() {
         .unwrap_program();
 
     let mut host = TestHost::default();
-    miden_processor::execute_sync(
-        &program,
+    FastProcessor::new_with_options(
         StackInputs::default(),
         AdviceInputs::default(),
-        &mut host,
         ExecutionOptions::default(),
     )
+    .unwrap()
+    .execute_sync(&program, &mut host)
     .unwrap();
 
     assert_eq!(host.trace_handler, vec![1000]);

--- a/miden-vm/tests/integration/operations/decorators/trace_events.rs
+++ b/miden-vm/tests/integration/operations/decorators/trace_events.rs
@@ -2,7 +2,8 @@ use std::sync::{Arc, Mutex};
 
 use miden_assembly::Assembler;
 use miden_processor::{
-    DefaultHost, ExecutionOptions, Felt, ProcessorState, Program, StackInputs, StackOutputs,
+    DefaultHost, ExecutionOptions, FastProcessor, Felt, ProcessorState, Program, StackInputs,
+    StackOutputs,
     advice::AdviceInputs,
     event::{EventName, SystemEvent, TraceError},
 };
@@ -37,13 +38,13 @@ fn test_trace_event_handling() {
         .unwrap()
         .unwrap_program();
     let mut host = TestHost::default();
-    miden_processor::execute_sync(
-        &program,
+    FastProcessor::new_with_options(
         StackInputs::default(),
         AdviceInputs::default(),
-        &mut host,
         ExecutionOptions::default(),
     )
+    .expect("failed to construct FastProcessor")
+    .execute_sync(&program, &mut host)
     .unwrap();
 
     assert_eq!(host.event_handler, vec![3000, 4000]);
@@ -71,13 +72,13 @@ fn test_unhandled_trace_does_not_raise_error() {
 
     // No trace handler is registered on this host.
     let mut host = DefaultHost::default();
-    let output = miden_processor::execute_sync(
-        &program,
+    let output = FastProcessor::new_with_options(
         StackInputs::default(),
         AdviceInputs::default(),
-        &mut host,
         ExecutionOptions::default(),
     )
+    .expect("failed to construct FastProcessor")
+    .execute_sync(&program, &mut host)
     .expect("emitting an unhandled trace event must not abort execution");
 
     assert_eq!(output.stack, StackOutputs::default());
@@ -114,13 +115,13 @@ fn test_trace_handler_registry() {
     host.register_trace_handler(EventName::new(trace_name), Arc::new(recorder))
         .unwrap();
 
-    miden_processor::execute_sync(
-        &program,
+    FastProcessor::new_with_options(
         StackInputs::default(),
         AdviceInputs::default(),
-        &mut host,
         ExecutionOptions::default(),
     )
+    .expect("failed to construct FastProcessor")
+    .execute_sync(&program, &mut host)
     .unwrap();
 
     let recorded = recorded.lock().unwrap();

--- a/processor/src/execution/operations/io_ops/tests.rs
+++ b/processor/src/execution/operations/io_ops/tests.rs
@@ -24,7 +24,7 @@ fn test_op_advpop() {
     // popping from the advice stack should push the value onto the operand stack
     let mut advice_stack = AdviceStack::new();
     advice_stack.append_element(Felt::new_unchecked(3));
-    let advice_inputs = AdviceInputs::default().with_advice_stack(advice_stack);
+    let advice_inputs = AdviceInputs::default().with_stack(advice_stack);
     let mut processor = FastProcessor::new(StackInputs::default())
         .with_advice(advice_inputs)
         .expect("advice inputs should fit advice map limits");
@@ -57,7 +57,7 @@ fn test_op_advpopw() {
         ]
         .into(),
     );
-    let advice_inputs = AdviceInputs::default().with_advice_stack(advice_stack);
+    let advice_inputs = AdviceInputs::default().with_stack(advice_stack);
     let mut processor = FastProcessor::new(StackInputs::default())
         .with_advice(advice_inputs)
         .expect("advice inputs should fit advice map limits");
@@ -416,7 +416,7 @@ fn test_op_pipe() {
     .into();
     let mut advice_stack = AdviceStack::new();
     advice_stack.append_dword([advice_word1, advice_word2]);
-    let advice_inputs = AdviceInputs::default().with_advice_stack(advice_stack);
+    let advice_inputs = AdviceInputs::default().with_stack(advice_stack);
     let mut processor = FastProcessor::new(StackInputs::default())
         .with_advice(advice_inputs)
         .expect("advice inputs should fit advice map limits");

--- a/processor/src/executor.rs
+++ b/processor/src/executor.rs
@@ -1,0 +1,175 @@
+use miden_mast_package::debug_info::{DebugSourceNodeId, PackageDebugInfo};
+
+use crate::{
+    ExecutionError, ExecutionOptions, ExecutionOutput, FastProcessor, FutureMaybeSend, Host,
+    Program, StackInputs, advice::AdviceInputs,
+};
+
+// PROGRAM EXECUTOR
+// ================================================================================================
+
+/// A pluggable program executor used to run a [`Program`] against a [`Host`].
+///
+/// Defaults to [`FastProcessor`]. Alternative implementations can wrap execution in a debugger,
+/// add instrumentation, or redirect to a different backend, while leaving the surrounding
+/// executor wiring untouched.
+///
+/// The `new` constructor is infallible from the trait's perspective: invalid advice inputs are a
+/// caller bug, and the default [`FastProcessor`] implementation panics in that case, matching the
+/// contract of [`FastProcessor::new_with_options`].
+pub trait ProgramExecutor {
+    /// Creates a new executor configured with the provided inputs and options.
+    ///
+    /// In generic code (`E: ProgramExecutor`) this resolves normally. For the concrete
+    /// [`FastProcessor`] type, however, the inherent
+    /// [`FastProcessor::new`](crate::FastProcessor::new) (which takes only stack inputs)
+    /// shadows this trait method by name, so invoke the trait constructor with fully-qualified
+    /// syntax: `<FastProcessor as ProgramExecutor>::new(stack_inputs, advice_inputs, options)`.
+    fn new(
+        stack_inputs: StackInputs,
+        advice_inputs: AdviceInputs,
+        options: ExecutionOptions,
+    ) -> Self
+    where
+        Self: Sized;
+
+    /// Executes the provided program against the given host.
+    fn execute<H: Host + Send>(
+        self,
+        program: &Program,
+        host: &mut H,
+    ) -> impl FutureMaybeSend<Result<ExecutionOutput, ExecutionError>>;
+
+    /// Executes the provided program with package-owned source/debug context.
+    ///
+    /// When `entrypoint_source_node` is `Some`, the debug context is rooted at that node.
+    /// Executors that do not support package debug execution may fall back to [`Self::execute`].
+    fn execute_with_package_debug_info<H: Host + Send>(
+        self,
+        program: &Program,
+        package_debug_info: &PackageDebugInfo,
+        entrypoint_source_node: Option<DebugSourceNodeId>,
+        host: &mut H,
+    ) -> impl FutureMaybeSend<Result<ExecutionOutput, ExecutionError>>
+    where
+        Self: Sized,
+    {
+        let _ = (package_debug_info, entrypoint_source_node);
+        self.execute(program, host)
+    }
+}
+
+impl ProgramExecutor for FastProcessor {
+    fn new(
+        stack_inputs: StackInputs,
+        advice_inputs: AdviceInputs,
+        options: ExecutionOptions,
+    ) -> Self {
+        FastProcessor::new_with_options(stack_inputs, advice_inputs, options)
+            .expect("constructing FastProcessor failed due to invalid advice inputs")
+    }
+
+    fn execute<H: Host + Send>(
+        self,
+        program: &Program,
+        host: &mut H,
+    ) -> impl FutureMaybeSend<Result<ExecutionOutput, ExecutionError>> {
+        FastProcessor::execute(self, program, host)
+    }
+
+    fn execute_with_package_debug_info<H: Host + Send>(
+        self,
+        program: &Program,
+        package_debug_info: &PackageDebugInfo,
+        entrypoint_source_node: Option<DebugSourceNodeId>,
+        host: &mut H,
+    ) -> impl FutureMaybeSend<Result<ExecutionOutput, ExecutionError>> {
+        async move {
+            match entrypoint_source_node {
+                Some(entrypoint_source_node) => {
+                    FastProcessor::execute_with_package_debug_info_at_source_node(
+                        self,
+                        program,
+                        package_debug_info,
+                        entrypoint_source_node,
+                        host,
+                    )
+                    .await
+                },
+                None => {
+                    FastProcessor::execute_with_package_debug_info(
+                        self,
+                        program,
+                        package_debug_info,
+                        host,
+                    )
+                    .await
+                },
+            }
+        }
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use miden_assembly::Assembler;
+
+    use super::*;
+    use crate::{DefaultHost, StackInputs};
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn program_executor_default_impl_runs_via_trait() {
+        let program = Assembler::default()
+            .assemble_program("program", "begin push.3 swap drop end")
+            .unwrap()
+            .unwrap_program();
+
+        // Drive execution entirely through the trait, defaulting to `FastProcessor`.
+        let processor = <FastProcessor as ProgramExecutor>::new(
+            StackInputs::default(),
+            AdviceInputs::default(),
+            ExecutionOptions::default(),
+        );
+        let output = <FastProcessor as ProgramExecutor>::execute(
+            processor,
+            &program,
+            &mut DefaultHost::default(),
+        )
+        .await
+        .unwrap();
+
+        // push.3 leaves 3 on top; `swap drop` restores the operand stack to its
+        // fixed depth of 16 so the program ends with a well-formed output stack.
+        assert_eq!(output.stack.get_element(0), Some(crate::Felt::from_u32(3)));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn program_executor_default_falls_back_when_no_source_node() {
+        let program = Assembler::default()
+            .assemble_program("program", "begin push.3 swap drop end")
+            .unwrap()
+            .unwrap_program();
+
+        // `execute_with_package_debug_info` overrides only to route to the package-debug path;
+        // without an entrypoint node it still executes and returns the same stack.
+        let processor = <FastProcessor as ProgramExecutor>::new(
+            StackInputs::default(),
+            AdviceInputs::default(),
+            ExecutionOptions::default(),
+        );
+        let output = <FastProcessor as ProgramExecutor>::execute_with_package_debug_info(
+            processor,
+            &program,
+            &PackageDebugInfo::default(),
+            None,
+            &mut DefaultHost::default(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(output.stack.get_element(0), Some(crate::Felt::from_u32(3)));
+    }
+}

--- a/processor/src/executor.rs
+++ b/processor/src/executor.rs
@@ -14,7 +14,6 @@ use crate::{
 /// Defaults to [`FastProcessor`]. Alternative implementations can wrap execution in a debugger,
 /// add instrumentation, or redirect to a different backend, while leaving the surrounding
 /// executor wiring untouched.
-///
 pub trait ProgramExecutor {
     /// Creates a new executor configured with the provided inputs and options.
     ///

--- a/processor/src/executor.rs
+++ b/processor/src/executor.rs
@@ -2,7 +2,8 @@ use miden_mast_package::debug_info::{DebugSourceNodeId, PackageDebugInfo};
 
 use crate::{
     ExecutionError, ExecutionOptions, ExecutionOutput, FastProcessor, FutureMaybeSend, Host,
-    Program, StackInputs, advice::AdviceInputs,
+    Program, StackInputs,
+    advice::{AdviceError, AdviceInputs},
 };
 
 // PROGRAM EXECUTOR
@@ -14,9 +15,6 @@ use crate::{
 /// add instrumentation, or redirect to a different backend, while leaving the surrounding
 /// executor wiring untouched.
 ///
-/// The `new` constructor is infallible from the trait's perspective: invalid advice inputs are a
-/// caller bug, and the default [`FastProcessor`] implementation panics in that case, matching the
-/// contract of [`FastProcessor::new_with_options`].
 pub trait ProgramExecutor {
     /// Creates a new executor configured with the provided inputs and options.
     ///
@@ -29,9 +27,16 @@ pub trait ProgramExecutor {
         stack_inputs: StackInputs,
         advice_inputs: AdviceInputs,
         options: ExecutionOptions,
-    ) -> Self
+    ) -> Result<Self, AdviceError>
     where
         Self: Sized;
+
+    /// Configures package-owned source and debug information for execution.
+    fn with_debug_info(self, package_debug_info: PackageDebugInfo) -> Self;
+
+    /// Configures the source node at which execution begins.
+    fn with_entrypoint_source_node(self, entrypoint_source_node: Option<DebugSourceNodeId>)
+    -> Self;
 
     /// Executes the provided program against the given host.
     fn execute<H: Host + Send>(
@@ -39,24 +44,6 @@ pub trait ProgramExecutor {
         program: &Program,
         host: &mut H,
     ) -> impl FutureMaybeSend<Result<ExecutionOutput, ExecutionError>>;
-
-    /// Executes the provided program with package-owned source/debug context.
-    ///
-    /// When `entrypoint_source_node` is `Some`, the debug context is rooted at that node.
-    /// Executors that do not support package debug execution may fall back to [`Self::execute`].
-    fn execute_with_package_debug_info<H: Host + Send>(
-        self,
-        program: &Program,
-        package_debug_info: &PackageDebugInfo,
-        entrypoint_source_node: Option<DebugSourceNodeId>,
-        host: &mut H,
-    ) -> impl FutureMaybeSend<Result<ExecutionOutput, ExecutionError>>
-    where
-        Self: Sized,
-    {
-        let _ = (package_debug_info, entrypoint_source_node);
-        self.execute(program, host)
-    }
 }
 
 impl ProgramExecutor for FastProcessor {
@@ -64,9 +51,21 @@ impl ProgramExecutor for FastProcessor {
         stack_inputs: StackInputs,
         advice_inputs: AdviceInputs,
         options: ExecutionOptions,
-    ) -> Self {
+    ) -> Result<Self, AdviceError> {
         FastProcessor::new_with_options(stack_inputs, advice_inputs, options)
-            .expect("constructing FastProcessor failed due to invalid advice inputs")
+    }
+
+    fn with_debug_info(mut self, package_debug_info: PackageDebugInfo) -> Self {
+        self.package_debug_info = Some(package_debug_info);
+        self
+    }
+
+    fn with_entrypoint_source_node(
+        mut self,
+        entrypoint_source_node: Option<DebugSourceNodeId>,
+    ) -> Self {
+        self.entrypoint_source_node = entrypoint_source_node;
+        self
     }
 
     fn execute<H: Host + Send>(
@@ -74,37 +73,28 @@ impl ProgramExecutor for FastProcessor {
         program: &Program,
         host: &mut H,
     ) -> impl FutureMaybeSend<Result<ExecutionOutput, ExecutionError>> {
-        FastProcessor::execute(self, program, host)
-    }
-
-    fn execute_with_package_debug_info<H: Host + Send>(
-        self,
-        program: &Program,
-        package_debug_info: &PackageDebugInfo,
-        entrypoint_source_node: Option<DebugSourceNodeId>,
-        host: &mut H,
-    ) -> impl FutureMaybeSend<Result<ExecutionOutput, ExecutionError>> {
         async move {
-            match entrypoint_source_node {
-                Some(entrypoint_source_node) => {
+            match (self.package_debug_info.clone(), self.entrypoint_source_node) {
+                (Some(package_debug_info), Some(entrypoint_source_node)) => {
                     FastProcessor::execute_with_package_debug_info_at_source_node(
                         self,
                         program,
-                        package_debug_info,
+                        &package_debug_info,
                         entrypoint_source_node,
                         host,
                     )
                     .await
                 },
-                None => {
+                (Some(package_debug_info), None) => {
                     FastProcessor::execute_with_package_debug_info(
                         self,
                         program,
-                        package_debug_info,
+                        &package_debug_info,
                         host,
                     )
                     .await
                 },
+                (None, _) => FastProcessor::execute(self, program, host).await,
             }
         }
     }
@@ -132,7 +122,8 @@ mod tests {
             StackInputs::default(),
             AdviceInputs::default(),
             ExecutionOptions::default(),
-        );
+        )
+        .unwrap();
         let output = <FastProcessor as ProgramExecutor>::execute(
             processor,
             &program,
@@ -144,6 +135,18 @@ mod tests {
         // push.3 leaves 3 on top; `swap drop` restores the operand stack to its
         // fixed depth of 16 so the program ends with a well-formed output stack.
         assert_eq!(output.stack.get_element(0), Some(crate::Felt::from_u32(3)));
+    }
+
+    #[test]
+    fn program_executor_reports_invalid_advice_inputs() {
+        let advice_inputs =
+            AdviceInputs::default().with_map([(crate::Word::default(), vec![crate::Felt::ONE])]);
+        let options = ExecutionOptions::default().with_max_adv_map_elements(0);
+
+        let result =
+            <FastProcessor as ProgramExecutor>::new(StackInputs::default(), advice_inputs, options);
+
+        assert!(result.is_err());
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -159,12 +162,15 @@ mod tests {
             StackInputs::default(),
             AdviceInputs::default(),
             ExecutionOptions::default(),
+        )
+        .unwrap();
+        let processor = <FastProcessor as ProgramExecutor>::with_debug_info(
+            processor,
+            PackageDebugInfo::default(),
         );
-        let output = <FastProcessor as ProgramExecutor>::execute_with_package_debug_info(
+        let output = <FastProcessor as ProgramExecutor>::execute(
             processor,
             &program,
-            &PackageDebugInfo::default(),
-            None,
             &mut DefaultHost::default(),
         )
         .await

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -9,7 +9,10 @@ use miden_core::{
     program::{MIN_STACK_DEPTH, Program, StackInputs, StackOutputs},
     utils::range,
 };
-use miden_mast_package::Package;
+use miden_mast_package::{
+    Package,
+    debug_info::{DebugSourceNodeId, PackageDebugInfo},
+};
 
 use crate::{
     AdviceInputs, AdviceProvider, ContextId, ExecutionError, ExecutionOptions, ProcessorState,
@@ -146,6 +149,12 @@ pub struct FastProcessor {
 
     /// Deferred witness accumulated during execution and returned for verifier rehydration.
     deferred_state: DeferredState,
+
+    /// Package debug information configured through [`ProgramExecutor`](crate::ProgramExecutor).
+    pub(crate) package_debug_info: Option<PackageDebugInfo>,
+
+    /// Entrypoint source node configured through [`ProgramExecutor`](crate::ProgramExecutor).
+    pub(crate) entrypoint_source_node: Option<DebugSourceNodeId>,
 }
 
 impl FastProcessor {
@@ -284,6 +293,8 @@ impl FastProcessor {
                 options.max_deferred_elements(),
             )
             .map_err(AdviceError::DeferredStateInitializationFailed)?,
+            package_debug_info: None,
+            entrypoint_source_node: None,
             options,
         })
     }

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -837,16 +837,17 @@ async fn program_executor_routes_package_debug_to_entrypoint_source_node() {
         StackInputs::default(),
         AdviceInputs::default(),
         ExecutionOptions::default(),
-    );
-    let err = <FastProcessor as ProgramExecutor>::execute_with_package_debug_info(
-        processor,
-        &fixture.program,
-        &fixture.debug_info,
-        Some(fixture.entrypoint_source_node_id),
-        &mut host,
     )
-    .await
-    .unwrap_err();
+    .unwrap();
+    let processor =
+        <FastProcessor as ProgramExecutor>::with_debug_info(processor, fixture.debug_info.clone());
+    let processor = <FastProcessor as ProgramExecutor>::with_entrypoint_source_node(
+        processor,
+        Some(fixture.entrypoint_source_node_id),
+    );
+    let err = <FastProcessor as ProgramExecutor>::execute(processor, &fixture.program, &mut host)
+        .await
+        .unwrap_err();
 
     assert_matches!(
         err,

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -32,7 +32,8 @@ use rstest::rstest;
 
 use super::*;
 use crate::{
-    AdviceInputs, BaseHost, DefaultHost, LoadedMastForest, ProcessorState, SyncHost,
+    AdviceInputs, BaseHost, DefaultHost, LoadedMastForest, ProcessorState, ProgramExecutor,
+    SyncHost,
     advice::AdviceMutation,
     event::EventError,
     operation::OperationError,
@@ -801,6 +802,51 @@ fn package_source_debug_execution_uses_manifest_entrypoint_source_node() {
             &mut host,
         )
         .unwrap_err();
+
+    assert_matches!(
+        err,
+        ExecutionError::OperationError {
+            label,
+            source_file: Some(actual_source_file),
+            err: OperationError::FailedAssertion { err_code, .. },
+        } if label == SourceSpan::new(fixture.source_file.id(), 9u32..17)
+            && actual_source_file.id() == fixture.source_file.id()
+            && err_code == Felt::from_u32(9)
+    );
+}
+
+/// Covers the `Some(entrypoint_source_node)` arm of
+/// [`ProgramExecutor::execute_with_package_debug_info`], so the trait-level dispatch to
+/// [`FastProcessor::execute_with_package_debug_info_at_source_node`] is not left untested. It
+/// mirrors [`package_source_debug_execution_uses_manifest_entrypoint_source_node`] but drives
+/// execution through the trait instead of the inherent method.
+#[tokio::test(flavor = "current_thread")]
+async fn program_executor_routes_package_debug_to_entrypoint_source_node() {
+    let fixture =
+        same_digest_entrypoint_fixture(vec![Operation::Assert(Felt::from_u32(9))], "assert");
+    assert!(
+        fixture
+            .debug_info
+            .unique_source_root_for_exec_node(fixture.program.entrypoint())
+            .is_err(),
+        "debug info alone cannot pick the manifest-selected same-digest entrypoint"
+    );
+
+    let mut host = DefaultHost::default().with_source_manager(fixture.source_manager);
+    let processor = <FastProcessor as ProgramExecutor>::new(
+        StackInputs::default(),
+        AdviceInputs::default(),
+        ExecutionOptions::default(),
+    );
+    let err = <FastProcessor as ProgramExecutor>::execute_with_package_debug_info(
+        processor,
+        &fixture.program,
+        &fixture.debug_info,
+        Some(fixture.entrypoint_source_node_id),
+        &mut host,
+    )
+    .await
+    .unwrap_err();
 
     assert_matches!(
         err,

--- a/processor/src/host/advice/mod.rs
+++ b/processor/src/host/advice/mod.rs
@@ -675,9 +675,9 @@ impl AdviceProvider {
 
     /// Extends the contents of this instance with the contents of an `AdviceInputs`.
     pub fn extend_from_inputs(&mut self, inputs: &AdviceInputs) -> Result<(), AdviceError> {
-        self.extend_advice_stack(inputs.advice_stack())?;
-        self.extend_merkle_store(inputs.store.inner_nodes())?;
-        self.extend_map(&inputs.map)
+        self.extend_advice_stack(inputs.stack())?;
+        self.extend_merkle_store(inputs.store().inner_nodes())?;
+        self.extend_map(inputs.map())
     }
 
     /// Consumes `self` and return its parts (stack, map, store).
@@ -791,7 +791,7 @@ mod tests {
         let mut mutation_stack = AdviceStack::new();
         mutation_stack.append_elements([Felt::new_unchecked(1), Felt::new_unchecked(2)]);
         let mut provider = AdviceProvider::new(
-            AdviceInputs::default().with_advice_stack(initial_stack),
+            AdviceInputs::default().with_stack(initial_stack),
             &Default::default(),
         )
         .unwrap();

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -21,6 +21,7 @@ mod continuation_stack;
 mod errors;
 mod execution;
 mod execution_options;
+mod executor;
 mod fast;
 mod host;
 mod processor;
@@ -57,6 +58,7 @@ pub use errors::{
     procedure_not_found_with_package_source_context,
 };
 pub use execution_options::{ExecutionOptions, ExecutionOptionsError};
+pub use executor::ProgramExecutor;
 pub use fast::{BreakReason, ExecutionOutput, FastProcessor, ResumeContext};
 pub use host::{
     BaseHost, FutureMaybeSend, Host, LoadedMastForest, MastForestStore, MemMastForestStore,

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -34,7 +34,7 @@ use miden_core::{
 use crate::{
     advice::{AdviceInputs, AdviceProvider},
     continuation_stack::ContinuationStack,
-    errors::{MapExecErr, MapExecErrNoCtx},
+    errors::MapExecErr,
     processor::{Processor, SystemInterface},
     trace::RowIndex,
 };
@@ -99,52 +99,6 @@ pub mod operation {
 }
 
 pub mod trace;
-
-// EXECUTORS
-// ================================================================================================
-
-/// Executes the provided program against the provided inputs and returns the resulting execution
-/// output.
-///
-/// The `host` parameter is used to provide the external environment to the program being executed,
-/// such as access to the advice provider and libraries that the program depends on.
-///
-/// # Errors
-/// Returns an error if program execution fails for any reason.
-#[tracing::instrument("execute_program", skip_all)]
-pub async fn execute(
-    program: &Program,
-    stack_inputs: StackInputs,
-    advice_inputs: AdviceInputs,
-    host: &mut impl Host,
-    options: ExecutionOptions,
-) -> Result<ExecutionOutput, ExecutionError> {
-    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, options)
-        .map_exec_err_no_ctx()?;
-    processor.execute(program, host).await
-}
-
-/// Synchronous wrapper for the async `execute()` function.
-///
-/// This method is only available on non-wasm32 targets. On wasm32, use the async `execute()`
-/// method directly since wasm32 runs in the browser's event loop.
-///
-/// # Panics
-/// Panics if called from within an existing Tokio runtime. Use the async `execute()` method
-/// instead in async contexts.
-#[cfg(not(target_family = "wasm"))]
-#[tracing::instrument("execute_program_sync", skip_all)]
-pub fn execute_sync(
-    program: &Program,
-    stack_inputs: StackInputs,
-    advice_inputs: AdviceInputs,
-    host: &mut impl SyncHost,
-    options: ExecutionOptions,
-) -> Result<ExecutionOutput, ExecutionError> {
-    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, options)
-        .map_exec_err_no_ctx()?;
-    processor.execute_sync(program, host)
-}
 
 // PROCESSOR STATE
 // ===============================================================================================

--- a/processor/src/test_utils/non_tracing_test_host.rs
+++ b/processor/src/test_utils/non_tracing_test_host.rs
@@ -71,7 +71,7 @@ mod tests {
     use miden_assembly::Assembler;
 
     use super::NonTracingTestHost;
-    use crate::{AdviceInputs, ExecutionOptions, Program, StackInputs};
+    use crate::{AdviceInputs, ExecutionOptions, FastProcessor, Program, StackInputs};
 
     /// A host which does not implement `on_trace` should still execute trace events gracefully via
     /// the default no-op implementation, and trace events must not be routed to `on_event`.
@@ -100,13 +100,13 @@ mod tests {
             .unwrap()
             .unwrap_program();
         let mut host = NonTracingTestHost::default();
-        crate::execute_sync(
-            &program,
+        FastProcessor::new_with_options(
             StackInputs::default(),
             AdviceInputs::default(),
-            &mut host,
             ExecutionOptions::default(),
         )
+        .expect("failed to construct FastProcessor")
+        .execute_sync(&program, &mut host)
         .unwrap();
 
         assert_eq!(host.events, vec![REGULAR_EVENT_ID_1, REGULAR_EVENT_ID_2]);

--- a/processor/src/test_utils/test_host.rs
+++ b/processor/src/test_utils/test_host.rs
@@ -211,7 +211,7 @@ mod tests {
     use miden_assembly::Assembler;
 
     use super::TestHost;
-    use crate::{AdviceInputs, ExecutionOptions, Program, StackInputs};
+    use crate::{AdviceInputs, ExecutionOptions, FastProcessor, Program, StackInputs};
 
     #[test]
     fn test_host_records_trace_and_snapshot() {
@@ -234,13 +234,13 @@ mod tests {
             .unwrap()
             .unwrap_program();
         let mut host = TestHost::default();
-        crate::execute_sync(
-            &program,
+        FastProcessor::new_with_options(
             StackInputs::default(),
             AdviceInputs::default(),
-            &mut host,
             ExecutionOptions::default(),
         )
+        .expect("failed to construct FastProcessor")
+        .execute_sync(&program, &mut host)
         .unwrap();
 
         // Each trace id is recorded, in emission order.

--- a/processor/tests/advice_public_api.rs
+++ b/processor/tests/advice_public_api.rs
@@ -9,7 +9,7 @@ fn advice_stack_is_available_through_processor_advice_facade() {
     let value = Felt::new_unchecked(1);
     stack.append_element(value);
 
-    let advice_inputs = AdviceInputs::default().with_advice_stack(stack);
+    let advice_inputs = AdviceInputs::default().with_stack(stack);
 
-    assert_eq!(advice_inputs.advice_stack().into_elements(), vec![value]);
+    assert_eq!(advice_inputs.stack().into_elements(), vec![value]);
 }

--- a/processor/tests/async_compat.rs
+++ b/processor/tests/async_compat.rs
@@ -91,25 +91,22 @@ async fn execute_async_matches_execute() {
     let advice_inputs = AdviceInputs::default();
 
     let mut sync_host = DefaultHost::default();
-    let sync_output = miden_processor::execute_sync(
-        &program,
+    let sync_output = FastProcessor::new_with_options(
         stack_inputs,
         advice_inputs.clone(),
-        &mut sync_host,
         ExecutionOptions::default(),
     )
+    .expect("failed to construct FastProcessor")
+    .execute_sync(&program, &mut sync_host)
     .unwrap();
 
     let mut async_host = DefaultHost::default();
-    let async_output = miden_processor::execute(
-        &program,
-        stack_inputs,
-        advice_inputs,
-        &mut async_host,
-        ExecutionOptions::default(),
-    )
-    .await
-    .unwrap();
+    let async_output =
+        FastProcessor::new_with_options(stack_inputs, advice_inputs, ExecutionOptions::default())
+            .expect("failed to construct FastProcessor")
+            .execute(&program, &mut async_host)
+            .await
+            .unwrap();
 
     assert_eq!(sync_output.stack, async_output.stack);
 }

--- a/processor/tests/issue_2456_test.rs
+++ b/processor/tests/issue_2456_test.rs
@@ -1,7 +1,9 @@
 /// Test case for issue #2456: statically linked library calls should preserve valid MAST
 /// structure when copying nodes between forests.
 use miden_assembly::Assembler;
-use miden_processor::{DefaultHost, ExecutionOptions, StackInputs, advice::AdviceInputs};
+use miden_processor::{
+    DefaultHost, ExecutionOptions, FastProcessor, StackInputs, advice::AdviceInputs,
+};
 
 #[test]
 fn test_issue_2456_statically_linked_library_call() {
@@ -47,7 +49,8 @@ fn test_issue_2456_statically_linked_library_call() {
     let mut host = DefaultHost::default();
     let options = ExecutionOptions::default();
 
-    let result =
-        miden_processor::execute_sync(&program, stack_inputs, advice_inputs, &mut host, options);
+    let result = FastProcessor::new_with_options(stack_inputs, advice_inputs, options)
+        .expect("failed to construct FastProcessor")
+        .execute_sync(&program, &mut host);
     assert!(result.is_ok(), "Execution should succeed but got error: {:?}", result.err());
 }

--- a/verifier/src/recursive/mod.rs
+++ b/verifier/src/recursive/mod.rs
@@ -33,7 +33,7 @@ use miden_air::{
 };
 use miden_core::{
     Felt, Word,
-    advice::AdviceInputs,
+    advice::{AdviceInputs, AdviceStack},
     crypto::merkle::{MerklePath, MerkleStore, PartialMerkleTree},
     deferred::{DEFAULT_MAX_DEFERRED_ELEMENTS, DeferredState, IntegrityError, TRUE_DIGEST},
     field::QuadFelt,
@@ -110,10 +110,9 @@ impl RecursiveVerifierInputs {
     /// `proof_request_key(verifier_root, claim_commitment)`, leaving the advice stack empty.
     fn into_request_package(mut self, verifier_root: Word) -> Self {
         let key = proof_request_key(verifier_root, self.claim_commitment);
-        let (proof_stream, map, store) = self.advice.into_parts();
-        self.advice = AdviceInputs::default().with_merkle_store(store);
-        self.advice.map = map;
-        self.advice.map.insert(key, proof_stream.into_elements());
+        let (proof_stream, mut map, store) = self.advice.into_parts();
+        map.insert(key, proof_stream.into_elements());
+        self.advice = AdviceInputs::new(AdviceStack::default(), map, store);
         self
     }
 }
@@ -138,12 +137,14 @@ fn build_verifier_inputs(
     let mut inputs = build_from_proof_bytes(stark.bytes(), &pub_inputs, claim_commitment)?;
 
     // The MASM verifier authenticates this preimage against the caller-provided commitment.
-    inputs.advice.map.insert(claim_commitment, claim.to_elements().to_vec());
+    inputs.advice = core::mem::take(&mut inputs.advice)
+        .with_map([(claim_commitment, claim.to_elements().to_vec())]);
 
     let kernel = claim.kernel();
     // The MASM verifier derives the procedure count from the value length.
     let kernel_witness = Word::words_as_elements(kernel.proc_hashes()).to_vec();
-    inputs.advice.map.insert(kernel.commitment(), kernel_witness);
+    inputs.advice =
+        core::mem::take(&mut inputs.advice).with_map([(kernel.commitment(), kernel_witness)]);
 
     Ok(inputs)
 }
@@ -316,7 +317,7 @@ fn build_advice(
     let (store, advice_map) = build_merkle_data(config, stark, &heights.proof_order)?;
 
     let advice = AdviceInputs::default()
-        .with_advice_stack(advice_stack.into())
+        .with_stack(advice_stack.into())
         .with_map(advice_map)
         .with_merkle_store(store);
 
@@ -539,25 +540,22 @@ mod tests {
         let store: MerkleStore = [merkle_node].into_iter().collect();
 
         let advice = AdviceInputs::default()
-            .with_advice_stack(proof_stream.clone().into())
+            .with_stack(proof_stream.clone().into())
             .with_map([query_entry.clone()])
             .with_merkle_store(store.clone());
         let inputs = RecursiveVerifierInputs { advice, claim_commitment };
 
         let package = inputs.into_request_package(verifier_root);
 
-        assert!(
-            package.advice().advice_stack().is_empty(),
-            "the proof must leave the advice stack"
-        );
+        assert!(package.advice().stack().is_empty(), "the proof must leave the advice stack");
         assert_eq!(package.claim_commitment(), claim_commitment);
-        assert_eq!(&package.advice().store, &store);
-        assert_eq!(package.advice().map.len(), 2, "existing entries stay, proof entry added");
-        assert_eq!(package.advice().map.get(&query_entry.0).unwrap().as_ref(), query_entry.1);
+        assert_eq!(package.advice().store(), &store);
+        assert_eq!(package.advice().map().len(), 2, "existing entries stay, proof entry added");
+        assert_eq!(package.advice().map().get(&query_entry.0).unwrap().as_ref(), query_entry.1);
         assert_eq!(
             package
                 .advice()
-                .map
+                .map()
                 .get(&proof_request_key(verifier_root, claim_commitment))
                 .unwrap()
                 .as_ref(),


### PR DESCRIPTION
Closes #3474, closes #3538.

This PR bundles two related cleanups to the advice and execution APIs.

### 1. Advice inputs constructors (closes #3474)

Adds a full constructor that assembles `AdviceInputs` from owned parts, and a `From<AdviceMap>` impl that defaults the stack and store:

```rust
let inputs = AdviceInputs::new(advice_stack, advice_map, merkle_store);
let inputs = AdviceInputs::from(advice_map);
```

These complement the existing builder-style accessors (`with_advice_stack`, `with_map`, `with_merkle_store`) for callers that already own their parts. `From<AdviceMap>` matches the common case where only the map is needed.

### 2. Program executor boundary (closes #3538)

Consolidates the program execution entry points so alternative execution backends can be plugged in without changing the surrounding wiring.

**New `ProgramExecutor` trait.** A pluggable executor abstraction in `miden-processor`, with `FastProcessor` as the default implementation:

```rust
pub trait ProgramExecutor {
    fn new(
        stack_inputs: StackInputs,
        advice_inputs: AdviceInputs,
        options: ExecutionOptions,
    ) -> Self
    where
        Self: Sized;

    fn execute<H: Host + Send>(
        self,
        program: &Program,
        host: &mut H,
    ) -> impl FutureMaybeSend<Result<ExecutionOutput, ExecutionError>>;

    fn execute_with_package_debug_info<H: Host + Send>(
        self,
        program: &Program,
        package_debug_info: &PackageDebugInfo,
        entrypoint_source_node: Option<DebugSourceNodeId>,
        host: &mut H,
    ) -> impl FutureMaybeSend<Result<ExecutionOutput, ExecutionError>>
    where
        Self: Sized;
}
```

The trait is byte-for-byte faithful to the one already living in `miden-tx` (which carries a TODO to move it into `miden-vm`), so `miden-tx` can later delete its local copy and re-export this one. `execute_with_package_debug_info` routes to the source-node-anchored variant when an entrypoint node is supplied and falls back to the package-rooted variant otherwise.

**Note on the `new` constructor.** For the concrete `FastProcessor` type, the trait constructor is shadowed by the inherent 1-arg `FastProcessor::new(stack_inputs)`. In generic code (`E: ProgramExecutor`) the trait method resolves normally. To call it on `FastProcessor` directly, use fully-qualified syntax: `<FastProcessor as ProgramExecutor>::new(stack, advice, options)`.

**BREAKING: removed the free `execute()` / `execute_sync()` functions.** These module-level functions in `miden-processor` and `miden-vm` had no external callers. The prover and `miden-base` already use `FastProcessor` directly because they need the trace or package-debug path. The free functions are removed; every in-repo caller is migrated to:

```rust
let output = FastProcessor::new_with_options(stack_inputs, advice_inputs, options)
    .execute(&program, &mut host)
    .await?;
```

If you previously called `miden_processor::execute(...)` or `miden_vm::execute(...)`, switch to `FastProcessor::new_with_options(...)` followed by `execute()` (async) or `execute_sync()`.

### Migration summary

| Before | After |
| --- | --- |
| assemble parts then call `.with_map(...)` etc. | `AdviceInputs::new(stack, map, store)` or `AdviceInputs::from(map)` |
| `miden_processor::execute(program, stack, host, options)` | `FastProcessor::new_with_options(stack, advice, options).execute(&program, &mut host).await` |
| `miden_processor::execute_sync(...)` | `...execute_sync(&program, &mut host)` |

---

### Addendum: `AdviceInputs` API after review

Review feedback led to a more consistent `AdviceInputs` API. The `stack`, `map`, and `store` fields are now private. Callers create a value with `AdviceInputs::new(stack, map, store)` or `AdviceInputs::from(map)`, and can configure it with `with_stack()`, `with_map()`, and `with_merkle_store()`.

The old `advice_stack` name has been shortened to `stack`. Read access is available through `stack()`, `map()`, and `store()`, while `into_parts()` consumes the value and returns all three owned components. This addendum supersedes the earlier references to `with_advice_stack()` in the original description.
