### PR TITLE
feat(debug): define typed variable locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 #### Features
 
 - [BREAKING] Added inline call-chain metadata to package source maps so debuggers can reconstruct inlined stack frames, and preserved source-node context during stepped execution. This extends public assembly instruction and processor continuation enums, so downstream exhaustive matches must handle the new debug metadata ([#3427](https://github.com/0xMiden/miden-vm/pull/3427)).
+- [BREAKING] Replaced source-specific and opaque debug variable locations with explicit unavailable
+  locations, tagged Miden frame bases, and bounded structured Miden-runtime expressions. This bumps
+  the package debug-info wire format to version 3.
 - [BREAKING] Added `trace`, `trace.CONST`, and `trace.event("...")` assembly as syntactic sugar for emitting optional read-only trace events. This adds variants `Trace` and `TraceImm` to the public enum `miden_assembly_syntax::ast::Instruction` ([#3478](https://github.com/0xMiden/miden-vm/pull/3478)).
 - Added `Mmr::nodes_from(start)`, returning the MMR's nodes at indices `start..` in insertion (postorder) order ([#3585](https://github.com/0xMiden/miden-vm/pull/3585)).
 - [BREAKING] Added `Mmr::from_nodes_unchecked(forest, nodes)`, constructing an MMR from its complete postorder node array without recomputing hashes ([#3585](https://github.com/0xMiden/miden-vm/pull/3585)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@
 
 #### Changes
 
-- Added explicit unavailable and tagged Miden frame-base debug variable locations, replacing private compiler/debugger expression encodings for new packages and bumping the package debug-info wire format to version 3.
+- Added explicit unavailable and tagged Miden frame-base debug variable locations, plus a structured Miden-runtime expression fallback for compound locations. This replaces private compiler/debugger expression encodings for new packages and bumps the package debug-info wire format to version 3.
 
 ## v0.29.1 (2026-08-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@
 #### Changes
 
 - [BREAKING] Added inline call-chain metadata to package source maps so debuggers can reconstruct inlined stack frames, and preserved source-node context during stepped execution. This extends public assembly instruction and processor continuation enums, so downstream exhaustive matches must handle the new debug metadata ([#3427](https://github.com/0xMiden/miden-vm/pull/3427)).
+## v0.29.2 (Unreleased)
+
+#### Changes
+
+- Added explicit unavailable and tagged Miden frame-base debug variable locations, replacing private compiler/debugger expression encodings for new packages and bumping the package debug-info wire format to version 3.
 
 ## v0.29.1 (2026-08-11)
 

--- a/crates/assembly-syntax/src/ast/instruction/debug_var.rs
+++ b/crates/assembly-syntax/src/ast/instruction/debug_var.rs
@@ -1,4 +1,4 @@
-use alloc::{format, sync::Arc, vec::Vec};
+use alloc::{format, string::ToString, sync::Arc, vec::Vec};
 use core::{fmt, num::NonZeroU32};
 
 use miden_core::serde::{
@@ -146,15 +146,47 @@ pub enum DebugFrameBase {
 /// simple [`DebugVarLocation`] variants. Producers must resolve source-specific coordinates, such
 /// as Wasm local/global indices, before constructing this expression.
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct DebugLocationExpression {
     operations: Vec<DebugLocationExpressionOp>,
 }
 
+/// Error returned when a structured debug location expression exceeds the wire-format limit.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error(
+    "debug location expression has {operation_count} operations, but at most {MAX_DEBUG_LOCATION_EXPRESSION_OPS} are supported"
+)]
+pub struct DebugLocationExpressionError {
+    operation_count: usize,
+}
+
+impl DebugLocationExpressionError {
+    /// Returns the rejected operation count.
+    pub fn operation_count(&self) -> usize {
+        self.operation_count
+    }
+}
+
+#[cfg(feature = "serde")]
+#[derive(Deserialize)]
+struct DebugLocationExpressionSerde {
+    operations: Vec<DebugLocationExpressionOp>,
+}
+
+const MAX_DEBUG_LOCATION_EXPRESSION_OPS: usize = 256;
+
 impl DebugLocationExpression {
     /// Creates a location expression from runtime-resolved operations.
-    pub fn new(operations: Vec<DebugLocationExpressionOp>) -> Self {
-        Self { operations }
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the expression exceeds the maximum operation count accepted by the
+    /// package wire format.
+    pub fn new(
+        operations: Vec<DebugLocationExpressionOp>,
+    ) -> Result<Self, DebugLocationExpressionError> {
+        validate_debug_location_expression_len(operations.len())?;
+        Ok(Self { operations })
     }
 
     /// Returns the operations in evaluation order.
@@ -165,6 +197,17 @@ impl DebugLocationExpression {
     /// Returns true if this expression contains no operations.
     pub fn is_empty(&self) -> bool {
         self.operations.is_empty()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for DebugLocationExpression {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let expression = DebugLocationExpressionSerde::deserialize(deserializer)?;
+        Self::new(expression.operations).map_err(serde::de::Error::custom)
     }
 }
 
@@ -350,16 +393,27 @@ impl Serializable for DebugLocationExpression {
 impl Deserializable for DebugLocationExpression {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let count = read_bounded_len(source, "debug location expression operations", 1)?;
-        let mut operations = Vec::with_capacity(count);
+        validate_debug_location_expression_len(count)
+            .map_err(|error| DeserializationError::InvalidValue(error.to_string()))?;
+        let mut operations = Vec::with_capacity(count.min(8));
         for _ in 0..count {
             operations.push(DebugLocationExpressionOp::read_from(source)?);
         }
-        Ok(Self::new(operations))
+        Ok(Self { operations })
     }
 
     fn min_serialized_size() -> usize {
         usize::min_serialized_size()
     }
+}
+
+fn validate_debug_location_expression_len(
+    operation_count: usize,
+) -> Result<(), DebugLocationExpressionError> {
+    if operation_count > MAX_DEBUG_LOCATION_EXPRESSION_OPS {
+        return Err(DebugLocationExpressionError { operation_count });
+    }
+    Ok(())
 }
 
 impl Serializable for DebugLocationExpressionOp {
@@ -503,14 +557,17 @@ mod tests {
         );
         assert_eq!(DebugVarLocation::Unavailable.to_string(), "unavailable");
         assert_eq!(
-            DebugVarLocation::Expression(DebugLocationExpression::new(vec![
-                DebugLocationExpressionOp::FrameBaseAddress {
-                    base: DebugFrameBase::Local(-2),
-                    byte_offset: 4,
-                },
-                DebugLocationExpressionOp::AddUnsigned(8),
-                DebugLocationExpressionOp::DerefBytes,
-            ]))
+            DebugVarLocation::Expression(
+                DebugLocationExpression::new(vec![
+                    DebugLocationExpressionOp::FrameBaseAddress {
+                        base: DebugFrameBase::Local(-2),
+                        byte_offset: 4,
+                    },
+                    DebugLocationExpressionOp::AddUnsigned(8),
+                    DebugLocationExpressionOp::DerefBytes,
+                ])
+                .unwrap(),
+            )
             .to_string(),
             "expr([FrameBaseAddress { base: Local(-2), byte_offset: 4 }, AddUnsigned(8), DerefBytes])"
         );
@@ -532,12 +589,15 @@ mod tests {
                 base: DebugFrameBase::Memory(100),
                 byte_offset: -16,
             },
-            DebugVarLocation::Expression(DebugLocationExpression::new(vec![
-                DebugLocationExpressionOp::ReadStack(2),
-                DebugLocationExpressionOp::ConstI64(-4),
-                DebugLocationExpressionOp::Add,
-                DebugLocationExpressionOp::DerefBytes,
-            ])),
+            DebugVarLocation::Expression(
+                DebugLocationExpression::new(vec![
+                    DebugLocationExpressionOp::ReadStack(2),
+                    DebugLocationExpressionOp::ConstI64(-4),
+                    DebugLocationExpressionOp::Add,
+                    DebugLocationExpressionOp::DerefBytes,
+                ])
+                .unwrap(),
+            ),
         ];
 
         for loc in &locations {
@@ -575,6 +635,30 @@ mod tests {
     }
 
     #[test]
+    fn debug_location_expression_caps_operation_count_before_allocation() {
+        let count = MAX_DEBUG_LOCATION_EXPRESSION_OPS + 1;
+        let mut bytes = Vec::new();
+        bytes.write_usize(count);
+        bytes.resize(bytes.len() + count, 0);
+
+        let mut reader = SliceReader::new(&bytes);
+        let err = DebugLocationExpression::read_from(&mut reader).unwrap_err();
+        let DeserializationError::InvalidValue(message) = err else {
+            panic!("expected InvalidValue error");
+        };
+        assert!(message.contains("at most 256"));
+    }
+
+    #[test]
+    fn debug_location_expression_constructor_rejects_oversized_input() {
+        let operations =
+            vec![DebugLocationExpressionOp::Add; MAX_DEBUG_LOCATION_EXPRESSION_OPS + 1];
+        let error = DebugLocationExpression::new(operations).unwrap_err();
+
+        assert_eq!(error.operation_count(), MAX_DEBUG_LOCATION_EXPRESSION_OPS + 1);
+    }
+
+    #[test]
     fn debug_var_info_set_value_location() {
         let mut var = DebugVarInfo::new("x", DebugVarLocation::Stack(0));
         var.set_value_location(DebugVarLocation::ResolvedFrameBase {
@@ -588,5 +672,30 @@ mod tests {
                 byte_offset: 12,
             }
         );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_round_trips_location_expressions() {
+        let expression = DebugLocationExpression::new(vec![
+            DebugLocationExpressionOp::ReadLocal(-2),
+            DebugLocationExpressionOp::DerefBytes,
+        ])
+        .unwrap();
+        let json = serde_json::to_string(&expression).unwrap();
+
+        assert_eq!(serde_json::from_str::<DebugLocationExpression>(&json).unwrap(), expression);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_rejects_oversized_location_expressions() {
+        let expression = DebugLocationExpression {
+            operations: vec![DebugLocationExpressionOp::Add; MAX_DEBUG_LOCATION_EXPRESSION_OPS + 1],
+        };
+        let json = serde_json::to_string(&expression).unwrap();
+        let error = serde_json::from_str::<DebugLocationExpression>(&json).unwrap_err();
+
+        assert!(error.to_string().contains("at most 256"));
     }
 }

--- a/crates/assembly-syntax/src/ast/instruction/debug_var.rs
+++ b/crates/assembly-syntax/src/ast/instruction/debug_var.rs
@@ -170,7 +170,55 @@ impl DebugLocationExpressionError {
 #[cfg(feature = "serde")]
 #[derive(Deserialize)]
 struct DebugLocationExpressionSerde {
+    #[serde(deserialize_with = "deserialize_debug_location_expression_operations")]
     operations: Vec<DebugLocationExpressionOp>,
+}
+
+#[cfg(feature = "serde")]
+fn deserialize_debug_location_expression_operations<'de, D>(
+    deserializer: D,
+) -> Result<Vec<DebugLocationExpressionOp>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct OperationsVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for OperationsVisitor {
+        type Value = Vec<DebugLocationExpressionOp>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                formatter,
+                "at most {MAX_DEBUG_LOCATION_EXPRESSION_OPS} debug location operations"
+            )
+        }
+
+        fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            if let Some(operation_count) = sequence.size_hint()
+                && operation_count > MAX_DEBUG_LOCATION_EXPRESSION_OPS
+            {
+                return Err(serde::de::Error::custom(DebugLocationExpressionError {
+                    operation_count,
+                }));
+            }
+
+            let mut operations = Vec::with_capacity(sequence.size_hint().unwrap_or(0).min(8));
+            while let Some(operation) = sequence.next_element()? {
+                if operations.len() == MAX_DEBUG_LOCATION_EXPRESSION_OPS {
+                    return Err(serde::de::Error::custom(DebugLocationExpressionError {
+                        operation_count: operations.len() + 1,
+                    }));
+                }
+                operations.push(operation);
+            }
+            Ok(operations)
+        }
+    }
+
+    deserializer.deserialize_seq(OperationsVisitor)
 }
 
 const MAX_DEBUG_LOCATION_EXPRESSION_OPS: usize = 256;

--- a/crates/assembly-syntax/src/ast/instruction/debug_var.rs
+++ b/crates/assembly-syntax/src/ast/instruction/debug_var.rs
@@ -293,7 +293,7 @@ impl Serializable for DebugVarLocation {
             },
             Self::ResolvedFrameBase { base, byte_offset } => {
                 target.write_u8(5);
-                write_debug_frame_base(base, target);
+                write_debug_frame_base(*base, target);
                 target.write_bytes(&byte_offset.to_le_bytes());
             },
             Self::Expression(expression) => {
@@ -394,7 +394,7 @@ impl Serializable for DebugLocationExpressionOp {
             Self::DerefBytes => target.write_u8(8),
             Self::FrameBaseAddress { base, byte_offset } => {
                 target.write_u8(9);
-                write_debug_frame_base(base, target);
+                write_debug_frame_base(*base, target);
                 target.write_bytes(&byte_offset.to_le_bytes());
             },
         }
@@ -429,7 +429,7 @@ impl Deserializable for DebugLocationExpressionOp {
     }
 }
 
-fn write_debug_frame_base<W: ByteWriter>(base: &DebugFrameBase, target: &mut W) {
+fn write_debug_frame_base<W: ByteWriter>(base: DebugFrameBase, target: &mut W) {
     match base {
         DebugFrameBase::Local(offset) => {
             target.write_u8(0);
@@ -437,7 +437,7 @@ fn write_debug_frame_base<W: ByteWriter>(base: &DebugFrameBase, target: &mut W) 
         },
         DebugFrameBase::Memory(address) => {
             target.write_u8(1);
-            target.write_u32(*address);
+            target.write_u32(address);
         },
     }
 }

--- a/crates/assembly-syntax/src/ast/instruction/debug_var.rs
+++ b/crates/assembly-syntax/src/ast/instruction/debug_var.rs
@@ -1,8 +1,8 @@
-use alloc::{format, sync::Arc};
+use alloc::{format, sync::Arc, vec::Vec};
 use core::{fmt, num::NonZeroU32};
 
 use miden_core::serde::{
-    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, read_bounded_len,
 };
 use miden_debug_types::Location;
 
@@ -140,6 +140,71 @@ pub enum DebugFrameBase {
     Memory(u32),
 }
 
+/// A location expression in Miden runtime coordinates.
+///
+/// This is the package-level escape hatch for locations which cannot be represented by one of the
+/// simple [`DebugVarLocation`] variants. Producers must resolve source-specific coordinates, such
+/// as Wasm local/global indices, before constructing this expression.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DebugLocationExpression {
+    operations: Vec<DebugLocationExpressionOp>,
+}
+
+impl DebugLocationExpression {
+    /// Creates a location expression from runtime-resolved operations.
+    pub fn new(operations: Vec<DebugLocationExpressionOp>) -> Self {
+        Self { operations }
+    }
+
+    /// Returns the operations in evaluation order.
+    pub fn operations(&self) -> &[DebugLocationExpressionOp] {
+        &self.operations
+    }
+
+    /// Returns true if this expression contains no operations.
+    pub fn is_empty(&self) -> bool {
+        self.operations.is_empty()
+    }
+}
+
+/// An operation in a [`DebugLocationExpression`].
+///
+/// Operations evaluate on a signed integer stack. Read operations push canonical field element
+/// values as integers, arithmetic operations transform those values, and the final integer is
+/// converted back to a field element. Invalid arithmetic or field conversions make the location
+/// unavailable rather than wrapping.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum DebugLocationExpressionOp {
+    /// Push the value at this Miden operand-stack position (0 is the top).
+    ReadStack(u8),
+    /// Push the value stored at this Miden memory element address.
+    ReadMemory(u32),
+    /// Push the value stored at this signed FMP-relative local offset.
+    ReadLocal(i16),
+    /// Push an unsigned integer constant.
+    ConstU64(u64),
+    /// Push a signed integer constant.
+    ConstI64(i64),
+    /// Add an unsigned integer constant to the top value.
+    AddUnsigned(u64),
+    /// Pop two values and push `lhs + rhs`.
+    Add,
+    /// Pop two values and push `lhs - rhs`.
+    Sub,
+    /// Interpret the top value as a Wasm byte address, convert it to a Miden element address, and
+    /// push the value stored at that address.
+    DerefBytes,
+    /// Resolve and push a byte address relative to a runtime frame base.
+    FrameBaseAddress {
+        /// Resolved location containing the frame-base byte address.
+        base: DebugFrameBase,
+        /// Byte offset from the base.
+        byte_offset: i64,
+    },
+}
+
 /// Describes where a variable's value can be found during execution.
 ///
 /// This enum models the different ways a variable's value might be stored
@@ -172,6 +237,8 @@ pub enum DebugVarLocation {
         /// Byte offset from the base (may be positive or negative).
         byte_offset: i64,
     },
+    /// A compound location expressed entirely in Miden runtime coordinates.
+    Expression(DebugLocationExpression),
 }
 
 impl fmt::Display for DebugVarLocation {
@@ -189,6 +256,11 @@ impl fmt::Display for DebugVarLocation {
                 DebugFrameBase::Memory(address) => {
                     write!(f, "frame-base(mem[{address}]){byte_offset:+}")
                 },
+            },
+            Self::Expression(expression) => {
+                f.write_str("expr(")?;
+                f.debug_list().entries(expression.operations()).finish()?;
+                f.write_str(")")
             },
         }
     }
@@ -221,17 +293,12 @@ impl Serializable for DebugVarLocation {
             },
             Self::ResolvedFrameBase { base, byte_offset } => {
                 target.write_u8(5);
-                match base {
-                    DebugFrameBase::Local(offset) => {
-                        target.write_u8(0);
-                        target.write_bytes(&offset.to_le_bytes());
-                    },
-                    DebugFrameBase::Memory(address) => {
-                        target.write_u8(1);
-                        target.write_u32(*address);
-                    },
-                }
+                write_debug_frame_base(base, target);
                 target.write_bytes(&byte_offset.to_le_bytes());
+            },
+            Self::Expression(expression) => {
+                target.write_u8(6);
+                expression.write_into(target);
             },
         }
     }
@@ -253,22 +320,12 @@ impl Deserializable for DebugVarLocation {
             },
             4 => Ok(Self::Unavailable),
             5 => {
-                let base = match source.read_u8()? {
-                    0 => {
-                        let bytes = source.read_array::<2>()?;
-                        DebugFrameBase::Local(i16::from_le_bytes(bytes))
-                    },
-                    1 => DebugFrameBase::Memory(source.read_u32()?),
-                    tag => {
-                        return Err(DeserializationError::InvalidValue(format!(
-                            "invalid resolved debug frame-base tag: {tag}"
-                        )));
-                    },
-                };
+                let base = read_debug_frame_base(source)?;
                 let bytes = source.read_array::<8>()?;
                 let byte_offset = i64::from_le_bytes(bytes);
                 Ok(Self::ResolvedFrameBase { base, byte_offset })
             },
+            6 => Ok(Self::Expression(DebugLocationExpression::read_from(source)?)),
             _ => Err(DeserializationError::InvalidValue(format!(
                 "invalid DebugVarLocation tag: {tag}"
             ))),
@@ -278,6 +335,122 @@ impl Deserializable for DebugVarLocation {
     fn min_serialized_size() -> usize {
         // `Unavailable` is encoded as a one-byte tag with no payload.
         u8::min_serialized_size()
+    }
+}
+
+impl Serializable for DebugLocationExpression {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        target.write_usize(self.operations.len());
+        for operation in &self.operations {
+            operation.write_into(target);
+        }
+    }
+}
+
+impl Deserializable for DebugLocationExpression {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        let count = read_bounded_len(source, "debug location expression operations", 1)?;
+        let mut operations = Vec::with_capacity(count);
+        for _ in 0..count {
+            operations.push(DebugLocationExpressionOp::read_from(source)?);
+        }
+        Ok(Self::new(operations))
+    }
+
+    fn min_serialized_size() -> usize {
+        usize::min_serialized_size()
+    }
+}
+
+impl Serializable for DebugLocationExpressionOp {
+    fn write_into<W: ByteWriter>(&self, target: &mut W) {
+        match self {
+            Self::ReadStack(position) => {
+                target.write_u8(0);
+                target.write_u8(*position);
+            },
+            Self::ReadMemory(address) => {
+                target.write_u8(1);
+                target.write_u32(*address);
+            },
+            Self::ReadLocal(offset) => {
+                target.write_u8(2);
+                target.write_bytes(&offset.to_le_bytes());
+            },
+            Self::ConstU64(value) => {
+                target.write_u8(3);
+                target.write_u64(*value);
+            },
+            Self::ConstI64(value) => {
+                target.write_u8(4);
+                target.write_bytes(&value.to_le_bytes());
+            },
+            Self::AddUnsigned(value) => {
+                target.write_u8(5);
+                target.write_u64(*value);
+            },
+            Self::Add => target.write_u8(6),
+            Self::Sub => target.write_u8(7),
+            Self::DerefBytes => target.write_u8(8),
+            Self::FrameBaseAddress { base, byte_offset } => {
+                target.write_u8(9);
+                write_debug_frame_base(base, target);
+                target.write_bytes(&byte_offset.to_le_bytes());
+            },
+        }
+    }
+}
+
+impl Deserializable for DebugLocationExpressionOp {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
+        match source.read_u8()? {
+            0 => Ok(Self::ReadStack(source.read_u8()?)),
+            1 => Ok(Self::ReadMemory(source.read_u32()?)),
+            2 => Ok(Self::ReadLocal(i16::from_le_bytes(source.read_array::<2>()?))),
+            3 => Ok(Self::ConstU64(source.read_u64()?)),
+            4 => Ok(Self::ConstI64(i64::from_le_bytes(source.read_array::<8>()?))),
+            5 => Ok(Self::AddUnsigned(source.read_u64()?)),
+            6 => Ok(Self::Add),
+            7 => Ok(Self::Sub),
+            8 => Ok(Self::DerefBytes),
+            9 => {
+                let base = read_debug_frame_base(source)?;
+                let byte_offset = i64::from_le_bytes(source.read_array::<8>()?);
+                Ok(Self::FrameBaseAddress { base, byte_offset })
+            },
+            tag => Err(DeserializationError::InvalidValue(format!(
+                "invalid DebugLocationExpressionOp tag: {tag}"
+            ))),
+        }
+    }
+
+    fn min_serialized_size() -> usize {
+        u8::min_serialized_size()
+    }
+}
+
+fn write_debug_frame_base<W: ByteWriter>(base: &DebugFrameBase, target: &mut W) {
+    match base {
+        DebugFrameBase::Local(offset) => {
+            target.write_u8(0);
+            target.write_bytes(&offset.to_le_bytes());
+        },
+        DebugFrameBase::Memory(address) => {
+            target.write_u8(1);
+            target.write_u32(*address);
+        },
+    }
+}
+
+fn read_debug_frame_base<R: ByteReader>(
+    source: &mut R,
+) -> Result<DebugFrameBase, DeserializationError> {
+    match source.read_u8()? {
+        0 => Ok(DebugFrameBase::Local(i16::from_le_bytes(source.read_array::<2>()?))),
+        1 => Ok(DebugFrameBase::Memory(source.read_u32()?)),
+        tag => Err(DeserializationError::InvalidValue(format!(
+            "invalid resolved debug frame-base tag: {tag}"
+        ))),
     }
 }
 
@@ -329,6 +502,18 @@ mod tests {
             "frame-base(FMP-3)+12"
         );
         assert_eq!(DebugVarLocation::Unavailable.to_string(), "unavailable");
+        assert_eq!(
+            DebugVarLocation::Expression(DebugLocationExpression::new(vec![
+                DebugLocationExpressionOp::FrameBaseAddress {
+                    base: DebugFrameBase::Local(-2),
+                    byte_offset: 4,
+                },
+                DebugLocationExpressionOp::AddUnsigned(8),
+                DebugLocationExpressionOp::DerefBytes,
+            ]))
+            .to_string(),
+            "expr([FrameBaseAddress { base: Local(-2), byte_offset: 4 }, AddUnsigned(8), DerefBytes])"
+        );
     }
 
     #[test]
@@ -347,6 +532,12 @@ mod tests {
                 base: DebugFrameBase::Memory(100),
                 byte_offset: -16,
             },
+            DebugVarLocation::Expression(DebugLocationExpression::new(vec![
+                DebugLocationExpressionOp::ReadStack(2),
+                DebugLocationExpressionOp::ConstI64(-4),
+                DebugLocationExpressionOp::Add,
+                DebugLocationExpressionOp::DerefBytes,
+            ])),
         ];
 
         for loc in &locations {
@@ -367,6 +558,20 @@ mod tests {
 
         assert_eq!(min_serialized_size, 1);
         assert_eq!(bytes.len(), min_serialized_size);
+    }
+
+    #[test]
+    fn debug_location_expression_rejects_unknown_operation() {
+        let mut bytes = Vec::new();
+        bytes.write_usize(1);
+        bytes.write_u8(u8::MAX);
+
+        let mut reader = SliceReader::new(&bytes);
+        let err = DebugLocationExpression::read_from(&mut reader).unwrap_err();
+        let DeserializationError::InvalidValue(message) = err else {
+            panic!("expected InvalidValue error");
+        };
+        assert!(message.contains("invalid DebugLocationExpressionOp tag"));
     }
 
     #[test]

--- a/crates/assembly-syntax/src/ast/instruction/debug_var.rs
+++ b/crates/assembly-syntax/src/ast/instruction/debug_var.rs
@@ -1,8 +1,8 @@
-use alloc::{format, sync::Arc, vec::Vec};
+use alloc::{format, sync::Arc};
 use core::{fmt, num::NonZeroU32};
 
 use miden_core::serde::{
-    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, read_bounded_len,
+    ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
 };
 use miden_debug_types::Location;
 
@@ -130,6 +130,16 @@ impl fmt::Display for DebugVarInfo {
 // DEBUG VARIABLE LOCATION
 // ================================================================================================
 
+/// A frame base resolved into Miden execution coordinates.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum DebugFrameBase {
+    /// The base value is stored in local memory at this signed FMP-relative offset.
+    Local(i16),
+    /// The base value is stored at this Miden memory element address.
+    Memory(u32),
+}
+
 /// Describes where a variable's value can be found during execution.
 ///
 /// This enum models the different ways a variable's value might be stored
@@ -149,22 +159,19 @@ pub enum DebugVarLocation {
     /// where offset is typically negative (locals are below FMP).
     /// For example, with 3 locals: local\[0\] has offset -3, local\[2\] has offset -1.
     Local(i16),
-    /// Variable is in WASM linear memory at an address computed from a global base
-    /// plus a byte offset: `value_of(global[global_index]) + byte_offset`.
+    /// The variable has no representable location at this program point.
+    Unavailable,
+    /// Variable is in Wasm linear memory at `value_of(base) + byte_offset`.
     ///
-    /// This corresponds to DWARF's `DW_OP_fbreg` where the frame base is a WASM
-    /// global (typically `__stack_pointer`). The byte offset is divided by the
-    /// element size (4 for i32) to get the Miden memory element address.
-    FrameBase {
-        /// WASM global index whose runtime value provides the base address.
-        global_index: u32,
+    /// The base is expressed entirely in Miden execution coordinates. Its runtime value and the
+    /// offset are byte addresses; the debugger converts the resulting address to a Miden memory
+    /// element address before reading the variable.
+    ResolvedFrameBase {
+        /// Resolved location containing the frame-base byte address.
+        base: DebugFrameBase,
         /// Byte offset from the base (may be positive or negative).
         byte_offset: i64,
     },
-    /// Complex location described by expression bytes.
-    /// This is used for variables that require computation to locate,
-    /// such as struct fields or array elements.
-    Expression(Vec<u8>),
 }
 
 impl fmt::Display for DebugVarLocation {
@@ -174,18 +181,14 @@ impl fmt::Display for DebugVarLocation {
             Self::Memory(addr) => write!(f, "mem[{addr}]"),
             Self::Const(val) => write!(f, "const({})", val.as_canonical_u64()),
             Self::Local(offset) => write!(f, "FMP{offset:+}"),
-            Self::FrameBase { global_index, byte_offset } => {
-                write!(f, "global[{global_index}]{byte_offset:+}")
-            },
-            Self::Expression(bytes) => {
-                write!(f, "expr(")?;
-                for (i, byte) in bytes.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, " ")?;
-                    }
-                    write!(f, "{byte:02x}")?;
-                }
-                write!(f, ")")
+            Self::Unavailable => f.write_str("unavailable"),
+            Self::ResolvedFrameBase { base, byte_offset } => match base {
+                DebugFrameBase::Local(offset) => {
+                    write!(f, "frame-base(FMP{offset:+}){byte_offset:+}")
+                },
+                DebugFrameBase::Memory(address) => {
+                    write!(f, "frame-base(mem[{address}]){byte_offset:+}")
+                },
             },
         }
     }
