### PR TITLE
ci: check local documentation links on pull requests

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,7 +1,9 @@
-# Checks documentation for broken links once per day and creates issues if broken links are found
+# Checks local documentation links on pull requests and external links once per day.
 name: Check documentation links
 
 on:
+  pull_request:
+    types: [opened, reopened, synchronize]
   workflow_call:
     inputs:
       fail-fast:
@@ -15,7 +17,28 @@ on:
 permissions: {}
 
 jobs:
+  localLinks:
+    name: Check local documentation links
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check local documentation links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          fail: true
+          args: |
+            --offline
+            --include-fragments
+            **/*.md
+
   linkChecker:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Changes
 
 - [BREAKING] Removed the unused `CsrMatrix` and `CsrValidationError` APIs from `miden-utils-indexing` and `miden-core::utils` ([#3591](https://github.com/0xMiden/miden-vm/issues/3591)).
+- Added a Lychee check for local Markdown links in pull requests and fixed 17 broken links in README and docs files ([#3606](https://github.com/0xMiden/miden-vm/pull/3606)).
 - [BREAKING] Reduced the precompile STARK relation from 12 AIRs to 10 by merging the chunk/node/sponge and EC point/group stores ([#3464](https://github.com/0xMiden/miden-vm/pull/3464)).
 - Raised the minimum supported Plonky3 version to 0.6.3 to match the `num-bigint` 0.5 types used by `miden-field` ([#3569](https://github.com/0xMiden/miden-vm/pull/3569)).
 

--- a/core/README.md
+++ b/core/README.md
@@ -2,10 +2,10 @@
 This crate contains core components used by Miden VM. These components include:
 
 * Miden VM instruction set, defined in the [Operation](./src/operations/mod.rs) struct.
-* Miden VM program kernel, defined in [KernelDescriptor](./src/kernel.rs) struct which contains a set of roots of kernel routines.
-* Miden VM program structure, defined in [Program](./src/program.rs) struct and described [here](https://docs.miden.xyz/miden-vm/design/programs).
-* Miden VM program metadata, defined in [ProgramInfo](./src/program.rs) struct which contains a program's MAST root and the kernel used by the program.
-* Input and output containers for Miden VM programs, defined in [StackInputs](./src/stack/inputs.rs) and [StackOutputs](./src/stack/outputs.rs) structs.
+* Miden VM program kernel, defined in [KernelDescriptor](./src/program/kernel.rs) struct which contains a set of roots of kernel routines.
+* Miden VM program structure, defined in [Program](./src/program/mod.rs) struct and described [here](https://docs.miden.xyz/miden-vm/design/programs).
+* Miden VM program metadata, defined in [ProgramInfo](./src/program/mod.rs) struct which contains a program's MAST root and the kernel used by the program.
+* Input and output containers for Miden VM programs, defined in [StackInputs](./src/program/stack/inputs.rs) and [StackOutputs](./src/program/stack/outputs.rs) structs.
 * Constants describing the shape of the VM's execution trace.
 * Various minor utility functions used by other VM crates.
 

--- a/crates/assembly/README.md
+++ b/crates/assembly/README.md
@@ -4,7 +4,7 @@ This crate contains Miden assembler.
 
 The purpose of the assembler is to compile/assemble [Miden Assembly (MASM)](https://docs.miden.xyz/miden-vm/user_docs/assembly)
 source code into a Miden VM program (represented by `Program` struct). The program
-can then be executed on Miden VM [processor](../processor).
+can then be executed on Miden VM [processor](../../processor).
 
 ## Compiling Miden Assembly
 

--- a/crates/crypto-derive/README.md
+++ b/crates/crypto-derive/README.md
@@ -4,4 +4,4 @@ Procedural macros for the `miden-crypto` crate.
 
 ## License
 
-Any contribution intentionally submitted for inclusion in this repository, as defined in the Apache-2.0 license, shall be dual licensed under the [MIT](../LICENSE-MIT) and [Apache 2.0](../LICENSE-APACHE) licenses, without any additional terms or conditions.
+Any contribution intentionally submitted for inclusion in this repository, as defined in the Apache-2.0 license, shall be dual licensed under the [MIT](../../LICENSE-MIT) and [Apache 2.0](../../LICENSE-APACHE) licenses, without any additional terms or conditions.

--- a/crates/lib/core/README.md
+++ b/crates/lib/core/README.md
@@ -1,7 +1,7 @@
 # Miden core library
 Core library for Miden VM.
 
-Miden core library provides a set of procedures which can be used by any Miden program. These procedures build on the core instruction set of [Miden assembly](../assembly) expanding the functionality immediately available to the user.
+Miden core library provides a set of procedures which can be used by any Miden program. These procedures build on the core instruction set of [Miden assembly](../../assembly) expanding the functionality immediately available to the user.
 
 The goals of Miden core library are:
 * Provide highly-optimized and battle-tested implementations of commonly-used primitives.
@@ -35,8 +35,8 @@ Currently, Miden core library contains just a few modules, which are listed belo
 - [miden::core::math::u256](./docs/math/u256.md)
 - [miden::core::math::u64](./docs/math/u64.md)
 - [miden::core::mem](./docs/mem.md)
-- [miden::core::pcs::fri::frie2f4](./docs/pcs/frie2f4.md)
-- [miden::core::stark](./docs/stark/mod.md)
+- [miden::core::pcs::fri::frie2f4](./docs/pcs/fri/frie2f4.md)
+- [miden::core::stark](./docs/stark.md)
 - [miden::core::stark::constants](./docs/stark/constants.md)
 - [miden::core::stark::deep_queries](./docs/stark/deep_queries.md)
 - [miden::core::stark::ood_frames](./docs/stark/ood_frames.md)

--- a/crates/serde-utils/README.md
+++ b/crates/serde-utils/README.md
@@ -18,4 +18,4 @@ This crate provides serialization and deserialization utilities for the Miden pr
 
 ## License
 
-Any contribution intentionally submitted for inclusion in this repository, as defined in the Apache-2.0 license, shall be dual licensed under the [MIT](../LICENSE-MIT) and [Apache 2.0](../LICENSE-APACHE) licenses, without any additional terms or conditions.
+Any contribution intentionally submitted for inclusion in this repository, as defined in the Apache-2.0 license, shall be dual licensed under the [MIT](../../LICENSE-MIT) and [Apache 2.0](../../LICENSE-APACHE) licenses, without any additional terms or conditions.

--- a/docs/src/advanced_topics/execution_trace_optimization.md
+++ b/docs/src/advanced_topics/execution_trace_optimization.md
@@ -10,7 +10,7 @@ draft: true
 
 When we refer to "number of cycles" in most Miden VM documentation, we're specifically referring to the **stack rows** portion of the execution trace. However, the actual proving time is determined by what we call the "true number of cycles," which is the maximum of all trace segment lengths:
 
-- **Stack rows**: One row per VM operation (what `clk` outputs). This corresponds to the System, Program decoder and Operand Stack set of columns from the [execution trace diagram](../design/index.md#execution-trace)
+- **Stack rows**: One row per VM operation (what `clk` outputs). This corresponds to the System, Program decoder and Operand Stack set of columns from the [execution trace diagram](../design/index.md#vm-execution-trace)
 - **Range checker rows**: Added for all u32 and memory operations (no more, no less)
 - **Chiplet rows**: Added when opcodes call specialized chiplets:
   - `hperm` calls the hasher chiplet

--- a/docs/src/design/chiplets/index.md
+++ b/docs/src/design/chiplets/index.md
@@ -205,7 +205,7 @@ Lookup requests are sent to the chiplets bus by the following components:
 - The decoder sends a procedure access request to the [Kernel ROM chiplet](./kernel_rom.md) for each `SYSCALL` during [program block hashing](../decoder/index.md#program-block-hashing).
 - The verifier initializes the bus with requests to the [Kernel ROM chiplet](./kernel_rom.md) for each unique kernel procedure digest.
 
-Responses are provided by the [hash](./hasher.md#chiplets-bus-constraints), [bitwise](./bitwise.md#chiplets-bus-constraints), [memory](./memory.md#chiplets-bus-constraints), and [kernel ROM](./kernel_rom.md#chiplets-bus-constraints) chiplets.
+Responses are provided by the [hash](./hasher.md#chiplets-bus), [bitwise](./bitwise.md#chiplets-bus-constraints), [memory](./memory.md#chiplets-bus-constraints), and [kernel ROM](./kernel_rom.md#chiplets-bus-constraints) chiplets.
 
 The verifier computes the expected final value of $b_{chip}$ from public inputs and checks it
 against `aux_finals`. There is no explicit last-row boundary constraint in the chiplets bus.

--- a/lychee.toml
+++ b/lychee.toml
@@ -2,10 +2,6 @@
 
 # Exclude URLs and mail addresses from checking (supports regex).
 exclude = [
-    '^file:///.*test-utils',                    # Missing test-utils directory
-    '^file:///.*crates/lib/core/docs/sys\.md',  # Missing core lib docs file
-    '^file:///.*\.png$',                        # Image files
-    '^file:///.*\.svg$',                        # SVG files
     '^https://www.gnu.org/software/make/manual/make\.html$',  # GNU make manual
 ]
 
@@ -15,4 +11,3 @@ exclude_path = [
     "node_modules/*",
     "target/*",
 ]
-

--- a/miden-vm/README.md
+++ b/miden-vm/README.md
@@ -8,7 +8,7 @@ An in-depth description of Miden VM is available in the full Miden VM [documenta
 
 ### Writing programs
 
-Our goal is to make Miden VM an easy compilation target for high-level languages such as Rust, Move, Sway, and others. We believe it is important to let people write programs in the languages of their choice. However, compilers to help with this have not been developed yet. Thus, for now, the primary way to write programs for Miden VM is to use [Miden assembly](../assembly).
+Our goal is to make Miden VM an easy compilation target for high-level languages such as Rust, Move, Sway, and others. We believe it is important to let people write programs in the languages of their choice. However, compilers to help with this have not been developed yet. Thus, for now, the primary way to write programs for Miden VM is to use [Miden assembly](../crates/assembly).
 
 Miden assembler compiles assembly source code in a [program MAST](https://docs.miden.xyz/miden-vm/design/programs), which is represented by a `Program` struct. It is possible to construct a `Program` struct manually, but we don't recommend this approach because it is tedious, error-prone, and requires an in-depth understanding of VM internals. All examples throughout these docs use assembly syntax.
 
@@ -186,7 +186,7 @@ match Verifier::new().verify(&proof, &claim) {
 
 ## Fibonacci calculator
 
-Let's write a simple program for Miden VM (using [Miden assembly](../assembly)). Our program will compute the 5-th [Fibonacci number](https://en.wikipedia.org/wiki/Fibonacci_number):
+Let's write a simple program for Miden VM (using [Miden assembly](../crates/assembly)). Our program will compute the 5-th [Fibonacci number](https://en.wikipedia.org/wiki/Fibonacci_number):
 
 ```masm
 push.0      // stack state: 0


### PR DESCRIPTION
README and docs links now point to current files and sections.

Lychee checks all local Markdown links on each pull request. It runs offline and includes section links. The daily job keeps checking external links and opens an issue on failure.

Closes #3548. Obviates #3551 #3549.