### PR TITLE
fix(ci): check-changelog.sh no longer silently passes when git diff f…

### DIFF
--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -13,8 +13,17 @@ EOF
 
 require_changelog() {
     local changelog_file="$1"
+    local status
 
-    if git diff --quiet "origin/${BASE_REF}" -- "${changelog_file}"; then
+    git diff --quiet "origin/${BASE_REF}" -- "${changelog_file}"
+    status=$?
+
+    if [ "${status}" -gt 1 ]; then
+        >&2 echo "Failed to diff \"${changelog_file}\" against \"origin/${BASE_REF}\" (git exited ${status}). Check that BASE_REF is correct and that the ref is available in this checkout."
+        exit 1
+    fi
+
+    if [ "${status}" -eq 0 ]; then
         >&2 echo "Changes should come with an entry in the \"${changelog_file}\" file. This behavior
 can be overridden by using the \"no changelog\" label, which is used for changes
 that are trivial / explicitly stated not to require a changelog entry."

--- a/scripts/check-changelog.test.sh
+++ b/scripts/check-changelog.test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Regression tests for check-changelog.sh.
+#
+# There is no shell test framework wired up for scripts/ in this repo yet,
+# so this is a small, self-contained script: each case runs
+# check-changelog.sh in a throwaway git repo and checks its exit code and
+# output. Run directly: ./scripts/check-changelog.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SCRIPT="${SCRIPT_DIR}/check-changelog.sh"
+failures=0
+
+# Sets up a throwaway repo with a base branch and a "PR" branch checked out,
+# so `origin/base` resolves the same way it would in CI.
+setup_repo() {
+    local dir
+    dir="$(mktemp -d)"
+    (
+        cd "${dir}" || exit 1
+        git init -q
+        git config user.email test@example.com
+        git config user.name test
+        git remote add origin .
+        echo "existing changelog" > CHANGELOG.md
+        git add . && git commit -qm init
+        git branch base
+        git branch pr
+        git checkout -q pr
+        git update-ref refs/remotes/origin/base refs/heads/base
+    )
+    echo "${dir}"
+}
+
+assert_exit_code() {
+    local description="$1" expected="$2" actual="$3"
+    if [ "${actual}" -eq "${expected}" ]; then
+        echo "ok - ${description}"
+    else
+        echo "FAIL - ${description} (expected exit ${expected}, got ${actual})"
+        failures=$((failures + 1))
+    fi
+}
+
+# Case 1: changelog untouched on a real BASE_REF -> should fail (exit 1),
+# same as before this fix.
+repo="$(setup_repo)"
+(cd "${repo}" && BASE_REF=base "${CHECK_SCRIPT}" > /tmp/out.$$ 2>&1)
+status=$?
+assert_exit_code "unchanged changelog is rejected" 1 "${status}"
+rm -rf "${repo}" /tmp/out.$$
+
+# Case 2: changelog updated on a real BASE_REF -> should pass (exit 0),
+# same as before this fix.
+repo="$(setup_repo)"
+(cd "${repo}" && echo "new entry" >> CHANGELOG.md && git add . && git commit -qm "update changelog" \
+    && BASE_REF=base "${CHECK_SCRIPT}" > /tmp/out.$$ 2>&1)
+status=$?
+assert_exit_code "updated changelog is accepted" 0 "${status}"
+rm -rf "${repo}" /tmp/out.$$
+
+# Case 3 (regression): BASE_REF that doesn't exist on origin -> `git diff`
+# itself fails (exit 128), which must now be a hard failure instead of a
+# silent pass.
+repo="$(setup_repo)"
+(cd "${repo}" && BASE_REF=does-not-exist "${CHECK_SCRIPT}" > /tmp/out.$$ 2>&1)
+status=$?
+assert_exit_code "a bad BASE_REF fails loudly instead of passing silently" 1 "${status}"
+if grep -q "Failed to diff" /tmp/out.$$; then
+    echo "ok - failure message explains the git error"
+else
+    echo "FAIL - expected output to explain the git error, got:"
+    cat /tmp/out.$$
+    failures=$((failures + 1))
+fi
+rm -rf "${repo}" /tmp/out.$$
+
+if [ "${failures}" -gt 0 ]; then
+    echo "${failures} test(s) failed"
+    exit 1
+fi
+echo "all tests passed"


### PR DESCRIPTION
I found a bug in a CI script called check-changelog.sh. This script checks whether a PR has updated the changelog file. The problem is that when a git command fails for some reason (like using a wrong reference), the script doesn't notice and just says everything is fine and passes. So it looks successful without actually checking what it's supposed to check.

I tested this on my own computer and confirmed it really does work this way (the steps are below).

### Repro

git init -q /tmp/repro && cd /tmp/repro
git config user.email t@t.com && git config user.name t
echo hello > CHANGELOG.md && git add . && git commit -qm init

git diff --quiet "origin/does-not-exist" -- CHANGELOG.md
echo "exit code: $?"   # 128, not 0 or 1

if git diff --quiet "origin/does-not-exist" -- CHANGELOG.md; then
    echo "would report: changelog not updated"
else
    echo "silently passes instead"   # this is what happens
fi

### Fix

Captures the actual exit status of git diff --quiet instead of only checking it with if. Exit code 0 still means "no diff" (missing changelog entry), exit code 1 still means "diff found" (pass), and anything else is now a hard failure with a clear message instead of a silent pass.

### Tests

Added scripts/check-changelog.test.sh, a small self-contained regression test covering all three cases. Ran it against the pre-fix script first to confirm it goes red (reproduces the bug), then against the fix to confirm it goes green. Ran it locally: 4/4 passed.

Fixes #3627.