### PR TITLE
fix(crypto): correct the documented substitution for galois_adjoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
 - Moved the `read_bounded_len` and `validate_bounded_len` helpers from `miden-core` to `miden-serde-utils`, where they are now public. `miden-core::serde` re-exports them unchanged, and the private duplicates in `miden-utils-indexing` were removed ([#3415](https://github.com/0xMiden/miden-vm/issues/3415)).
+- Corrected the documentation of `Polynomial::galois_adjoint`, which computes `f(-x)` rather than `f(x^2)`, and pinned both it and `lift_next_cyclotomic` with tests ([#3621](https://github.com/0xMiden/miden-vm/issues/3621)).
 #### Features
 
 - Added `LinkMode::Analysis` and `Linker::link_analysis`, which commit resolved modules and call edges and report a static recursion cycle as a nonfatal diagnostic (`LinkAnalysis`) instead of rejecting it. Strict linking is unchanged: it still rejects cycles before MAST is built and rolls back on failure ([#3535](https://github.com/0xMiden/miden-vm/pull/3535)).

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
@@ -136,7 +136,8 @@ impl<
         f0_squared - (x * f1_squared).reduce_by_cyclotomic(n / 2)
     }
 
-    /// Lifts an element from a cyclotomic polynomial ring to one of double the size.
+    /// Lifts an element from a cyclotomic polynomial ring to one of double the size, which
+    /// corresponds to `f(x^2)`.
     pub fn lift_next_cyclotomic(&self) -> Self {
         let n = self.coefficients.len();
         let mut coefficients = vec![F::zero(); n * 2];
@@ -147,7 +148,7 @@ impl<
     }
 
     /// Computes the galois adjoint of the polynomial in the cyclotomic ring F\[ X \] / < X^n + 1 >
-    /// , which corresponds to f(x^2).
+    /// , which corresponds to `f(-x)`.
     pub fn galois_adjoint(&self) -> Self {
         Self::new(
             self.coefficients
@@ -660,6 +661,24 @@ mod tests {
         let nonzero = Polynomial::new(vec![1, 2, 3]);
         let result = zero / nonzero;
         assert!(result.is_zero());
+    }
+
+    /// `galois_adjoint` substitutes `-x` for `x`, so it keeps the even-power coefficients and
+    /// negates the odd-power ones. `ntru_solve` relies on this to build `f(-x)` and `g(-x)`.
+    #[test]
+    fn galois_adjoint_substitutes_minus_x() {
+        // 1 + 2x + 3x^2 + 4x^3  ->  1 - 2x + 3x^2 - 4x^3
+        let f = Polynomial::new(vec![1i64, 2, 3, 4]);
+        assert_eq!(f.galois_adjoint().coefficients, vec![1i64, -2, 3, -4]);
+    }
+
+    /// `lift_next_cyclotomic` substitutes `x^2` for `x`, spreading the coefficients over the even
+    /// powers of a ring of twice the size.
+    #[test]
+    fn lift_next_cyclotomic_substitutes_x_squared() {
+        // 1 + 2x  ->  1 + 2x^2
+        let f = Polynomial::new(vec![1i64, 2]);
+        assert_eq!(f.lift_next_cyclotomic().coefficients, vec![1i64, 0, 2, 0]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #3621.

galois_adjoint is documented as computing f(x^2), but it negates the odd-power coefficients, which is f(-x). f(x^2) is what lift_next_cyclotomic does, and ntru_solve already names its results that way. The code is right, only the comment is wrong.

Corrects it and adds a test for each function, since neither had one.

Test plan: cargo test -p miden-crypto --lib. 679 passed locally, and clippy is clean with the xclippy lint set.