### PR TITLE
release: bump workspace crates to 0.29.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-constraint-compiler",
  "miden-core",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "insta",
  "miden-ace-codegen",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "env_logger",
  "insta",
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "env_logger",
  "log",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "miden-bench"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "clap",
  "miden-lifted-stark",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "miden-constraint-compiler"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "criterion",
  "derive_more",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "criterion",
  "env_logger",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib-codegen"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-core",
  "miden-precompiles",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "assert_matches",
  "blake3",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-field",
  "quote",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-smt-codspeed-bench"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-crypto",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-wycheproof-tests"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "miden-format"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "clap",
  "miden-assembly-syntax-cst",
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-field",
  "p3-air",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "criterion",
  "miden-lifted-air",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "hashbrown 0.17.1",
  "log",
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry-local"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "clap",
  "miden-assembly-syntax",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles-prover"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "insta",
  "k256",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "hashbrown 0.17.1",
  "insta",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-air",
  "miden-assembly",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-bn254",
  "p3-field",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "miden-test-serde-macros"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "proc-macro2",
  "proptest",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "miden-test-utils"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "env_logger",
  "miden-air",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-serde-utils",
  "miden-test-serde-macros",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "lock_api",
  "loom",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-blake3-bench"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "clap",
  "codspeed-criterion-compat",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-precompiles-bench"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-core",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-synthetic-bench"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-assembly",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,10 +56,8 @@ homepage = "https://miden.xyz"
 repository = "https://github.com/0xMiden/miden-vm"
 exclude = [".github/"]
 rust-version = "1.96.1"
-# Private workspace members inherit this version. Publishable crates keep their
-# own package versions so release tooling can publish only the crates selected
-# for a release.
-version = "0.29.0"
+# First-party packages on the VM release line inherit this version.
+version = "0.29.1"
 
 [profile.optimized]
 inherits = "release"

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-air"
-version = "0.29.0"
+version.workspace = true
 description = "Algebraic intermediate representation of Miden VM processor"
 documentation = "https://docs.rs/miden-air"
 readme = "README.md"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.29.0"
+version.workspace = true
 description = "Miden VM core components"
 documentation = "https://docs.rs/miden-core"
 readme = "README.md"

--- a/crates/ace-codegen/Cargo.toml
+++ b/crates/ace-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-ace-codegen"
-version = "0.29.0"
+version.workspace = true
 description = "ACE circuit codegen for Plonky3-based Miden AIRs."
 documentation = "https://docs.rs/miden-ace-codegen"
 readme = "README.md"

--- a/crates/assembly-syntax-cst/Cargo.toml
+++ b/crates/assembly-syntax-cst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax-cst"
-version = "0.29.0"
+version.workspace = true
 description = "Lossless concrete syntax tree support for the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax-cst"
 readme = "README.md"

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax"
-version = "0.29.0"
+version.workspace = true
 description = "Parsing and semantic analysis of the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax"
 readme = "README.md"

--- a/crates/assembly/Cargo.toml
+++ b/crates/assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly"
-version = "0.29.0"
+version.workspace = true
 description = "Miden VM assembly language"
 documentation = "https://docs.rs/miden-assembly"
 readme = "README.md"

--- a/crates/crypto-derive/Cargo.toml
+++ b/crates/crypto-derive/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "miden-crypto-derive"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.29.0"
+version.workspace = true
 
 [lib]
 doctest    = false

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-crypto"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.29.0"
+version.workspace = true
 
 [[bin]]
 bench             = false

--- a/crates/debug-types/Cargo.toml
+++ b/crates/debug-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-debug-types"
-version = "0.29.0"
+version.workspace = true
 description = "Core source-level debugging information types used throughout the Miden toolchain"
 documentation = "https://docs.rs/miden-debug-types"
 readme = "README.md"

--- a/crates/field/Cargo.toml
+++ b/crates/field/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-field"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.29.0"
+version.workspace = true
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core-lib"
-version = "0.29.0"
+version.workspace = true
 description = "Miden VM core library"
 documentation = "https://docs.rs/miden-core-lib"
 readme = "README.md"

--- a/crates/lib/core/asm/miden-project.toml
+++ b/crates/lib/core/asm/miden-project.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.29.0"
+version = "0.29.1"
 
 [lib]
 namespace = "miden::core"

--- a/crates/lifted-air/Cargo.toml
+++ b/crates/lifted-air/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-lifted-air"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.29.0"
+version.workspace = true
 
 [lib]
 doctest = true

--- a/crates/lifted-stark/Cargo.toml
+++ b/crates/lifted-stark/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-lifted-stark"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.29.0"
+version.workspace = true
 
 [lib]
 doctest = false

--- a/crates/mast-package/Cargo.toml
+++ b/crates/mast-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-mast-package"
-version = "0.29.0"
+version.workspace = true
 description = "Package containing a compiled Miden MAST artifact with declared dependencies and exports"
 documentation = "https://docs.rs/miden-mast-package"
 readme = "README.md"

