### PR TITLE
fix(utils-indexing): validate CsrMatrix on deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 #### Features
 
 - Added `LinkMode::Analysis` and `Linker::link_analysis`, which commit resolved modules and call edges and report a static recursion cycle as a nonfatal diagnostic (`LinkAnalysis`) instead of rejecting it. Strict linking is unchanged: it still rejects cycles before MAST is built and rolls back on failure ([#3535](https://github.com/0xMiden/miden-vm/pull/3535)).
+- Validated `CsrMatrix` on deserialization, so an `indptr` that does not describe `data` is rejected by `read_from()` instead of panicking later in `row()` ([#3591](https://github.com/0xMiden/miden-vm/issues/3591)).
 
 ## v0.29.0 (2026-08-04)
 

--- a/crates/utils-indexing/src/csr.rs
+++ b/crates/utils-indexing/src/csr.rs
@@ -4,7 +4,7 @@
 //! data. It's commonly used for storing decorator IDs, assembly operation IDs, and similar
 //! sparse mappings in the Miden VM.
 
-use alloc::vec::Vec;
+use alloc::{string::ToString, vec::Vec};
 
 use miden_serde_utils::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
@@ -372,7 +372,15 @@ where
             DeserializationError::InvalidValue("indptr too large for IndexVec".into())
         })?;
 
-        Ok(Self { data, indptr })
+        // `indptr` holds offsets into `data`, and the accessors slice `data` with them without
+        // re-checking. A decoded pair that breaks the structural invariants would therefore panic
+        // in `row()` instead of being reported here.
+        let matrix = Self { data, indptr };
+        matrix
+            .validate()
+            .map_err(|err| DeserializationError::InvalidValue(err.to_string()))?;
+
+        Ok(matrix)
     }
 
     /// Returns the minimum serialized size for a CsrMatrix.
@@ -538,5 +546,51 @@ mod tests {
         let restored: CsrMatrix<TestRowId, u32> = CsrMatrix::read_from(&mut reader).unwrap();
 
         assert_eq!(csr, restored);
+    }
+
+    /// Encodes a matrix in the wire format from raw parts, bypassing [`CsrMatrix::push_row`].
+    fn encode_parts(data: &[u32], indptr: &[usize]) -> Vec<u8> {
+        let mut bytes = vec![];
+        bytes.write_usize(data.len());
+        for value in data {
+            value.write_into(&mut bytes);
+        }
+        bytes.write_usize(indptr.len());
+        for &ptr in indptr {
+            bytes.write_usize(ptr);
+        }
+        bytes
+    }
+
+    fn read_parts(
+        data: &[u32],
+        indptr: &[usize],
+    ) -> Result<CsrMatrix<TestRowId, u32>, DeserializationError> {
+        CsrMatrix::read_from_bytes(&encode_parts(data, indptr))
+    }
+
+    #[test]
+    fn test_read_from_rejects_indptr_past_end_of_data() {
+        // Row 0 would span `data[0..5]`, but no data was encoded.
+        assert!(read_parts(&[], &[0, 5]).is_err());
+    }
+
+    #[test]
+    fn test_read_from_rejects_non_monotonic_indptr() {
+        // Row 1 would span `data[2..1]`, i.e. a reversed range.
+        assert!(read_parts(&[1, 2], &[0, 2, 1]).is_err());
+    }
+
+    #[test]
+    fn test_read_from_rejects_indptr_not_starting_at_zero() {
+        assert!(read_parts(&[1], &[1, 1]).is_err());
+    }
+
+    #[test]
+    fn test_read_from_accepts_a_valid_encoding() {
+        let csr = read_parts(&[1, 2, 3], &[0, 2, 3]).unwrap();
+        assert_eq!(csr.num_rows(), 2);
+        assert_eq!(csr.row(TestRowId::from(0)), Some([1, 2].as_slice()));
+        assert_eq!(csr.row(TestRowId::from(1)), Some([3].as_slice()));
     }
 }


### PR DESCRIPTION
Closes #3591.

### Problem

`CsrMatrix` stores row offsets in `indptr` and row payloads in `data`, and the accessors slice `data` with those offsets without re-checking them. `validate()` documents the invariants that keep that sound: `indptr` starts at 0, is monotonically increasing, and ends at `data.len()`. `push_row()` upholds all three — it seeds `indptr` with `0` and afterwards only pushes `self.data.len()`.

`read_from()` built the value straight from the two decoded vectors:

```rust
Ok(Self { data, indptr })
```

The only rejection was `indptr` being too long for `IndexVec`. A stream whose offsets do not describe `data` was accepted, and the mismatch then surfaced inside `row()`:

```rust
Some(&self.data[start..end])
```

That is an accessor returning `Option`, documented to yield `None` only when the row does not exist. `iter()` and `iter_enumerated()` reach the same line through `row_expect()`.

### Change

`read_from()` now runs the existing validator and maps the failure to `DeserializationError::InvalidValue`, so construction and deserialization agree on the same invariants. Calling `validate()` here is safe on a not-yet-validated matrix: every structural check in `validate_with()` returns before it iterates rows.

Reusing `validate()` rather than open-coding the checks keeps one definition of the invariants, at the cost of one extra pass over `data` with a trivially-true predicate. Happy to swap in a structure-only helper if you would rather not pay that on every decode.

### Test plan

```bash
cargo test -p miden-utils-indexing --all-features
```

Four tests are added next to the existing `test_serialization_roundtrip`, one per invariant plus a positive control:

- `test_read_from_rejects_indptr_past_end_of_data` — `data = []`, `indptr = [0, 5]`; without the fix this decodes and `row(0)` panics with `range end index 5 out of range for slice of length 0`.
- `test_read_from_rejects_non_monotonic_indptr` — `data = [1, 2]`, `indptr = [0, 2, 1]`; without the fix `row(1)` panics with `slice index starts at 2 but ends at 1`.
- `test_read_from_rejects_indptr_not_starting_at_zero` — `data = [1]`, `indptr = [1, 1]`.
- `test_read_from_accepts_a_valid_encoding` — pins that a well-formed encoding still decodes and its rows read back.

Reverting the `validate()` call makes the first three fail: the two panic in `row()`, the third returns `Ok`.

Also verified locally, since the crate builds on Windows:

- `cargo test -p miden-utils-indexing --all-features` — 26 passed (includes the `serde_test` round trips generated from `Arbitrary`)
- `cargo clippy -p miden-utils-indexing --all-targets -- -D warnings` — clean
- `cargo clippy -p miden-utils-indexing --no-default-features -- -D warnings` — clean
- `cargo build -p miden-utils-indexing --no-default-features --target wasm32-unknown-unknown` — clean
- `rustfmt --check` — clean

### Note

Per CONTRIBUTING I am not asking for this to be merged ahead of #3591 being assigned; I put the diff up so it is reviewable alongside the report, and I am happy to close it if you would rather handle this internally. `CsrMatrix` has no in-tree deserializer today, so this is a latent defect rather than a reachable panic — same class as #3559 (merged as #3560) and #3277.
