### PR TITLE
chore: allow keccak-hashing an uninitialized memory region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Fixed `PartialSmt::from_unique_nodes()` reconstruction for partial trees containing both inclusion and exclusion proofs by processing leaf-derived and inner-node-derived branches in a shared bottom-up priority order ([#3470](https://github.com/0xMiden/miden-vm/issues/3470)).
 - Added `ecdsa_k256_keccak::verify_bytes` for verifying signatures over variable-length Keccak256 message bytes stored in VM memory ([#3563](https://github.com/0xMiden/miden-vm/pull/3563)).
 - Fixed persistent `LargeSmtForest::entries()` iteration, including snapshot-backed readers, by bounding RocksDB scans to the requested lineage prefix instead of scanning subsequent lineages ([#3576](https://github.com/0xMiden/miden-vm/pull/3576)).
+## Unreleased
+
+#### Fixes
+
+- Keccak-256 wrapper preimages may now cover memory that was never written to, matching the in-VM rule that unwritten memory reads as zero ([#3537](https://github.com/0xMiden/miden-vm/issues/3537)).
 
 ## v0.29.0 (2026-08-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@
 - Fixed `PartialSmt::from_unique_nodes()` reconstruction for partial trees containing both inclusion and exclusion proofs by processing leaf-derived and inner-node-derived branches in a shared bottom-up priority order ([#3470](https://github.com/0xMiden/miden-vm/issues/3470)).
 - Added `ecdsa_k256_keccak::verify_bytes` for verifying signatures over variable-length Keccak256 message bytes stored in VM memory ([#3563](https://github.com/0xMiden/miden-vm/pull/3563)).
 - Fixed persistent `LargeSmtForest::entries()` iteration, including snapshot-backed readers, by bounding RocksDB scans to the requested lineage prefix instead of scanning subsequent lineages ([#3576](https://github.com/0xMiden/miden-vm/pull/3576)).
-## Unreleased
-
-#### Fixes
-
 - Keccak-256 wrapper preimages may now cover memory that was never written to, matching the in-VM rule that unwritten memory reads as zero ([#3537](https://github.com/0xMiden/miden-vm/issues/3537)).
 
 ## v0.29.0 (2026-08-04)

--- a/crates/lib/core/src/handlers/mod.rs
+++ b/crates/lib/core/src/handlers/mod.rs
@@ -79,10 +79,12 @@ fn memory_region_range(start_ptr: u64, len: u64) -> Option<Range<u32>> {
     let start_addr: u32 = start_ptr.try_into().ok()?;
     let len: u32 = len.try_into().ok()?;
 
+    // Enforce word alignment (required for crypto_stream, mem_stream operations)
     if !start_addr.is_multiple_of(4) {
         return None;
     }
 
+    // Calculate end address with overflow check
     let end_addr = start_addr.checked_add(len)?;
 
     Some(start_addr..end_addr)

--- a/crates/lib/core/src/handlers/mod.rs
+++ b/crates/lib/core/src/handlers/mod.rs
@@ -1,3 +1,5 @@
+use core::ops::Range;
+
 use miden_core::Felt;
 use miden_processor::ProcessorState;
 
@@ -24,22 +26,15 @@ fn u64_to_u32_elements(value: u64) -> (Felt, Felt) {
     (hi, lo)
 }
 
-/// Reads a contiguous region of memory elements.
+/// Reads a contiguous region of memory elements, requiring every address to be initialized.
 ///
-/// This is a safe wrapper around memory reads that:
-/// - Validates the starting address fits in u32
-/// - Validates the starting address is word-aligned (multiple of 4)
-/// - Validates the length doesn't overflow when converted to u32
-/// - Uses checked arithmetic to compute the end address
-/// - Returns `None` if any validation fails or if any memory location is uninitialized
+/// Returns `None` if the region is invalid (see [`memory_region_range`]) or if any address in it
+/// was never written to.
 ///
 /// # Arguments
 /// * `process` - Process state to read memory from
 /// * `start_ptr` - Starting address (u64 from stack), must be word-aligned
 /// * `len` - Number of elements to read (u64)
-///
-/// # Returns
-/// `Some(Vec<Felt>)` with `len` elements, or `None` if any check fails
 ///
 /// # Example
 /// ```ignore
@@ -51,19 +46,44 @@ pub(crate) fn read_memory_region(
     start_ptr: u64,
     len: u64,
 ) -> Option<Vec<Felt>> {
-    // Validate inputs fit in u32
-    let start_addr: u32 = start_ptr.try_into().ok()?;
-    let len_u32: u32 = len.try_into().ok()?;
+    let ctx = process.ctx();
+    memory_region_range(start_ptr, len)?
+        .map(|addr| process.get_mem_value(ctx, addr))
+        .collect()
+}
 
-    // Enforce word alignment (required for crypto_stream, mem_stream operations)
+/// Reads a contiguous region of memory elements, treating addresses that were never written to as
+/// zero.
+///
+/// This matches the in-VM rule that unwritten memory reads as zero, so callers are not forced to
+/// explicitly initialize regions that are legitimately zero. See [`read_memory_region`] for the
+/// variant that rejects such regions, and for the argument semantics.
+pub(crate) fn read_uninitialized_memory_region(
+    process: &ProcessorState,
+    start_ptr: u64,
+    len: u64,
+) -> Option<Vec<Felt>> {
+    let ctx = process.ctx();
+    let elements = memory_region_range(start_ptr, len)?
+        .map(|addr| process.get_mem_value(ctx, addr).unwrap_or(Felt::ZERO))
+        .collect();
+
+    Some(elements)
+}
+
+/// Returns the address range covered by a memory region, or `None` if the region is invalid.
+///
+/// A region is valid if its start address fits in a u32 and is word-aligned, its length fits in a
+/// u32, and its end address does not overflow.
+fn memory_region_range(start_ptr: u64, len: u64) -> Option<Range<u32>> {
+    let start_addr: u32 = start_ptr.try_into().ok()?;
+    let len: u32 = len.try_into().ok()?;
+
     if !start_addr.is_multiple_of(4) {
         return None;
     }
 
-    // Calculate end address with overflow check
-    let end_addr = start_addr.checked_add(len_u32)?;
+    let end_addr = start_addr.checked_add(len)?;
 
-    // Read all elements in the range from the current execution context
-    let ctx = process.ctx();
-    (start_addr..end_addr).map(|addr| process.get_mem_value(ctx, addr)).collect()
+    Some(start_addr..end_addr)
 }

--- a/crates/lib/core/src/handlers/precompiles/keccak256.rs
+++ b/crates/lib/core/src/handlers/precompiles/keccak256.rs
@@ -15,7 +15,7 @@ use miden_processor::{
     event::EventError,
 };
 
-use crate::handlers::read_memory_region;
+use crate::handlers::read_uninitialized_memory_region;
 
 /// Event emitted by bundled `miden::precompiles::hashes::keccak256` wrappers to request a
 /// Keccak-256 digest witness from the host.
@@ -80,7 +80,7 @@ fn read_memory_packed_u32(
         .checked_next_multiple_of(BYTES_PER_U32)
         .ok_or(Keccak256DigestEventError::AddressOverflow { start, len_bytes })?;
 
-    let felts = read_memory_region(process, start, len_felts_u64)
+    let felts = read_uninitialized_memory_region(process, start, len_felts_u64)
         .ok_or(Keccak256DigestEventError::MemoryAccessFailed { address: start_u32 })?;
 
     for (offset, felt) in felts.iter().enumerate() {

--- a/crates/lib/core/tests/precompiles/hashes.rs
+++ b/crates/lib/core/tests/precompiles/hashes.rs
@@ -9,12 +9,14 @@ use super::helpers::{
 
 const IN_PTR: u32 = 128;
 const OUT_PTR: u32 = 256;
+const DIGEST_FELTS: usize = 8;
+const BYTES_PER_FELT: usize = 4;
 
 #[test]
 fn keccak_hash_1_chunk_mem_writes_expected_digest() {
     let input: Vec<u8> = (0u8..32).collect();
 
-    let keccak = run_hash_mem("keccak256", "hash_1_chunk_mem", &input, 8)
+    let keccak = run_hash_mem("keccak256", "hash_1_chunk_mem", &input, 0)
         .expect("keccak256::hash_1_chunk_mem must execute");
     assert_eq!(keccak, pack_digest(&Keccak256::hash(&input)));
 }
@@ -23,7 +25,7 @@ fn keccak_hash_1_chunk_mem_writes_expected_digest() {
 fn keccak_hash_bytes_mem_handles_short_preimages() {
     let input = b"hash wrapper coverage";
 
-    let keccak = run_hash_mem("keccak256", "hash_bytes_mem", input, 8)
+    let keccak = run_hash_mem("keccak256", "hash_bytes_mem", input, 0)
         .expect("keccak256::hash_bytes_mem must execute");
     assert_eq!(keccak, pack_digest(&Keccak256::hash(input)));
 }
@@ -35,16 +37,44 @@ fn keccak_hash_2_chunks_mem_hashes_concatenated_inputs() {
     let mut preimage = left;
     preimage.extend_from_slice(&right);
 
-    let output = run_hash_mem("keccak256", "hash_2_chunks_mem", &preimage, 8)
+    let output = run_hash_mem("keccak256", "hash_2_chunks_mem", &preimage, 0)
         .expect("keccak256::hash_2_chunks_mem must execute");
     assert_eq!(output, pack_digest(&Keccak256::hash(&preimage)));
 }
 
+/// The wrapper must accept preimage memory that was never written to, matching the in-VM rule
+/// that unwritten memory reads as zero.
+#[test]
+fn keccak_hash_bytes_mem_hashes_never_written_region() {
+    const UNWRITTEN_FELTS: usize = 8;
+    let preimage = vec![0u8; UNWRITTEN_FELTS * BYTES_PER_FELT];
+
+    let output = run_hash_mem("keccak256", "hash_bytes_mem", &[], UNWRITTEN_FELTS)
+        .expect("keccak256::hash_bytes_mem must execute");
+    assert_eq!(output, pack_digest(&Keccak256::hash(&preimage)));
+}
+
+/// Same as above, but the preimage starts with non-zero elements that are written to memory, so
+/// only its tail relies on unwritten memory.
+#[test]
+fn keccak_hash_2_chunks_mem_hashes_never_written_tail() {
+    const UNWRITTEN_FELTS: usize = 8;
+    let written: Vec<u8> = (1u8..=32).collect();
+    let mut preimage = written.clone();
+    preimage.resize(written.len() + UNWRITTEN_FELTS * BYTES_PER_FELT, 0);
+
+    let output = run_hash_mem("keccak256", "hash_2_chunks_mem", &written, UNWRITTEN_FELTS)
+        .expect("keccak256::hash_2_chunks_mem must execute");
+    assert_eq!(output, pack_digest(&Keccak256::hash(&preimage)));
+}
+
+/// Hashes `input` followed by `trailing_zero_felts` zero elements which the test program does not
+/// write to memory, so that they rely on zero-initialized VM memory.
 fn run_hash_mem(
     module: &str,
     proc: &str,
     input: &[u8],
-    output_len: usize,
+    trailing_zero_felts: usize,
 ) -> Result<Vec<Felt>, ExecutionError> {
     let input_felts = bytes_to_packed_u32_elements(input);
     let stores = masm_store_felts(&input_felts, IN_PTR);
@@ -58,12 +88,12 @@ fn run_hash_mem(
             exec.::miden::precompiles::hashes::{module}::{proc}
         end
         "#,
-        len_bytes = input.len(),
+        len_bytes = input.len() + trailing_zero_felts * BYTES_PER_FELT,
     );
 
     let output = run_precompile_program(&source)?;
     assert_deferred_state_round_trips(&output);
-    Ok(read_memory_felts(&output, OUT_PTR, output_len))
+    Ok(read_memory_felts(&output, OUT_PTR, DIGEST_FELTS))
 }
 
 fn pack_digest(bytes: &[u8]) -> Vec<Felt> {


### PR DESCRIPTION
## Describe your changes



The bundled `miden::precompiles::hashes::keccak256` wrappers rejected preimages whose memory was never written to, even though the VM itself reads unwritten memory as zero. This forced callers to explicitly zero-fill regions that are legitimately zero. The keccak256 event handler now reads its preimage through a variant that substitutes zero for unwritten addresses, so a region that is partially or fully never written hashes the same as one explicitly filled with zeros.

- `read_memory_region` is split: the address-range validation (u32 fit, word alignment, no end-address overflow) moves into a shared `memory_region_range` helper, and the new `read_uninitialized_memory_region` reuses it while treating unwritten addresses as zero. The strict variant is unchanged in behaviour and stays available for handlers that should reject unwritten memory.
- Tests cover a preimage that is entirely never written and one whose tail is never written, and the existing hash-memory tests now exercise the path where the declared byte length exceeds what the test program stores.

Closes #3537.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md`
