### PR TITLE
fix: make `Instruction::EmitImm` round-trip `print -> parse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - [BREAKING] Removed the unused `CsrMatrix` and `CsrValidationError` APIs from `miden-utils-indexing` and `miden-core::utils` ([#3591](https://github.com/0xMiden/miden-vm/issues/3591)).
 - Added a Lychee check for local Markdown links in pull requests and fixed 17 broken links in README and docs files ([#3606](https://github.com/0xMiden/miden-vm/pull/3606)).
+- [BREAKING] `Instruction::EmitImm` now pretty-prints as the equivalent `push.<value> emit drop` sequence instead of `emit.<felt>`, since `emit.<felt>` is invalid MASM which cannot be parsed ([#3567](https://github.com/0xMiden/miden-vm/pull/3567)).
 - [BREAKING] Reduced the precompile STARK relation from 12 AIRs to 10 by merging the chunk/node/sponge and EC point/group stores ([#3464](https://github.com/0xMiden/miden-vm/pull/3464)).
 - Raised the minimum supported Plonky3 version to 0.6.3 to match the `num-bigint` 0.5 types used by `miden-field` ([#3569](https://github.com/0xMiden/miden-vm/pull/3569)).
 

--- a/crates/assembly-syntax/src/ast/instruction/print.rs
+++ b/crates/assembly-syntax/src/ast/instruction/print.rs
@@ -333,9 +333,13 @@ impl PrettyPrint for Instruction {
                 flatten(const_text("procref") + const_text(".") + display(path))
             },
 
-            // ----- event decorators -------------------------------------------------------------
+            // ----- events -----------------------------------------------------------------------
             Self::Emit => const_text("emit"),
-            Self::EmitImm(value) => inst_with_felt_imm("emit", value),
+            // `emit.<FELT_IMM>` is invalid syntax, so to support a `print -> parse` round trip
+            // we print the equivalent `push.<value> emit drop` sequence instead.
+            Self::EmitImm(value) => {
+                flatten(inst_with_felt_imm("push", value) + const_text(" emit drop"))
+            },
 
             // ----- traces (read-only events) ----------------------------------------------------
             Self::Trace => const_text("trace"),

--- a/crates/assembly-syntax/src/ast/tests.rs
+++ b/crates/assembly-syntax/src/ast/tests.rs
@@ -1623,6 +1623,65 @@ end
     assert_eq!(&formatted, expected);
 }
 
+/// `EmitImm` is printed as the equivalent `push.<id> emit drop` sequence, since `emit.<felt>`
+/// is not valid syntax.
+#[test]
+fn test_emit_imm_roundtrip_formatting() {
+    let event_name = "test::emit::roundtrip";
+    let event_id = EventId::from_name(event_name).as_felt();
+
+    let source = format!(
+        "\
+begin
+    push.1
+    emit
+    drop
+    emit.event(\"{event_name}\")
+end
+"
+    );
+
+    let context = SyntaxTestContext::default();
+    let source = source_file!(&context, source);
+    let module = context.parse_program_source_file(source).unwrap_or_else(|err| panic!("{err}"));
+    let formatted = module.to_string();
+    let expected = format!(
+        "\
+namespace $exec
+
+begin
+    push.1
+    emit
+    drop
+    push.{event_id} emit drop
+end
+"
+    );
+    assert_eq!(&formatted, &expected);
+
+    // The printed output must parse back.
+    let source = source_file!(&context, &expected);
+    let reparsed = context.parse_program_source_file(source).unwrap_or_else(|err| panic!("{err}"));
+    let expanded = format!(
+        "\
+namespace $exec
+
+begin
+    push.1
+    emit
+    drop
+    push.{event_id}
+    emit
+    drop
+end
+"
+    );
+    let source = source_file!(&context, &expanded);
+    let expanded_module =
+        context.parse_program_source_file(source).unwrap_or_else(|err| panic!("{err}"));
+    assert_eq!(reparsed, expanded_module);
+}
+
 /// `TraceImm` is printed as the equivalent `push.<id> trace drop` sequence, since `trace.<felt>`
 /// is not valid syntax.
 #[test]

--- a/crates/assembly-syntax/src/ast/tests.rs
+++ b/crates/assembly-syntax/src/ast/tests.rs
@@ -1627,75 +1627,28 @@ end
 /// is not valid syntax.
 #[test]
 fn test_emit_imm_roundtrip_formatting() {
-    let event_name = "test::emit::roundtrip";
-    let event_id = EventId::from_name(event_name).as_felt();
-
-    let source = format!(
-        "\
-begin
-    push.1
-    emit
-    drop
-    emit.event(\"{event_name}\")
-end
-"
-    );
-
-    let context = SyntaxTestContext::default();
-    let source = source_file!(&context, source);
-    let module = context.parse_program_source_file(source).unwrap_or_else(|err| panic!("{err}"));
-    let formatted = module.to_string();
-    let expected = format!(
-        "\
-namespace $exec
-
-begin
-    push.1
-    emit
-    drop
-    push.{event_id} emit drop
-end
-"
-    );
-    assert_eq!(&formatted, &expected);
-
-    // The printed output must parse back.
-    let source = source_file!(&context, &expected);
-    let reparsed = context.parse_program_source_file(source).unwrap_or_else(|err| panic!("{err}"));
-    let expanded = format!(
-        "\
-namespace $exec
-
-begin
-    push.1
-    emit
-    drop
-    push.{event_id}
-    emit
-    drop
-end
-"
-    );
-    let source = source_file!(&context, &expanded);
-    let expanded_module =
-        context.parse_program_source_file(source).unwrap_or_else(|err| panic!("{err}"));
-    assert_eq!(reparsed, expanded_module);
+    check_imm_event_roundtrip_formatting("emit");
 }
 
 /// `TraceImm` is printed as the equivalent `push.<id> trace drop` sequence, since `trace.<felt>`
 /// is not valid syntax.
 #[test]
 fn test_trace_roundtrip_formatting() {
-    let trace_name = "test::trace::roundtrip";
-    let trace_id = EventId::from_name(trace_name).as_felt();
+    check_imm_event_roundtrip_formatting("trace");
+}
+
+/// Checks that immediate `emit`/`trace` instructions round-trip through parsing and formatting.
+fn check_imm_event_roundtrip_formatting(kind: &str) {
+    let event_name = format!("test::{kind}::roundtrip");
+    let event_id = EventId::from_name(&event_name).as_felt();
 
     let source = format!(
         "\
 begin
     push.1
-    trace
+    {kind}
     drop
-    trace.event(\"{trace_name}\")
+    {kind}.event(\"{event_name}\")
 end
 "
     );
@@ -1710,9 +1663,9 @@ namespace $exec
 
 begin
     push.1
-    trace
+    {kind}
     drop
-    push.{trace_id} trace drop
+    push.{event_id} {kind} drop
 end
 "
     );
@@ -1727,10 +1680,10 @@ namespace $exec
 
 begin
     push.1
-    trace
+    {kind}
     drop
-    push.{trace_id}
-    trace
+    push.{event_id}
+    {kind}
     drop
 end
 "


### PR DESCRIPTION
Closes #3545 

Print `EmitImm` as `push.<felt> emit drop`, which is equivalent valid MASM and can be parsed. Currently this prints as `emit.<felt>`, which is invalid MASM.
