### PR TITLE
fix(crypto): return zero polynomial when dividing zero by non-zero

### DIFF
--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
@@ -650,9 +650,10 @@ impl<F: Zeroize> ZeroizeOnDrop for Polynomial<F> {}
 
 #[cfg(test)]
 mod tests {
+    use num::Zero;
+
     use super::{FalconFelt, N, Polynomial};
     use crate::rand::test_utils::prng_array;
-    use num::Zero;
 
     #[test]
     fn test_negacyclic_reduction() {

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
@@ -451,7 +451,7 @@ where
             panic!();
         }
         if self.is_zero() {
-            Self::zero();
+            return Self::zero();
         }
         let mut remainder = self;
         let mut quotient = Polynomial::<F>::zero();
@@ -652,6 +652,7 @@ impl<F: Zeroize> ZeroizeOnDrop for Polynomial<F> {}
 mod tests {
     use super::{FalconFelt, N, Polynomial};
     use crate::rand::test_utils::prng_array;
+    use num::Zero;
 
     #[test]
     fn test_negacyclic_reduction() {
@@ -666,5 +667,12 @@ mod tests {
             prod.reduce_by_cyclotomic(N),
             Polynomial::reduce_negacyclic(&Polynomial::mul_modulo_p(&poly1, &poly2))
         );
+    }
+    #[test]
+    fn div_zero_numerator_returns_zero() {
+        let zero = Polynomial::<i64>::zero();
+        let nonzero = Polynomial::new(vec![1, 2, 3]);
+        let result = zero / nonzero;
+        assert!(result.is_zero());
     }
 }


### PR DESCRIPTION
## Rationale
Dividing a zero polynomial by a non-zero polynomial currently causes a panic. The early-exit branch created `Self::zero()` but did not `return` it, causing execution to fall through to `remainder.degree().unwrap()` on a zero polynomial. This PR fixes the panic by adding the missing `return`.

## What was broken
Dividing a zero polynomial by a non-zero polynomial caused a panic. 

## What I changed
- Added the missing `return` in the zero-numerator branch of `Div for Polynomial`.
- Added a regression test `div_zero_numerator_returns_zero` proving `zero / nonzero` returns zero without panicking.

## Test plan
- Added a new unit test `div_zero_numerator_returns_zero` inside the `polynomial.rs` tests module.
- Ran `cargo test -p miden-crypto div_zero_numerator` to verify the fix.
- Ran the full `cargo test -p miden-crypto` suite locally to ensure no regressions (all tests passed).

Fixes #3534

/cc @huitseeker @bobbinth (Could a maintainer please assign Issue #3534 to me? GitHub doesn't give me the permissions to self-assign issues!)

Note: @Sertug17 mentioned interest in fixing this earlier — happy to hand over or close this PR if preferred!