### PR TITLE
ci: Exclude setup and cleanup work from CodSpeed benchmark timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Changes
 
+- Changed CodSpeed benchmarks to exclude input setup and result cleanup from timed samples, so comparisons measure only the operation under test ([#3613](https://github.com/0xMiden/miden-vm/pull/3613)).
 - [BREAKING] Removed the unused `CsrMatrix` and `CsrValidationError` APIs from `miden-utils-indexing` and `miden-core::utils` ([#3591](https://github.com/0xMiden/miden-vm/issues/3591)).
 - Added a Lychee check for local Markdown links in pull requests and fixed 17 broken links in README and docs files ([#3606](https://github.com/0xMiden/miden-vm/pull/3606)).
 - [BREAKING] `Instruction::EmitImm` now pretty-prints as the equivalent `push.<value> emit drop` sequence instead of `emit.<felt>`, since `emit.<felt>` is invalid MASM which cannot be parsed ([#3567](https://github.com/0xMiden/miden-vm/pull/3567)).

--- a/benches/blake3-bench/benches/blake3_bench.rs
+++ b/benches/blake3-bench/benches/blake3_bench.rs
@@ -119,7 +119,7 @@ fn blake3_bench(c: &mut Criterion) {
                     || execute_trace_inputs(&fixture),
                     |trace_inputs| {
                         let trace_inputs = black_box(trace_inputs);
-                        prove_trace(trace_inputs);
+                        black_box(prove_trace(trace_inputs))
                     },
                     BatchSize::SmallInput,
                 );
@@ -140,24 +140,13 @@ fn blake3_bench(c: &mut Criterion) {
 
         if has_axis(&axes, "execute_sync") {
             group.bench_function("execute_sync", |b| {
-                b.iter_batched(
-                    || fixture.clone(),
-                    |fixture| {
-                        execute_program(&fixture);
-                        black_box(())
-                    },
-                    BatchSize::SmallInput,
-                );
+                b.iter_with_large_drop(|| black_box(execute_program(&fixture)));
             });
         }
 
         if has_axis(&axes, "execute_trace_inputs_sync") {
             group.bench_function("execute_trace_inputs_sync", |b| {
-                b.iter_batched(
-                    || fixture.clone(),
-                    |fixture| black_box(execute_trace_inputs(&fixture)),
-                    BatchSize::SmallInput,
-                );
+                b.iter_with_large_drop(|| black_box(execute_trace_inputs(&fixture)));
             });
         }
 
@@ -167,7 +156,7 @@ fn blake3_bench(c: &mut Criterion) {
                     || execute_trace_inputs(&fixture),
                     |trace_inputs| {
                         let trace_inputs = black_box(trace_inputs);
-                        build_trace(trace_inputs);
+                        black_box(build_trace(trace_inputs))
                     },
                     BatchSize::SmallInput,
                 );

--- a/benches/blake3-bench/src/lib.rs
+++ b/benches/blake3-bench/src/lib.rs
@@ -6,8 +6,9 @@ use std::{
 
 use miden_core_lib::CoreLibrary;
 use miden_vm::{
-    Assembler, DefaultHost, ExecutionOptions, FastProcessor, HashFunction, Program, ProvingOptions,
-    StackInputs, TraceBuildInputs, TraceProvingInputs, Verifier,
+    Assembler, DefaultHost, ExecutionOptions, ExecutionOutput, ExecutionProof, ExecutionTrace,
+    FastProcessor, HashFunction, Program, ProvingOptions, StackInputs, StackOutputs,
+    TraceBuildInputs, TraceProvingInputs, Verifier,
     advice::AdviceInputs,
     assembly::{
         DefaultSourceManager, Path as LibraryPath,
@@ -133,7 +134,7 @@ pub fn execute_trace_inputs(fixture: &Blake3Fixture) -> TraceBuildInputs {
     }
 }
 
-pub fn execute_program(fixture: &Blake3Fixture) {
+pub fn execute_program(fixture: &Blake3Fixture) -> ExecutionOutput {
     let mut host = host_for_fixture(fixture);
     let processor = FastProcessor::new_with_options(
         fixture.stack_inputs,
@@ -143,7 +144,7 @@ pub fn execute_program(fixture: &Blake3Fixture) {
     .expect("processor advice inputs should fit advice map limits");
     processor
         .execute_sync(&fixture.program, &mut host)
-        .expect("failed to execute Blake3 benchmark");
+        .expect("failed to execute Blake3 benchmark")
 }
 
 pub fn prove_program(fixture: &Blake3Fixture) {
@@ -151,8 +152,8 @@ pub fn prove_program(fixture: &Blake3Fixture) {
     prove_trace(execute_trace_inputs(fixture));
 }
 
-pub fn prove_trace(trace_inputs: TraceBuildInputs) {
-    let _ = prove_trace_outputs(trace_inputs);
+pub fn prove_trace(trace_inputs: TraceBuildInputs) -> (StackOutputs, ExecutionProof) {
+    prove_trace_outputs(trace_inputs)
 }
 
 pub fn prove_and_verify_once(fixture: &Blake3Fixture) {
@@ -169,15 +170,13 @@ pub fn prove_and_verify_once(fixture: &Blake3Fixture) {
         .expect("failed to verify Blake3 benchmark proof");
 }
 
-fn prove_trace_outputs(
-    trace_inputs: TraceBuildInputs,
-) -> (miden_vm::StackOutputs, miden_vm::ExecutionProof) {
+fn prove_trace_outputs(trace_inputs: TraceBuildInputs) -> (StackOutputs, ExecutionProof) {
     prove_from_trace_sync(TraceProvingInputs::new(trace_inputs, proving_options()))
         .expect("failed to prove Blake3 benchmark trace")
 }
 
-pub fn build_trace(trace_inputs: TraceBuildInputs) {
-    trace::build_trace(trace_inputs).expect("failed to build Blake3 execution trace");
+pub fn build_trace(trace_inputs: TraceBuildInputs) -> ExecutionTrace {
+    trace::build_trace(trace_inputs).expect("failed to build Blake3 execution trace")
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/benches/smt-codspeed/benches/smt_codspeed.rs
+++ b/benches/smt-codspeed/benches/smt_codspeed.rs
@@ -137,17 +137,21 @@ fn smt_benches(c: &mut Criterion) {
         mutations.bench_function(BenchmarkId::new("Smt::compute_mutations", size), |bench| {
             let smt = Smt::with_entries(entries(4_096, 0)).unwrap();
             let updates = entries(size, 10_000);
-            bench.iter(|| black_box(smt.compute_mutations(updates.clone()).unwrap()));
+            bench.iter_batched(
+                || updates.clone(),
+                |updates| black_box(smt.compute_mutations(updates).unwrap()),
+                BatchSize::LargeInput,
+            );
         });
         mutations.bench_function(BenchmarkId::new("Smt::apply_mutations", size), |bench| {
-            bench.iter_batched(
+            bench.iter_batched_ref(
                 || {
                     let smt = Smt::with_entries(entries(4_096, 0)).unwrap();
                     let mutations = smt.compute_mutations(entries(size, 10_000)).unwrap();
-                    (smt, mutations)
+                    (smt, Some(mutations))
                 },
-                |(mut smt, mutations)| {
-                    smt.apply_mutations(mutations).unwrap();
+                |(smt, mutations)| {
+                    smt.apply_mutations(mutations.take().unwrap()).unwrap();
                     black_box(())
                 },
                 BatchSize::LargeInput,
@@ -176,32 +180,36 @@ fn large_smt_memory_benches(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("compute_mutations", size), |bench| {
             let smt = LargeSmt::with_entries(MemoryStorage::new(), entries(4_096, 0)).unwrap();
             let updates = entries(size, 10_000);
-            bench.iter(|| black_box(smt.compute_mutations(updates.clone()).unwrap()));
+            bench.iter_batched(
+                || updates.clone(),
+                |updates| black_box(smt.compute_mutations(updates).unwrap()),
+                BatchSize::LargeInput,
+            );
         });
         group.bench_function(BenchmarkId::new("apply_mutations", size), |bench| {
-            bench.iter_batched(
+            bench.iter_batched_ref(
                 || {
                     let smt =
                         LargeSmt::with_entries(MemoryStorage::new(), entries(4_096, 0)).unwrap();
                     let mutations = smt.compute_mutations(entries(size, 10_000)).unwrap();
-                    (smt, mutations)
+                    (smt, Some(mutations))
                 },
-                |(mut smt, mutations)| {
-                    smt.apply_mutations(mutations).unwrap();
+                |(smt, mutations)| {
+                    smt.apply_mutations(mutations.take().unwrap()).unwrap();
                     black_box(())
                 },
                 BatchSize::LargeInput,
             );
         });
         group.bench_function(BenchmarkId::new("insert_batch/populated", size), |bench| {
-            bench.iter_batched(
+            bench.iter_batched_ref(
                 || {
                     let smt =
                         LargeSmt::with_entries(MemoryStorage::new(), entries(4_096, 0)).unwrap();
                     let batch = entries(size, 10_000);
                     (smt, batch)
                 },
-                |(mut smt, batch)| black_box(smt.insert_batch(batch).unwrap()),
+                |(smt, batch)| black_box(smt.insert_batch(std::mem::take(batch)).unwrap()),
                 BatchSize::LargeInput,
             );
         });
@@ -236,7 +244,11 @@ fn large_smt_rocksdb_benches(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new("compute_mutations", size), |bench| {
             let (_temp_dir, smt) = rocksdb_smt(4_096);
             let updates = entries(size, 10_000);
-            bench.iter(|| black_box(smt.compute_mutations(updates.clone()).unwrap()));
+            bench.iter_batched(
+                || updates.clone(),
+                |updates| black_box(smt.compute_mutations(updates).unwrap()),
+                BatchSize::LargeInput,
+            );
         });
         group.bench_function(BenchmarkId::new("apply_mutations", size), |bench| {
             bench.iter_batched_ref(

--- a/benches/smt-codspeed/benches/smt_codspeed.rs
+++ b/benches/smt-codspeed/benches/smt_codspeed.rs
@@ -239,27 +239,29 @@ fn large_smt_rocksdb_benches(c: &mut Criterion) {
             bench.iter(|| black_box(smt.compute_mutations(updates.clone()).unwrap()));
         });
         group.bench_function(BenchmarkId::new("apply_mutations", size), |bench| {
-            bench.iter_batched(
+            bench.iter_batched_ref(
                 || {
                     let (temp_dir, smt) = rocksdb_smt(4_096);
                     let mutations = smt.compute_mutations(entries(size, 10_000)).unwrap();
-                    (temp_dir, smt, mutations)
+                    (temp_dir, smt, Some(mutations))
                 },
-                |(_temp_dir, mut smt, mutations)| {
-                    smt.apply_mutations(mutations).unwrap();
+                |(_temp_dir, smt, mutations)| {
+                    smt.apply_mutations(mutations.take().unwrap()).unwrap();
                     black_box(())
                 },
                 BatchSize::LargeInput,
             );
         });
         group.bench_function(BenchmarkId::new("insert_batch/populated", size), |bench| {
-            bench.iter_batched(
+            bench.iter_batched_ref(
                 || {
                     let (temp_dir, smt) = rocksdb_smt(4_096);
                     let batch = entries(size, 10_000);
                     (temp_dir, smt, batch)
                 },
-                |(_temp_dir, mut smt, batch)| black_box(smt.insert_batch(batch).unwrap()),
+                |(_temp_dir, smt, batch)| {
+                    black_box(smt.insert_batch(std::mem::take(batch)).unwrap())
+                },
                 BatchSize::LargeInput,
             );
         });

--- a/benches/synthetic-bench/benches/recursive_verify.rs
+++ b/benches/synthetic-bench/benches/recursive_verify.rs
@@ -890,7 +890,7 @@ fn bench_recursive_verify(c: &mut Criterion) {
             b.iter_batched(
                 || (case.clone(), recursive_host()),
                 execute_recursive_case,
-                BatchSize::SmallInput,
+                BatchSize::PerIteration,
             );
         });
 
@@ -898,7 +898,7 @@ fn bench_recursive_verify(c: &mut Criterion) {
             b.iter_batched(
                 || execute_trace_inputs(case.clone(), recursive_host()),
                 build_trace_case,
-                BatchSize::SmallInput,
+                BatchSize::PerIteration,
             );
         });
 
@@ -906,7 +906,7 @@ fn bench_recursive_verify(c: &mut Criterion) {
             b.iter_batched(
                 || (case.clone(), recursive_host()),
                 execute_and_build_case,
-                BatchSize::SmallInput,
+                BatchSize::PerIteration,
             );
         });
 
@@ -914,7 +914,7 @@ fn bench_recursive_verify(c: &mut Criterion) {
             b.iter_batched(
                 || (case.clone(), recursive_host(), config.hash_fn),
                 prove_recursive_case,
-                BatchSize::SmallInput,
+                BatchSize::PerIteration,
             );
         });
     }

--- a/benches/synthetic-bench/benches/recursive_verify.rs
+++ b/benches/synthetic-bench/benches/recursive_verify.rs
@@ -56,8 +56,8 @@ use miden_processor::{
 use miden_prover::prove_sync;
 use miden_verifier::recursive::RecursiveVerifierInputs;
 use miden_vm::{
-    Assembler, ExecutionProof, HashFunction, Program, ProgramInfo, ProvingOptions, StackInputs,
-    StackOutputs, TraceBuildInputs, trace::build_trace,
+    Assembler, ExecutionProof, ExecutionTrace, HashFunction, Program, ProgramInfo, ProvingOptions,
+    StackInputs, StackOutputs, TraceBuildInputs, trace::build_trace,
 };
 
 const DEFAULT_PROOF_COUNTS: [usize; 7] = [2, 3, 4, 5, 6, 7, 8];
@@ -628,23 +628,23 @@ fn execute_trace_inputs(case: RecursionCase, mut host: DefaultHost) -> TraceBuil
         .expect("execute recursive verifier")
 }
 
-fn execute_recursive_case((case, host): (RecursionCase, DefaultHost)) {
+fn execute_recursive_case((case, host): (RecursionCase, DefaultHost)) -> TraceBuildInputs {
+    execute_trace_inputs(case, host)
+}
+
+fn build_trace_case(trace_inputs: TraceBuildInputs) -> ExecutionTrace {
+    build_trace(trace_inputs).expect("build recursive verifier trace")
+}
+
+fn execute_and_build_case((case, host): (RecursionCase, DefaultHost)) -> ExecutionTrace {
     let trace_inputs = execute_trace_inputs(case, host);
-    black_box(trace_inputs);
+    build_trace_case(trace_inputs)
 }
 
-fn build_trace_case(trace_inputs: TraceBuildInputs) {
-    let trace = build_trace(trace_inputs).expect("build recursive verifier trace");
-    black_box(trace);
-}
-
-fn execute_and_build_case((case, host): (RecursionCase, DefaultHost)) {
-    let trace_inputs = execute_trace_inputs(case, host);
-    build_trace_case(trace_inputs);
-}
-
-fn prove_recursive_case((case, mut host, hash_fn): (RecursionCase, DefaultHost, HashFunction)) {
-    let proof = prove_sync(
+fn prove_recursive_case(
+    (case, mut host, hash_fn): (RecursionCase, DefaultHost, HashFunction),
+) -> (StackOutputs, ExecutionProof) {
+    prove_sync(
         &case.program,
         StackInputs::default(),
         case.advice_inputs,
@@ -652,8 +652,7 @@ fn prove_recursive_case((case, mut host, hash_fn): (RecursionCase, DefaultHost, 
         ExecutionOptions::default(),
         ProvingOptions::new(hash_fn),
     )
-    .expect("prove recursive verifier");
-    black_box(proof);
+    .expect("prove recursive verifier")
 }
 
 fn prove_recursive_once(case: &RecursionCase, hash_fn: HashFunction) -> (f64, usize) {

--- a/benches/synthetic-bench/benches/synthetic_bench.rs
+++ b/benches/synthetic-bench/benches/synthetic_bench.rs
@@ -22,9 +22,7 @@
 //! - `SYNTH_MASM_WRITE`: if set, write the emitted MASM to
 //!   `target/synthetic_bench_<producer-stem>__<scenario-slug>.masm`.
 
-use std::{
-    cell::RefCell, collections::BTreeSet, hint::black_box, path::PathBuf, rc::Rc, time::Duration,
-};
+use std::{collections::BTreeSet, hint::black_box, path::PathBuf, time::Duration};
 
 use codspeed_criterion_compat as criterion;
 use criterion::{BatchSize, Criterion, SamplingMode, criterion_group, criterion_main};
@@ -32,8 +30,8 @@ use miden_processor::{
     DefaultHost, ExecutionOptions, FastProcessor, StackInputs, advice::AdviceInputs,
 };
 use miden_vm::{
-    Assembler, ExecutionClaim, ExecutionProof, HashFunction, Program, ProgramInfo, ProvingOptions,
-    StackOutputs, Verifier, prove_sync,
+    Assembler, ExecutionClaim, HashFunction, Program, ProgramInfo, ProvingOptions, Verifier,
+    prove_sync,
 };
 use miden_vm_synthetic_bench::{
     calibrator::{Calibration, calibrate, measure_program},
@@ -46,7 +44,6 @@ use miden_vm_synthetic_bench::{
 /// Hash function used for STARK `prove` and `verify` axes.
 const BENCH_HASH: HashFunction = HashFunction::Poseidon2;
 const ALL_AXES: [&str; 4] = ["exec", "trace_prep", "prove", "verify"];
-type ProofFixture = (StackOutputs, ExecutionProof);
 
 fn resolve_bench_axes() -> BTreeSet<&'static str> {
     let Some(raw) = std::env::var("SYNTH_BENCH_AXES").ok().filter(|s| !s.trim().is_empty()) else {
@@ -291,10 +288,13 @@ fn bench_one_scenario(
     //   verify     -- Verifier::new().verify against a proof generated once outside the timed loop
     if axes.contains("exec") {
         group.bench_function("exec", |b| {
-            b.iter_batched(
-                || processor_inputs(&program),
-                |(mut host, program, processor)| {
-                    black_box(processor.execute_sync(&program, &mut host).expect("exec"));
+            b.iter_batched_ref(
+                || {
+                    let (host, program, processor) = processor_inputs(&program);
+                    (host, program, Some(processor))
+                },
+                |(host, program, processor)| {
+                    black_box(processor.take().unwrap().execute_sync(program, host).expect("exec"))
                 },
                 BatchSize::SmallInput,
             );
@@ -303,46 +303,46 @@ fn bench_one_scenario(
 
     if axes.contains("trace_prep") {
         group.bench_function("trace_prep", |b| {
-            b.iter_batched(
-                || processor_inputs(&program),
-                |(mut host, program, processor)| {
+            b.iter_batched_ref(
+                || {
+                    let (host, program, processor) = processor_inputs(&program);
+                    (host, program, Some(processor))
+                },
+                |(host, program, processor)| {
                     black_box(
                         processor
-                            .execute_trace_inputs_sync(&program, &mut host)
+                            .take()
+                            .unwrap()
+                            .execute_trace_inputs_sync(program, host)
                             .expect("trace_prep"),
-                    );
+                    )
                 },
                 BatchSize::SmallInput,
             );
         });
     }
 
-    let cached_proof: Rc<RefCell<Option<ProofFixture>>> = Rc::default();
     if axes.contains("prove") {
-        let cached_proof = Rc::clone(&cached_proof);
         group.bench_function("prove", |b| {
-            b.iter_batched(
+            b.iter_batched_ref(
                 || {
                     let host = DefaultHost::default();
                     let stack = StackInputs::default();
                     let advice = AdviceInputs::default();
-                    (host, program.clone(), stack, advice)
+                    (host, program.clone(), Some(stack), Some(advice))
                 },
-                |(mut host, program, stack, advice)| {
-                    let proof = prove_sync(
-                        &program,
-                        stack,
-                        advice,
-                        &mut host,
-                        ExecutionOptions::default(),
-                        ProvingOptions::new(BENCH_HASH),
+                |(host, program, stack, advice)| {
+                    black_box(
+                        prove_sync(
+                            program,
+                            stack.take().unwrap(),
+                            advice.take().unwrap(),
+                            host,
+                            ExecutionOptions::default(),
+                            ProvingOptions::new(BENCH_HASH),
+                        )
+                        .expect("prove"),
                     )
-                    .expect("prove");
-                    let mut cached = cached_proof.borrow_mut();
-                    if cached.is_none() {
-                        *cached = Some(proof.clone());
-                    }
-                    black_box(proof);
                 },
                 BatchSize::SmallInput,
             );
@@ -350,20 +350,16 @@ fn bench_one_scenario(
     }
 
     if axes.contains("verify") {
-        // Reuse a proof from the `prove` axis when it ran for this scenario. This keeps prove time
-        // out of the verify measurement without forcing an extra proof in all-axes runs.
-        let (stack_outputs, proof) = cached_proof.borrow().clone().unwrap_or_else(|| {
-            let mut host = DefaultHost::default();
-            prove_sync(
-                &program,
-                StackInputs::default(),
-                AdviceInputs::default(),
-                &mut host,
-                ExecutionOptions::default(),
-                ProvingOptions::new(BENCH_HASH),
-            )
-            .expect("prove for verify setup")
-        });
+        let mut host = DefaultHost::default();
+        let (stack_outputs, proof) = prove_sync(
+            &program,
+            StackInputs::default(),
+            AdviceInputs::default(),
+            &mut host,
+            ExecutionOptions::default(),
+            ProvingOptions::new(BENCH_HASH),
+        )
+        .expect("prove for verify setup");
         let claim = ExecutionClaim::from_program_info(
             ProgramInfo::from(program.clone()),
             StackInputs::default(),

--- a/benches/synthetic-bench/benches/synthetic_bench.rs
+++ b/benches/synthetic-bench/benches/synthetic_bench.rs
@@ -296,7 +296,7 @@ fn bench_one_scenario(
                 |(host, program, processor)| {
                     black_box(processor.take().unwrap().execute_sync(program, host).expect("exec"))
                 },
-                BatchSize::SmallInput,
+                BatchSize::PerIteration,
             );
         });
     }
@@ -317,7 +317,7 @@ fn bench_one_scenario(
                             .expect("trace_prep"),
                     )
                 },
-                BatchSize::SmallInput,
+                BatchSize::PerIteration,
             );
         });
     }
@@ -344,7 +344,7 @@ fn bench_one_scenario(
                         .expect("prove"),
                     )
                 },
-                BatchSize::SmallInput,
+                BatchSize::PerIteration,
             );
         });
     }

--- a/crates/precompiles/benches/precompiles_bench.rs
+++ b/crates/precompiles/benches/precompiles_bench.rs
@@ -55,8 +55,10 @@ fn precompiles_bench(c: &mut Criterion) {
                 let mut total = Duration::ZERO;
                 for _ in 0..iterations {
                     let started_at = std::time::Instant::now();
-                    black_box(prove_once_with_hash(&fixture, proof_hash));
-                    total += started_at.elapsed();
+                    let proof = black_box(prove_once_with_hash(&fixture, proof_hash));
+                    let elapsed = started_at.elapsed();
+                    black_box(proof);
+                    total += elapsed;
                 }
                 total
             });


### PR DESCRIPTION
CodSpeed runs the same speed tests on two commits and reports the difference. It often reported slower code when a commit did not change the code under test. The RocksDB sparse Merkle tree test was the clearest case.

The root cause was extra work inside the timed part of each test. RocksDB wrote data to disk when the test database was removed from memory. Other tests removed large results from memory before the timer stopped. Some tests also copied input data after the timer started.

This change moves input setup and cleanup outside the timed part. It also releases large results after each sample so they do not build up in memory. The same rule now covers every benchmark reviewed here, including the synthetic and Blake3 tests.

TL;DR CodSpeed will now report the time for the named operation without also timing setup or cleanup.
