### PR TITLE
fix(crypto): dedupe SMT roots before pruning

### DIFF
--- a/crates/crypto/src/merkle/smt/forest/mod.rs
+++ b/crates/crypto/src/merkle/smt/forest/mod.rs
@@ -228,7 +228,7 @@ impl SmtForest {
                 // don't use self.contains_root here because we don't remove empty trees
                 self.roots.contains(root)
             })
-            .collect::<Vec<_>>();
+            .collect::<BTreeSet<_>>();
 
         for root in &roots {
             self.roots.remove(root);

--- a/crates/crypto/src/merkle/smt/forest/tests.rs
+++ b/crates/crypto/src/merkle/smt/forest/tests.rs
@@ -320,6 +320,33 @@ fn test_pop_and_reinsert_same_tree() -> Result<(), MerkleError> {
 }
 
 #[test]
+fn test_pop_duplicate_roots_does_not_corrupt_shared_nodes() -> Result<(), MerkleError> {
+    let mut forest = SmtForest::new();
+
+    let empty_tree_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);
+    let key1 = Word::new([ZERO; Word::NUM_ELEMENTS]);
+    let key2 = Word::new([ONE, ZERO, ZERO, ZERO]);
+    let value1 = Word::new([ONE; Word::NUM_ELEMENTS]);
+    let value2 = Word::new([Felt::new_unchecked(2); Word::NUM_ELEMENTS]);
+
+    let root1 = forest.insert(empty_tree_root, key1, value1)?;
+    let duplicate_root1 = forest.insert(empty_tree_root, key1, value1)?;
+    assert_eq!(root1, duplicate_root1);
+
+    let root2 = forest.insert(root1, key2, value2)?;
+
+    forest.pop_smts(vec![root1, root1]);
+
+    let proof1 = forest.open(root2, key1)?;
+    proof1.verify_presence(&key1, &value1, &root2).unwrap();
+
+    let proof2 = forest.open(root2, key2)?;
+    proof2.verify_presence(&key2, &value2, &root2).unwrap();
+
+    Ok(())
+}
+
+#[test]
 fn test_removing_empty_smt_from_forest() {
     let mut forest = SmtForest::new();
     let empty_tree_root = *EmptySubtreeRoots::entry(SMT_DEPTH, 0);


### PR DESCRIPTION
## Summary

- Deduplicate the root list passed to `SmtForest::pop_smts` before removing roots from the underlying store.
- Add a regression test covering duplicate root pruning while another root still shares nodes with the pruned tree.

## Motivation

`pop_smts()` previously filtered input roots against `self.roots`, collected them into a `Vec`, and then passed the list to `SmtStore::remove_roots`. If the same root appeared more than once in the input, it could be removed from `self.roots` once but still be walked by the store multiple times. That decremented shared node reference counts more than once and could corrupt another SMT root that still depended on those nodes.

The forest root set is already unique, so pruning should treat duplicate input roots as a single root removal.

Fixes #3510.

## Validation

- `git diff --check -- crates/crypto/src/merkle/smt/forest/mod.rs crates/crypto/src/merkle/smt/forest/tests.rs`

I could not run the Rust test suite locally in this environment because `cargo`, `rustc`, and `rustup` are not available on Windows PATH, and the Ubuntu WSL environment did not expose `cargo` either.

## Notes

This is ready for maintainer review. Happy to update/re-sign/rework if the project prefers a different contribution flow or wants the issue assigned first.