### PR TITLE
fix(crypto): bound persistent forest entry iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Fixes
 
+- Bounded persistent `LargeSmtForest` entry iteration to the requested lineage, avoiding scans across later RocksDB leaf ranges ([#3571](https://github.com/0xMiden/miden-vm/issues/3571)).
 - Fixed `PartialSmt::from_unique_nodes()` reconstruction for partial trees containing both inclusion and exclusion proofs by processing leaf-derived and inner-node-derived branches in a shared bottom-up priority order ([#3470](https://github.com/0xMiden/miden-vm/issues/3470)).
 
 ## v0.29.0 (2026-08-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Fixes
 
-- Bounded persistent `LargeSmtForest` entry iteration to the requested lineage, avoiding scans across later RocksDB leaf ranges ([#3571](https://github.com/0xMiden/miden-vm/issues/3571)).
+- Bounded persistent `LargeSmtForest` entry iteration to the requested lineage, avoiding scans across later RocksDB leaf ranges ([#3577](https://github.com/0xMiden/miden-vm/pull/3577)).
 - Fixed `PartialSmt::from_unique_nodes()` reconstruction for partial trees containing both inclusion and exclusion proofs by processing leaf-derived and inner-node-derived branches in a shared bottom-up priority order ([#3470](https://github.com/0xMiden/miden-vm/issues/3470)).
 
 ## v0.29.0 (2026-08-04)

--- a/crates/crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
+++ b/crates/crypto/src/merkle/smt/large_forest/backend/persistent/mod.rs
@@ -300,11 +300,15 @@ impl BackendReader for PersistentBackend {
 
         let lineage_bytes = lineage.to_bytes();
 
-        // In order to improve iteration performance significantly, we iterate with a prefix. As
-        // leaves are keyed on `LeafKey`, which begins with the bytes of the lineage, we can use the
-        // lineage as our prefix. That means that the iterator should only yield values whose key
-        // begins with the prefix with a high likelihood.
-        let pfx_iterator = self.db.prefix_iterator_cf(self.cf(LEAVES_CF)?, lineage_bytes);
+        // Bound iteration to the lineage's key prefix. `prefix_iterator_cf` cannot enforce this
+        // boundary because `LEAVES_CF` has no prefix extractor.
+        let mut read_opts = db::ReadOptions::default();
+        read_opts.set_iterate_range(db::PrefixRange(lineage_bytes.clone()));
+        let pfx_iterator = self.db.iterator_cf_opt(
+            self.cf(LEAVES_CF)?,
+            read_opts,
+            db::IteratorMode::From(&lineage_bytes, db::Direction::Forward),
+        );
 
         // Data ownership concerns mean we cannot use this iterator directly even if we could change
         // its type, so we delegate to our custom entries iterator impl.

--- a/crates/crypto/src/merkle/smt/large_forest/backend/persistent/snapshot.rs
+++ b/crates/crypto/src/merkle/smt/large_forest/backend/persistent/snapshot.rs
@@ -209,7 +209,7 @@ impl BackendReader for PersistentBackendReader {
         let lineage_bytes = lineage.to_bytes();
         let cf = self.cf(LEAVES_CF)?;
         let mut read_opts = db::ReadOptions::default();
-        read_opts.set_prefix_same_as_start(true);
+        read_opts.set_iterate_range(db::PrefixRange(lineage_bytes.clone()));
         let pfx_iterator = self.inner.snapshot.iterator_cf_opt(
             cf,
             read_opts,

--- a/crates/crypto/src/merkle/smt/large_forest/backend/persistent/tests.rs
+++ b/crates/crypto/src/merkle/smt/large_forest/backend/persistent/tests.rs
@@ -11,7 +11,7 @@ use assert_matches::assert_matches;
 use itertools::Itertools;
 use tempfile::{TempDir, tempdir};
 
-use super::{PersistentBackend, Result};
+use super::{LEAVES_CF, PersistentBackend, Result};
 use crate::{
     EMPTY_WORD, Word,
     merkle::smt::{
@@ -511,6 +511,48 @@ fn entries() -> Result<()> {
     assert!(entries.contains(&TreeEntry { key: key_1_1, value: value_1_1 }));
     assert!(entries.contains(&TreeEntry { key: key_1_2, value: value_1_2 }));
     assert!(entries.contains(&TreeEntry { key: key_1_3, value: value_1_3 }));
+
+    Ok(())
+}
+
+#[test]
+fn entries_stops_at_end_of_lineage_prefix() -> Result<()> {
+    let (_file, mut backend) = default_backend()?;
+
+    // Choose the lowest possible lineage so that any key beginning with a nonzero byte sorts after
+    // all of this lineage's leaves.
+    let lineage = LineageId::new([0; 32]);
+    let key = Word::from([1_u32, 2, 3, 4]);
+    let value = Word::from([5_u32, 6, 7, 8]);
+    backend.add_lineage(lineage, 1, SmtUpdateBatch::from([(key, value)].into_iter()))?;
+
+    // Insert a malformed key outside the requested lineage's prefix. A correctly bounded entries
+    // iterator must stop before inspecting it. An unbounded iterator will try to deserialize it as
+    // a LeafKey and return an error.
+    let leaves_cf = backend.cf(LEAVES_CF)?;
+    backend.db.put_cf(leaves_cf, [1], [])?;
+
+    let entries = backend.entries(lineage)?.collect::<Result<Vec<_>>>()?;
+    assert_eq!(entries, vec![TreeEntry { key, value }]);
+
+    Ok(())
+}
+
+#[test]
+fn snapshot_entries_stops_at_end_of_lineage_prefix() -> Result<()> {
+    let (_file, mut backend) = default_backend()?;
+
+    let lineage = LineageId::new([0; 32]);
+    let key = Word::from([1_u32, 2, 3, 4]);
+    let value = Word::from([5_u32, 6, 7, 8]);
+    backend.add_lineage(lineage, 1, SmtUpdateBatch::from([(key, value)].into_iter()))?;
+
+    let leaves_cf = backend.cf(LEAVES_CF)?;
+    backend.db.put_cf(leaves_cf, [1], [])?;
+
+    let snapshot = backend.reader()?;
+    let entries = snapshot.entries(lineage)?.collect::<Result<Vec<_>>>()?;
+    assert_eq!(entries, vec![TreeEntry { key, value }]);
 
     Ok(())
 }


### PR DESCRIPTION
As #3571 explains, there's a missing prefix extractor on `LEAVES_CF`. Without it, RocksDB does not enforce the lineage boundary for a prefix iterator. As a result, `entries()` can read every later lineage. This is slow on large databases and can return an error if a later key is malformed.

The fix sets an explicit RocksDB `PrefixRange` for the mutable backend and snapshot reader. New tests confirm that both readers stop at the end of the requested lineage.

Fixes #3571.