@@ -213,13 +216,21 @@ impl Serializable for DebugVarLocation {
                 target.write_u8(3);
                 target.write_bytes(&offset.to_le_bytes());
             },
-            Self::Expression(bytes) => {
+            Self::Unavailable => {
                 target.write_u8(4);
-                bytes.write_into(target);
             },
-            Self::FrameBase { global_index, byte_offset } => {
+            Self::ResolvedFrameBase { base, byte_offset } => {
                 target.write_u8(5);
-                target.write_u32(*global_index);
+                match base {
+                    DebugFrameBase::Local(offset) => {
+                        target.write_u8(0);
+                        target.write_bytes(&offset.to_le_bytes());
+                    },
+                    DebugFrameBase::Memory(address) => {
+                        target.write_u8(1);
+                        target.write_u32(*address);
+                    },
+                }
                 target.write_bytes(&byte_offset.to_le_bytes());
             },
         }
@@ -240,15 +251,23 @@ impl Deserializable for DebugVarLocation {
                 let bytes = source.read_array::<2>()?;
                 Ok(Self::Local(i16::from_le_bytes(bytes)))
             },
-            4 => {
-                let bytes = read_bounded_bytes(source, "debug variable expression bytes")?;
-                Ok(Self::Expression(bytes))
-            },
+            4 => Ok(Self::Unavailable),
             5 => {
-                let global_index = source.read_u32()?;
+                let base = match source.read_u8()? {
+                    0 => {
+                        let bytes = source.read_array::<2>()?;
+                        DebugFrameBase::Local(i16::from_le_bytes(bytes))
+                    },
+                    1 => DebugFrameBase::Memory(source.read_u32()?),
+                    tag => {
+                        return Err(DeserializationError::InvalidValue(format!(
+                            "invalid resolved debug frame-base tag: {tag}"
+                        )));
+                    },
+                };
                 let bytes = source.read_array::<8>()?;
                 let byte_offset = i64::from_le_bytes(bytes);
-                Ok(Self::FrameBase { global_index, byte_offset })
+                Ok(Self::ResolvedFrameBase { base, byte_offset })
             },
             _ => Err(DeserializationError::InvalidValue(format!(
                 "invalid DebugVarLocation tag: {tag}"
@@ -257,22 +276,14 @@ impl Deserializable for DebugVarLocation {
     }
 
     fn min_serialized_size() -> usize {
-        // `Stack` is encoded as a one-byte tag followed by a one-byte stack position.
-        u8::min_serialized_size() + u8::min_serialized_size()
+        // `Unavailable` is encoded as a one-byte tag with no payload.
+        u8::min_serialized_size()
     }
-}
-
-fn read_bounded_bytes<R: ByteReader>(
-    source: &mut R,
-    label: &str,
-) -> Result<Vec<u8>, DeserializationError> {
-    let len = read_bounded_len(source, label, 1)?;
-    source.read_slice(len).map(<[u8]>::to_vec)
 }
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::ToString;
+    use alloc::{string::ToString, vec::Vec};
 
     use miden_core::serde::{Deserializable, Serializable, SliceReader};
     use miden_debug_types::{ByteIndex, Uri};
@@ -283,18 +294,6 @@ mod tests {
     fn debug_var_info_display_simple() {
         let var = DebugVarInfo::new("x", DebugVarLocation::Stack(0));
         assert_eq!(var.to_string(), "var.x = stack[0]");
-    }
-
-    #[test]
-    fn debug_var_location_rejects_oversized_expression_length() {
-        let bytes = [4, 0x08, 0x2a, 0xfe, 0xfe, 0x01];
-        let mut reader = SliceReader::new(&bytes);
-        let err = DebugVarLocation::read_from(&mut reader).unwrap_err();
-        let DeserializationError::InvalidValue(message) = err else {
-            panic!("expected InvalidValue error");
-        };
-        assert!(message.contains("debug variable expression bytes count"));
-        assert!(message.contains("exceeds remaining input"));
     }
 
     #[test]
@@ -322,13 +321,14 @@ mod tests {
         assert_eq!(DebugVarLocation::Const(Felt::new_unchecked(42)).to_string(), "const(42)");
         assert_eq!(DebugVarLocation::Local(-3).to_string(), "FMP-3");
         assert_eq!(
-            DebugVarLocation::FrameBase { global_index: 20, byte_offset: -12 }.to_string(),
-            "global[20]-12"
+            DebugVarLocation::ResolvedFrameBase {
+                base: DebugFrameBase::Local(-3),
+                byte_offset: 12,
+            }
+            .to_string(),
+            "frame-base(FMP-3)+12"
         );
-        assert_eq!(
-            DebugVarLocation::Expression(vec![0x10, 0x20, 0x30]).to_string(),
-            "expr(10 20 30)"
-        );
+        assert_eq!(DebugVarLocation::Unavailable.to_string(), "unavailable");
     }
 
     #[test]
@@ -338,8 +338,15 @@ mod tests {
             DebugVarLocation::Memory(0xdead_beef),
             DebugVarLocation::Const(Felt::new_unchecked(999)),
             DebugVarLocation::Local(-3),
-            DebugVarLocation::FrameBase { global_index: 20, byte_offset: -12 },
-            DebugVarLocation::Expression(vec![0x10, 0x20, 0x30]),
+            DebugVarLocation::Unavailable,
+            DebugVarLocation::ResolvedFrameBase {
+                base: DebugFrameBase::Local(-3),
+                byte_offset: 28,
+            },
+            DebugVarLocation::ResolvedFrameBase {
+                base: DebugFrameBase::Memory(100),
+                byte_offset: -16,
+            },
         ];
 
         for loc in &locations {
@@ -353,24 +360,28 @@ mod tests {
 
     #[test]
     fn debug_var_location_min_serialized_size_matches_shortest_variant() {
-        let locations = [DebugVarLocation::Stack(0), DebugVarLocation::Expression(Vec::new())];
+        let location = DebugVarLocation::Unavailable;
         let min_serialized_size = DebugVarLocation::min_serialized_size();
+        let mut bytes = Vec::new();
+        location.write_into(&mut bytes);
 
-        assert_eq!(min_serialized_size, 2);
-        for location in locations {
-            let mut bytes = Vec::new();
-            location.write_into(&mut bytes);
-            assert_eq!(bytes.len(), min_serialized_size);
-        }
+        assert_eq!(min_serialized_size, 1);
+        assert_eq!(bytes.len(), min_serialized_size);
     }
 
     #[test]
     fn debug_var_info_set_value_location() {
         let mut var = DebugVarInfo::new("x", DebugVarLocation::Stack(0));
-        var.set_value_location(DebugVarLocation::FrameBase { global_index: 20, byte_offset: -12 });
+        var.set_value_location(DebugVarLocation::ResolvedFrameBase {
+            base: DebugFrameBase::Local(-2),
+            byte_offset: 12,
+        });
         assert_eq!(
             var.value_location(),
-            &DebugVarLocation::FrameBase { global_index: 20, byte_offset: -12 }
+            &DebugVarLocation::ResolvedFrameBase {
+                base: DebugFrameBase::Local(-2),
+                byte_offset: 12,
+            }
         );
     }
 }

--- a/crates/assembly-syntax/src/ast/instruction/debug_var.rs
+++ b/crates/assembly-syntax/src/ast/instruction/debug_var.rs
@@ -5,6 +5,8 @@ use miden_core::serde::{
     ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable, read_bounded_len,
 };
 use miden_debug_types::Location;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     Felt,

--- a/crates/assembly-syntax/src/ast/instruction/debug_var.rs
+++ b/crates/assembly-syntax/src/ast/instruction/debug_var.rs
@@ -660,6 +660,44 @@ mod tests {
     }
 
     #[test]
+    fn debug_location_expression_wire_encoding_is_stable() {
+        let expression = DebugLocationExpression::new(vec![
+            DebugLocationExpressionOp::ReadStack(0x2a),
+            DebugLocationExpressionOp::ReadMemory(0x1234_5678),
+            DebugLocationExpressionOp::ReadLocal(-2),
+            DebugLocationExpressionOp::ConstU64(0x0102_0304_0506_0708),
+            DebugLocationExpressionOp::ConstI64(-2),
+            DebugLocationExpressionOp::AddUnsigned(0x1112_1314_1516_1718),
+            DebugLocationExpressionOp::Add,
+            DebugLocationExpressionOp::Sub,
+            DebugLocationExpressionOp::DerefBytes,
+            DebugLocationExpressionOp::FrameBaseAddress {
+                base: DebugFrameBase::Local(-4),
+                byte_offset: 0x0102_0304_0506_0708,
+            },
+            DebugLocationExpressionOp::FrameBaseAddress {
+                base: DebugFrameBase::Memory(0xa1b2_c3d4),
+                byte_offset: -3,
+            },
+        ])
+        .unwrap();
+        let expected = vec![
+            0x17, 0x00, 0x2a, 0x01, 0x78, 0x56, 0x34, 0x12, 0x02, 0xfe, 0xff, 0x03, 0x08, 0x07,
+            0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x04, 0xfe, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0x05, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12, 0x11, 0x06, 0x07, 0x08, 0x09,
+            0x00, 0xfc, 0xff, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x09, 0x01, 0xd4,
+            0xc3, 0xb2, 0xa1, 0xfd, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        ];
+
+        let mut bytes = Vec::new();
+        expression.write_into(&mut bytes);
+        assert_eq!(bytes, expected);
+
+        let mut reader = SliceReader::new(&expected);
+        assert_eq!(DebugLocationExpression::read_from(&mut reader).unwrap(), expression);
+    }
+
+    #[test]
     fn debug_var_location_min_serialized_size_matches_shortest_variant() {
         let location = DebugVarLocation::Unavailable;
         let min_serialized_size = DebugVarLocation::min_serialized_size();

--- a/crates/assembly-syntax/src/ast/instruction/mod.rs
+++ b/crates/assembly-syntax/src/ast/instruction/mod.rs
@@ -9,8 +9,8 @@ use core::ops::Range;
 pub use self::{
     advice::SystemEventNode,
     debug_var::{
-        DebugFrameBase, DebugLocationExpression, DebugLocationExpressionOp, DebugVarInfo,
-        DebugVarLocation,
+        DebugFrameBase, DebugLocationExpression, DebugLocationExpressionError,
+        DebugLocationExpressionOp, DebugVarInfo, DebugVarLocation,
     },
     inline_call::DebugInlineCallInfo,
 };

--- a/crates/assembly-syntax/src/ast/instruction/mod.rs
+++ b/crates/assembly-syntax/src/ast/instruction/mod.rs
@@ -8,7 +8,7 @@ use core::ops::Range;
 
 pub use self::{
     advice::SystemEventNode,
-    debug_var::{DebugVarInfo, DebugVarLocation},
+    debug_var::{DebugFrameBase, DebugVarInfo, DebugVarLocation},
     inline_call::DebugInlineCallInfo,
 };
 use crate::{

--- a/crates/assembly-syntax/src/ast/instruction/mod.rs
+++ b/crates/assembly-syntax/src/ast/instruction/mod.rs
@@ -8,7 +8,10 @@ use core::ops::Range;
 
 pub use self::{
     advice::SystemEventNode,
-    debug_var::{DebugFrameBase, DebugVarInfo, DebugVarLocation},
+    debug_var::{
+        DebugFrameBase, DebugLocationExpression, DebugLocationExpressionOp, DebugVarInfo,
+        DebugVarLocation,
+    },
     inline_call::DebugInlineCallInfo,
 };
 use crate::{

--- a/crates/assembly-syntax/src/ast/mod.rs
+++ b/crates/assembly-syntax/src/ast/mod.rs
@@ -39,8 +39,8 @@ pub use self::{
         Import, ImportDecl, ImportKind, ImportSpec, ItemImport, ItemImportGroup, ModuleImport,
     },
     instruction::{
-        DebugFrameBase, DebugInlineCallInfo, DebugVarInfo, DebugVarLocation, Instruction,
-        SystemEventNode,
+        DebugFrameBase, DebugInlineCallInfo, DebugLocationExpression, DebugLocationExpressionOp,
+        DebugVarInfo, DebugVarLocation, Instruction, SystemEventNode,
     },
     invocation_target::{InvocationTarget, Invoke, InvokeKind},
     item::*,

--- a/crates/assembly-syntax/src/ast/mod.rs
+++ b/crates/assembly-syntax/src/ast/mod.rs
@@ -39,7 +39,8 @@ pub use self::{
         Import, ImportDecl, ImportKind, ImportSpec, ItemImport, ItemImportGroup, ModuleImport,
     },
     instruction::{
-        DebugInlineCallInfo, DebugVarInfo, DebugVarLocation, Instruction, SystemEventNode,
+        DebugFrameBase, DebugInlineCallInfo, DebugVarInfo, DebugVarLocation, Instruction,
+        SystemEventNode,
     },
     invocation_target::{InvocationTarget, Invoke, InvokeKind},
     item::*,

--- a/crates/assembly-syntax/src/ast/mod.rs
+++ b/crates/assembly-syntax/src/ast/mod.rs
@@ -39,8 +39,8 @@ pub use self::{
         Import, ImportDecl, ImportKind, ImportSpec, ItemImport, ItemImportGroup, ModuleImport,
     },
     instruction::{
-        DebugFrameBase, DebugInlineCallInfo, DebugLocationExpression, DebugLocationExpressionOp,
-        DebugVarInfo, DebugVarLocation, Instruction, SystemEventNode,
+        DebugFrameBase, DebugInlineCallInfo, DebugLocationExpression, DebugLocationExpressionError,
+        DebugLocationExpressionOp, DebugVarInfo, DebugVarLocation, Instruction, SystemEventNode,
     },
     invocation_target::{InvocationTarget, Invoke, InvokeKind},
     item::*,

--- a/crates/mast-package/src/debug_info/mod.rs
+++ b/crates/mast-package/src/debug_info/mod.rs
@@ -24,7 +24,7 @@ pub use types::*;
 type FxHashMap<K, V> = hashbrown::HashMap<K, V, rustc_hash::FxBuildHasher>;
 type FxHashSet<K> = hashbrown::HashSet<K, rustc_hash::FxBuildHasher>;
 
-pub const DEBUG_INFO_VERSION: u8 = 2;
+pub const DEBUG_INFO_VERSION: u8 = 3;
 
 /// Maximum encoded payload size accepted for package-owned debug information.
 ///

--- a/crates/mast-package/src/debug_info/serialization.rs
+++ b/crates/mast-package/src/debug_info/serialization.rs
@@ -1227,7 +1227,7 @@ mod tests {
     }
 
     #[test]
-    fn debug_function_v2_wire_bytes_are_stable() {
+    fn debug_function_v3_wire_bytes_are_stable() {
         const EXPECTED_ROW: [u8; size_of::<WireDebugFunctionInfo>()] = [
             1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0,
             0, 0, 0, 1, 0, 0, 0, 7, 0, 0, 0, 1, 0, 0, 0, 9, 0, 0, 0, 1, 0, 0, 0, 11, 0, 0, 0, 13,
@@ -1254,7 +1254,7 @@ mod tests {
         let debug_info = builder.build();
 
         let bytes = debug_info.to_bytes();
-        assert_eq!(bytes[0], 2);
+        assert_eq!(bytes[0], 3);
         assert!(
             bytes.windows(EXPECTED_ROW.len()).any(|window| window == EXPECTED_ROW),
             "serialized debug info did not contain the expected function row",
@@ -1527,14 +1527,14 @@ mod tests {
     }
 
     #[test]
-    fn test_debug_info_v1_is_rejected() {
-        let bytes = [1];
+    fn test_debug_info_v2_is_rejected() {
+        let bytes = [2];
         let mut reader = miden_core::serde::SliceReader::new(&bytes);
         let error = PackageDebugInfo::read_from(&mut reader).unwrap_err();
         let DeserializationError::InvalidValue(message) = error else {
             panic!("expected InvalidValue error");
         };
-        assert!(message.contains("unsupported debug_info version: 1"));
+        assert!(message.contains("unsupported debug_info version: 2"));
     }
 
     #[test]


### PR DESCRIPTION
This addresses the https://github.com/0xMiden/compiler/issues/1317.

It introduces typed debug-variable locations in Miden coordinates, replacing opaque compiler-specific expressions. Adds explicit frame-base and unavailable locations and bumps debug-info to v3.