### PR TITLE
test(core-lib): add regression vectors for std::math::u64 wrapping_mul

### DIFF
--- a/crates/lib/core/tests/math/u64_mod.rs
+++ b/crates/lib/core/tests/math/u64_mod.rs
@@ -1813,7 +1813,7 @@ fn split_u128(value: u128) -> (u64, u64, u64, u64) {
         (value >> 32) as u32 as u64,
         value as u32 as u64,
     )
-    }
+}
 #[test]
 fn wrapping_mul_regression_vectors() {
     // Run 100 random regression vectors to prove MASM matches Rust

--- a/crates/lib/core/tests/math/u64_mod.rs
+++ b/crates/lib/core/tests/math/u64_mod.rs
@@ -1813,4 +1813,28 @@ fn split_u128(value: u128) -> (u64, u64, u64, u64) {
         (value >> 32) as u32 as u64,
         value as u32 as u64,
     )
+    }
+#[test]
+fn wrapping_mul_regression_vectors() {
+    // Run 100 random regression vectors to prove MASM matches Rust
+    for _ in 0..100 {
+        let a: u64 = rand_value();
+        let b: u64 = rand_value();
+        let c = a.wrapping_mul(b);
+
+        let source = "
+            use miden::core::math::u64
+            begin
+                exec.u64::wrapping_mul
+            end";
+
+        let (a1, a0) = split_u64(a);
+        let (b1, b0) = split_u64(b);
+        let (c1, c0) = split_u64(c);
+
+        // [a_lo, a_hi, b_lo, b_hi] -> [c_lo, c_hi]
+        let input_stack = stack![a0, a1, b0, b1];
+        let test = build_test!(source, &input_stack);
+        test.expect_stack(&[c0, c1]);
+    }
 }


### PR DESCRIPTION
## Rationale
Inspired by the regression-vector style previously used for the u256 core-lib math, this PR adds property-style regression coverage for the 64-bit math standard library. It verifies that the MASM `wrapping_mul` implementation matches Rust's native `u64::wrapping_mul` across 100 random inputs, protecting the VM against silent arithmetic errors.

## What I changed
- Added `wrapping_mul_regression_vectors` to `crates/lib/core/tests/math/u64_mod.rs`.
- Uses the existing testing tooling (`rand_value`, `split_u64`, `build_test!`, `expect_stack`) to match project style.

## Test plan
- Ran `cargo test -p miden-core-lib regression` locally: 7 passed, 0 failed (including the existing u256 regression vectors).