### PR TITLE
fix(crypto): reject an empty forest in the in-order index accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
 - Moved the `read_bounded_len` and `validate_bounded_len` helpers from `miden-core` to `miden-serde-utils`, where they are now public. `miden-core::serde` re-exports them unchanged, and the private duplicates in `miden-utils-indexing` were removed ([#3415](https://github.com/0xMiden/miden-vm/issues/3415)).
+- Fixed `Forest::root_in_order_index` and `Forest::rightmost_in_order_index` underflowing on an empty forest, which returned a bogus index in release builds ([#3624](https://github.com/0xMiden/miden-vm/issues/3624)).
 #### Features
 
 - Added `LinkMode::Analysis` and `Linker::link_analysis`, which commit resolved modules and call edges and report a static recursion cycle as a nonfatal diagnostic (`LinkAnalysis`) instead of rejecting it. Strict linking is unchanged: it still rejects cycles before MAST is built and rolls back on failure ([#3535](https://github.com/0xMiden/miden-vm/pull/3535)).

--- a/crates/crypto/src/merkle/mmr/forest.rs
+++ b/crates/crypto/src/merkle/mmr/forest.rs
@@ -321,7 +321,13 @@ impl Forest {
     /// This function takes the smallest tree in this forest, "pretends" that it is a subtree of a
     /// fully balanced binary tree, and returns the the in-order index of that balanced tree's root
     /// node.
+    ///
+    /// # Panics
+    /// Panics if the forest is empty, since it then holds no tree whose root could be indexed.
+    /// Check with [`Forest::is_empty`] first.
     pub fn root_in_order_index(&self) -> InOrderIndex {
+        assert!(!self.is_empty(), "an empty forest has no root in-order index");
+
         // Count total size of all trees in the forest.
         let nodes = self.num_nodes();
 
@@ -339,7 +345,13 @@ impl Forest {
     }
 
     /// Returns the in-order index of the rightmost element (the smallest tree).
+    ///
+    /// # Panics
+    /// Panics if the forest is empty, since it then holds no element to index.
+    /// Check with [`Forest::is_empty`] first.
     pub fn rightmost_in_order_index(&self) -> InOrderIndex {
+        assert!(!self.is_empty(), "an empty forest has no rightmost in-order index");
+
         // Count total size of all trees in the forest.
         let nodes = self.num_nodes();
 

--- a/crates/crypto/src/merkle/mmr/tests.rs
+++ b/crates/crypto/src/merkle/mmr/tests.rs
@@ -354,6 +354,21 @@ fn test_forest_to_root_index() {
     assert_eq!(Forest::new(0b1110).unwrap().root_in_order_index(), idx(26));
 }
 
+/// An empty forest holds no tree, so it has no in-order index to return. Both accessors compute
+/// `num_trees() - 1`, which underflows for an empty forest: that panics in debug builds and wraps
+/// to `usize::MAX` in release builds, yielding a bogus index instead of failing.
+#[test]
+#[should_panic(expected = "an empty forest has no root in-order index")]
+fn test_empty_forest_root_in_order_index_panics() {
+    let _ = Forest::empty().root_in_order_index();
+}
+
+#[test]
+#[should_panic(expected = "an empty forest has no rightmost in-order index")]
+fn test_empty_forest_rightmost_in_order_index_panics() {
+    let _ = Forest::empty().rightmost_in_order_index();
+}
+
 #[test]
 fn test_forest_to_rightmost_index() {
     fn idx(pos: usize) -> InOrderIndex {


### PR DESCRIPTION
Closes #3624.

Both in-order index accessors compute num_trees() - 1, which underflows on an empty forest. Debug builds panic with "attempt to subtract with overflow"; release builds wrap, so rightmost_in_order_index returns InOrderIndex(usize::MAX) and reports nothing wrong. I confirmed the release value is 18446744073709551615.

An empty forest is a normal value, since Forest::empty() is public and Mmr::new() starts there, and neither accessor documented a precondition. InOrderIndex wraps a NonZeroUsize, so there is no index to return for an empty forest, and callers already guard by hand: PartialMmr only reaches these behind non-empty checks, and rust-sdk guards in its SQLite store.

This asserts the forest is non-empty and documents it, so debug and release agree, and adds a test for each. The existing tests cover forests 0b0001 through 0b1111 but never the empty one. Happy to switch to Option<InOrderIndex> instead if you would rather change the signature.

Test plan: cargo test -p miden-crypto --lib, and the same with --release since the old behaviour only showed up there. 681 passed in both, and clippy is clean with the xclippy lint set.
