### PR TITLE
fix(crypto): make Polynomial::karatsuba agree with Mul for all operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
+- Fixed `Polynomial::karatsuba` panicking on zero operands and on operands whose lengths were unequal or odd, and returning a wrong product for some unequal lengths, by zero-extending both operands to a length the recursion accepts. It now agrees with `Mul` for all operands ([#3575](https://github.com/0xMiden/miden-vm/issues/3575)).
 
 ## v0.29.0 (2026-08-04)
 

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
@@ -377,8 +377,38 @@ impl<F: Mul<Output = F> + Sub<Output = F> + AddAssign + Zero + Div<Output = F> +
     Polynomial<F>
 {
     /// Multiply two polynomials using Karatsuba's divide-and-conquer algorithm.
+    ///
+    /// This returns the same product as [`Mul`], including the length of the coefficient vector,
+    /// for every pair of operands.
     pub fn karatsuba(&self, other: &Self) -> Self {
-        Polynomial::new(vector_karatsuba(&self.coefficients, &other.coefficients))
+        if self.coefficients.iter().all(Zero::is_zero)
+            || other.coefficients.iter().all(Zero::is_zero)
+        {
+            return Polynomial::new(Vec::new());
+        }
+
+        let self_len = self.coefficients.len();
+        let other_len = other.coefficients.len();
+        // `vector_karatsuba` only accepts operands of equal length that halve down to its base
+        // case of eight without ever passing through an odd length greater than eight, i.e.
+        // lengths of the form `m * 2^k` with `m <= 8`. Rounding up to a multiple of the block
+        // size below yields the smallest such length. Trailing zero coefficients do not change
+        // the polynomial they encode, so zero-extending both operands to it leaves the product
+        // unchanged.
+        let n = self_len.max(other_len);
+        let block = n.next_power_of_two().max(8) / 8;
+        let padded_len = n.next_multiple_of(block);
+
+        let mut self_coefficients = self.coefficients.clone();
+        let mut other_coefficients = other.coefficients.clone();
+        self_coefficients.resize(padded_len, F::zero());
+        other_coefficients.resize(padded_len, F::zero());
+
+        let mut product = vector_karatsuba(&self_coefficients, &other_coefficients);
+        // The product of the unpadded operands has degree at most (self_len - 1) + (other_len - 1),
+        // so every coefficient past that index comes from the zero-extension above.
+        product.truncate(self_len + other_len - 1);
+        Polynomial::new(product)
     }
 }
 
@@ -469,6 +499,14 @@ where
     }
 }
 
