### PR TITLE
docs: repair relative links broken by crate and module moves

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -2,10 +2,10 @@
 This crate contains core components used by Miden VM. These components include:
 
 * Miden VM instruction set, defined in the [Operation](./src/operations/mod.rs) struct.
-* Miden VM program kernel, defined in [KernelDescriptor](./src/kernel.rs) struct which contains a set of roots of kernel routines.
-* Miden VM program structure, defined in [Program](./src/program.rs) struct and described [here](https://docs.miden.xyz/miden-vm/design/programs).
-* Miden VM program metadata, defined in [ProgramInfo](./src/program.rs) struct which contains a program's MAST root and the kernel used by the program.
-* Input and output containers for Miden VM programs, defined in [StackInputs](./src/stack/inputs.rs) and [StackOutputs](./src/stack/outputs.rs) structs.
+* Miden VM program kernel, defined in [KernelDescriptor](./src/program/kernel.rs) struct which contains a set of roots of kernel routines.
+* Miden VM program structure, defined in [Program](./src/program/mod.rs) struct and described [here](https://docs.miden.xyz/miden-vm/design/programs).
+* Miden VM program metadata, defined in [ProgramInfo](./src/program/mod.rs) struct which contains a program's MAST root and the kernel used by the program.
+* Input and output containers for Miden VM programs, defined in [StackInputs](./src/program/stack/inputs.rs) and [StackOutputs](./src/program/stack/outputs.rs) structs.
 * Constants describing the shape of the VM's execution trace.
 * Various minor utility functions used by other VM crates.
 

--- a/crates/assembly/README.md
+++ b/crates/assembly/README.md
@@ -4,7 +4,7 @@ This crate contains Miden assembler.
 
 The purpose of the assembler is to compile/assemble [Miden Assembly (MASM)](https://docs.miden.xyz/miden-vm/user_docs/assembly)
 source code into a Miden VM program (represented by `Program` struct). The program
-can then be executed on Miden VM [processor](../processor).
+can then be executed on Miden VM [processor](../../processor).
 
 ## Compiling Miden Assembly
 

--- a/crates/crypto-derive/README.md
+++ b/crates/crypto-derive/README.md
@@ -4,4 +4,4 @@ Procedural macros for the `miden-crypto` crate.
 
 ## License
 
-Any contribution intentionally submitted for inclusion in this repository, as defined in the Apache-2.0 license, shall be dual licensed under the [MIT](../LICENSE-MIT) and [Apache 2.0](../LICENSE-APACHE) licenses, without any additional terms or conditions.
+Any contribution intentionally submitted for inclusion in this repository, as defined in the Apache-2.0 license, shall be dual licensed under the [MIT](../../LICENSE-MIT) and [Apache 2.0](../../LICENSE-APACHE) licenses, without any additional terms or conditions.

--- a/crates/lib/core/README.md
+++ b/crates/lib/core/README.md
@@ -1,7 +1,7 @@
 # Miden core library
 Core library for Miden VM.
 
-Miden core library provides a set of procedures which can be used by any Miden program. These procedures build on the core instruction set of [Miden assembly](../assembly) expanding the functionality immediately available to the user.
+Miden core library provides a set of procedures which can be used by any Miden program. These procedures build on the core instruction set of [Miden assembly](../../assembly) expanding the functionality immediately available to the user.
 
 The goals of Miden core library are:
 * Provide highly-optimized and battle-tested implementations of commonly-used primitives.
@@ -35,8 +35,8 @@ Currently, Miden core library contains just a few modules, which are listed belo
 - [miden::core::math::u256](./docs/math/u256.md)
 - [miden::core::math::u64](./docs/math/u64.md)
 - [miden::core::mem](./docs/mem.md)
-- [miden::core::pcs::fri::frie2f4](./docs/pcs/frie2f4.md)
-- [miden::core::stark](./docs/stark/mod.md)
+- [miden::core::pcs::fri::frie2f4](./docs/pcs/fri/frie2f4.md)
+- [miden::core::stark](./docs/stark.md)
 - [miden::core::stark::constants](./docs/stark/constants.md)
 - [miden::core::stark::deep_queries](./docs/stark/deep_queries.md)
 - [miden::core::stark::ood_frames](./docs/stark/ood_frames.md)

--- a/crates/serde-utils/README.md
+++ b/crates/serde-utils/README.md
@@ -18,4 +18,4 @@ This crate provides serialization and deserialization utilities for the Miden pr
 
 ## License
 
-Any contribution intentionally submitted for inclusion in this repository, as defined in the Apache-2.0 license, shall be dual licensed under the [MIT](../LICENSE-MIT) and [Apache 2.0](../LICENSE-APACHE) licenses, without any additional terms or conditions.
+Any contribution intentionally submitted for inclusion in this repository, as defined in the Apache-2.0 license, shall be dual licensed under the [MIT](../../LICENSE-MIT) and [Apache 2.0](../../LICENSE-APACHE) licenses, without any additional terms or conditions.

--- a/miden-vm/README.md
+++ b/miden-vm/README.md
@@ -8,7 +8,7 @@ An in-depth description of Miden VM is available in the full Miden VM [documenta
 
 ### Writing programs
 
-Our goal is to make Miden VM an easy compilation target for high-level languages such as Rust, Move, Sway, and others. We believe it is important to let people write programs in the languages of their choice. However, compilers to help with this have not been developed yet. Thus, for now, the primary way to write programs for Miden VM is to use [Miden assembly](../assembly).
+Our goal is to make Miden VM an easy compilation target for high-level languages such as Rust, Move, Sway, and others. We believe it is important to let people write programs in the languages of their choice. However, compilers to help with this have not been developed yet. Thus, for now, the primary way to write programs for Miden VM is to use [Miden assembly](../crates/assembly).
 
 Miden assembler compiles assembly source code in a [program MAST](https://docs.miden.xyz/miden-vm/design/programs), which is represented by a `Program` struct. It is possible to construct a `Program` struct manually, but we don't recommend this approach because it is tedious, error-prone, and requires an in-depth understanding of VM internals. All examples throughout these docs use assembly syntax.
 
@@ -180,7 +180,7 @@ match Verifier::new().verify(proof, claim) {
 
 ## Fibonacci calculator
 
-Let's write a simple program for Miden VM (using [Miden assembly](../assembly)). Our program will compute the 5-th [Fibonacci number](https://en.wikipedia.org/wiki/Fibonacci_number):
+Let's write a simple program for Miden VM (using [Miden assembly](../crates/assembly)). Our program will compute the 5-th [Fibonacci number](https://en.wikipedia.org/wiki/Fibonacci_number):
 
 ```masm
 push.0      // stack state: 0


### PR DESCRIPTION
Closes #3548

Draft while I wait to be assigned on the issue.

## Rationale

Fifteen relative links across six READMEs point at paths that no longer exist. They are local `file://` targets, which the link checker skips, so they survived the crate and module moves that broke them.

## Approach

Rather than fixing the listed examples, I resolved every non-http markdown link in the repo against the filesystem and fixed everything that did not exist. That caught one link the issue did not list: `crates/assembly/README.md` points at `../processor`, one level short now that assembly lives under `crates/`.

| File | Was | Now |
| --- | --- | --- |
| `core/README.md` | `./src/kernel.rs` | `./src/program/kernel.rs` |
| `core/README.md` | `./src/program.rs` (×2) | `./src/program/mod.rs` |
| `core/README.md` | `./src/stack/{inputs,outputs}.rs` | `./src/program/stack/{inputs,outputs}.rs` |
| `crates/assembly/README.md` | `../processor` | `../../processor` |
| `crates/lib/core/README.md` | `../assembly` | `../../assembly` |
| `crates/lib/core/README.md` | `./docs/pcs/frie2f4.md` | `./docs/pcs/fri/frie2f4.md` |
| `crates/lib/core/README.md` | `./docs/stark/mod.md` | `./docs/stark.md` |
| `crates/crypto-derive/README.md` | `../LICENSE-{MIT,APACHE}` | `../../LICENSE-{MIT,APACHE}` |
| `crates/serde-utils/README.md` | `../LICENSE-{MIT,APACHE}` | `../../LICENSE-{MIT,APACHE}` |
| `miden-vm/README.md` | `../assembly` (×2) | `../crates/assembly` |

Each target was resolved against the current tree rather than guessed: `Program` and `ProgramInfo` are both in `core/src/program/mod.rs`, `KernelDescriptor` in `core/src/program/kernel.rs`, and `StackInputs`/`StackOutputs` under `core/src/program/stack/`.

## Test plan

The sweep is a few lines of Python — walk every `*.md`, extract `[text](href)`, skip `http(s)`/`#`/`mailto`, and check the rest resolves relative to the file's directory. Before: 15 broken. After: 0.

Five entries remain in the sweep output and are false positives, noted here in case you ever want to automate this check: three image files legitimately have parentheses in their names (`DUP(n).png`, `MOVUP(n).png`, `MOVDN(n).png`), which a naive `[^)]+` href pattern truncates, and two are angle-bracket autolinks rather than markdown links.

Docs only — no code changes, so this wants the `no changelog` label.
