### PR TITLE
fix(crypto): add missing return in Polynomial::div for zero numerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 - [BREAKING] Removed the free `execute()` and `execute_sync()` functions from `miden-vm`/`miden-processor`. Use `FastProcessor::new_with_options(...)` followed by `execute()`/`execute_sync()` instead ([#3540](https://github.com/0xMiden/miden-vm/pull/3540)).
 
+#### Fixes
+
+- Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
+
 ## v0.29.0 (2026-08-04)
 
 #### Changes

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
@@ -451,7 +451,7 @@ where
             panic!();
         }
         if self.is_zero() {
-            Self::zero();
+            return Self::zero();
         }
         let mut remainder = self;
         let mut quotient = Polynomial::<F>::zero();
@@ -652,6 +652,15 @@ impl<F: Zeroize> ZeroizeOnDrop for Polynomial<F> {}
 mod tests {
     use super::{FalconFelt, N, Polynomial};
     use crate::rand::test_utils::prng_array;
+
+    #[test]
+    fn div_zero_by_nonzero_returns_zero() {
+        use num::Zero;
+        let zero = Polynomial::<i64>::zero();
+        let nonzero = Polynomial::new(vec![1, 2, 3]);
+        let result = zero / nonzero;
+        assert!(result.is_zero());
+    }
 
     #[test]
     fn test_negacyclic_reduction() {


### PR DESCRIPTION
## Summary

- Add the missing `return` keyword in `Polynomial::div` so dividing a zero polynomial by a non-zero one returns `Self::zero()` instead of panicking on `remainder.degree().unwrap()`.
- Add regression test `div_zero_by_nonzero_returns_zero`.
- Add CHANGELOG entry.

## Test plan

- `div_zero_by_nonzero_returns_zero`: divides a zero polynomial by `[1, 2, 3]` and asserts the result is zero.
- Existing `test_negacyclic_reduction` still passes (2/2).

Closes #3534