--- a/crates/miden-constraint-compiler/Cargo.toml
+++ b/crates/miden-constraint-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-constraint-compiler"
-version = "0.29.0"
+version.workspace = true
 description = "Constraint compiler for Plonky3-based Miden AIRs."
 documentation = "https://docs.rs/miden-constraint-compiler"
 readme = "README.md"

--- a/crates/miden-format/Cargo.toml
+++ b/crates/miden-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-format"
-version = "0.29.0"
+version.workspace = true
 description = "Formatter for the Miden Assembly language"
 documentation = "https://docs.rs/miden-format"
 readme = "README.md"

--- a/crates/package-registry-local/Cargo.toml
+++ b/crates/package-registry-local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry-local"
-version = "0.29.0"
+version.workspace = true
 description = "Filesystem-backed local package registry for Miden packages"
 documentation = "https://docs.rs/miden-package-registry-local"
 readme = "README.md"

--- a/crates/package-registry/Cargo.toml
+++ b/crates/package-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry"
-version = "0.29.0"
+version.workspace = true
 description = "Package registry interfaces and dependency resolution for Miden packages"
 documentation = "https://docs.rs/miden-package-registry"
 readme = "README.md"

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-project"
-version = "0.29.0"
+version.workspace = true
 description = "Interface for working with Miden projects"
 documentation = "https://docs.rs/miden-project"
 readme = "README.md"

--- a/crates/serde-utils/Cargo.toml
+++ b/crates/serde-utils/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-serde-utils"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.29.0"
+version.workspace = true
 
 [features]
 default = ["std"]

--- a/crates/stark-transcript/Cargo.toml
+++ b/crates/stark-transcript/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-stark-transcript"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.29.0"
+version.workspace = true
 
 [lib]
 doctest = false

--- a/crates/stateful-hasher/Cargo.toml
+++ b/crates/stateful-hasher/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-stateful-hasher"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.29.0"
+version.workspace = true
 
 [lib]
 doctest = false

--- a/crates/test-serde-macros/Cargo.toml
+++ b/crates/test-serde-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-test-serde-macros"
-version = "0.29.0"
+version.workspace = true
 description = "Proc macros for serde roundtrip testing in Miden VM"
 readme = "README.md"
 categories = ["development-tools::testing", "no-std"]

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-test-utils"
-version = "0.29.0"
+version.workspace = true
 description = "Test utilities for Miden VM programs"
 readme = "README.md"
 categories = ["development-tools::testing", "no-std"]

--- a/crates/utils-core-derive/Cargo.toml
+++ b/crates/utils-core-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-core-derive"
-version = "0.29.0"
+version.workspace = true
 description = "Proc macro to derive enum dispatch trait implementations on miden-core structs"
 readme = "README.md"
 categories = ["development-tools::procedural-macro-helpers", "no-std"]

--- a/crates/utils-diagnostics/Cargo.toml
+++ b/crates/utils-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-diagnostics"
-version = "0.29.0"
+version.workspace = true
 description = "Diagnostic infrastructure used in the Miden assembler and VM"
 documentation = "https://docs.rs/miden-utils-diagnostics"
 readme = "README.md"

--- a/crates/utils-indexing/Cargo.toml
+++ b/crates/utils-indexing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-indexing"
-version = "0.29.0"
+version.workspace = true
 description = "Type-safe u32-indexed vector utilities for Miden"
 readme = "README.md"
 categories = ["development-tools", "no-std"]

--- a/crates/utils-sync/Cargo.toml
+++ b/crates/utils-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-sync"
-version = "0.29.0"
+version.workspace = true
 description = "no-std compatible locking primitives for the Miden project"
 documentation = "https://docs.rs/miden-utils-sync"
 readme = "README.md"

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-vm"
-version = "0.29.0"
+version.workspace = true
 description = "Miden virtual machine"
 documentation = "https://docs.rs/miden-vm"
 readme = "README.md"

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-processor"
-version = "0.29.0"
+version.workspace = true
 description = "Miden VM processor"
 documentation = "https://docs.rs/miden-processor"
 readme = "README.md"

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-prover"
-version = "0.29.0"
+version.workspace = true
 description = "Miden VM prover"
 documentation = "https://docs.rs/miden-prover"
 readme = "README.md"

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-assembly"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "log",
  "miden-assembly-syntax-cst",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "derive_more",
  "log",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "blake3",
  "cc",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-air",
  "p3-challenger",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "hashbrown",
  "log",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-field",
  "p3-symmetric",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-serde-utils",
  "proptest",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "lock_api",
  "loom",

--- a/tools/miden-crypto-fuzz/Cargo.lock
+++ b/tools/miden-crypto-fuzz/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "blake3",
  "cc",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-air",
  "p3-challenger",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-field",
  "p3-symmetric",

--- a/tools/miden-serde-utils-fuzz/Cargo.lock
+++ b/tools/miden-serde-utils-fuzz/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "p3-field",
  "p3-goldilocks",

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-verifier"
-version = "0.29.0"
+version.workspace = true
 description = "Miden VM execution verifier"
 documentation = "https://docs.rs/miden-verifier"
 readme = "README.md"


### PR DESCRIPTION
The release ~should~ includes #3563, #3576 and #3568 ~as well, at least.~