### PR TITLE
fix(crypto/large_smt_forest): bound persistent `LargeSmtForest` entry iteration to lineage prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed `PartialSmt::from_unique_nodes()` reconstruction for partial trees containing both inclusion and exclusion proofs by processing leaf-derived and inner-node-derived branches in a shared bottom-up priority order ([#3470](https://github.com/0xMiden/miden-vm/issues/3470)).
 - Added `ecdsa_k256_keccak::verify_bytes` for verifying signatures over variable-length Keccak256 message bytes stored in VM memory ([#3563](https://github.com/0xMiden/miden-vm/pull/3563)).
+- Fixed persistent `LargeSmtForest::entries()` iteration, including snapshot-backed readers, by bounding RocksDB scans to the requested lineage prefix instead of scanning subsequent lineages ([#3576](https://github.com/0xMiden/miden-vm/pull/3576)).
 
 ## v0.29.0 (2026-08-04)
 

--- a/crates/crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
+++ b/crates/crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
@@ -178,6 +178,16 @@ const MIN_LINEAGES_IN_BATCH_TO_PARALLELIZE: usize = 5;
 /// The minimum number of items per rayon chunk when parallelizing deserialization and extraction.
 const CHUNKING_UNIT: usize = 100;
 
+// HELPERS
+// ================================================================================================
+
+/// Builds read options that restrict iteration to keys beginning with `lineage_bytes`.
+fn lineage_entries_read_options(lineage_bytes: &[u8]) -> db::ReadOptions {
+    let mut read_options = db::ReadOptions::default();
+    read_options.set_iterate_range(db::PrefixRange(lineage_bytes));
+    read_options
+}
+
 // BACKEND READER TRAIT
 // ================================================================================================
 
@@ -299,16 +309,19 @@ impl BackendReader for PersistentBackend {
         }
 
         let lineage_bytes = lineage.to_bytes();
+        let read_options = lineage_entries_read_options(&lineage_bytes);
 
-        // In order to improve iteration performance significantly, we iterate with a prefix. As
-        // leaves are keyed on `LeafKey`, which begins with the bytes of the lineage, we can use the
-        // lineage as our prefix. That means that the iterator should only yield values whose key
-        // begins with the prefix with a high likelihood.
-        let pfx_iterator = self.db.prefix_iterator_cf(self.cf(LEAVES_CF)?, lineage_bytes);
+        // Leaf keys begin with their lineage bytes, so an explicit prefix range prevents RocksDB
+        // from scanning into leaves belonging to later lineages.
+        let entries_iterator = self.db.iterator_cf_opt(
+            self.cf(LEAVES_CF)?,
+            read_options,
+            db::IteratorMode::From(&lineage_bytes, db::Direction::Forward),
+        );
 
         // Data ownership concerns mean we cannot use this iterator directly even if we could change
         // its type, so we delegate to our custom entries iterator impl.
-        Ok(PersistentBackendEntriesIterator::new(lineage, pfx_iterator))
+        Ok(PersistentBackendEntriesIterator::new(lineage, entries_iterator))
     }
 }
 

--- a/crates/crypto/src/merkle/smt/large_forest/backend/persistent/snapshot.rs
+++ b/crates/crypto/src/merkle/smt/large_forest/backend/persistent/snapshot.rs
@@ -10,7 +10,7 @@ use super::{
     LEAVES_CF,
     iterator::PersistentBackendEntriesIterator,
     keys::{LeafKey, SubtreeKey},
-    subtree_cf_name,
+    lineage_entries_read_options, subtree_cf_name,
     tree_metadata::TreeMetadata,
 };
 use crate::{
@@ -208,14 +208,13 @@ impl BackendReader for PersistentBackendReader {
         }
         let lineage_bytes = lineage.to_bytes();
         let cf = self.cf(LEAVES_CF)?;
-        let mut read_opts = db::ReadOptions::default();
-        read_opts.set_prefix_same_as_start(true);
-        let pfx_iterator = self.inner.snapshot.iterator_cf_opt(
+        let read_options = lineage_entries_read_options(&lineage_bytes);
+        let entries_iterator = self.inner.snapshot.iterator_cf_opt(
             cf,
-            read_opts,
+            read_options,
             db::IteratorMode::From(&lineage_bytes, db::Direction::Forward),
         );
-        Ok(PersistentBackendEntriesIterator::new(lineage, pfx_iterator))
+        Ok(PersistentBackendEntriesIterator::new(lineage, entries_iterator))
     }
 }
 

--- a/crates/crypto/src/merkle/smt/large_forest/backend/persistent/tests.rs
+++ b/crates/crypto/src/merkle/smt/large_forest/backend/persistent/tests.rs
@@ -11,7 +11,7 @@ use assert_matches::assert_matches;
 use itertools::Itertools;
 use tempfile::{TempDir, tempdir};
 
-use super::{PersistentBackend, Result};
+use super::{LEAVES_CF, PersistentBackend, Result};
 use crate::{
     EMPTY_WORD, Word,
     merkle::smt::{
@@ -511,6 +511,33 @@ fn entries() -> Result<()> {
     assert!(entries.contains(&TreeEntry { key: key_1_1, value: value_1_1 }));
     assert!(entries.contains(&TreeEntry { key: key_1_2, value: value_1_2 }));
     assert!(entries.contains(&TreeEntry { key: key_1_3, value: value_1_3 }));
+
+    Ok(())
+}
+
+#[test]
+fn entries_stops_at_end_of_lineage_prefix() -> Result<()> {
+    let (_file, mut backend) = default_backend()?;
+
+    // Choose the lowest possible lineage so that any key beginning with a nonzero byte sorts after
+    // all of this lineage's leaves.
+    let lineage = LineageId::new([0; 32]);
+    let key = Word::from([1_u32, 2, 3, 4]);
+    let value = Word::from([5_u32, 6, 7, 8]);
+    backend.add_lineage(lineage, 1, SmtUpdateBatch::from([(key, value)].into_iter()))?;
+
+    // Insert a malformed key outside the requested lineage's prefix. A correctly bounded entries
+    // iterator must stop before inspecting it. An unbounded iterator will try to deserialize it as
+    // a LeafKey and return an error.
+    let leaves_cf = backend.cf(LEAVES_CF)?;
+    backend.db.put_cf(leaves_cf, [1], [])?;
+
+    let entries = backend.entries(lineage)?.collect::<Result<Vec<_>>>()?;
+    assert_eq!(entries, vec![TreeEntry { key, value }]);
+
+    let reader = backend.reader()?;
+    let entries = reader.entries(lineage)?.collect::<Result<Vec<_>>>()?;
+    assert_eq!(entries, vec![TreeEntry { key, value }]);
 
     Ok(())
 }


### PR DESCRIPTION
## Overview

Persistent `LargeSmtForest::entries()` iterators could scan every leaf after the requested lineage in the RocksDB column family. This caused entry iteration time to grow with unrelated later lineages, producing significant latency even for trees containing few entries.

The issue affected both direct `PersistentBackend` reads and snapshot-backed `PersistentBackendReader` reads.

## Implementation

RocksDB’s prefix iterator only enforces `prefix_same_as_start` when the column family has a prefix extractor configured. The leaves column family does not have one, so the iterator sought to the requested lineage but did not stop when that prefix ended.

This change:

- Defines the exact key range for a lineage using `rocksdb::PrefixRange`.
- Applies those bounds to both live and snapshot-backed entry iterators.
- Retains the existing forward seek from the lineage prefix.
- Avoids changes to the column-family configuration or on-disk format. Since this fix is targeting `main` we can't break compatibility. For `next` we could set up a proper prefix extractor for the leaves column family so that we can use `prefix_same_as_start`.

Fixes #3571.