+/// Multiplies two coefficient vectors of equal length, which must halve down to the base case of
+/// eight without ever passing through an odd length greater than eight.
+///
+/// Halving an odd length greater than eight produces a low half and a high half of different
+/// sizes, which the recursion does not handle: the `zip`s that build the operand sums silently
+/// drop the top coefficient of the longer half, and the accumulation of the high sub-product runs
+/// past the end of the output buffer. Callers must establish both properties;
+/// [`Polynomial::karatsuba`] does so by zero-extending its operands.
 fn vector_karatsuba<
     F: Zero + AddAssign + Mul<Output = F> + Sub<Output = F> + Div<Output = F> + Clone,
 >(
@@ -650,8 +688,29 @@ impl<F: Zeroize> ZeroizeOnDrop for Polynomial<F> {}
 
 #[cfg(test)]
 mod tests {
+    use num::Zero;
+
     use super::{FalconFelt, N, Polynomial};
     use crate::rand::test_utils::prng_array;
+
+    /// Builds a polynomial of the given length with small, non-symmetric coefficients.
+    fn poly(len: usize) -> Polynomial<i64> {
+        Polynomial::new((0..len).map(|i| (i as i64 % 7) - 3).collect())
+    }
+
+    /// Asserts that `karatsuba` agrees with `Mul` coefficient for coefficient, lengths included.
+    fn assert_karatsuba_matches_mul(left_len: usize, right_len: usize) {
+        let left = poly(left_len);
+        let right = poly(right_len);
+
+        let expected = left.clone() * right.clone();
+        let actual = left.karatsuba(&right);
+
+        assert_eq!(
+            actual.coefficients, expected.coefficients,
+            "karatsuba disagrees with Mul for lengths ({left_len}, {right_len})"
+        );
+    }
 
     #[test]
     fn div_zero_by_nonzero_returns_zero() {
@@ -675,5 +734,67 @@ mod tests {
             prod.reduce_by_cyclotomic(N),
             Polynomial::reduce_negacyclic(&Polynomial::mul_modulo_p(&poly1, &poly2))
         );
+    }
+
+    // KARATSUBA
+    // ============================================================================================
+
+    /// A zero operand used to underflow the base case length `left.len() + right.len() - 1`.
+    #[test]
+    fn karatsuba_zero_operand_returns_zero() {
+        let empty = Polynomial::<i64>::new(vec![]);
+        let all_zeros = Polynomial::new(vec![0i64; 9]);
+        let nonzero = poly(3);
+
+        assert!(empty.karatsuba(&empty).is_zero());
+        assert!(empty.karatsuba(&nonzero).is_zero());
+        assert!(nonzero.karatsuba(&empty).is_zero());
+        assert!(all_zeros.karatsuba(&all_zeros).is_zero());
+        assert!(nonzero.karatsuba(&all_zeros).is_zero());
+    }
+
+    /// The smallest operands that used to be silently wrong rather than panicking: `1 * 1`
+    /// returned `1 - x^4`, because the high half of the shorter operand degenerated and the
+    /// `zip`s building the operand sums collapsed with it.
+    #[test]
+    fn karatsuba_of_one_times_one_is_one() {
+        let one_len_9 = Polynomial::new(vec![1i64, 0, 0, 0, 0, 0, 0, 0, 0]);
+        let one_len_4 = Polynomial::new(vec![1i64, 0, 0, 0]);
+
+        assert_eq!(
+            one_len_9.karatsuba(&one_len_4).coefficients,
+            vec![1i64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
+    }
+
+    /// Exhaustive check that `karatsuba` is a drop-in replacement for `Mul` on small operands.
+    ///
+    /// This covers every shape that used to fail below length 25: unequal lengths that sliced the
+    /// shorter operand out of bounds, unequal lengths that returned a wrong product without
+    /// panicking, and equal odd lengths greater than eight whose high sub-product was accumulated
+    /// past the end of the output buffer.
+    #[test]
+    fn karatsuba_matches_mul_for_all_small_shapes() {
+        for left_len in 0..=24 {
+            for right_len in 0..=24 {
+                assert_karatsuba_matches_mul(left_len, right_len);
+            }
+        }
+    }
+
+    /// The same agreement at lengths past the exhaustive sweep: equal powers of two, which are
+    /// what `ntru_solve` and `babai_reduce` pass and for which the zero-extension must be a no-op,
+    /// plus larger unequal and odd lengths.
+    #[test]
+    fn karatsuba_matches_mul_at_larger_boundaries() {
+        for len in [32, 64, 128, 256, 512] {
+            assert_karatsuba_matches_mul(len, len);
+        }
+
+        for (left_len, right_len) in [(32, 5), (512, 7), (36, 36), (65, 65)] {
+            assert_karatsuba_matches_mul(left_len, right_len);
+        }
+
+        assert_eq!(poly(N).karatsuba(&poly(N)).coefficients.len(), 2 * N - 1);
     }
 }


### PR DESCRIPTION
## Rationale

Closes #3575.

`Polynomial::karatsuba` and `Mul::mul` compute the same product, but only
`Mul` handles its operands safely. `karatsuba` passed coefficients straight
to `vector_karatsuba`, which has an unstated precondition: operands must be
of equal length, and that length must halve down to the base case without
ever passing through an odd value greater than 8. Nothing enforced it.

Three failure modes followed. Probing all 1681 length pairs up to 40 through
the public API: 377 correct, 83 silently wrong, 1221 panicking.

The silent case is the serious one. `Polynomial::new(vec![1,0,0,0,0,0,0,0,0])
.karatsuba(&Polynomial::new(vec![1,0,0,0]))` returns `1 - x^4`. The correct
product is `1`. At odd lengths the zips building the operand sums truncate,
and the high sub-product accumulation runs past the end of the buffer.

## Approach

`karatsuba` now mirrors the `Mul` zero guard, zero-extends both operands to
a common admissible length, and truncates the product back to
`a.len() + b.len() - 1` so the output is byte-identical to `Mul`.

Zero-extension is free: trailing zero coefficients don't change the
polynomial. Padding to `max(len)` would not have been enough, since (9,5)
becomes (9,9), which still panics. `karatsuba_admissible_len` rounds up to
the next length that halves cleanly.

`vector_karatsuba` itself is unchanged apart from a doc comment stating the
precondition it always relied on.

## Existing behaviour

`ntru_solve` and `babai_reduce` pass equal power-of-two lengths.
`karatsuba_admissible_len` is the identity on every power of two, so nothing
currently working is padded or reshaped.
`karatsuba_is_unchanged_for_power_of_two_lengths` covers this and passes
both before and after the fix.

## Test plan

Five regression tests, one per failure mode plus an exhaustive check over
all shapes up to 24x24. Each was verified red against the unfixed code with
the failure its name claims.

    cargo test -p miden-crypto --all-features    # 778 passed, 0 failed

Clippy `--all-targets --all-features` clean, rustfmt applied.

## Note on trait bounds

The impl block gained `+ PartialEq` on `F`, required by `is_zero()`. The
adjacent `Mul for Polynomial<F>` already requires it, so no `F` usable with
`*` is affected. Happy to swap the guard for an `is_empty()` check if you'd
rather keep the bounds untouched.
