### PR TITLE
fix(crypto): reject a zero tree depth in MerkleStore::get_leaf_depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 - [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
 - Moved the `read_bounded_len` and `validate_bounded_len` helpers from `miden-core` to `miden-serde-utils`, where they are now public. `miden-core::serde` re-exports them unchanged, and the private duplicates in `miden-utils-indexing` were removed ([#3415](https://github.com/0xMiden/miden-vm/issues/3415)).
+- Fixed `MerkleStore::get_leaf_depth` overflowing its path shift for a `tree_depth` of 0, which now returns `MerkleError::DepthTooSmall` ([#3599](https://github.com/0xMiden/miden-vm/issues/3599)).
+
 #### Features
 
 - Added `LinkMode::Analysis` and `Linker::link_analysis`, which commit resolved modules and call edges and report a static recursion cycle as a nonfatal diagnostic (`LinkAnalysis`) instead of rejecting it. Strict linking is unchanged: it still rejects cycles before MAST is built and rolls back on failure ([#3535](https://github.com/0xMiden/miden-vm/pull/3535)).

--- a/crates/crypto/src/merkle/store/mod.rs
+++ b/crates/crypto/src/merkle/store/mod.rs
@@ -224,6 +224,7 @@ impl MerkleStore {
     /// # Errors
     /// Will return an error if:
     /// - The provided root is not found.
+    /// - The provided `tree_depth` is smaller than 1.
     /// - The provided `tree_depth` is greater than 64.
     /// - The provided `index` is not valid for a depth equivalent to `tree_depth`.
     /// - No leaf or an empty node was found while traversing the tree down to `tree_depth`.
@@ -234,6 +235,9 @@ impl MerkleStore {
         index: u64,
     ) -> Result<u8, MerkleError> {
         // validate depth and index
+        if tree_depth == 0 {
+            return Err(MerkleError::DepthTooSmall(tree_depth));
+        }
         if tree_depth > 64 {
             return Err(MerkleError::DepthTooBig(tree_depth as u64));
         }
@@ -247,6 +251,8 @@ impl MerkleStore {
         }
 
         // we traverse from root to leaf, so the path is reversed
+        //
+        // `tree_depth` is at least 1 here, so the shift stays below the width of `u64`.
         let mut path = (index << (64 - tree_depth)).reverse_bits();
 
         // iterate every depth and reconstruct the path from root to leaf

--- a/crates/crypto/src/merkle/store/tests.rs
+++ b/crates/crypto/src/merkle/store/tests.rs
@@ -712,6 +712,22 @@ fn node_path_should_be_truncated_by_midtier_insert() {
 // ================================================================================================
 
 #[test]
+fn get_leaf_depth_rejects_depth_zero() {
+    let mut store = MerkleStore::new();
+    let empty_root: Word = EmptySubtreeRoots::empty_hashes(64)[0];
+
+    // put the root in the store so that the depth check is what rejects the call
+    let index = NodeIndex::new(64, 0).unwrap();
+    let node = Word::from([Felt::new_unchecked(1); Word::NUM_ELEMENTS]);
+    let root = store.set_node(empty_root, index, node).unwrap().root;
+
+    // `64 - tree_depth` is the shift used to build the traversal path, so a depth of 0 would
+    // shift by the full width of a `u64`.
+    let err = store.get_leaf_depth(root, 0, 0).unwrap_err();
+    assert_matches!(err, MerkleError::DepthTooSmall(0));
+}
+
+#[test]
 fn get_leaf_depth_works_depth_64() {
     let mut store = MerkleStore::new();
     let mut root: Word = EmptySubtreeRoots::empty_hashes(64)[0];


### PR DESCRIPTION
Closes #3599.

### Problem

`MerkleStore::get_leaf_depth` builds the root-to-leaf path by shifting the index up to the top of a `u64`:

```rust
let mut path = (index << (64 - tree_depth)).reverse_bits();
```

`tree_depth` is a `u8`, so a `tree_depth` of 0 shifts by 64 — the full width of the shifted type. That is an arithmetic overflow: it panics with `attempt to shift left with overflow` in debug builds, and in release builds the shift amount is masked, so it silently computes `index << 0` instead.

Nothing rejected the value before reaching that line:

- the upper-bound check only covers `tree_depth > 64`;
- `NodeIndex::new(0, 0)` is `Ok`, because depth 0 is the root index and `64 - 0u64.leading_zeros() == 0` does not exceed `0`;
- the `# Errors` list documented four conditions, none of them a depth below 1, and the method says the maximum accepted `tree_depth` is `u64::BITS`.

So any root present in the store reached the shift. Only `tree_depth == 0` is affected — `1..=64` give shift amounts of `63..=0`.

### Change

Reject a zero depth alongside the existing upper-bound check, and document it:

```rust
if tree_depth == 0 {
    return Err(MerkleError::DepthTooSmall(tree_depth));
}
```

`MerkleError::DepthTooSmall` already exists for this case and is what the rest of the crate returns for an undersized tree depth (`MerkleTree::new`, `PartialMerkleTree::add_path`, `SimpleSmt::new`, `SparseMerkleTree`), and `SMT_MIN_DEPTH` is `1`. I also left a note on the shift itself recording that `tree_depth` is at least 1 by that point.

### Test plan

```bash
cargo test -p miden-crypto --lib merkle::store
```

`get_leaf_depth_rejects_depth_zero` is added next to the existing `get_leaf_depth_*` tests. It inserts a node first so the root is present in the store — otherwise the pre-existing root lookup would return `RootNotInStore` before the shift is reached, and the test would pass without the fix. With the `tree_depth == 0` check reverted, the test panics with `attempt to shift left with overflow`; with it, the call returns `MerkleError::DepthTooSmall(0)`.

The overflow itself is not a judgement call — `rustc` rejects the same expression at compile time when the operands are constants:

```rust
pub const TREE_DEPTH: u8 = 0;
pub const INDEX: u64 = 0;
pub const PATH: u64 = INDEX << (64 - TREE_DEPTH);
```

```
error[E0080]: attempt to shift left by `64_u8`, which would overflow
 --> shiftproof.rs:4:23
  |
4 | pub const PATH: u64 = INDEX << (64 - TREE_DEPTH);
  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `PATH` failed here
```

One caveat I want to be upfront about: I verified formatting with `rustfmt --check` and the overflow with the `rustc` snippet above, but I could not compile or run `miden-crypto` locally for this change — Windows Smart App Control started blocking freshly built `build.rs` executables on this machine (`os error 4551`), so the crate does not build here at the moment. I am relying on this PR's CI for the compile and test run, and I will follow up promptly on anything it flags.

### Note

Per CONTRIBUTING I am not asking for this to be merged ahead of #3599 being assigned; I put the diff up so it is reviewable alongside the report, and I am happy to close it if you would rather handle this internally. `get_leaf_depth` has had no in-tree caller since the `AdviceProvider::get_leaf_depth()` wrapper was removed in #1905, so this is a latent defect rather than a reachable panic; the line dates to the method's introduction in April 2023.
