### PR TITLE
fix: require Plonky3 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 #### Changes
 
 - [BREAKING] Reduced the precompile STARK relation from 12 AIRs to 10 by merging the chunk/node/sponge and EC point/group stores ([#3464](https://github.com/0xMiden/miden-vm/pull/3464)).
+- Raised the minimum supported Plonky3 version to 0.6.3 to match the `num-bigint` 0.5 types used by `miden-field` ([#3569](https://github.com/0xMiden/miden-vm/pull/3569)).
+
 #### Features
 
 - Added `AdviceInputs::new` constructor and `From<AdviceMap>` impl, complementing the existing builder-style accessors for assembling advice inputs from their parts ([#3540](https://github.com/0xMiden/miden-vm/pull/3540)).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,28 +174,28 @@ windows-sys     = { version = "0.61.2" }
 x25519-dalek    = { version = "3.0.0", default-features = false }
 zerocopy        = { version = "0.8", default-features = false, features = ["derive"] }
 
-p3-air           = { version = "0.6", default-features = false }
-p3-batch-stark   = { version = "0.6", default-features = false }
-p3-blake3        = { version = "0.6", default-features = false }
-p3-blake3-air    = { version = "0.6", default-features = false }
-p3-bn254         = { version = "0.6", default-features = false }
-p3-challenger    = { version = "0.6", default-features = false }
-p3-commit        = { version = "0.6", default-features = false }
-p3-dft           = { version = "0.6", default-features = false }
-p3-field         = { version = "0.6", default-features = false }
-p3-fri           = { version = "0.6", default-features = false }
-p3-goldilocks    = { version = "0.6", default-features = false }
-p3-keccak        = { version = "0.6", default-features = false }
-p3-keccak-air    = { version = "0.6", default-features = false }
-p3-lookup        = { version = "0.6", default-features = false }
-p3-matrix        = { version = "0.6", default-features = false }
-p3-maybe-rayon   = { version = "0.6", default-features = false }
-p3-merkle-tree   = { version = "0.6", default-features = false }
-p3-mersenne-31   = { version = "0.6", default-features = false }
-p3-poseidon2-air = { version = "0.6", default-features = false }
-p3-symmetric     = { version = "0.6", default-features = false }
-p3-uni-stark     = { version = "0.6", default-features = false }
-p3-util          = { version = "0.6", default-features = false }
+p3-air           = { version = "0.6.3", default-features = false }
+p3-batch-stark   = { version = "0.6.3", default-features = false }
+p3-blake3        = { version = "0.6.3", default-features = false }
+p3-blake3-air    = { version = "0.6.3", default-features = false }
+p3-bn254         = { version = "0.6.3", default-features = false }
+p3-challenger    = { version = "0.6.3", default-features = false }
+p3-commit        = { version = "0.6.3", default-features = false }
+p3-dft           = { version = "0.6.3", default-features = false }
+p3-field         = { version = "0.6.3", default-features = false }
+p3-fri           = { version = "0.6.3", default-features = false }
+p3-goldilocks    = { version = "0.6.3", default-features = false }
+p3-keccak        = { version = "0.6.3", default-features = false }
+p3-keccak-air    = { version = "0.6.3", default-features = false }
+p3-lookup        = { version = "0.6.3", default-features = false }
+p3-matrix        = { version = "0.6.3", default-features = false }
+p3-maybe-rayon   = { version = "0.6.3", default-features = false }
+p3-merkle-tree   = { version = "0.6.3", default-features = false }
+p3-mersenne-31   = { version = "0.6.3", default-features = false }
+p3-poseidon2-air = { version = "0.6.3", default-features = false }
+p3-symmetric     = { version = "0.6.3", default-features = false }
+p3-uni-stark     = { version = "0.6.3", default-features = false }
+p3-util          = { version = "0.6.3", default-features = false }
 
 loom = "0.7"
 miette = { package = "miden-miette", version = "8.0", default-features = false }

--- a/tools/miden-serde-utils-fuzz/Cargo.toml
+++ b/tools/miden-serde-utils-fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-p3-goldilocks = { default-features = false, version = "0.6" }
+p3-goldilocks = { default-features = false, version = "0.6.3" }
 
 [dependencies.miden-serde-utils]
 path = "../../crates/serde-utils"


### PR DESCRIPTION
Raise all workspace Plonky3 minimum versions to 0.6.3, including the standalone serde fuzz target. This preserves compatibility with later 0.6 releases while excluding the incompatible range.

Fixes #3536.