### PR TITLE
fix(core-lib): preserve the ECDSA verify root

### DIFF
--- a/crates/lib/core/asm/crypto/dsa/ecdsa_k256_keccak.masm
+++ b/crates/lib/core/asm/crypto/dsa/ecdsa_k256_keccak.masm
@@ -53,15 +53,34 @@ use miden::core::word
 #! Invocation: exec
 @locals(24)
 pub proc verify
-    locaddr.0
-    # => [pubkey_ptr=loc[0], PK_COMM, MSG_WORD, ...]
-    exec.load_and_verify_public_key
-    # => [digest_ptr=loc[16], MSG_WORD, ...]
+    # load QX || QY from advice into the verifier public-key buffer while absorbing the same
+    # two chunks into the Poseidon2 `hash_elements` state. Since there are exactly 16 elements,
+    # the `hash_elements` capacity word is zero and no partial-block padding is required.
+    # `adv_pipe` exposes each just-written chunk in the rate slots in the same order that
+    # `mem_stream` would read it back from memory.
+    locaddr.0 padw padw padw
+    # => [R0=0w, R1=0w, C=0w, write_ptr=loc[0], PK_COMM, MSG_WORD, ...]
+    adv_pipe
+    # => [QX_RATE[8], C=0w, write_ptr=loc[8], PK_COMM, MSG_WORD, ...]
+    hperm
+    # => [R0, R1, C, write_ptr=loc[8], PK_COMM, MSG_WORD, ...]
+    adv_pipe
+    # => [QY_RATE[8], C, write_ptr=loc[16], PK_COMM, MSG_WORD, ...]
+    hperm
+    # => [R0, R1, C, write_ptr=loc[16], PK_COMM, MSG_WORD, ...]
+    # assert Poseidon2::hash_elements(QX[8] || QY[8]) == PK_COMM.
+    exec.poseidon2::squeeze_digest
+    # => [PK_HASH, write_ptr=loc[16], PK_COMM, MSG_WORD, ...]
+    movup.4 movdn.8
+    # => [PK_HASH, PK_COMM, write_ptr=loc[16], MSG_WORD, ...]
+    assert_eqw.err="invalid public key commitment"
+    # => [write_ptr=loc[16], MSG_WORD, ...]
 
     movdn.4
     # => [MSG_WORD, digest_ptr=loc[16], ...]
 
-    # Stage MSG_WORD[32] in loc[16..24], hash it in-place via the memory-oriented Keccak precompile.
+    # stage MSG_WORD[32] in loc[16..24], hash it in-place via the memory-oriented Keccak precompile,
+    # then convert the digest bytes into the native little-endian scalar limbs used as ECDSA z.
     exec.store_word_u32s_le
     # => [digest_ptr, ...]  (MSG_U32[8] written to loc[16..24])
 
@@ -70,9 +89,41 @@ pub proc verify
     exec.keccak256::hash_1_chunk_mem
     # => [digest_ptr=loc[16], ...]  (DIGEST_U32[8] written to loc[16..24])
 
-    exec.load_keccak_digest_as_z
-    # => [PREHASH_U32[8], pubkey_ptr=loc[0], ...]
-    exec.verify_digest_impl
+    dup sub.16 swap
+    # => [read_ptr=loc[16], pubkey_ptr=loc[0], ...]
+    repeat.8
+        dup mem_load
+        exec.reverse_u32_bytes
+        swap add.1
+    end
+    # => [read_ptr=loc[24], PREHASH_U32[8], pubkey_ptr, ...]
+    drop
+    # => [PREHASH_U32[8], pubkey_ptr, ...] where PREHASH[0] = byte_reverse(KeccakDigest[7])
+
+    exec.prepare_verify_inputs
+    # => [U1, Q, U2, SIG_R, ...]
+
+    dupw.1
+    # => [Q, U1, Q, U2, SIG_R, ...]
+    exec.secp256k1::push_generator
+    # => [G, Q, U1, Q, U2, SIG_R, ...]
+    exec.word::eq
+    # => [is_q_generator, U1, Q, U2, SIG_R, ...]
+    if.true
+        movupw.2 swapw
+        # => [U1, U2, Q, SIG_R, ...]
+        exec.k1_scalar::add
+        # => [U1_PLUS_U2, Q, SIG_R, ...]
+        swapw dropw
+        # => [U1_PLUS_U2, SIG_R, ...]
+        exec.secp256k1::mul_scalar_generator
+    else
+        exec.secp256k1::push_generator
+        # => [G, U1, Q, U2, SIG_R, ...]
+        exec.secp256k1::msm2
+    end
+    # => [VERIFY_POINT, SIG_R, ...]
+    exec.assert_x_eq_scalar_k1
     # => [...]
 end
 

--- a/crates/lib/core/tests/crypto/dsa.rs
+++ b/crates/lib/core/tests/crypto/dsa.rs
@@ -24,7 +24,7 @@ use rand_chacha::{ChaCha20Rng, rand_core::SeedableRng};
 use crate::helpers::masm_store_felts;
 
 // Core invokes the separately packaged precompile wrappers through dynamic MAST calls.
-const VERIFY_EXPECTED_CYCLES: u64 = 1_584;
+const VERIFY_EXPECTED_CYCLES: u64 = 1_587;
 const VERIFY_EXPECTED_WIRE_ENTRIES: usize = 36;
 const VERIFY_EXPECTED_WIRE_BYTES: usize = 2_455;
 const MESSAGE_PTR: u32 = 128;

--- a/scripts/check-masm-export-digests.rs
+++ b/scripts/check-masm-export-digests.rs
@@ -130,11 +130,10 @@ fn compare_exports(previous: Exports, current: Exports) -> Result<(), String> {
             },
             (None, Some(current_export)) => match current_export {
                 ExportInfo::Procedure(_) => {
-                    eprintln!(
-                        "::error::export added: {name} current={}",
+                    println!(
+                        "::notice::export added: {name} current={}",
                         current_export.describe()
                     );
-                    status = Err("procedure exports changed".to_string());
                 },
                 ExportInfo::Type(_) => {
                     println!("{name} {}", current_export.describe());
@@ -390,6 +389,31 @@ fn normalize(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn procedure(digest: &str) -> ExportInfo {
+        ExportInfo::Procedure(ProcedureInfo {
+            digest: digest.to_string(),
+            signature: None,
+            abi_attributes: BTreeMap::new(),
+        })
+    }
+
+    #[test]
+    fn compare_exports_allows_added_procedure() {
+        let previous = Exports::new();
+        let current = Exports::from([("new_proc".to_string(), procedure("0x01"))]);
+
+        assert_eq!(compare_exports(previous, current), Ok(()));
+    }
+
+    #[test]
+    fn compare_exports_rejects_changed_procedure() {
+        let previous =
+            Exports::from([("existing_proc".to_string(), procedure("0x01"))]);
+        let current = Exports::from([("existing_proc".to_string(), procedure("0x02"))]);
+
+        assert!(compare_exports(previous, current).is_err());
+    }
 
     #[test]
     fn canonicalize_strips_struct_field_labels() {


### PR DESCRIPTION
## Summary

This PR keeps `ecdsa_k256_keccak::verify_bytes` from #3563 and restores the v0.29.0 instruction sequence for `ecdsa_k256_keccak::verify`. The existing `verify` procedure therefore keeps its published root.

The MASM root checker now reports a new procedure export as a notice. It still fails when an existing export changes or disappears. This PR is stacked on #3580 and is an alternative to the full backout in #3581.

