### PR TITLE
refactor(serde-utils): move bounded length helpers out of miden-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
+- Moved the `read_bounded_len` and `validate_bounded_len` helpers from `miden-core` to `miden-serde-utils`, where they are now public. `miden-core::serde` re-exports them unchanged, and the private duplicates in `miden-utils-indexing` were removed ([#3415](https://github.com/0xMiden/miden-vm/issues/3415)).
 
 ## v0.29.0 (2026-08-04)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2182,6 +2182,7 @@ dependencies = [
  "miden-crypto",
  "miden-debug-types",
  "miden-formatting",
+ "miden-serde-utils",
  "miden-test-serde-macros",
  "miden-test-utils",
  "miden-utils-core-derive",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -34,6 +34,7 @@ std = [
     "miden-crypto/std",
     "miden-debug-types/std",
     "miden-formatting/std",
+    "miden-serde-utils/std",
     "miden-utils-indexing/std",
     "miden-utils-sync/std",
     "thiserror/std",
@@ -53,6 +54,7 @@ fuzzing = []
 miden-crypto.workspace = true
 miden-debug-types.workspace = true
 miden-formatting.workspace = true
+miden-serde-utils.workspace = true
 miden-utils-core-derive.workspace = true
 miden-utils-indexing.workspace = true
 miden-utils-sync.workspace = true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -31,48 +31,10 @@ pub mod field {
 }
 
 pub mod serde {
-    pub use miden_crypto::utils::{
+    pub use miden_serde_utils::{
         BudgetedReader, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-        SliceReader,
+        SliceReader, read_bounded_len, validate_bounded_len,
     };
-
-    /// Reads and validates a serialized length before it is used for allocation.
-    pub fn read_bounded_len<R: ByteReader>(
-        source: &mut R,
-        label: &str,
-        min_element_size: usize,
-    ) -> Result<usize, DeserializationError> {
-        let len = source.read_usize()?;
-        validate_bounded_len(source, label, len, min_element_size)?;
-        Ok(len)
-    }
-
-    /// Validates that a serialized length fits both the reader budget and remaining input.
-    pub fn validate_bounded_len<R: ByteReader>(
-        source: &R,
-        label: &str,
-        len: usize,
-        min_element_size: usize,
-    ) -> Result<(), DeserializationError> {
-        let max_len = source.max_alloc(min_element_size);
-        if len > max_len {
-            return Err(DeserializationError::InvalidValue(alloc::format!(
-                "{label} count {len} exceeds budget {max_len}"
-            )));
-        }
-
-        let min_bytes = len.checked_mul(min_element_size).ok_or_else(|| {
-            DeserializationError::InvalidValue(alloc::format!(
-                "{label} count {len} overflows minimum serialized size {min_element_size}"
-            ))
-        })?;
-        source.check_eor(min_bytes).map_err(|err| match err {
-            DeserializationError::UnexpectedEOF => DeserializationError::InvalidValue(
-                alloc::format!("{label} count {len} exceeds remaining input"),
-            ),
-            err => err,
-        })
-    }
 }
 
 pub mod crypto {

--- a/crates/serde-utils/src/lib.rs
+++ b/crates/serde-utils/src/lib.rs
@@ -94,6 +94,63 @@ pub use byte_reader::{BudgetedReader, ByteReader, ReadManyIter, SliceReader};
 mod byte_writer;
 pub use byte_writer::ByteWriter;
 
+// BOUNDED LENGTH HELPERS
+// ================================================================================================
+
+/// Reads and validates a serialized length before it is used for allocation.
+///
+/// `label` names the collection being read and is only used to build the error message.
+/// `min_element_size` is the minimum number of bytes one element occupies once serialized.
+///
+/// # Errors
+/// Returns an error if the length cannot be read, or if it fails the checks described in
+/// [`validate_bounded_len`].
+pub fn read_bounded_len<R: ByteReader>(
+    source: &mut R,
+    label: &str,
+    min_element_size: usize,
+) -> Result<usize, DeserializationError> {
+    let len = source.read_usize()?;
+    validate_bounded_len(source, label, len, min_element_size)?;
+    Ok(len)
+}
+
+/// Validates that a serialized length fits both the reader budget and remaining input.
+///
+/// This guards against malicious length prefixes that would otherwise cause a compact payload
+/// to be amplified into a large allocation.
+///
+/// # Errors
+/// Returns [`DeserializationError::InvalidValue`] if:
+/// * `len` exceeds the number of elements the reader's remaining budget allows.
+/// * `len * min_element_size` overflows.
+/// * The source does not hold `len * min_element_size` more bytes.
+pub fn validate_bounded_len<R: ByteReader>(
+    source: &R,
+    label: &str,
+    len: usize,
+    min_element_size: usize,
+) -> Result<(), DeserializationError> {
+    let max_len = source.max_alloc(min_element_size);
+    if len > max_len {
+        return Err(DeserializationError::InvalidValue(format!(
+            "{label} count {len} exceeds budget {max_len}"
+        )));
+    }
+
+    let min_bytes = len.checked_mul(min_element_size).ok_or_else(|| {
+        DeserializationError::InvalidValue(format!(
+            "{label} count {len} overflows minimum serialized size {min_element_size}"
+        ))
+    })?;
+    source.check_eor(min_bytes).map_err(|err| match err {
+        DeserializationError::UnexpectedEOF => DeserializationError::InvalidValue(format!(
+            "{label} count {len} exceeds remaining input"
+        )),
+        err => err,
+    })
+}
+
 // SERIALIZABLE TRAIT
 // ================================================================================================
 
@@ -923,6 +980,49 @@ mod tests {
         let result = BTreeSet::<u8>::read_from_bytes(&bytes);
 
         assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
+    }
+
+    #[test]
+    fn read_bounded_len_accepts_a_length_backed_by_enough_input() {
+        let mut bytes = 3usize.to_bytes();
+        bytes.extend_from_slice(&[0u8; 3]);
+        let mut source = SliceReader::new(&bytes);
+
+        assert_eq!(read_bounded_len(&mut source, "elements", 1).unwrap(), 3);
+    }
+
+    #[test]
+    fn read_bounded_len_rejects_a_length_exceeding_remaining_input() {
+        let mut bytes = 8usize.to_bytes();
+        bytes.extend_from_slice(&[0u8; 3]);
+        let mut source = SliceReader::new(&bytes);
+
+        assert!(matches!(
+            read_bounded_len(&mut source, "elements", 1),
+            Err(DeserializationError::InvalidValue(_))
+        ));
+    }
+
+    #[test]
+    fn read_bounded_len_rejects_a_length_exceeding_the_budget() {
+        let mut bytes = 64usize.to_bytes();
+        bytes.extend_from_slice(&[0u8; 64]);
+        let mut source = BudgetedReader::new(SliceReader::new(&bytes), 16);
+
+        assert!(matches!(
+            read_bounded_len(&mut source, "elements", 1),
+            Err(DeserializationError::InvalidValue(_))
+        ));
+    }
+
+    #[test]
+    fn validate_bounded_len_rejects_a_length_overflowing_the_element_size() {
+        let source = SliceReader::new(&[]);
+
+        assert!(matches!(
+            validate_bounded_len(&source, "elements", usize::MAX, 2),
+            Err(DeserializationError::InvalidValue(_))
+        ));
     }
 
     #[test]

--- a/crates/utils-indexing/src/lib.rs
+++ b/crates/utils-indexing/src/lib.rs
@@ -419,7 +419,7 @@ impl<I: Idx, T> TryFrom<Vec<T>> for IndexVec<I, T> {
 // ================================================================================================
 
 use miden_serde_utils::{
-    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, read_bounded_len,
 };
 
 impl<I, T> Serializable for IndexVec<I, T>
@@ -497,44 +497,6 @@ where
 
         Ok(Self { raw: vec, _m: PhantomData })
     }
-}
-
-/// Reads and validates a serialized length before it is used for allocation.
-fn read_bounded_len<R: ByteReader>(
-    source: &mut R,
-    label: &str,
-    min_element_size: usize,
-) -> Result<usize, DeserializationError> {
-    let len = source.read_usize()?;
-    validate_bounded_len(source, label, len, min_element_size)?;
-    Ok(len)
-}
-
-/// Validates that a serialized length fits both the reader budget and remaining input.
-fn validate_bounded_len<R: ByteReader>(
-    source: &R,
-    label: &str,
-    len: usize,
-    min_element_size: usize,
-) -> Result<(), DeserializationError> {
-    let max_len = source.max_alloc(min_element_size);
-    if len > max_len {
-        return Err(DeserializationError::InvalidValue(alloc::format!(
-            "{label} count {len} exceeds budget {max_len}"
-        )));
-    }
-
-    let min_bytes = len.checked_mul(min_element_size).ok_or_else(|| {
-        DeserializationError::InvalidValue(alloc::format!(
-            "{label} count {len} overflows minimum serialized size {min_element_size}"
-        ))
-    })?;
-    source.check_eor(min_bytes).map_err(|err| match err {
-        DeserializationError::UnexpectedEOF => DeserializationError::InvalidValue(alloc::format!(
-            "{label} count {len} exceeds remaining input"
-        )),
-        err => err,
-    })
 }
 
 /// Bounds speculative collection capacity by both the declared length and the reader's remaining

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -768,6 +768,7 @@ dependencies = [
  "miden-crypto",
  "miden-debug-types",
  "miden-formatting",
+ "miden-serde-utils",
  "miden-utils-core-derive",
  "miden-utils-indexing",
  "miden-utils-sync",


### PR DESCRIPTION
Closes #3415

## Rationale

`read_bounded_len` and `validate_bounded_len` were defined in `miden-core::serde`, with a byte-identical private copy of both in `miden-utils-indexing`. As [noted on #3398](https://github.com/0xMiden/miden-vm/pull/3398#discussion_r3626097131), the duplication existed only because `miden-utils-indexing` does not (and should not) depend on `miden-core`, and moving the helpers to their natural home was blocked on the release-cycle dance.

Now that `miden-crypto` lives in this workspace, `miden-serde-utils` is a direct dependency of every crate involved, so both helpers can move there.

## Changes

- Added `read_bounded_len` and `validate_bounded_len` to `miden-serde-utils` as public items, alongside the `ByteReader` they operate on.
- `miden-core::serde` now re-exports them. That module already re-exported its reader/writer traits from `miden-serde-utils` via `miden-crypto`'s pass-through, so the module now names a single source instead of two. `miden-core` gains a direct `miden-serde-utils` dependency for this.
- Removed the private duplicates from `miden-utils-indexing`, which now imports `read_bounded_len` from `miden-serde-utils`.

Behaviour is unchanged — the moved bodies are identical apart from `alloc::format!` becoming `format!` (already imported in `miden-serde-utils`). Every existing caller keeps working through the `miden-core::serde` re-export, so no call sites needed touching.

## Test plan

```
cargo test -p miden-serde-utils -p miden-utils-indexing -p miden-core
cargo test -p miden-mast-package -p miden-assembly-syntax   # downstream consumers of the re-export
cargo clippy -p miden-serde-utils -p miden-utils-indexing -p miden-core --all-targets --all-features
```

To review the move itself, the two function bodies are unchanged apart from `alloc::format!` becoming `format!`, so `git show --color-moved` makes the diff read as a relocation rather than a rewrite.

### Tests added

The helpers had no direct coverage. Added four tests next to the new definitions, one per rejection path plus the accepting case:

- a length backed by enough input is accepted
- a length exceeding remaining input is rejected
- a length exceeding the reader budget is rejected
- `len * min_element_size` overflow is rejected

## Results

`cargo check --workspace --all-targets` is clean with no warnings, as is clippy over the three touched crates with `--all-features`. Tests pass for `miden-serde-utils`, `miden-utils-indexing`, `miden-core`, and the downstream consumers of the re-export (`miden-mast-package`, `miden-assembly-syntax`).

One gap to flag: `benches/smt-codspeed` did not build locally because `librocksdb-sys` needs a working C++ toolchain and mine is broken — a plain `#include <cstdint>` fails on this machine. That bench is the only thing pulling rocksdb in and it is untouched here, but I could not verify it myself.


