### PR TITLE
fix(crypto): add safety check for odd lengths in vector_karatsuba

### DIFF
--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
@@ -476,13 +476,10 @@ fn vector_karatsuba<
     right: &[F],
 ) -> Vec<F> {
     let n = left.len();
-    
+
     // ??? ADD THIS SAFETY NET:
-    assert!(
-        n.is_power_of_two(),
-        "vector_karatsuba only supports power-of-two lengths"
-    );
-    
+    assert!(n.is_power_of_two(), "vector_karatsuba only supports power-of-two lengths");
+
     if n <= 8 {
         let mut product = vec![F::zero(); left.len() + right.len() - 1];
         for (i, l) in left.iter().enumerate() {

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
@@ -476,6 +476,13 @@ fn vector_karatsuba<
     right: &[F],
 ) -> Vec<F> {
     let n = left.len();
+    
+    // ??? ADD THIS SAFETY NET:
+    assert!(
+        n.is_power_of_two(),
+        "vector_karatsuba only supports power-of-two lengths"
+    );
+    
     if n <= 8 {
         let mut product = vec![F::zero(); left.len() + right.len() - 1];
         for (i, l) in left.iter().enumerate() {
@@ -666,5 +673,17 @@ mod tests {
             prod.reduce_by_cyclotomic(N),
             Polynomial::reduce_negacyclic(&Polynomial::mul_modulo_p(&poly1, &poly2))
         );
+    }
+
+    // ?? PASTE THE NEW TEST RIGHT HERE! ??
+
+    #[test]
+    #[should_panic(expected = "vector_karatsuba only supports power-of-two lengths")]
+    fn karatsuba_panics_on_non_power_of_two() {
+        // We are intentionally using length 9 (not a power of 2)
+        // This should trigger our safety guard and panic!
+        let p1 = Polynomial::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        let p2 = Polynomial::new(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        p1.karatsuba(&p2);
     }
 }


### PR DESCRIPTION
## Rationale
The `vector_karatsuba` function is only used for Falcon signature generation, which always operates on power-of-two lengths (e.g., 512). However, the function is accessible, and calling it with odd lengths (like 9 or 17) currently causes a panic due to out-of-bounds indexing or silent math errors.

Following the maintainer's recommendation in #3550 to "make the power-of-two precondition explicit," this PR adds a safety check to fail fast with a clear error message.

## What I changed
- Added `assert!(n.is_power_of_two())` at the entry of `vector_karatsuba`.
- This prevents silent math errors or confusing index panics for unsupported lengths.
- Added a regression test `karatsuba_panics_on_non_power_of_two` to prove the guard works.

## Test plan
- Ran `cargo test -p miden-crypto` locally.
- Verified that the new test correctly catches the odd-length case and successfully panics.

Fixes #3550