### PR TITLE
feat: Mmr cheap clone with new storage layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [BREAKING] Reduced the precompile STARK relation from 12 AIRs to 10 by merging the chunk/node/sponge and EC point/group stores ([#3464](https://github.com/0xMiden/miden-vm/pull/3464)).
 - Raised the minimum supported Plonky3 version to 0.6.3 to match the `num-bigint` 0.5 types used by `miden-field` ([#3569](https://github.com/0xMiden/miden-vm/pull/3569)).
 - [BREAKING] Moved the secp256k1 GLV endomorphism scalar decomposition from the ECDSA verifier's MASM/advice ABI into the precompiles prover's addition-chain strategy: `ecdsa_k256_keccak::verify` logs a plain `u1*G + u2*Q` claim, and the deferred prover satisfies it with a GLV-decomposed chain, certified in-circuit ([#3426](https://github.com/0xMiden/miden-vm/pull/3426)).
+- Made `Mmr::clone()` cheap by storing MMR nodes in chunked, `Arc`-shared storage. Clones share all chunk storage with the original; appending after a clone copies at most one 32 KiB chunk. Public API and serialization formats are unchanged. ([#3562](https://github.com/0xMiden/miden-vm/pull/3562)).
 
 #### Features
 
@@ -66,7 +67,6 @@
 - Added `ecdsa_k256_keccak::verify_bytes` for verifying signatures over variable-length Keccak256 message bytes stored in VM memory ([#3563](https://github.com/0xMiden/miden-vm/pull/3563)).
 - Fixed persistent `LargeSmtForest::entries()` iteration, including snapshot-backed readers, by bounding RocksDB scans to the requested lineage prefix instead of scanning subsequent lineages ([#3576](https://github.com/0xMiden/miden-vm/pull/3576)).
 - Keccak-256 wrapper preimages may now cover memory that was never written to, matching the in-VM rule that unwritten memory reads as zero ([#3537](https://github.com/0xMiden/miden-vm/issues/3537)).
-- Made `Mmr::clone()` cheap by storing MMR nodes in chunked, `Arc`-shared storage. Clones share all chunk storage with the original; appending after a clone copies at most one 32 KiB chunk. Public API and serialization formats are unchanged.
 
 ## v0.29.0 (2026-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - Added `ecdsa_k256_keccak::verify_bytes` for verifying signatures over variable-length Keccak256 message bytes stored in VM memory ([#3563](https://github.com/0xMiden/miden-vm/pull/3563)).
 - Fixed persistent `LargeSmtForest::entries()` iteration, including snapshot-backed readers, by bounding RocksDB scans to the requested lineage prefix instead of scanning subsequent lineages ([#3576](https://github.com/0xMiden/miden-vm/pull/3576)).
 - Keccak-256 wrapper preimages may now cover memory that was never written to, matching the in-VM rule that unwritten memory reads as zero ([#3537](https://github.com/0xMiden/miden-vm/issues/3537)).
+- Made `Mmr::clone()` cheap by storing MMR nodes in chunked, `Arc`-shared storage. Clones share all chunk storage with the original; appending after a clone copies at most one 32 KiB chunk. Public API and serialization formats are unchanged.
 
 ## v0.29.0 (2026-08-04)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,7 @@ dependencies = [
  "p3-maybe-rayon",
  "p3-symmetric",
  "p3-util",
+ "postcard",
  "proptest",
  "rand 0.10.2",
  "rand_chacha 0.10.0",

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -140,6 +140,7 @@ assert_matches = { workspace = true }
 hex            = { features = ["alloc"], workspace = true }
 itertools      = { features = ["use_std"], workspace = true }
 miden-field    = { features = ["testing"], workspace = true }
+postcard       = { workspace = true }
 proptest       = { features = ["alloc"], workspace = true }
 seq-macro      = { workspace = true }
 serde_json     = { workspace = true }

--- a/crates/crypto/src/merkle/mmr/full.rs
+++ b/crates/crypto/src/merkle/mmr/full.rs
@@ -10,7 +10,8 @@
 //! depths, i.e. as part of adding a new element to the forest the trees with same depth are
 //! merged, creating a new tree with depth d+1, this process is continued until the property is
 //! reestablished.
-use alloc::vec::Vec;
+use alloc::{sync::Arc, vec::Vec};
+use core::ops::Index;
 
 use super::{
     super::{InnerNodeInfo, MerklePath},
@@ -24,6 +25,101 @@ use crate::{
     utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
 };
 
+// NODE STORE
+// ===============================================================================================
+
+/// Number of nodes per chunk in [NodeStore]: 1024 nodes * 32 bytes = 32 KiB per chunk.
+const NODE_CHUNK_CAPACITY: usize = 1024;
+
+/// Append-only node storage backed by fixed-size chunks shared between clones via [Arc].
+///
+/// The MMR's postorder node buffer is strictly append-only, so a clone taken at any point is
+/// fully described by a frozen prefix of the buffer. Cloning a [NodeStore] copies only the spine
+/// of [Arc] pointers, sharing all chunk contents with the original. [NodeStore::push] copies the
+/// last chunk before appending if (and only if) it is shared with a clone, bounding the
+/// copy-on-write cost at one chunk regardless of how many nodes the store holds.
+///
+/// Invariant: every chunk except the last contains exactly [NODE_CHUNK_CAPACITY] nodes, and no
+/// chunk is empty.
+#[derive(Debug, Clone, Default)]
+pub(super) struct NodeStore {
+    chunks: Vec<Arc<Vec<Word>>>,
+}
+
+impl NodeStore {
+    /// Constructor for an empty [NodeStore].
+    pub fn new() -> Self {
+        Self { chunks: Vec::new() }
+    }
+
+    /// Returns the number of nodes in the store.
+    pub fn len(&self) -> usize {
+        match self.chunks.last() {
+            Some(last) => (self.chunks.len() - 1) * NODE_CHUNK_CAPACITY + last.len(),
+            None => 0,
+        }
+    }
+
+    /// Appends a node to the store.
+    pub fn push(&mut self, node: Word) {
+        match self.chunks.last_mut() {
+            Some(last) if last.len() < NODE_CHUNK_CAPACITY => {
+                if Arc::get_mut(last).is_none() {
+                    // The chunk is shared with a clone; copy it before appending. A plain
+                    // `Arc::make_mut` would clone with capacity == len, growing past
+                    // NODE_CHUNK_CAPACITY on later pushes, so copy with the full capacity instead.
+                    let mut copy = Vec::with_capacity(NODE_CHUNK_CAPACITY);
+                    copy.extend_from_slice(last);
+                    *last = Arc::new(copy);
+                }
+                Arc::get_mut(last).expect("chunk is unique").push(node);
+            },
+            _ => {
+                let mut chunk = Vec::with_capacity(NODE_CHUNK_CAPACITY);
+                chunk.push(node);
+                self.chunks.push(Arc::new(chunk));
+            },
+        }
+    }
+
+    /// Returns an iterator over all nodes in the store, in insertion (postorder) order.
+    pub fn iter(&self) -> impl Iterator<Item = &Word> {
+        self.chunks.iter().flat_map(|chunk| chunk.iter())
+    }
+}
+
+impl Index<usize> for NodeStore {
+    type Output = Word;
+
+    fn index(&self, index: usize) -> &Word {
+        &self.chunks[index / NODE_CHUNK_CAPACITY][index % NODE_CHUNK_CAPACITY]
+    }
+}
+
+impl FromIterator<Word> for NodeStore {
+    fn from_iter<T: IntoIterator<Item = Word>>(iter: T) -> Self {
+        let mut store = Self::new();
+        for node in iter {
+            store.push(node);
+        }
+        store
+    }
+}
+
+impl PartialEq for NodeStore {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.iter().eq(other.iter())
+    }
+}
+
+impl Eq for NodeStore {}
+
+impl PartialEq<&[Word]> for NodeStore {
+    fn eq(&self, other: &&[Word]) -> bool {
+        self.len() == other.len() && self.iter().eq(other.iter())
+    }
+}
+
 // MMR
 // ===============================================================================================
 
@@ -32,8 +128,13 @@ use crate::{
 ///
 /// Since this is a full representation of the MMR, elements are never removed and the MMR will
 /// grow roughly `O(2n)` in number of leaf elements.
+///
+/// Cloning is cheap: the nodes are stored in chunks shared between clones, so a clone copies
+/// `O(num_nodes / 1024)` pointers instead of the full node buffer, and appending to the original
+/// after a clone copies at most one chunk.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(from = "SerdeMmr", into = "SerdeMmr"))]
 pub struct Mmr {
     /// Refer to the `forest` method documentation for details of the semantics of this value.
     pub(super) forest: Forest,
@@ -44,7 +145,7 @@ pub struct Mmr {
     /// the elements of every tree in the forest to be stored in the same sequential buffer. It
     /// also means new elements can be added to the forest, and merging of trees is very cheap with
     /// no need to copy elements.
-    pub(super) nodes: Vec<Word>,
+    pub(super) nodes: NodeStore,
 }
 
 impl Default for Mmr {
@@ -61,7 +162,7 @@ impl Mmr {
     pub fn new() -> Mmr {
         Mmr {
             forest: Forest::empty(),
-            nodes: Vec::new(),
+            nodes: NodeStore::new(),
         }
     }
 
@@ -389,15 +490,65 @@ impl Mmr {
 impl Serializable for Mmr {
     fn write_into<W: ByteWriter>(&self, target: &mut W) {
         self.forest.write_into(target);
-        self.nodes.write_into(target);
+        // Matches the wire format of `Vec<Word>`: a `write_usize` length prefix followed by the
+        // elements in postorder.
+        target.write_usize(self.nodes.len());
+        target.write_many(self.nodes.iter());
     }
 }
 
 impl Deserializable for Mmr {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let forest = Forest::read_from(source)?;
-        let nodes = Vec::<Word>::read_from(source)?;
+        let count = source.read_usize()?;
+        if count != forest.num_nodes() {
+            return Err(DeserializationError::InvalidValue(alloc::format!(
+                "MMR node count {count} does not match forest node count {}",
+                forest.num_nodes()
+            )));
+        }
+        let mut nodes = NodeStore::new();
+        for _ in 0..count {
+            nodes.push(Word::read_from(source)?);
+        }
         Ok(Self { forest, nodes })
+    }
+}
+
+/// Shadow struct that [Mmr] converts through when (de)serialized with serde, via
+/// `#[serde(from/into)]`.
+///
+/// [Mmr] used to store its nodes as a flat `Vec<Word>` and derive serde directly, so that shape
+/// is the wire format previously-serialized data was written in. Deriving serde on the current
+/// representation would instead emit [NodeStore]'s chunked layout (a sequence of 1024-node
+/// sequences), breaking compatibility with that data and leaking the chunk size into the wire
+/// format. This struct preserves the original format by mirroring the old [Mmr] exactly: same
+/// struct name (via the rename, as some formats include it), same field names, order, and types.
+#[cfg(feature = "serde")]
+#[derive(serde::Deserialize, serde::Serialize)]
+#[serde(rename = "Mmr")]
+struct SerdeMmr {
+    forest: Forest,
+    nodes: Vec<Word>,
+}
+
+#[cfg(feature = "serde")]
+impl From<Mmr> for SerdeMmr {
+    fn from(mmr: Mmr) -> Self {
+        Self {
+            forest: mmr.forest,
+            nodes: mmr.nodes.iter().copied().collect(),
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<SerdeMmr> for Mmr {
+    fn from(mmr: SerdeMmr) -> Self {
+        Self {
+            forest: mmr.forest,
+            nodes: mmr.nodes.into_iter().collect(),
+        }
     }
 }
 
@@ -484,14 +635,18 @@ impl Iterator for MmrNodes<'_> {
 // ================================================================================================
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
+    use alloc::{sync::Arc, vec::Vec};
 
-    use super::super::nodes_from_mask;
+    use super::{super::nodes_from_mask, NODE_CHUNK_CAPACITY};
     use crate::{
         Felt, Word, ZERO,
         merkle::mmr::{Forest, Mmr},
         utils::{Deserializable, DeserializationError, Serializable},
     };
+
+    fn leaves(count: u64) -> impl Iterator<Item = Word> {
+        (0..count).map(|value| Word::new([ZERO, ZERO, ZERO, Felt::new_unchecked(value)]))
+    }
 
     #[test]
     fn test_serialization() {
@@ -513,6 +668,74 @@ mod tests {
 
         let result = Mmr::read_from_bytes(&bytes);
         assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
+    }
+
+    #[test]
+    fn test_serialization_matches_vec_format() {
+        // Build an MMR spanning multiple chunks (> 2048 nodes) to cover chunk boundaries.
+        let num_leaves = NODE_CHUNK_CAPACITY as u64 + NODE_CHUNK_CAPACITY as u64 / 2;
+        let mmr = Mmr::try_from_iter(leaves(num_leaves)).unwrap();
+        assert!(mmr.nodes.len() > 2 * NODE_CHUNK_CAPACITY);
+
+        let mut expected = mmr.forest.to_bytes();
+        let nodes_vec: Vec<Word> = mmr.nodes.iter().copied().collect();
+        expected.extend_from_slice(&nodes_vec.to_bytes());
+
+        assert_eq!(mmr.to_bytes(), expected);
+        let deserialized = Mmr::read_from_bytes(&expected).unwrap();
+        assert_eq!(mmr.forest, deserialized.forest);
+        assert_eq!(mmr.nodes, deserialized.nodes);
+    }
+
+    #[test]
+    fn test_deserialization_rejects_node_count_mismatch() {
+        let mmr = Mmr::try_from_iter(leaves(8)).unwrap();
+        let mut bytes = mmr.forest.to_bytes();
+        let mut nodes_vec: Vec<Word> = mmr.nodes.iter().copied().collect();
+        nodes_vec.pop();
+        bytes.extend_from_slice(&nodes_vec.to_bytes());
+
+        let result = Mmr::read_from_bytes(&bytes);
+        assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
+    }
+
+    #[test]
+    fn test_clone_stays_frozen_after_push() {
+        let num_leaves = 2 * NODE_CHUNK_CAPACITY as u64;
+        let mut mmr = Mmr::try_from_iter(leaves(num_leaves)).unwrap();
+        let clone = mmr.clone();
+
+        for leaf in leaves(3 * NODE_CHUNK_CAPACITY as u64).skip(num_leaves as usize) {
+            mmr.add(leaf).unwrap();
+        }
+
+        // the clone is an unchanged snapshot of the original at the time of cloning
+        let reference = Mmr::try_from_iter(leaves(num_leaves)).unwrap();
+        assert_eq!(clone.forest, reference.forest);
+        assert_eq!(clone.nodes, reference.nodes);
+        assert_eq!(clone.peaks(), reference.peaks());
+
+        // the original matches a freshly built MMR of the same size
+        let reference = Mmr::try_from_iter(leaves(3 * NODE_CHUNK_CAPACITY as u64)).unwrap();
+        assert_eq!(mmr.forest, reference.forest);
+        assert_eq!(mmr.nodes, reference.nodes);
+        assert_eq!(mmr.peaks(), reference.peaks());
+    }
+
+    #[test]
+    fn test_clone_shares_full_chunks() {
+        let mut mmr = Mmr::try_from_iter(leaves(NODE_CHUNK_CAPACITY as u64)).unwrap();
+        let clone = mmr.clone();
+        mmr.add(Word::empty()).unwrap();
+
+        // pushing into the original diverges only the last (shared) chunk
+        let orig_chunks = &mmr.nodes.chunks;
+        let clone_chunks = &clone.nodes.chunks;
+        assert_eq!(orig_chunks.len(), clone_chunks.len());
+        for (orig, cloned) in orig_chunks.iter().zip(clone_chunks).take(orig_chunks.len() - 1) {
+            assert!(Arc::ptr_eq(orig, cloned));
+        }
+        assert!(!Arc::ptr_eq(orig_chunks.last().unwrap(), clone_chunks.last().unwrap()));
     }
 
     #[test]

--- a/crates/crypto/src/merkle/mmr/full.rs
+++ b/crates/crypto/src/merkle/mmr/full.rs
@@ -507,10 +507,7 @@ impl Deserializable for Mmr {
                 forest.num_nodes()
             )));
         }
-        let mut nodes = NodeStore::new();
-        for _ in 0..count {
-            nodes.push(Word::read_from(source)?);
-        }
+        let nodes = source.read_many_iter(count)?.collect::<Result<NodeStore, _>>()?;
         Ok(Self { forest, nodes })
     }
 }

--- a/crates/crypto/src/merkle/mmr/full.rs
+++ b/crates/crypto/src/merkle/mmr/full.rs
@@ -709,13 +709,13 @@ mod tests {
             mmr.add(leaf).unwrap();
         }
 
-        // the clone is an unchanged snapshot of the original at the time of cloning
+        // The clone is an unchanged snapshot of the original at the time of cloning.
         let reference = Mmr::try_from_iter(leaves(num_leaves)).unwrap();
         assert_eq!(clone.forest, reference.forest);
         assert_eq!(clone.nodes, reference.nodes);
         assert_eq!(clone.peaks(), reference.peaks());
 
-        // the original matches a freshly built MMR of the same size
+        // The original matches a freshly built MMR of the same size.
         let reference = Mmr::try_from_iter(leaves(3 * NODE_CHUNK_CAPACITY as u64)).unwrap();
         assert_eq!(mmr.forest, reference.forest);
         assert_eq!(mmr.nodes, reference.nodes);
@@ -728,7 +728,7 @@ mod tests {
         let clone = mmr.clone();
         mmr.add(Word::empty()).unwrap();
 
-        // pushing into the original diverges only the last (shared) chunk
+        // Pushing into the original diverges only the last (shared) chunk.
         let orig_chunks = &mmr.nodes.chunks;
         let clone_chunks = &clone.nodes.chunks;
         assert_eq!(orig_chunks.len(), clone_chunks.len());

--- a/crates/crypto/src/merkle/mmr/full.rs
+++ b/crates/crypto/src/merkle/mmr/full.rs
@@ -41,7 +41,7 @@ const NODE_CHUNK_CAPACITY: usize = 1024;
 ///
 /// Invariant: every chunk except the last contains exactly [NODE_CHUNK_CAPACITY] nodes, and no
 /// chunk is empty.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(super) struct NodeStore {
     chunks: Vec<Arc<Vec<Word>>>,
 }
@@ -105,14 +105,6 @@ impl FromIterator<Word> for NodeStore {
         store
     }
 }
-
-impl PartialEq for NodeStore {
-    fn eq(&self, other: &Self) -> bool {
-        self.len() == other.len() && self.iter().eq(other.iter())
-    }
-}
-
-impl Eq for NodeStore {}
 
 impl PartialEq<&[Word]> for NodeStore {
     fn eq(&self, other: &&[Word]) -> bool {

--- a/crates/crypto/src/merkle/mmr/full.rs
+++ b/crates/crypto/src/merkle/mmr/full.rs
@@ -134,7 +134,6 @@ impl PartialEq<&[Word]> for NodeStore {
 /// after a clone copies at most one chunk.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "serde", serde(from = "SerdeMmr", into = "SerdeMmr"))]
 pub struct Mmr {
     /// Refer to the `forest` method documentation for details of the semantics of this value.
     pub(super) forest: Forest,
@@ -512,40 +511,50 @@ impl Deserializable for Mmr {
     }
 }
 
-/// Shadow struct that [Mmr] converts through when (de)serialized with serde, via
-/// `#[serde(from/into)]`.
-///
-/// [Mmr] used to store its nodes as a flat `Vec<Word>` and derive serde directly, so that shape
-/// is the wire format previously-serialized data was written in. Deriving serde on the current
-/// representation would instead emit [NodeStore]'s chunked layout (a sequence of 1024-node
-/// sequences), breaking compatibility with that data and leaking the chunk size into the wire
-/// format. This struct preserves the original format by mirroring the old [Mmr] exactly: same
-/// struct name (via the rename, as some formats include it), same field names, order, and types.
+/// [Mmr] used to store its nodes as a flat `Vec<Word>` and derive serde directly, so a flat
+/// sequence of words is the wire format previously-serialized data was written in. Deriving serde
+/// on [NodeStore] would instead emit its chunked layout (a sequence of 1024-node sequences),
+/// breaking compatibility with that data and leaking the chunk size into the wire format. These
+/// impls preserve the original format by mirroring `Vec<Word>`'s serde representation — a length-
+/// hinted sequence — streaming directly from/into the chunks with no intermediate flat copy.
 #[cfg(feature = "serde")]
-#[derive(serde::Deserialize, serde::Serialize)]
-#[serde(rename = "Mmr")]
-struct SerdeMmr {
-    forest: Forest,
-    nodes: Vec<Word>,
-}
+impl serde::Serialize for NodeStore {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeSeq;
 
-#[cfg(feature = "serde")]
-impl From<Mmr> for SerdeMmr {
-    fn from(mmr: Mmr) -> Self {
-        Self {
-            forest: mmr.forest,
-            nodes: mmr.nodes.iter().copied().collect(),
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for node in self.iter() {
+            seq.serialize_element(node)?;
         }
+        seq.end()
     }
 }
 
 #[cfg(feature = "serde")]
-impl From<SerdeMmr> for Mmr {
-    fn from(mmr: SerdeMmr) -> Self {
-        Self {
-            forest: mmr.forest,
-            nodes: mmr.nodes.into_iter().collect(),
+impl<'de> serde::Deserialize<'de> for NodeStore {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct SeqVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for SeqVisitor {
+            type Value = NodeStore;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.write_str("a sequence of MMR nodes")
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<NodeStore, A::Error> {
+                let mut store = NodeStore::new();
+                while let Some(node) = seq.next_element::<Word>()? {
+                    store.push(node);
+                }
+                Ok(store)
+            }
         }
+
+        deserializer.deserialize_seq(SeqVisitor)
     }
 }
 

--- a/crates/crypto/src/merkle/mmr/full.rs
+++ b/crates/crypto/src/merkle/mmr/full.rs
@@ -693,6 +693,42 @@ mod tests {
         assert_eq!(mmr.nodes, deserialized.nodes);
     }
 
+    /// Verifies the custom serde impls on [NodeStore] produce the exact representation the
+    /// pre-[NodeStore] `Mmr` derive did (a flat `Vec<Word>` field), in both a self-describing
+    /// format (JSON: struct/field names, flat array shape) and a compact binary format
+    /// (postcard: length-prefixed, exercising the `serialize_seq` length hint).
+    #[cfg(feature = "serde")]
+    #[test]
+    fn test_serde_matches_vec_format() {
+        /// Replica of `Mmr` as it was when its nodes were a `Vec<Word>` and serde was derived.
+        #[derive(serde::Deserialize, serde::Serialize)]
+        #[serde(rename = "Mmr")]
+        struct VecMmr {
+            forest: Forest,
+            nodes: Vec<Word>,
+        }
+
+        // span multiple chunks to cover chunk boundaries
+        let num_leaves = NODE_CHUNK_CAPACITY as u64 + NODE_CHUNK_CAPACITY as u64 / 2;
+        let mmr = Mmr::try_from_iter(leaves(num_leaves)).unwrap();
+        let vec_mmr = VecMmr {
+            forest: mmr.forest,
+            nodes: mmr.nodes.iter().copied().collect(),
+        };
+
+        let json = serde_json::to_string(&mmr).unwrap();
+        assert_eq!(json, serde_json::to_string(&vec_mmr).unwrap());
+        let from_json: Mmr = serde_json::from_str(&json).unwrap();
+        assert_eq!(mmr.forest, from_json.forest);
+        assert_eq!(mmr.nodes, from_json.nodes);
+
+        let bytes = postcard::to_allocvec(&mmr).unwrap();
+        assert_eq!(bytes, postcard::to_allocvec(&vec_mmr).unwrap());
+        let from_bytes: Mmr = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(mmr.forest, from_bytes.forest);
+        assert_eq!(mmr.nodes, from_bytes.nodes);
+    }
+
     #[test]
     fn test_deserialization_rejects_node_count_mismatch() {
         let mmr = Mmr::try_from_iter(leaves(8)).unwrap();

--- a/crates/crypto/src/merkle/mmr/tests.rs
+++ b/crates/crypto/src/merkle/mmr/tests.rs
@@ -4,7 +4,9 @@ use assert_matches::assert_matches;
 
 use super::{
     super::{InnerNodeInfo, Poseidon2, Word},
-    Mmr, MmrError, MmrPeaks, PartialMmr, nodes_from_mask,
+    Mmr, MmrError, MmrPeaks, PartialMmr,
+    full::NodeStore,
+    nodes_from_mask,
 };
 use crate::{
     Felt,
@@ -221,7 +223,7 @@ fn test_forest_without_trees_does_not_add_bits() {
 fn test_mmr_add_limit_prevents_mutation() {
     let mut mmr = Mmr {
         forest: Forest::new(Forest::MAX_LEAVES).unwrap(),
-        nodes: Vec::new(),
+        nodes: NodeStore::new(),
     };
     let result = mmr.add(Word::empty());
     assert_matches!(result, Err(MmrError::ForestSizeExceeded { .. }));
@@ -597,7 +599,7 @@ fn test_mmr_simple() {
     mmr.add(LEAVES[0]).unwrap();
     assert_eq!(mmr.forest().num_leaves(), 1);
     assert_eq!(mmr.nodes.len(), 1);
-    assert_eq!(mmr.nodes.as_slice(), &postorder[0..mmr.nodes.len()]);
+    assert_eq!(mmr.nodes, &postorder[0..mmr.nodes.len()]);
 
     let acc = mmr.peaks();
     assert_eq!(acc.num_leaves(), 1);
@@ -606,7 +608,7 @@ fn test_mmr_simple() {
     mmr.add(LEAVES[1]).unwrap();
     assert_eq!(mmr.forest().num_leaves(), 2);
     assert_eq!(mmr.nodes.len(), 3);
-    assert_eq!(mmr.nodes.as_slice(), &postorder[0..mmr.nodes.len()]);
+    assert_eq!(mmr.nodes, &postorder[0..mmr.nodes.len()]);
 
     let acc = mmr.peaks();
     assert_eq!(acc.num_leaves(), 2);
@@ -615,7 +617,7 @@ fn test_mmr_simple() {
     mmr.add(LEAVES[2]).unwrap();
     assert_eq!(mmr.forest().num_leaves(), 3);
     assert_eq!(mmr.nodes.len(), 4);
-    assert_eq!(mmr.nodes.as_slice(), &postorder[0..mmr.nodes.len()]);
+    assert_eq!(mmr.nodes, &postorder[0..mmr.nodes.len()]);
 
     let acc = mmr.peaks();
     assert_eq!(acc.num_leaves(), 3);
@@ -624,7 +626,7 @@ fn test_mmr_simple() {
     mmr.add(LEAVES[3]).unwrap();
     assert_eq!(mmr.forest().num_leaves(), 4);
     assert_eq!(mmr.nodes.len(), 7);
-    assert_eq!(mmr.nodes.as_slice(), &postorder[0..mmr.nodes.len()]);
+    assert_eq!(mmr.nodes, &postorder[0..mmr.nodes.len()]);
 
     let acc = mmr.peaks();
     assert_eq!(acc.num_leaves(), 4);
@@ -633,7 +635,7 @@ fn test_mmr_simple() {
     mmr.add(LEAVES[4]).unwrap();
     assert_eq!(mmr.forest().num_leaves(), 5);
     assert_eq!(mmr.nodes.len(), 8);
-    assert_eq!(mmr.nodes.as_slice(), &postorder[0..mmr.nodes.len()]);
+    assert_eq!(mmr.nodes, &postorder[0..mmr.nodes.len()]);
 
     let acc = mmr.peaks();
     assert_eq!(acc.num_leaves(), 5);
@@ -642,7 +644,7 @@ fn test_mmr_simple() {
     mmr.add(LEAVES[5]).unwrap();
     assert_eq!(mmr.forest().num_leaves(), 6);
     assert_eq!(mmr.nodes.len(), 10);
-    assert_eq!(mmr.nodes.as_slice(), &postorder[0..mmr.nodes.len()]);
+    assert_eq!(mmr.nodes, &postorder[0..mmr.nodes.len()]);
 
     let acc = mmr.peaks();
     assert_eq!(acc.num_leaves(), 6);
@@ -651,7 +653,7 @@ fn test_mmr_simple() {
     mmr.add(LEAVES[6]).unwrap();
     assert_eq!(mmr.forest().num_leaves(), 7);
     assert_eq!(mmr.nodes.len(), 11);
-    assert_eq!(mmr.nodes.as_slice(), &postorder[0..mmr.nodes.len()]);
+    assert_eq!(mmr.nodes, &postorder[0..mmr.nodes.len()]);
 
     let acc = mmr.peaks();
     assert_eq!(acc.num_leaves(), 7);


### PR DESCRIPTION
Closes https://github.com/0xMiden/miden-vm/issues/3561.

## Describe your changes

Makes `Mmr::clone()` cheap by replacing the flat `Vec<Word>` node buffer with `NodeStore`, a chunked store of `Arc<Vec<Word>>` (1024 nodes / 32 KiB per chunk). Since the MMR's postorder buffer is append-only, clones share all chunks structurally; cloning copies only the `Arc` spine, and pushing after a clone copies at most one chunk (copy-on-write).

- Public API unchanged; downstream crates compile without modification.
- Winter-serde wire format is byte-identical (manual impls mirror the `Vec<Word>` format); deserialization now also validates node count against the forest.
- `serde` format preserved via a `SerdeMmr` shadow struct with `#[serde(from/into)]`.
- New tests: byte-format parity across chunk boundaries, clone-then-push divergence, structural sharing (`Arc::ptr_eq`), node-count validation.

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] Relevant issues are linked in the PR description.
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
- [x] Updated `CHANGELOG.md`