### PR TITLE
fix(cli): reject invalid prove extensions before inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
 - Moved the `read_bounded_len` and `validate_bounded_len` helpers from `miden-core` to `miden-serde-utils`, where they are now public. `miden-core::serde` re-exports them unchanged, and the private duplicates in `miden-utils-indexing` were removed ([#3415](https://github.com/0xMiden/miden-vm/issues/3415)).
+- Fixed `miden-vm prove` so unsupported program extensions are rejected before inferred input files are loaded ([#3587](https://github.com/0xMiden/miden-vm/issues/3587)).
 #### Features
 
 - Added `LinkMode::Analysis` and `Linker::link_analysis`, which commit resolved modules and call edges and report a static recursion cycle as a nonfatal diagnostic (`LinkAnalysis`) instead of rejecting it. Strict linking is unchanged: it still rejects cycles before MAST is built and rolls back on failure ([#3535](https://github.com/0xMiden/miden-vm/pull/3535)).

--- a/miden-vm/src/cli/prove.rs
+++ b/miden-vm/src/cli/prove.rs
@@ -90,6 +90,17 @@ impl ProveCmd {
         println!("Prove program: {}", self.program_file.display());
         println!("-------------------------------------------------------------------------------");
 
+        // determine file type based on extension
+        let ext = self
+            .program_file
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+        if !matches!(ext.as_str(), "masm" | "masp") {
+            return Err(Report::msg("The provided file must have a .masm or .masp extension"));
+        }
+
         // load libraries from files
         let libraries = Libraries::new(&self.library_paths)?;
 
@@ -102,14 +113,6 @@ impl ProveCmd {
                 kernel_path.display()
             )));
         }
-
-        // determine file type based on extension
-        let ext = self
-            .program_file
-            .extension()
-            .and_then(|s| s.to_str())
-            .unwrap_or("")
-            .to_lowercase();
 
         let input_data = InputFile::read(&self.input_file, &self.program_file)?;
 
@@ -128,7 +131,7 @@ impl ProveCmd {
                 }
                 (program, package_debug_info, entrypoint_source_node, host)
             },
-            _ => return Err(Report::msg("The provided file must have a .masm or .masp extension")),
+            _ => unreachable!("program file extension was validated above"),
         };
 
         let program_hash: [u8; 32] = program.hash().into();

--- a/miden-vm/tests/integration/cli/cli_test.rs
+++ b/miden-vm/tests/integration/cli/cli_test.rs
@@ -79,6 +79,22 @@ fn prove_rejects_missing_inferred_inputs_file() {
 }
 
 #[test]
+fn prove_rejects_invalid_program_extension_before_inferred_inputs_file() {
+    let working_dir = TempDir::new().unwrap();
+    let program_path = working_dir.path().join("miden-vm-cli-invalid-prove-extension-test.txt");
+    fs::write(&program_path, "begin push.1 end").unwrap();
+
+    let mut cmd = bin_under_test(working_dir.path());
+    cmd.arg("prove").arg(&program_path);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "The provided file must have a .masm or .masp extension",
+        ))
+        .stderr(predicate::str::contains("Failed to open input file").not());
+}
+
+#[test]
 fn cli_bundle_debug() {
     let working_dir = TempDir::new().unwrap();
     let output_file = working_dir.path().join("cli_bundle_debug.masp");


### PR DESCRIPTION
`miden-vm prove invalid.txt` was trying to infer and read `invalid.inputs` before checking that the program path was a `.masm` or `.masp` file. That made the command report a missing inputs file instead of the invalid program extension.

Rationale:
`run` already rejects unsupported program extensions before looking for inputs. Doing the same in `prove` keeps the two commands consistent and avoids pointing users at an input file that is not relevant yet.

Changed the extension check to happen before input/library loading and added a CLI regression test.

Fixes #3587

Testing:
- `cargo test -p miden-vm --features executable --test miden-cli cli::cli_test --profile test-dev`
- `cargo build -p miden-vm --features executable --bin miden-vm --profile test-dev`
- `cargo clippy -p miden-vm --features executable --tests --profile test-dev -- -D warnings`
- `cargo +nightly fmt --all --check`
- `NO_CHANGELOG_LABEL=false BASE_REF=next ./scripts/check-changelog.sh`