### PR TITLE
fix(crypto): validate LeafIndex depth on deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 #### Fixes
 
-- Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, so a decoded index whose depth disagrees with `DEPTH` is rejected instead of producing an inconsistent value ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
+- [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 
 ## v0.29.0 (2026-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - [BREAKING] Removed the free `execute()` and `execute_sync()` functions from `miden-vm`/`miden-processor`. Use `FastProcessor::new_with_options(...)` followed by `execute()`/`execute_sync()` instead ([#3540](https://github.com/0xMiden/miden-vm/pull/3540)).
 
+#### Fixes
+
+- Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, so a decoded index whose depth disagrees with `DEPTH` is rejected instead of producing an inconsistent value ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
+
 ## v0.29.0 (2026-08-04)
 
 #### Changes

--- a/crates/crypto/src/merkle/smt/full/leaf.rs
+++ b/crates/crypto/src/merkle/smt/full/leaf.rs
@@ -15,7 +15,6 @@ const DOUBLE_WORD_LEN: usize = 8;
 ///
 /// A leaf can be empty, hold a single key-value pair, or multiple key-value pairs.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum SmtLeaf {
     /// An empty leaf at the specified index.
     Empty(LeafIndex<SMT_DEPTH>),

--- a/crates/crypto/src/merkle/smt/full/mod.rs
+++ b/crates/crypto/src/merkle/smt/full/mod.rs
@@ -97,7 +97,6 @@ type Leaves = super::Leaves<SmtLeaf>;
 ///              hash = H(key₁, value₁, key₂, value₂, ...)
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Smt {
     root: Word,
     num_entries: usize,

--- a/crates/crypto/src/merkle/smt/mod.rs
+++ b/crates/crypto/src/merkle/smt/mod.rs
@@ -593,7 +593,6 @@ impl InnerNode {
 
 /// The index of a leaf, at a depth known at compile-time.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct LeafIndex<const DEPTH: u8> {
     index: NodeIndex,
 }

--- a/crates/crypto/src/merkle/smt/mod.rs
+++ b/crates/crypto/src/merkle/smt/mod.rs
@@ -1,6 +1,6 @@
 //! Sparse Merkle Tree (SMT) data structures.
 
-use alloc::vec::Vec;
+use alloc::{string::ToString, vec::Vec};
 use core::{
     fmt::{self, Display},
     hash::Hash,
@@ -656,7 +656,11 @@ impl<const DEPTH: u8> Serializable for LeafIndex<DEPTH> {
 
 impl<const DEPTH: u8> Deserializable for LeafIndex<DEPTH> {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        Ok(Self { index: source.read()? })
+        // A `NodeIndex` is valid on its own terms without knowing `DEPTH`, so route through
+        // `TryFrom` to enforce that its depth matches this type's `DEPTH`.
+        let index: NodeIndex = source.read()?;
+
+        Self::try_from(index).map_err(|err| DeserializationError::InvalidValue(err.to_string()))
     }
 }
 
@@ -859,5 +863,40 @@ impl<const DEPTH: u8, K: Deserializable + Ord + Eq + Hash, V: Deserializable> De
             new_pairs,
             new_root,
         })
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::{LeafIndex, NodeIndex, SMT_MAX_DEPTH};
+    use crate::utils::{Deserializable, Serializable};
+
+    #[test]
+    fn leaf_index_read_from_rejects_depth_mismatch() {
+        // A depth-3 index is valid on its own terms, but wrong for a `LeafIndex<SMT_MAX_DEPTH>`.
+        let mismatched = NodeIndex::new(3, 5).unwrap();
+        assert!(LeafIndex::<SMT_MAX_DEPTH>::try_from(mismatched).is_err());
+
+        assert!(LeafIndex::<SMT_MAX_DEPTH>::read_from_bytes(&mismatched.to_bytes()).is_err());
+    }
+
+    #[test]
+    fn leaf_index_read_from_rejects_depth_below_minimum() {
+        assert!(LeafIndex::<0>::new(0).is_err());
+
+        let root = NodeIndex::new(0, 0).unwrap();
+        assert!(LeafIndex::<0>::read_from_bytes(&root.to_bytes()).is_err());
+    }
+
+    #[test]
+    fn leaf_index_round_trips_at_matching_depth() {
+        let leaf = LeafIndex::<SMT_MAX_DEPTH>::new(5).unwrap();
+
+        let decoded = LeafIndex::<SMT_MAX_DEPTH>::read_from_bytes(&leaf.to_bytes()).unwrap();
+
+        assert_eq!(leaf, decoded);
     }
 }

--- a/crates/crypto/src/merkle/smt/partial/mod.rs
+++ b/crates/crypto/src/merkle/smt/partial/mod.rs
@@ -39,7 +39,6 @@ pub use serialization::{NodeValue, UniqueNodes};
 /// Once a partial SMT has been constructed, its root is set in stone. All subsequently added proofs
 /// or merkle paths must match that root, otherwise an error is returned.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct PartialSmt {
     root: Word,
     num_entries: usize,


### PR DESCRIPTION
Closes #3559.

### Problem

`LeafIndex<DEPTH>` wraps a `NodeIndex`, and both of its checked constructors keep the wrapped index consistent with the const generic:

- `new` requires `DEPTH >= SMT_MIN_DEPTH` and delegates to `NodeIndex::new(DEPTH, value)`, which bounds the position by that depth.
- `TryFrom<NodeIndex>` additionally rejects a `NodeIndex` whose `depth()` differs from `DEPTH`.

The `Deserializable` impl built the value straight from the decoded `NodeIndex` and enforced neither:

```rust
Ok(Self { index: source.read()? })
```

`NodeIndex::read_from` does validate the `NodeIndex` on its own terms, but it cannot check the depth against `DEPTH`, because `NodeIndex` has no knowledge of the const generic. A depth-3 `NodeIndex` is entirely valid in isolation and wrong for a `LeafIndex<64>`. As a result a serialize/deserialize round trip could produce a value that fails the `TryFrom` of the very type it was decoded as, and `position()` would report a position in the wrong layer.

### Change

`read_from` routes through `TryFrom<NodeIndex>` and maps the failure to `DeserializationError::InvalidValue`, so construction and deserialization agree on the same invariant.

### Test plan

```
cargo test -p miden-crypto --lib leaf_index
```

Three unit tests in `merkle::smt`:

- `leaf_index_read_from_rejects_depth_mismatch` - a serialized depth-3 `NodeIndex` is rejected as a `LeafIndex<64>`
- `leaf_index_read_from_rejects_depth_below_minimum` - `LeafIndex<0>` is rejected, matching `new`
- `leaf_index_round_trips_at_matching_depth` - a well-formed value still round-trips

Restoring `read_from` to `Ok(Self { index: source.read()? })` makes the first two fail, which is the behaviour #3559 describes.

### Verification

Run locally on this branch, all clean:

- `cargo test --lib leaf_index` - 3 passed
- `cargo clippy --lib --tests -- -D warnings`
- `cargo clippy --no-default-features --lib -- -D warnings`
- `cargo build --no-default-features --lib`
- nightly `rustfmt --check` - no diff

### Notes

Same class as #3277, which validated `SectionId` on deserialization.

On severity, to be upfront: I could not find an in-tree caller that deserializes a `LeafIndex`, so this is not reachable from untrusted input today. It is a public API of a published crate where `Serializable`/`Deserializable` are expected to round-trip, which is why I think it is still worth closing.

I opened #3559 for this and, per CONTRIBUTING, am happy to wait for it to be assigned before this gets review time.
