### PR TITLE
fix(crypto): reject zero InOrderIndex during deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 
 #### Fixes
 
+- [BREAKING] Fixed `InOrderIndex` deserialization accepting zero, which violates its one-based indexing
+  invariant and can panic when traversed.
 - [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
 - Moved the `read_bounded_len` and `validate_bounded_len` helpers from `miden-core` to `miden-serde-utils`, where they are now public. `miden-core::serde` re-exports them unchanged, and the private duplicates in `miden-utils-indexing` were removed ([#3415](https://github.com/0xMiden/miden-vm/issues/3415)).

--- a/crates/crypto/src/merkle/mmr/inorder.rs
+++ b/crates/crypto/src/merkle/mmr/inorder.rs
@@ -6,7 +6,7 @@
 //! leaves count.
 use core::num::NonZeroUsize;
 
-use crate::utils::{ByteReader, ByteWriter, Deserializable, Serializable};
+use crate::utils::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable};
 
 // IN-ORDER INDEX
 // ================================================================================================
@@ -128,11 +128,13 @@ impl Serializable for InOrderIndex {
 }
 
 impl Deserializable for InOrderIndex {
-    fn read_from<R: ByteReader>(
-        source: &mut R,
-    ) -> Result<Self, crate::utils::DeserializationError> {
+    fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
         let idx = source.read_usize()?;
-        Ok(InOrderIndex { idx })
+        let idx = NonZeroUsize::new(idx).ok_or_else(|| {
+            DeserializationError::InvalidValue("in-order index cannot be zero".into())
+        })?;
+
+        Ok(Self::new(idx))
     }
 }
 
@@ -153,7 +155,7 @@ mod test {
     use proptest::prelude::*;
 
     use super::InOrderIndex;
-    use crate::utils::{Deserializable, Serializable};
+    use crate::utils::{Deserializable, DeserializationError, Serializable};
 
     proptest! {
         #[test]
@@ -194,5 +196,12 @@ mod test {
         let bytes = index.to_bytes();
         let index2 = InOrderIndex::read_from_bytes(&bytes).unwrap();
         assert_eq!(index, index2);
+    }
+
+    #[test]
+    fn test_inorder_index_deserialization_rejects_zero() {
+        let result = InOrderIndex::read_from_bytes(&0usize.to_bytes());
+
+        assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
     }
 }

--- a/crates/crypto/src/merkle/mmr/partial.rs
+++ b/crates/crypto/src/merkle/mmr/partial.rs
@@ -1384,14 +1384,6 @@ mod tests {
         let result = PartialMmr::from_parts(peaks.clone(), invalid_nodes, BTreeSet::new());
         assert!(result.is_err());
 
-        // Invalid case: index 0 (which is never valid for InOrderIndex)
-        let mut nodes_with_zero = BTreeMap::new();
-        // Create an InOrderIndex with value 0 via deserialization
-        let zero_idx = InOrderIndex::read_from_bytes(&0usize.to_bytes()).unwrap();
-        nodes_with_zero.insert(zero_idx, int_to_node(0));
-        let result = PartialMmr::from_parts(peaks.clone(), nodes_with_zero, BTreeSet::new());
-        assert!(result.is_err());
-
         // Invalid case: large even index (internal node) beyond forest bounds
         let mut nodes_with_large_even = BTreeMap::new();
         let large_even_idx = InOrderIndex::read_from_bytes(&1000usize.to_bytes()).unwrap();


### PR DESCRIPTION
## Describe your changes

Closes https://github.com/0xMiden/miden-vm/issues/3608

`InOrderIndex` uses one-based indexing, and its public constructor requires a `NonZeroUsize`. Its `Deserializable` implementation bypassed that invariant by writing the decoded `usize` directly into the private field.

As a result, untrusted bytes could construct an index of zero. Traversal operations assume a non-zero index and may panic for this value.

- validate the decoded index with `NonZeroUsize`;
- construct deserialized values through `InOrderIndex::new`;
- return `DeserializationError::InvalidValue` for zero;
- add a regression test for zero-value deserialization;
- remove a unit-test setup that depended on constructing an invalid zero index;
- add a changelog entry.

The serialized representation is unchanged, and all valid values continue to round-trip. This is marked as breaking because previously accepted invalid input is now rejected.

## Checklist before requesting a review
- Repo forked and branch created from `next` according to naming convention.
- Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- Relevant issues are linked in the PR description.
- Tests added for new functionality.
- Documentation/comments updated according to changes.
- Updated `CHANGELOG.md`
