### PR TITLE
fix(core): reject basic block payloads with uncovered operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
 - Moved the `read_bounded_len` and `validate_bounded_len` helpers from `miden-core` to `miden-serde-utils`, where they are now public. `miden-core::serde` re-exports them unchanged, and the private duplicates in `miden-utils-indexing` were removed ([#3415](https://github.com/0xMiden/miden-vm/issues/3415)).
 - Fixed `miden-vm prove` so unsupported program extensions are rejected before inferred input files are loaded ([#3587](https://github.com/0xMiden/miden-vm/issues/3587)).
+- Rejected MAST basic block payloads whose batch metadata does not cover every serialized operation, instead of silently dropping the trailing operations during deserialization ([#3594](https://github.com/0xMiden/miden-vm/issues/3594)).
 #### Features
 
 - Added `LinkMode::Analysis` and `Linker::link_analysis`, which commit resolved modules and call edges and report a static recursion cycle as a nonfatal diagnostic (`LinkAnalysis`) instead of rejecting it. Strict linking is unchanged: it still rejects cycles before MAST is built and rolls back on failure ([#3535](https://github.com/0xMiden/miden-vm/pull/3535)).

--- a/core/src/mast/serialization/basic_blocks.rs
+++ b/core/src/mast/serialization/basic_blocks.rs
@@ -302,6 +302,16 @@ impl BasicBlockDataDecoder<'_> {
             global_op_offset = batch_ops_end;
         }
 
+        // The encoder always emits batches which exactly cover the operations vector, so any
+        // leftover operations mean the batch metadata does not describe this payload.
+        if global_op_offset != operations.len() {
+            return Err(DeserializationError::InvalidValue(format!(
+                "batch metadata covers {} operations, but {} were serialized",
+                global_op_offset,
+                operations.len()
+            )));
+        }
+
         Ok(op_batches)
     }
 }
@@ -417,6 +427,26 @@ mod tests {
             ),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn decode_operations_rejects_operations_not_covered_by_batches() {
+        let mut bytes = Vec::new();
+
+        // three operations on the wire
+        vec![Operation::Add, Operation::Mul, Operation::Noop].write_into(&mut bytes);
+
+        // but the batch metadata describes a single batch holding only the first one
+        bytes.write_u32(1);
+        bytes.write_bytes(&[0x01, 0x00, 0x00, 0x00]);
+        bytes.write_u8(0);
+
+        let decoder = BasicBlockDataDecoder::new(&bytes);
+        let err = decoder.decode_operations(0).unwrap_err();
+        let DeserializationError::InvalidValue(message) = err else {
+            panic!("expected InvalidValue error");
+        };
+        assert!(message.contains("batch metadata covers 1 operations, but 3 were serialized"));
     }
 
     #[test]


### PR DESCRIPTION
## Rationale

The decoder's validation is asymmetric: it rejects batch metadata that claims more operations than were serialized, but silently accepts metadata that covers fewer, dropping the remainder. On trusted read paths this produces a `BasicBlockNode` whose digest does not match its own operations, instead of a deserialization error. The missing check restores the symmetry at the point where the data is parsed.

Closes #3594.

`decode_operations` reads the operations vector and the batch metadata as two independent sections. It rejected batch metadata claiming *more* operations than were serialized, but never checked that the batches covered *all* of them — so a payload describing fewer operations was accepted and the trailing ones were silently dropped.

The encoder always writes batches that exactly cover the operations vector (`operations()` is a `flat_map` over `op_batches`), so this only affects malformed input. On the untrusted path it was caught late as a digest mismatch; on the trusted paths it wasn't caught at all, yielding a `BasicBlockNode` whose digest doesn't match its own operations.

## Changes

- Added the symmetric check after the reconstruction loop, mirroring the existing upper-bound guard.
- Added `decode_operations_rejects_operations_not_covered_by_batches` alongside the existing `decode_operations_rejects_*` tests.
- CHANGELOG entry.

## Testing
```
cargo test -p miden-core --lib mast::serialization
```
The new test builds the payload from the issue — three operations on the wire, batch metadata describing a single batch holding one — and asserts it is now rejected with `batch metadata covers 1 operations, but 3 were serialized`.
The existing tests in the module cover the cases that must keep passing:
- `decode_operations_allows_exact_batch_budget` — zero operations, all-zero indptr, so the new equality holds at `0 == 0`.
- `decode_operations_accepts_padded_group_with_noop` — the batch covers both operations, so the new check is a no-op.
- Round-trip serialization tests in `mast::serialization::tests`, which confirm no encoder-produced payload is rejected.

## Notes

The check is a single `usize` comparison, so it adds no meaningful cost to the trusted path. It cannot reject a valid encoder-produced payload, since the invariant holds by construction.