### PR TITLE
Document, test, and harden the Falcon math module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Changes
 
 - [BREAKING] `UniqueNodes` entries are now keyed by tree position, and missing nodes mean canonical empty subtree roots. The `NodeValue` enum was removed ([#3620](https://github.com/0xMiden/miden-vm/pull/3620)).
+- Documented, tested, and hardened the Falcon `math` module: fixed `FalconFelt::new` canonicalization and `Polynomial::div` non-termination edge cases, enforced `karatsuba` and FFT size preconditions, and added oracle-style tests (SamplerZ reference vectors, RCDT boundaries, FFT self-derivation and convolution checks, NTRU equation checks) ([#3629](https://github.com/0xMiden/miden-vm/pull/3629)).
 - Changed CodSpeed benchmarks to exclude input setup and result cleanup from timed samples, so comparisons measure only the operation under test ([#3613](https://github.com/0xMiden/miden-vm/pull/3613)).
 - [BREAKING] Removed the unused `CsrMatrix` and `CsrValidationError` APIs from `miden-utils-indexing` and `miden-core::utils` ([#3591](https://github.com/0xMiden/miden-vm/issues/3591)).
 - Added a Lychee check for local Markdown links in pull requests and fixed 17 broken links in README and docs files ([#3606](https://github.com/0xMiden/miden-vm/pull/3606)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - [BREAKING] `UniqueNodes` entries are now keyed by tree position, and missing nodes mean canonical empty subtree roots. The `NodeValue` enum was removed ([#3620](https://github.com/0xMiden/miden-vm/pull/3620)).
 - Documented, tested, and hardened the Falcon `math` module: fixed `FalconFelt::new` canonicalization and `Polynomial::div` non-termination edge cases, enforced `karatsuba` and FFT size preconditions, and added oracle-style tests (SamplerZ reference vectors, RCDT boundaries, FFT self-derivation and convolution checks, NTRU equation checks) ([#3629](https://github.com/0xMiden/miden-vm/pull/3629)).
+- [BREAKING] Hardened and documented Falcon math. `Polynomial::karatsuba` now requires equal, nonempty coefficient vectors with supported recursive lengths. Also fixed field canonicalization and polynomial division edge cases, enforced FFT size limits, and added reference and oracle tests for SamplerZ, FFT, and NTRU ([#3629](https://github.com/0xMiden/miden-vm/pull/3629)).
 - Changed CodSpeed benchmarks to exclude input setup and result cleanup from timed samples, so comparisons measure only the operation under test ([#3613](https://github.com/0xMiden/miden-vm/pull/3613)).
 - [BREAKING] Removed the unused `CsrMatrix` and `CsrValidationError` APIs from `miden-utils-indexing` and `miden-core::utils` ([#3591](https://github.com/0xMiden/miden-vm/issues/3591)).
 - Added a Lychee check for local Markdown links in pull requests and fixed 17 broken links in README and docs files ([#3606](https://github.com/0xMiden/miden-vm/pull/3606)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 #### Changes
 
 - [BREAKING] `UniqueNodes` entries are now keyed by tree position, and missing nodes mean canonical empty subtree roots. The `NodeValue` enum was removed ([#3620](https://github.com/0xMiden/miden-vm/pull/3620)).
-- Documented, tested, and hardened the Falcon `math` module: fixed `FalconFelt::new` canonicalization and `Polynomial::div` non-termination edge cases, enforced `karatsuba` and FFT size preconditions, and added oracle-style tests (SamplerZ reference vectors, RCDT boundaries, FFT self-derivation and convolution checks, NTRU equation checks) ([#3629](https://github.com/0xMiden/miden-vm/pull/3629)).
 - [BREAKING] Hardened and documented Falcon math. `Polynomial::karatsuba` now requires equal, nonempty coefficient vectors with supported recursive lengths. Also fixed field canonicalization and polynomial division edge cases, enforced FFT size limits, and added reference and oracle tests for SamplerZ, FFT, and NTRU ([#3629](https://github.com/0xMiden/miden-vm/pull/3629)).
 - Changed CodSpeed benchmarks to exclude input setup and result cleanup from timed samples, so comparisons measure only the operation under test ([#3613](https://github.com/0xMiden/miden-vm/pull/3613)).
 - [BREAKING] Removed the unused `CsrMatrix` and `CsrValidationError` APIs from `miden-utils-indexing` and `miden-core::utils` ([#3591](https://github.com/0xMiden/miden-vm/issues/3591)).

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/fft.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/fft.rs
@@ -72,7 +72,8 @@ where
         rev
     }
 
-    /// Computes the first n powers of the 2nd root of unity, and put them in bit-reversed order.
+    /// Computes the first n powers of a primitive 2n-th root of unity, and puts them in
+    /// bit-reversed order.
     #[allow(dead_code)]
     fn bitreversed_powers(n: usize) -> Vec<Self> {
         let psi = Self::primitive_root_of_unity(2 * n);
@@ -86,8 +87,8 @@ where
         array
     }
 
-    /// Computes the first n powers of the 2nd root of unity, invert them, and put them in
-    /// bit-reversed order.
+    /// Computes the first n powers of the inverse of a primitive 2n-th root of unity, and puts
+    /// them in bit-reversed order.
     #[allow(dead_code)]
     fn bitreversed_powers_inverse(n: usize) -> Vec<Self> {
         let psi = Self::primitive_root_of_unity(2 * n).inverse_or_zero();
@@ -248,22 +249,30 @@ impl CyclotomicFourier for Complex64 {
     }
 }
 
+/// True for the transform sizes the precomputed 512-entry tables support: a power of two at most
+/// 512. Sizes below 512 reuse the same tables because the first `n` entries of a bit-reversed
+/// power table for a larger order are exactly the bit-reversed table for order `n` (a property
+/// the tests pin).
+const fn is_supported_transform_size(n: usize) -> bool {
+    n.is_power_of_two() && n <= 512
+}
+
 impl FastFft for Polynomial<Complex64> {
     type Field = Complex64;
     fn fft_inplace(&mut self) {
         let n = self.coefficients.len();
-        debug_assert!(
-            (1..=512).contains(&n),
-            "unsupported: n = {n} not a power of 2 or larger than 512"
+        assert!(
+            is_supported_transform_size(n),
+            "unsupported transform size n = {n}: must be a power of two at most 512"
         );
         Complex64::fft(&mut self.coefficients, &COMPLEX_BITREVERSED_POWERS);
     }
 
     fn ifft_inplace(&mut self) {
         let n = self.coefficients.len();
-        debug_assert!(
-            (1..=512).contains(&n),
-            "unsupported: n = {n} not a power of 2 or larger than 512"
+        assert!(
+            is_supported_transform_size(n),
+            "unsupported transform size n = {n}: must be a power of two at most 512"
         );
         let psi_inv_rev: Vec<Complex64> =
             COMPLEX_BITREVERSED_POWERS.iter().map(|c| Complex64::new(c.re, -c.im)).collect();
@@ -272,10 +281,18 @@ impl FastFft for Polynomial<Complex64> {
     }
 
     fn merge_fft(a: &Self, b: &Self) -> Self {
+        // Merging two n-halves yields a 2n-point transform and reads root-table entries up to
+        // index 2n - 1, so it is the OUTPUT size that must be supported.
         let n = a.coefficients.len();
-        debug_assert!(
-            (1..=512).contains(&n),
-            "unsupported: n = {n} not a power of 2 or larger than 512"
+        assert_eq!(
+            n,
+            b.coefficients.len(),
+            "merge_fft operands must have equal coefficient counts"
+        );
+        assert!(
+            is_supported_transform_size(2 * n),
+            "unsupported merge output size 2n = {}: must be a power of two at most 512",
+            2 * n
         );
         Self {
             coefficients: Self::Field::merge_fft(
@@ -288,9 +305,10 @@ impl FastFft for Polynomial<Complex64> {
 
     fn split_fft(&self) -> (Self, Self) {
         let n = self.coefficients.len();
-        debug_assert!(
-            (1..=512).contains(&n),
-            "unsupported: n = {n} not a power of 2 or larger than 512"
+        assert!(n >= 2, "split_fft requires at least two coefficients, got {n}");
+        assert!(
+            is_supported_transform_size(n),
+            "unsupported transform size n = {n}: must be a power of two at most 512"
         );
         let psi_inv_rev: Vec<Complex64> =
             COMPLEX_BITREVERSED_POWERS.iter().map(|c| Complex64::new(c.re, -c.im)).collect();
@@ -304,18 +322,18 @@ impl FastFft for Polynomial<FalconFelt> {
 
     fn fft_inplace(&mut self) {
         let n = self.coefficients.len();
-        debug_assert!(
-            (1..=512).contains(&n),
-            "unsupported: n = {n} not a power of 2 or larger than 512"
+        assert!(
+            is_supported_transform_size(n),
+            "unsupported transform size n = {n}: must be a power of two at most 512"
         );
         FalconFelt::fft(&mut self.coefficients, &FELT_BITREVERSED_POWERS);
     }
 
     fn ifft_inplace(&mut self) {
         let n = self.coefficients.len();
-        debug_assert!(
-            (1..=512).contains(&n),
-            "unsupported: n = {n} not a power of 2 or larger than 512"
+        assert!(
+            is_supported_transform_size(n),
+            "unsupported transform size n = {n}: must be a power of two at most 512"
         );
         let ninv = match n {
             1 => FELT_NINV_1,
@@ -334,10 +352,18 @@ impl FastFft for Polynomial<FalconFelt> {
     }
 
     fn merge_fft(a: &Self, b: &Self) -> Self {
+        // Merging two n-halves yields a 2n-point transform and reads root-table entries up to
+        // index 2n - 1, so it is the OUTPUT size that must be supported.
         let n = a.coefficients.len();
-        debug_assert!(
-            (1..=512).contains(&n),
-            "unsupported: n = {n} not a power of 2 or larger than 512"
+        assert_eq!(
+            n,
+            b.coefficients.len(),
+            "merge_fft operands must have equal coefficient counts"
+        );
+        assert!(
+            is_supported_transform_size(2 * n),
+            "unsupported merge output size 2n = {}: must be a power of two at most 512",
+            2 * n
         );
         Self {
             coefficients: Self::Field::merge_fft(
@@ -350,9 +376,10 @@ impl FastFft for Polynomial<FalconFelt> {
 
     fn split_fft(&self) -> (Self, Self) {
         let n = self.coefficients.len();
-        debug_assert!(
-            (1..=512).contains(&n),
-            "unsupported: n = {n} not a power of 2 or larger than 512"
+        assert!(n >= 2, "split_fft requires at least two coefficients, got {n}");
+        assert!(
+            is_supported_transform_size(n),
+            "unsupported transform size n = {n}: must be a power of two at most 512"
         );
         let (a, b) = Self::Field::split_fft(&self.coefficients, &FELT_BITREVERSED_POWERS_INVERSE);
         (Self { coefficients: a }, Self { coefficients: b })
@@ -1915,3 +1942,217 @@ const FELT_NINV_64: FalconFelt = FalconFelt::new(12097);
 const FELT_NINV_128: FalconFelt = FalconFelt::new(12193);
 const FELT_NINV_256: FalconFelt = FalconFelt::new(12241);
 const FELT_NINV_512: FalconFelt = FalconFelt::new(12265);
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use num::One;
+    use num_complex::Complex64;
+
+    use super::{
+        COMPLEX_BITREVERSED_POWERS, CyclotomicFourier, FELT_BITREVERSED_POWERS,
+        FELT_BITREVERSED_POWERS_INVERSE, FELT_NINV_1, FELT_NINV_2, FELT_NINV_4, FELT_NINV_8,
+        FELT_NINV_16, FELT_NINV_32, FELT_NINV_64, FELT_NINV_128, FELT_NINV_256, FELT_NINV_512,
+        FalconFelt, FastFft, Polynomial,
+    };
+    use crate::rand::test_utils::prng_array;
+
+    /// Deterministic pseudorandom polynomial over the Falcon field.
+    fn random_felt_poly(n: usize, seed: u8) -> Polynomial<FalconFelt> {
+        let bytes: [u8; 1024] = prng_array([seed; 32]);
+        Polynomial::new(
+            bytes[..2 * n]
+                .chunks(2)
+                .map(|ch| FalconFelt::new(i16::from_le_bytes([ch[0], ch[1]])))
+                .collect(),
+        )
+    }
+
+    /// Deterministic pseudorandom polynomial with small real coefficients.
+    fn random_complex_poly(n: usize, seed: u8) -> Polynomial<Complex64> {
+        let bytes: [u8; 512] = prng_array([seed; 32]);
+        Polynomial::new(
+            bytes[..n]
+                .iter()
+                .map(|&b| Complex64::new((b as f64 - 127.5) / 32.0, 0.0))
+                .collect(),
+        )
+    }
+
+    /// The precompiled Falcon-field tables must equal what the generic trait derivation produces
+    /// from the primitive root — the same self-check idiom that guards hand-copied constants
+    /// elsewhere in the codebase.
+    #[test]
+    fn felt_tables_match_their_generic_derivation() {
+        assert_eq!(FELT_BITREVERSED_POWERS.to_vec(), FalconFelt::bitreversed_powers(512));
+        assert_eq!(
+            FELT_BITREVERSED_POWERS_INVERSE.to_vec(),
+            FalconFelt::bitreversed_powers_inverse(512)
+        );
+    }
+
+    #[test]
+    fn complex_table_matches_its_generic_derivation() {
+        let derived = Complex64::bitreversed_powers(512);
+        for (i, (table, fresh)) in COMPLEX_BITREVERSED_POWERS.iter().zip(&derived).enumerate() {
+            assert!(
+                (table.re - fresh.re).abs() < 1e-12 && (table.im - fresh.im).abs() < 1e-12,
+                "table entry {i} deviates from its derivation"
+            );
+        }
+    }
+
+    /// Transform sizes below 512 reuse prefixes of the 512-entry tables; this is what makes that
+    /// sound: the first n entries of a larger bit-reversed power table are exactly the
+    /// bit-reversed table of order n.
+    #[test]
+    fn table_prefixes_serve_smaller_transform_sizes() {
+        for log2n in 0..=9usize {
+            let n = 1 << log2n;
+            assert_eq!(
+                FELT_BITREVERSED_POWERS[..n].to_vec(),
+                FalconFelt::bitreversed_powers(n),
+                "prefix property fails at n = {n}"
+            );
+        }
+    }
+
+    #[test]
+    fn ninv_constants_invert_their_transform_sizes() {
+        for (n, ninv) in [
+            (1i16, FELT_NINV_1),
+            (2, FELT_NINV_2),
+            (4, FELT_NINV_4),
+            (8, FELT_NINV_8),
+            (16, FELT_NINV_16),
+            (32, FELT_NINV_32),
+            (64, FELT_NINV_64),
+            (128, FELT_NINV_128),
+            (256, FELT_NINV_256),
+            (512, FELT_NINV_512),
+        ] {
+            assert_eq!(FalconFelt::new(n) * ninv, FalconFelt::one(), "wrong inverse for n = {n}");
+        }
+    }
+
+    #[test]
+    fn felt_fft_round_trips_at_every_supported_size() {
+        // Every power of two through 512, so each size's inverse-constant dispatch arm is
+        // exercised (a wrong NINV constant at any single size fails here).
+        for log2n in 0..=9u8 {
+            let n = 1usize << log2n;
+            let f = random_felt_poly(n, 20 + log2n);
+            assert_eq!(f.fft().ifft(), f, "fft/ifft round trip failed at n = {n}");
+        }
+    }
+
+    #[test]
+    fn complex_fft_round_trips_within_float_tolerance() {
+        for (n, seed) in [(8usize, 5u8), (512, 6)] {
+            let f = random_complex_poly(n, seed);
+            let round_tripped = f.fft().ifft();
+            for (a, b) in f.coefficients.iter().zip(&round_tripped.coefficients) {
+                assert!(
+                    (a.re - b.re).abs() < 1e-9 && (a.im - b.im).abs() < 1e-9,
+                    "complex round trip deviates at n = {n}"
+                );
+            }
+        }
+    }
+
+    /// The convolution theorem over Z_q[X]/(X^n + 1): pointwise multiplication in the transform
+    /// domain must match schoolbook multiplication followed by negacyclic reduction. This
+    /// exercises the transforms, both tables, and the ninv constants against an independent
+    /// oracle in one identity.
+    #[test]
+    fn felt_fft_multiplication_matches_negacyclic_schoolbook() {
+        for (n, seed) in [(8usize, 7u8), (64, 8), (512, 9)] {
+            let f = random_felt_poly(n, seed);
+            let g = random_felt_poly(n, seed.wrapping_add(100));
+            let via_fft = f.fft().hadamard_mul(&g.fft()).ifft();
+            let via_schoolbook = (f * g).reduce_by_cyclotomic(n);
+            assert_eq!(via_fft, via_schoolbook, "convolution theorem fails at n = {n}");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "unsupported merge output size")]
+    fn merge_fft_rejects_halves_that_would_overrun_the_root_tables() {
+        // Two 512-entry halves would produce a 1024-point transform and index root-table
+        // entry 512 -- past the precompiled tables.
+        let half = random_felt_poly(512, 12);
+        let _ = Polynomial::<FalconFelt>::merge_fft(&half, &half.clone());
+    }
+
+    #[test]
+    #[should_panic(expected = "unsupported merge output size")]
+    fn complex_merge_fft_rejects_halves_that_would_overrun_the_root_tables() {
+        let half = random_complex_poly(512, 15);
+        let _ = Polynomial::<Complex64>::merge_fft(&half, &half.clone());
+    }
+
+    #[test]
+    #[should_panic(expected = "equal coefficient counts")]
+    fn merge_fft_rejects_unequal_halves() {
+        // A longer right half would otherwise be silently truncated by the merge walk.
+        let a = random_felt_poly(8, 16);
+        let b = random_felt_poly(16, 17);
+        let _ = Polynomial::<FalconFelt>::merge_fft(&a, &b);
+    }
+
+    #[test]
+    #[should_panic(expected = "equal coefficient counts")]
+    fn complex_merge_fft_rejects_unequal_halves() {
+        let a = random_complex_poly(8, 18);
+        let b = random_complex_poly(16, 19);
+        let _ = Polynomial::<Complex64>::merge_fft(&a, &b);
+    }
+
+    #[test]
+    #[should_panic(expected = "at least two coefficients")]
+    fn split_fft_rejects_a_single_coefficient() {
+        // A length-1 split would return two empty halves, silently losing the value.
+        let f = random_felt_poly(1, 30);
+        let _ = f.split_fft();
+    }
+
+    /// Characterizes split_fft against an independent construction: for
+    /// f(X) = f0(X^2) + X*f1(X^2), splitting FFT(f) must yield (FFT(f0), FFT(f1)) where f0/f1
+    /// are the even/odd coefficient halves. A pure split/merge round trip could conceal
+    /// compensating defects in the two directions; this cannot.
+    #[test]
+    fn split_fft_yields_the_even_and_odd_coefficient_transforms() {
+        for (n, seed) in [(8usize, 31u8), (512, 32)] {
+            let f = random_felt_poly(n, seed);
+            let even =
+                Polynomial::new(f.coefficients.iter().copied().step_by(2).collect::<Vec<_>>());
+            let odd = Polynomial::new(
+                f.coefficients.iter().copied().skip(1).step_by(2).collect::<Vec<_>>(),
+            );
+            let (f0, f1) = f.fft().split_fft();
+            assert_eq!(f0, even.fft(), "split's first half is not FFT(even) at n = {n}");
+            assert_eq!(f1, odd.fft(), "split's second half is not FFT(odd) at n = {n}");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "unsupported transform size")]
+    fn fft_rejects_non_power_of_two_sizes() {
+        let mut f = Polynomial::new(vec![FalconFelt::new(1); 3]);
+        f.fft_inplace();
+    }
+
+    #[test]
+    fn felt_split_merge_round_trips_in_the_transform_domain() {
+        for (n, seed) in [(8usize, 10u8), (512, 11)] {
+            let f_hat = random_felt_poly(n, seed).fft();
+            let (even, odd) = f_hat.split_fft();
+            let merged = Polynomial::<FalconFelt>::merge_fft(&even, &odd);
+            assert_eq!(merged, f_hat, "split/merge round trip failed at n = {n}");
+        }
+    }
+}

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/fft.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/fft.rs
@@ -13,17 +13,51 @@ use super::{Inverse, field::FalconFelt, polynomial::Polynomial};
 /// 2n-th primitive root of unity.
 pub trait FastFft: Sized + Clone {
     type Field: Add + Mul + AddAssign + MulAssign + Neg + Sub + SubAssign;
+
+    /// Applies the FFT in place.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the coefficient count is not a supported power of two.
     fn fft_inplace(&mut self);
+
+    /// Returns a transformed clone.
+    ///
+    /// # Panics
+    ///
+    /// Panics under the conditions described by [`Self::fft_inplace`].
     fn fft(&self) -> Self {
         let mut a = self.clone();
         a.fft_inplace();
         a
     }
 
+    /// Merges two half-size transforms.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inputs have different lengths or their combined length is not supported.
     fn merge_fft(a: &Self, b: &Self) -> Self;
+
+    /// Splits a transform into its even- and odd-degree parts.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the coefficient count is less than two or is not a supported power of two.
     fn split_fft(&self) -> (Self, Self);
 
+    /// Applies the inverse FFT in place.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the coefficient count is not a supported power of two.
     fn ifft_inplace(&mut self);
+
+    /// Returns an inverse-transformed clone.
+    ///
+    /// # Panics
+    ///
+    /// Panics under the conditions described by [`Self::ifft_inplace`].
     fn ifft(&self) -> Self {
         let mut a = self.clone();
         a.ifft_inplace();
@@ -2116,6 +2150,14 @@ mod tests {
         let mut values = [FalconFelt::new(1); 4];
         let roots = [FalconFelt::new(1); 2];
         FalconFelt::fft(&mut values, &roots);
+    }
+
+    #[test]
+    #[should_panic(expected = "root-table length 2")]
+    fn cyclotomic_ifft_rejects_a_short_root_table() {
+        let mut values = [FalconFelt::new(1); 4];
+        let roots = [FalconFelt::new(1); 2];
+        FalconFelt::ifft(&mut values, &roots, FELT_NINV_4);
     }
 
     #[test]

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/fft.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/fft.rs
@@ -127,8 +127,14 @@ where
     ///    `Self::bitreversed_powers(psi, n)` for this purpose, but this trait implementation is not
     ///    const. For the performance benefit you want a precompiled array, which you can get if you
     ///    can get by implementing the same method and marking it "const".
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a` is empty, its length is not a power of two, or `psi_rev` is too short for
+    /// the transform.
     fn fft(a: &mut [Self], psi_rev: &[Self]) {
         let n = a.len();
+        assert_supported_transform_size(n, psi_rev.len());
         let mut t = n;
         let mut m = 1;
         while m < n {
@@ -163,8 +169,14 @@ where
     ///    trait implementation is not const. For the performance benefit you want a precompiled
     ///    array, which you can get if you can get by implementing the same methods and marking them
     ///    "const".
+    ///
+    /// # Panics
+    ///
+    /// Panics if `a` is empty, its length is not a power of two, or `psi_inv_rev` is too short for
+    /// the transform.
     fn ifft(a: &mut [Self], psi_inv_rev: &[Self], ninv: Self) {
         let n = a.len();
+        assert_supported_transform_size(n, psi_inv_rev.len());
         let mut t = 1;
         let mut m = n;
         while m > 1 {
@@ -189,7 +201,15 @@ where
         }
     }
 
+    /// Splits a transform into the transforms of its even- and odd-degree coefficients.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `f` has fewer than two elements, its length is not a power of two, or
+    /// `psi_inv_rev` is too short for the transform.
     fn split_fft(f: &[Self], psi_inv_rev: &[Self]) -> (Vec<Self>, Vec<Self>) {
+        assert!(f.len() >= 2, "split_fft requires at least two coefficients, got {}", f.len());
+        assert_supported_transform_size(f.len(), psi_inv_rev.len());
         let n_over_2 = f.len() / 2;
         let mut f0 = vec![Self::zero(); n_over_2];
         let mut f1 = vec![Self::zero(); n_over_2];
@@ -203,10 +223,18 @@ where
         (f0, f1)
     }
 
+    /// Merges transforms of even- and odd-degree coefficients into one transform.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inputs have different lengths or their combined length is not a power of two
+    /// supported by `psi_rev`.
     fn merge_fft(f0: &[Self], f1: &[Self], psi_rev: &[Self]) -> Vec<Self> {
+        assert_eq!(f0.len(), f1.len(), "merge_fft operands must have equal coefficient counts");
         let n_over_2 = f0.len();
-        let n = 2 * n_over_2;
-        let mut f = vec![Self::zero(); n];
+        let output_len = n_over_2.checked_mul(2).expect("merge_fft output length overflow");
+        assert_supported_merge_size(output_len, psi_rev.len());
+        let mut f = vec![Self::zero(); output_len];
         for i in 0..n_over_2 {
             let two_i = i * 2;
             f[two_i] = f0[i] + psi_rev[n_over_2 + i] * f1[i];
@@ -249,31 +277,28 @@ impl CyclotomicFourier for Complex64 {
     }
 }
 
-/// True for the transform sizes the precomputed 512-entry tables support: a power of two at most
-/// 512. Sizes below 512 reuse the same tables because the first `n` entries of a bit-reversed
-/// power table for a larger order are exactly the bit-reversed table for order `n` (a property
-/// the tests pin).
-const fn is_supported_transform_size(n: usize) -> bool {
-    n.is_power_of_two() && n <= 512
+fn assert_supported_transform_size(n: usize, table_len: usize) {
+    assert!(
+        n.is_power_of_two() && n <= table_len,
+        "unsupported transform size n = {n}: must be a power of two at most the root-table length {table_len}"
+    );
+}
+
+fn assert_supported_merge_size(output_len: usize, table_len: usize) {
+    assert!(
+        output_len.is_power_of_two() && output_len <= table_len,
+        "unsupported merge output size {output_len}: must be a power of two at most the root-table length {table_len}"
+    );
 }
 
 impl FastFft for Polynomial<Complex64> {
     type Field = Complex64;
     fn fft_inplace(&mut self) {
-        let n = self.coefficients.len();
-        assert!(
-            is_supported_transform_size(n),
-            "unsupported transform size n = {n}: must be a power of two at most 512"
-        );
         Complex64::fft(&mut self.coefficients, &COMPLEX_BITREVERSED_POWERS);
     }
 
     fn ifft_inplace(&mut self) {
         let n = self.coefficients.len();
-        assert!(
-            is_supported_transform_size(n),
-            "unsupported transform size n = {n}: must be a power of two at most 512"
-        );
         let psi_inv_rev: Vec<Complex64> =
             COMPLEX_BITREVERSED_POWERS.iter().map(|c| Complex64::new(c.re, -c.im)).collect();
         let ninv = Complex64::new(1.0 / (n as f64), 0.0);
@@ -281,19 +306,6 @@ impl FastFft for Polynomial<Complex64> {
     }
 
     fn merge_fft(a: &Self, b: &Self) -> Self {
-        // Merging two n-halves yields a 2n-point transform and reads root-table entries up to
-        // index 2n - 1, so it is the OUTPUT size that must be supported.
-        let n = a.coefficients.len();
-        assert_eq!(
-            n,
-            b.coefficients.len(),
-            "merge_fft operands must have equal coefficient counts"
-        );
-        assert!(
-            is_supported_transform_size(2 * n),
-            "unsupported merge output size 2n = {}: must be a power of two at most 512",
-            2 * n
-        );
         Self {
             coefficients: Self::Field::merge_fft(
                 &a.coefficients,
@@ -304,12 +316,6 @@ impl FastFft for Polynomial<Complex64> {
     }
 
     fn split_fft(&self) -> (Self, Self) {
-        let n = self.coefficients.len();
-        assert!(n >= 2, "split_fft requires at least two coefficients, got {n}");
-        assert!(
-            is_supported_transform_size(n),
-            "unsupported transform size n = {n}: must be a power of two at most 512"
-        );
         let psi_inv_rev: Vec<Complex64> =
             COMPLEX_BITREVERSED_POWERS.iter().map(|c| Complex64::new(c.re, -c.im)).collect();
         let (a, b) = Self::Field::split_fft(&self.coefficients, &psi_inv_rev);
@@ -321,20 +327,12 @@ impl FastFft for Polynomial<FalconFelt> {
     type Field = FalconFelt;
 
     fn fft_inplace(&mut self) {
-        let n = self.coefficients.len();
-        assert!(
-            is_supported_transform_size(n),
-            "unsupported transform size n = {n}: must be a power of two at most 512"
-        );
         FalconFelt::fft(&mut self.coefficients, &FELT_BITREVERSED_POWERS);
     }
 
     fn ifft_inplace(&mut self) {
         let n = self.coefficients.len();
-        assert!(
-            is_supported_transform_size(n),
-            "unsupported transform size n = {n}: must be a power of two at most 512"
-        );
+        assert_supported_transform_size(n, FELT_BITREVERSED_POWERS_INVERSE.len());
         let ninv = match n {
             1 => FELT_NINV_1,
             2 => FELT_NINV_2,
@@ -352,19 +350,6 @@ impl FastFft for Polynomial<FalconFelt> {
     }
 
     fn merge_fft(a: &Self, b: &Self) -> Self {
-        // Merging two n-halves yields a 2n-point transform and reads root-table entries up to
-        // index 2n - 1, so it is the OUTPUT size that must be supported.
-        let n = a.coefficients.len();
-        assert_eq!(
-            n,
-            b.coefficients.len(),
-            "merge_fft operands must have equal coefficient counts"
-        );
-        assert!(
-            is_supported_transform_size(2 * n),
-            "unsupported merge output size 2n = {}: must be a power of two at most 512",
-            2 * n
-        );
         Self {
             coefficients: Self::Field::merge_fft(
                 &a.coefficients,
@@ -375,12 +360,6 @@ impl FastFft for Polynomial<FalconFelt> {
     }
 
     fn split_fft(&self) -> (Self, Self) {
-        let n = self.coefficients.len();
-        assert!(n >= 2, "split_fft requires at least two coefficients, got {n}");
-        assert!(
-            is_supported_transform_size(n),
-            "unsupported transform size n = {n}: must be a power of two at most 512"
-        );
         let (a, b) = Self::Field::split_fft(&self.coefficients, &FELT_BITREVERSED_POWERS_INVERSE);
         (Self { coefficients: a }, Self { coefficients: b })
     }
@@ -2089,27 +2068,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "unsupported merge output size")]
-    fn complex_merge_fft_rejects_halves_that_would_overrun_the_root_tables() {
-        let half = random_complex_poly(512, 15);
-        let _ = Polynomial::<Complex64>::merge_fft(&half, &half.clone());
-    }
-
-    #[test]
     #[should_panic(expected = "equal coefficient counts")]
     fn merge_fft_rejects_unequal_halves() {
         // A longer right half would otherwise be silently truncated by the merge walk.
         let a = random_felt_poly(8, 16);
         let b = random_felt_poly(16, 17);
         let _ = Polynomial::<FalconFelt>::merge_fft(&a, &b);
-    }
-
-    #[test]
-    #[should_panic(expected = "equal coefficient counts")]
-    fn complex_merge_fft_rejects_unequal_halves() {
-        let a = random_complex_poly(8, 18);
-        let b = random_complex_poly(16, 19);
-        let _ = Polynomial::<Complex64>::merge_fft(&a, &b);
     }
 
     #[test]
@@ -2144,6 +2108,14 @@ mod tests {
     fn fft_rejects_non_power_of_two_sizes() {
         let mut f = Polynomial::new(vec![FalconFelt::new(1); 3]);
         f.fft_inplace();
+    }
+
+    #[test]
+    #[should_panic(expected = "root-table length 2")]
+    fn cyclotomic_fft_rejects_a_short_root_table() {
+        let mut values = [FalconFelt::new(1); 4];
+        let roots = [FalconFelt::new(1); 2];
+        FalconFelt::fft(&mut values, &roots);
     }
 
     #[test]

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/field.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/field.rs
@@ -16,11 +16,7 @@ pub struct FalconFelt(u32);
 impl FalconFelt {
     /// Reduces an arbitrary signed value into its canonical representative modulo q.
     pub const fn new(value: i16) -> Self {
-        // Truncated remainder lands in (-q, q); adding q and reducing once more lands in [0, q)
-        // for every input, including negative multiples of q.
-        let reduced = value as i32 % MODULUS as i32;
-        let canonical_representative = ((reduced + MODULUS as i32) % MODULUS as i32) as u32;
-        FalconFelt(canonical_representative)
+        FalconFelt(value.rem_euclid(MODULUS) as u32)
     }
 
     /// Returns the canonical representative in [0, q).

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/field.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/field.rs
@@ -167,12 +167,19 @@ impl CyclotomicFourier for FalconFelt {
     /// q - 1 = 3 * 2^12, so the 2-Sylow subgroup of Z_q* has order 2^12 = 4096, and 1331 generates
     /// it (a primitive 4096th root of unity). Squaring halves the order, so `12 - log2(n)`
     /// squarings yield a primitive n-th root.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `n` is not a power of two in `1..=4096`.
     fn primitive_root_of_unity(n: usize) -> Self {
+        assert!(
+            n.is_power_of_two() && n <= 1 << 12,
+            "root order must be a power of two at most 4096, got {n}"
+        );
         let log2n = n.ilog2();
-        assert!(log2n <= 12);
         // 1331 is a primitive 2^12-th root of unity.
         let mut a = FalconFelt::new(1331);
-        let num_squarings = 12 - n.ilog2();
+        let num_squarings = 12 - log2n;
         for _ in 0..num_squarings {
             a *= a;
         }
@@ -309,6 +316,12 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "power of two at most 4096")]
+    fn primitive_root_rejects_an_unsupported_order() {
+        let _ = FalconFelt::primitive_root_of_unity(3);
     }
 
     #[test]

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/field.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/field.rs
@@ -5,29 +5,40 @@ use num::{One, Zero};
 
 use super::{Inverse, MODULUS, fft::CyclotomicFourier};
 
+/// An element of the Falcon base field Z_q for q = [`MODULUS`] = 12289 = 3 * 2^12 + 1, stored as
+/// its canonical representative in [0, q).
+///
+/// The derived equality compares stored representatives, so every constructor must canonicalize —
+/// [`Self::new`] reduces arbitrary signed inputs, and the arithmetic impls preserve canonicity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct FalconFelt(u32);
 
 impl FalconFelt {
+    /// Reduces an arbitrary signed value into its canonical representative modulo q.
     pub const fn new(value: i16) -> Self {
-        let gtz_bool = value >= 0;
-        let gtz_int = gtz_bool as i16;
-        let gtz_sign = gtz_int - ((!gtz_bool) as i16);
-        let reduced = gtz_sign * (gtz_sign * value) % MODULUS;
-        let canonical_representative = (reduced + MODULUS * (1 - gtz_int)) as u32;
+        // Truncated remainder lands in (-q, q); adding q and reducing once more lands in [0, q)
+        // for every input, including negative multiples of q.
+        let reduced = value as i32 % MODULUS as i32;
+        let canonical_representative = ((reduced + MODULUS as i32) % MODULUS as i32) as u32;
         FalconFelt(canonical_representative)
     }
 
+    /// Returns the canonical representative in [0, q).
     pub const fn value(self) -> i16 {
         self.0 as i16
     }
 
+    /// Returns the balanced representative in (-q/2, q/2].
     pub fn balanced_value(self) -> i16 {
         let value = self.value();
         let g = (value > ((MODULUS) / 2)) as i16;
         value - (MODULUS) * g
     }
 
+    /// Multiplies two field elements; the `const` twin of the `Mul` impl.
+    ///
+    /// The product of two canonical representatives is at most (q - 1)^2 < 2^32, so the u32
+    /// multiplication cannot overflow.
     pub const fn multiply(self, other: Self) -> Self {
         FalconFelt((self.0 * other.0) % MODULUS as u32)
     }
@@ -92,6 +103,8 @@ impl MulAssign for FalconFelt {
 impl Div for FalconFelt {
     type Output = FalconFelt;
 
+    /// Field division via [`Inverse::inverse_or_zero`]; dividing by zero yields zero rather than
+    /// panicking, mirroring the convention that gives `inverse_or_zero` its name.
     #[allow(clippy::suspicious_arithmetic_impl)]
     fn div(self, rhs: Self) -> Self::Output {
         self * rhs.inverse_or_zero()
@@ -121,6 +134,11 @@ impl One for FalconFelt {
 }
 
 impl Inverse for FalconFelt {
+    /// Computes the multiplicative inverse as `a^(q-2)` (Fermat), or zero for zero input.
+    ///
+    /// The addition chain below tracks exponents in its variable names: `sixty_three` is `a^63`
+    /// (six ones in binary), `all_ones` is `a^4095` (twelve ones), and the final product has
+    /// exponent 8192 + 4095 = 12287 = q - 2.
     fn inverse_or_zero(self) -> Self {
         // q-2 = 0b10 11 11 11  11 11 11
         let two = self.multiply(self);
@@ -148,10 +166,15 @@ impl Inverse for FalconFelt {
 }
 
 impl CyclotomicFourier for FalconFelt {
+    /// Returns a primitive n-th root of unity for a power-of-two `n` up to 2^12.
+    ///
+    /// q - 1 = 3 * 2^12, so the 2-Sylow subgroup of Z_q* has order 2^12 = 4096, and 1331 generates
+    /// it (a primitive 4096th root of unity). Squaring halves the order, so `12 - log2(n)`
+    /// squarings yield a primitive n-th root.
     fn primitive_root_of_unity(n: usize) -> Self {
         let log2n = n.ilog2();
         assert!(log2n <= 12);
-        // and 1331 is a twelfth root of unity
+        // 1331 is a primitive 2^12-th root of unity.
         let mut a = FalconFelt::new(1331);
         let num_squarings = 12 - n.ilog2();
         for _ in 0..num_squarings {
@@ -170,5 +193,133 @@ impl TryFrom<u32> for FalconFelt {
         } else {
             Ok(FalconFelt::new(value as i16))
         }
+    }
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use num::{One, Zero};
+
+    use super::{FalconFelt, Inverse, MODULUS};
+    use crate::dsa::falcon512_poseidon2::math::fft::CyclotomicFourier;
+
+    const Q: i64 = MODULUS as i64;
+
+    /// The reference reduction every constructor and operation is checked against.
+    fn canonical(value: i64) -> u32 {
+        (((value % Q) + Q) % Q) as u32
+    }
+
+    /// A boundary-heavy sample of canonical representatives for pairwise operation checks.
+    fn representatives() -> Vec<u32> {
+        let mut values = vec![0, 1, 2, 3, (Q as u32) / 2, Q as u32 - 2, Q as u32 - 1];
+        // A fixed stride walks the whole range without blowing up the pairwise product count.
+        values.extend((0..Q as u32).step_by(97));
+        values
+    }
+
+    #[test]
+    fn new_canonicalizes_every_i16_input() {
+        for value in i16::MIN..=i16::MAX {
+            let felt = FalconFelt::new(value);
+            assert_eq!(felt.0, canonical(value as i64), "wrong reduction for {value}");
+        }
+    }
+
+    #[test]
+    fn new_identifies_negative_multiples_of_q_with_zero() {
+        // Regression: the previous branchless reduction mapped -q and -2q to the non-canonical
+        // internal value q, so they compared unequal to zero.
+        assert_eq!(FalconFelt::new(-(Q as i16)), FalconFelt::zero());
+        assert_eq!(FalconFelt::new(-2 * Q as i16), FalconFelt::zero());
+    }
+
+    #[test]
+    fn add_sub_neg_mul_agree_with_reference_arithmetic() {
+        for &a in &representatives() {
+            let fa = FalconFelt(a);
+            assert_eq!((-fa).0, canonical(-(a as i64)), "neg failed for {a}");
+            for &b in &representatives() {
+                let fb = FalconFelt(b);
+                let (a, b) = (a as i64, b as i64);
+                assert_eq!((fa + fb).0, canonical(a + b), "add failed for {a} + {b}");
+                assert_eq!((fa - fb).0, canonical(a - b), "sub failed for {a} - {b}");
+                assert_eq!((fa * fb).0, canonical(a * b), "mul failed for {a} * {b}");
+                assert_eq!(fa * fb, fa.multiply(fb), "const multiply disagrees with Mul");
+            }
+        }
+    }
+
+    #[test]
+    fn every_nonzero_element_has_a_working_inverse() {
+        for a in 1..Q as u32 {
+            let fa = FalconFelt(a);
+            let inv = fa.inverse_or_zero();
+            assert_eq!(fa * inv, FalconFelt::one(), "a * a^-1 != 1 for a = {a}");
+        }
+        assert_eq!(FalconFelt::zero().inverse_or_zero(), FalconFelt::zero());
+    }
+
+    #[test]
+    fn division_round_trips_and_division_by_zero_is_zero() {
+        for &a in &representatives() {
+            let fa = FalconFelt(a);
+            for &b in &representatives() {
+                let fb = FalconFelt(b);
+                if b != 0 {
+                    assert_eq!((fa / fb) * fb, fa, "a / b * b != a for {a}, {b}");
+                }
+            }
+            assert_eq!(fa / FalconFelt::zero(), FalconFelt::zero());
+        }
+    }
+
+    #[test]
+    fn balanced_value_is_balanced_and_round_trips() {
+        for a in 0..Q as u32 {
+            let balanced = FalconFelt(a).balanced_value();
+            assert!(
+                -(Q as i16) / 2 <= balanced && balanced <= Q as i16 / 2,
+                "balanced value {balanced} out of range for {a}"
+            );
+            assert_eq!(FalconFelt::new(balanced), FalconFelt(a), "round trip failed for {a}");
+        }
+    }
+
+    #[test]
+    fn primitive_roots_of_unity_have_exact_order() {
+        for log2n in 0..=12u32 {
+            let n = 1usize << log2n;
+            let root = FalconFelt::primitive_root_of_unity(n);
+            let mut power = FalconFelt::one();
+            for _ in 0..n {
+                power *= root;
+            }
+            assert_eq!(power, FalconFelt::one(), "root^n != 1 for n = {n}");
+            if n > 1 {
+                let mut half_power = FalconFelt::one();
+                for _ in 0..n / 2 {
+                    half_power *= root;
+                }
+                assert_eq!(
+                    half_power,
+                    -FalconFelt::one(),
+                    "root^(n/2) != -1 for n = {n}: the root is not primitive"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn try_from_accepts_below_modulus_and_rejects_at_modulus() {
+        assert_eq!(FalconFelt::try_from(0u32), Ok(FalconFelt::zero()));
+        assert_eq!(FalconFelt::try_from(MODULUS as u32 - 1), Ok(FalconFelt(MODULUS as u32 - 1)));
+        assert!(FalconFelt::try_from(MODULUS as u32).is_err());
+        assert!(FalconFelt::try_from(u32::MAX).is_err());
     }
 }

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/mod.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/mod.rs
@@ -37,6 +37,10 @@ const MAX_BIG_POLY_COEFFICIENT_SIZE: i16 = (1 << (WIDTH_BIG_POLY_COEFFICIENT - 1
 
 pub trait Inverse: Copy + Zero + MulAssign + One {
     /// Gets the inverse of a, or zero if it is zero.
+    ///
+    /// Only the exact-field implementations (e.g. [`FalconFelt`]) honor the zero-maps-to-zero
+    /// convention; the `f64` and `Complex64` implementations return non-finite values for zero
+    /// instead. Their Falcon call sites only ever invert nonzero denominators.
     fn inverse_or_zero(self) -> Self;
 
     /// Gets the inverses of a batch of elements, and skip over any that are zero.
@@ -321,4 +325,92 @@ fn xgcd(a: &BigInt, b: &BigInt) -> (BigInt, BigInt, BigInt) {
 /// [-bound, bound].
 fn check_coefficients_bound(polynomial: &Polynomial<i16>, bound: i16) -> bool {
     polynomial.to_balanced_values().iter().all(|c| *c <= bound && *c >= -bound)
+}
+
+// TESTS
+// ================================================================================================
+
+#[cfg(test)]
+mod tests {
+    use alloc::{vec, vec::Vec};
+
+    use num::{BigInt, FromPrimitive, One, Zero};
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+
+    use super::{
+        FalconFelt, Inverse, MODULUS, Polynomial, check_coefficients_bound, ntru_gen, xgcd,
+    };
+
+    /// `ntru_gen` returns the secret-key basis rows `[g, -f, G, -F]`; the NTRU equation
+    /// `f*G - g*F = q (mod X^n + 1)` is then exactly `a*d - b*c = q` on the returned
+    /// quadruple `[a, b, c, d]`. Schoolbook `Mul` is the oracle here, independent of the
+    /// karatsuba path `ntru_solve` itself uses.
+    #[test]
+    fn ntru_gen_output_satisfies_the_ntru_equation() {
+        for (n, seed_byte) in [(64usize, 7u8), (128, 11)] {
+            let mut rng = ChaCha20Rng::from_seed([seed_byte; 32]);
+            let [a, b, c, d] = ntru_gen(n, &mut rng).map(|p| p.map(|&c| c as i64));
+
+            let determinant = (a * d - b * c).reduce_by_cyclotomic(n);
+            assert_eq!(
+                determinant,
+                Polynomial::new(vec![MODULUS as i64]),
+                "basis determinant must equal q for n = {n}",
+            );
+        }
+    }
+
+    /// The identity `ntru_solve` recurses on: lifting the half-size field norm back up must agree
+    /// with multiplying `f` by its Galois adjoint, `N(f)(X^2) = f(X) * f(-X) (mod X^n + 1)`.
+    #[test]
+    fn field_norm_lift_matches_galois_adjoint_product() {
+        let n = 8;
+        let f = Polynomial::new(
+            [3i64, -1, 4, 1, -5, 9, -2, 6]
+                .iter()
+                .map(|&c| BigInt::from_i64(c).unwrap())
+                .collect(),
+        );
+
+        let lifted_norm = f.field_norm().lift_next_cyclotomic();
+        let adjoint_product = (f.clone() * f.galois_adjoint()).reduce_by_cyclotomic(n);
+        assert_eq!(lifted_norm, adjoint_product);
+    }
+
+    #[test]
+    fn xgcd_satisfies_bezout_identity() {
+        let big = |v: i64| BigInt::from_i64(v).unwrap();
+        for (a, b) in [(240, 46), (46, 240), (17, 5), (12, 18), (0, 9), (9, 0), (1, 1)] {
+            let (g, u, v) = xgcd(&big(a), &big(b));
+            assert_eq!(u.clone() * big(a) + v.clone() * big(b), g, "Bezout failed for ({a}, {b})");
+            if a != 0 && b != 0 {
+                assert!(
+                    (big(a) % g.clone()).is_zero() && (big(b) % g.clone()).is_zero(),
+                    "gcd does not divide both operands for ({a}, {b})"
+                );
+            }
+        }
+        // Coprimality is what ntru_solve's base case checks against One.
+        let (g, ..) = xgcd(&big(17), &big(5));
+        assert!(g.is_one());
+    }
+
+    #[test]
+    fn batch_inverse_or_zero_matches_individual_inverses_and_skips_zeros() {
+        let batch: Vec<FalconFelt> =
+            [5i16, 0, 1, 12288, 0, 7, 42].iter().map(|&v| FalconFelt::new(v)).collect();
+        let batch_inverses = FalconFelt::batch_inverse_or_zero(&batch);
+        assert_eq!(batch.len(), batch_inverses.len());
+        for (element, inverse) in batch.iter().zip(&batch_inverses) {
+            assert_eq!(element.inverse_or_zero(), *inverse);
+        }
+    }
+
+    #[test]
+    fn check_coefficients_bound_is_inclusive() {
+        let poly = Polynomial::new(vec![3i16, -3, 0]);
+        assert!(check_coefficients_bound(&poly, 3));
+        assert!(!check_coefficients_bound(&poly, 2));
+    }
 }

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
@@ -383,8 +383,12 @@ impl<F: Mul<Output = F> + Sub<Output = F> + AddAssign + Zero + Div<Output = F> +
     ///
     /// Both coefficient vectors must have the same nonzero length `n`, and `n` must stay even
     /// under repeated halving until it reaches the recursion's base case (`n <= 8`); any power of
-    /// two qualifies, and Falcon only multiplies power-of-two lengths. Unsupported shapes panic:
-    /// an odd split truncates a cross term and overruns the output buffer.
+    /// two qualifies, and Falcon only multiplies power-of-two lengths.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the coefficient vectors have different lengths, are empty, or have a length that
+    /// reaches an odd value above eight while being repeatedly halved.
     pub fn karatsuba(&self, other: &Self) -> Self {
         assert_eq!(
             self.coefficients.len(),
@@ -698,6 +702,8 @@ impl<F: Zeroize> ZeroizeOnDrop for Polynomial<F> {}
 
 #[cfg(test)]
 mod tests {
+    use proptest::{collection::vec, prelude::*};
+
     use super::{FalconFelt, N, Polynomial};
     use crate::rand::test_utils::prng_array;
 
@@ -737,7 +743,7 @@ mod tests {
     }
 
     #[test]
-    fn karatsuba_matches_schoolbook_for_every_accepted_shape() {
+    fn karatsuba_agrees_with_mul_for_representative_admissible_shapes() {
         // Powers of two (the live Falcon shapes) plus the accepted non-power-of-two lengths,
         // which halve evenly to the base case and would otherwise have no output coverage.
         for n in [2i64, 4, 8, 16, 32, 10, 20, 24] {
@@ -745,6 +751,20 @@ mod tests {
             let g = Polynomial::new((0..n).map(|i| 5 * i - 11).collect());
             let schoolbook = f.clone() * g.clone();
             assert_eq!(f.karatsuba(&g), schoolbook, "karatsuba disagrees at n = {n}");
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn karatsuba_agrees_with_mul_for_admissible_operands(
+            (left, right) in (1usize..=8, 0u32..=6).prop_flat_map(|(base, doublings)| {
+                let len = base << doublings;
+                (vec(-1_000i64..=1_000, len), vec(-1_000i64..=1_000, len))
+            }),
+        ) {
+            let left = Polynomial::new(left);
+            let right = Polynomial::new(right);
+            prop_assert_eq!(left.karatsuba(&right), left * right);
         }
     }
 

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/polynomial.rs
@@ -146,8 +146,11 @@ impl<
         Self::new(coefficients)
     }
 
-    /// Computes the galois adjoint of the polynomial in the cyclotomic ring F\[ X \] / < X^n + 1 >
-    /// , which corresponds to f(x^2).
+    /// Computes the Galois adjoint of the polynomial in the cyclotomic ring
+    /// F\[ X \] / < X^n + 1 >: the map f(X) -> f(-X), negating the odd-degree coefficients.
+    ///
+    /// Together with [`Self::lift_next_cyclotomic`], which computes f(X^2), this implements the
+    /// field-norm identity NTRU solving relies on: N(f)(X^2) = f(X) * f(-X).
     pub fn galois_adjoint(&self) -> Self {
         Self::new(
             self.coefficients
@@ -377,7 +380,21 @@ impl<F: Mul<Output = F> + Sub<Output = F> + AddAssign + Zero + Div<Output = F> +
     Polynomial<F>
 {
     /// Multiply two polynomials using Karatsuba's divide-and-conquer algorithm.
+    ///
+    /// Both coefficient vectors must have the same nonzero length `n`, and `n` must stay even
+    /// under repeated halving until it reaches the recursion's base case (`n <= 8`); any power of
+    /// two qualifies, and Falcon only multiplies power-of-two lengths. Unsupported shapes panic:
+    /// an odd split truncates a cross term and overruns the output buffer.
     pub fn karatsuba(&self, other: &Self) -> Self {
+        assert_eq!(
+            self.coefficients.len(),
+            other.coefficients.len(),
+            "karatsuba operands must have equal coefficient counts",
+        );
+        assert!(
+            karatsuba_length_is_supported(self.coefficients.len()),
+            "karatsuba operand length must be nonzero and stay even down to the base case (e.g. a power of two)",
+        );
         Polynomial::new(vector_karatsuba(&self.coefficients, &other.coefficients))
     }
 }
@@ -446,17 +463,27 @@ where
 {
     type Output = Polynomial<F>;
 
+    /// Polynomial long division.
+    ///
+    /// Each step divides the remainder's leading coefficient by the denominator's; that quotient
+    /// must cancel the remainder's leading term. This is automatic for exact field
+    /// implementations such as `FalconFelt`; it can fail for non-field coefficient types (e.g.
+    /// integers, where a step may not divide evenly) and for IEEE floats (where
+    /// `(a / b) * b` can leave a nonzero residue).
+    ///
+    /// # Panics
+    /// Panics if `denominator` is zero, or if a step's leading term does not cancel — with a
+    /// non-field `F` the loop would otherwise repeat forever on an unchanged remainder.
     fn div(self, denominator: Self) -> Self::Output {
-        if denominator.is_zero() {
-            panic!();
-        }
+        assert!(!denominator.is_zero(), "cannot divide a polynomial by the zero polynomial");
         if self.is_zero() {
             return Self::zero();
         }
         let mut remainder = self;
         let mut quotient = Polynomial::<F>::zero();
         while remainder.degree().unwrap() >= denominator.degree().unwrap() {
-            let shift = remainder.degree().unwrap() - denominator.degree().unwrap();
+            let degree_before = remainder.degree().unwrap();
+            let shift = degree_before - denominator.degree().unwrap();
             let quotient_coefficient = remainder.lc() / denominator.lc();
             let monomial = Self::constant(quotient_coefficient).shift(shift);
             quotient += monomial.clone();
@@ -464,9 +491,30 @@ where
             if remainder.is_zero() {
                 break;
             }
+            assert!(
+                remainder.degree().unwrap() < degree_before,
+                "inexact polynomial division: the leading-coefficient quotient did not cancel the leading term"
+            );
         }
         quotient
     }
+}
+
+/// True when `n` is nonzero and halves down to [`vector_karatsuba`]'s base case without passing
+/// through an odd intermediate length. An odd split overruns the output buffer (the cross term
+/// spills past `2n - 1` entries), and a zero length underflows the base case's `n + n - 1`
+/// product size.
+const fn karatsuba_length_is_supported(mut n: usize) -> bool {
+    if n == 0 {
+        return false;
+    }
+    while n > 8 {
+        if n % 2 == 1 {
+            return false;
+        }
+        n /= 2;
+    }
+    true
 }
 
 fn vector_karatsuba<
@@ -660,6 +708,99 @@ mod tests {
         let nonzero = Polynomial::new(vec![1, 2, 3]);
         let result = zero / nonzero;
         assert!(result.is_zero());
+    }
+
+    #[test]
+    fn div_exact_integer_division_returns_quotient() {
+        // (x + 1)(x + 2) = x^2 + 3x + 2 divides evenly at every step.
+        let numerator = Polynomial::new(vec![2i64, 3, 1]);
+        let denominator = Polynomial::new(vec![1i64, 1]);
+        assert_eq!((numerator / denominator).coefficients, vec![2, 1]);
+    }
+
+    #[test]
+    #[should_panic(expected = "inexact polynomial division")]
+    fn div_inexact_integer_division_panics_instead_of_looping() {
+        // 3 / 2 truncates to 1, leaving remainder 1 that no further step can reduce; without the
+        // progress check this repeated forever.
+        let numerator = Polynomial::new(vec![3i64]);
+        let denominator = Polynomial::new(vec![2i64]);
+        let _ = numerator / denominator;
+    }
+
+    #[test]
+    #[should_panic(expected = "zero polynomial")]
+    fn div_by_zero_panics_with_message() {
+        use num::Zero;
+        let numerator = Polynomial::new(vec![1i64]);
+        let _ = numerator / Polynomial::<i64>::zero();
+    }
+
+    #[test]
+    fn karatsuba_matches_schoolbook_for_every_accepted_shape() {
+        // Powers of two (the live Falcon shapes) plus the accepted non-power-of-two lengths,
+        // which halve evenly to the base case and would otherwise have no output coverage.
+        for n in [2i64, 4, 8, 16, 32, 10, 20, 24] {
+            let f = Polynomial::new((0..n).map(|i| i * i - 7 * i + 3).collect());
+            let g = Polynomial::new((0..n).map(|i| 5 * i - 11).collect());
+            let schoolbook = f.clone() * g.clone();
+            assert_eq!(f.karatsuba(&g), schoolbook, "karatsuba disagrees at n = {n}");
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "karatsuba operand length")]
+    fn karatsuba_rejects_empty_operands() {
+        let empty = Polynomial::<i64>::new(vec![]);
+        let _ = empty.karatsuba(&empty.clone());
+    }
+
+    #[test]
+    fn karatsuba_length_support_matches_the_recursion_shape() {
+        use super::karatsuba_length_is_supported;
+        for supported in [1usize, 2, 5, 8, 10, 20, 24, 64, 512] {
+            assert!(karatsuba_length_is_supported(supported), "{supported} must be supported");
+        }
+        for unsupported in [0usize, 9, 11, 17, 18, 34, 513] {
+            assert!(
+                !karatsuba_length_is_supported(unsupported),
+                "{unsupported} must be unsupported"
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "karatsuba operand length")]
+    fn karatsuba_rejects_odd_lengths_above_the_base_case() {
+        let f = Polynomial::new(vec![1i64; 9]);
+        let _ = f.karatsuba(&f.clone());
+    }
+
+    #[test]
+    #[should_panic(expected = "equal coefficient counts")]
+    fn karatsuba_rejects_unequal_lengths() {
+        let f = Polynomial::new(vec![1i64; 8]);
+        let g = Polynomial::new(vec![1i64; 4]);
+        let _ = f.karatsuba(&g);
+    }
+
+    #[test]
+    fn galois_adjoint_negates_odd_degree_coefficients() {
+        let f = Polynomial::new(vec![1i64, 2, 3, 4]);
+        assert_eq!(f.galois_adjoint().coefficients, vec![1, -2, 3, -4]);
+    }
+
+    #[test]
+    fn galois_adjoint_product_with_self_is_even() {
+        // f(X) * f(-X) is an even function, so before any cyclotomic reduction every odd-degree
+        // coefficient of the product vanishes -- the property the NTRU field norm relies on.
+        let f = Polynomial::new(vec![3i64, -1, 4, 1, -5, 9, -2, 6]);
+        let product = f.clone() * f.galois_adjoint();
+        for (degree, c) in product.coefficients.iter().enumerate() {
+            if degree % 2 == 1 {
+                assert_eq!(*c, 0, "odd-degree coefficient {degree} must vanish");
+            }
+        }
     }
 
     #[test]

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/samplerz.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/samplerz.rs
@@ -232,7 +232,7 @@ mod test {
     /// tests: a draw of exactly `RCDT[k]` must sample `k` (only the thresholds above index `k`
     /// exceed it), and `RCDT[k] - 1` must sample `k + 1`. The KAT vectors below only reach
     /// z0 in {0..3}, so this is what pins the table's lower fourteen thresholds. The expected
-    /// values are an independent copy: a change to either listing breaks the pairing.
+    /// thresholds are repeated here deliberately: changing either listing alone breaks the test.
     #[test]
     fn base_sampler_respects_every_rcdt_threshold_boundary() {
         const RCDT_PIN: [u128; 18] = [
@@ -276,8 +276,8 @@ mod test {
     /// across all rejection iterations (big-endian per 72-bit base draw); the replay applies the
     /// same per-draw reversal the upstream harness does, so this pins the base-sampler
     /// thresholds it reaches, the first-byte acceptance decisions, and the byte-consumption
-    /// order in one check. (Every vector decides on ber_exp's first comparison byte; the depth
-    /// test below covers the deeper comparisons.)
+    /// order in one check. Every vector decides on ber_exp's first comparison byte; the dedicated
+    /// depth test covers the deeper comparisons.
     #[test]
     fn sampler_z_matches_reference_known_answers() {
         #[rustfmt::skip]

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/samplerz.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/samplerz.rs
@@ -95,7 +95,14 @@ fn ber_exp<R: Rng>(x: f64, ccs: f64, rng: &mut R) -> bool {
 }
 
 /// Samples an integer from the Gaussian distribution with given mean (mu) and standard deviation
-/// (sigma).
+/// (sigma) -- SamplerZ, Algorithm 15 of the Falcon specification (which uses Algorithms 12-14).
+///
+/// `sigma_min / sigma` scales the acceptance probability, which helps make the running time
+/// independent of sigma; `sigma` must lie in [sigma_min, SIGMA_MAX = 1.8205].
+///
+/// Byte-consumption contract with `rng` (pinned by the reference known-answer test below): each
+/// rejection-loop attempt draws 9 bytes for the base sampler, 1 byte for the sign, then
+/// [`ber_exp`] draws up to 8 further bytes one at a time, most significant comparison first.
 pub(crate) fn sampler_z<R: Rng>(mu: f64, sigma: f64, sigma_min: f64, rng: &mut R) -> i16 {
     const SIGMA_MAX: f64 = 1.8205;
     const INV_2SIGMA_MAX_SQ: f64 = 1f64 / (2f64 * SIGMA_MAX * SIGMA_MAX);
@@ -127,7 +134,183 @@ pub(crate) fn sampler_z<R: Rng>(mu: f64, sigma: f64, sigma_min: f64, rng: &mut R
 
 #[cfg(test)]
 mod test {
-    use super::approx_exp;
+    use alloc::vec::Vec;
+
+    use rand::rand_core::{Infallible, TryRng, utils};
+
+    use super::{approx_exp, base_sampler, ber_exp, sampler_z};
+
+    /// Replays a fixed byte string, panicking if the sampler requests more bytes than the vector
+    /// provides.
+    struct ReplayRng {
+        bytes: Vec<u8>,
+        cursor: usize,
+    }
+
+    impl ReplayRng {
+        fn from_bytes(bytes: Vec<u8>) -> Self {
+            Self { bytes, cursor: 0 }
+        }
+
+        fn new(hex: &str) -> Self {
+            assert!(hex.len().is_multiple_of(2));
+            let bytes = (0..hex.len())
+                .step_by(2)
+                .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+                .collect();
+            Self { bytes, cursor: 0 }
+        }
+
+        fn fill(&mut self, dest: &mut [u8]) {
+            let end = self.cursor + dest.len();
+            assert!(end <= self.bytes.len(), "sampler requested more bytes than the KAT provides");
+            dest.copy_from_slice(&self.bytes[self.cursor..end]);
+            // Convention bridge: the upstream KAT file serializes each 72-bit base-sampler draw
+            // big-endian (first hex byte most significant). The samplers themselves -- falcon.py,
+            // the C reference's `(hi << 64) | lo`, and this port -- all treat the last of the 9
+            // drawn bytes as most significant, and falcon.py's own KAT harness performs exactly
+            // this per-draw reversal before feeding its sampler. The 1-byte sign and ber_exp
+            // draws are order-invariant.
+            if dest.len() == 9 {
+                dest.reverse();
+            }
+            self.cursor = end;
+        }
+    }
+
+    impl TryRng for ReplayRng {
+        type Error = Infallible;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            utils::next_word_via_fill::<u32, _>(self)
+        }
+
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            utils::next_u64_via_u32(self)
+        }
+
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+            self.fill(dest);
+            Ok(())
+        }
+    }
+
+    /// Drives ber_exp's lexicographic comparison to every depth from 1 to 8: with the first
+    /// k - 1 comparison bytes tying z's, the decision lands on byte k. The KAT vectors all
+    /// decide on the first byte, so without this a corruption confined to a deeper comparison
+    /// byte survives every other test in the crate (mutation-confirmed).
+    #[test]
+    fn ber_exp_decides_at_every_comparison_depth() {
+        // Parameters chosen so s = floor(x / ln 2) = 0 and every comparison byte of z is
+        // strictly interior; the assert below makes any platform float drift loud instead of
+        // silently weakening the test.
+        let (x, ccs) = (0.3f64, 0.7f64);
+        let z = (approx_exp(x, ccs) << 1) - 1;
+        let z_bytes: Vec<u8> = (0..8).map(|j| ((z >> (56 - 8 * j)) & 0xff) as u8).collect();
+        assert!(
+            z_bytes.iter().all(|&b| b > 0x00 && b < 0xff),
+            "test parameters must give interior comparison bytes: {z_bytes:?}"
+        );
+
+        for depth in 1..=8usize {
+            let mut accept = z_bytes[..depth - 1].to_vec();
+            accept.push(z_bytes[depth - 1] - 1);
+            let mut rng = ReplayRng::from_bytes(accept);
+            assert!(ber_exp(x, ccs, &mut rng), "must accept at depth {depth}");
+            assert_eq!(rng.cursor, depth, "accept must consume exactly {depth} bytes");
+
+            let mut reject = z_bytes[..depth - 1].to_vec();
+            reject.push(z_bytes[depth - 1] + 1);
+            let mut rng = ReplayRng::from_bytes(reject);
+            assert!(!ber_exp(x, ccs, &mut rng), "must reject at depth {depth}");
+            assert_eq!(rng.cursor, depth, "reject must consume exactly {depth} bytes");
+        }
+
+        // A full eight-byte tie leaves w = 0, which rejects.
+        let mut rng = ReplayRng::from_bytes(z_bytes);
+        assert!(!ber_exp(x, ccs, &mut rng), "a full tie must reject");
+        assert_eq!(rng.cursor, 8);
+    }
+
+    /// Boundary check for every RCDT threshold, in the spirit of the C reference's sampler
+    /// tests: a draw of exactly `RCDT[k]` must sample `k` (only the thresholds above index `k`
+    /// exceed it), and `RCDT[k] - 1` must sample `k + 1`. The KAT vectors below only reach
+    /// z0 in {0..3}, so this is what pins the table's lower fourteen thresholds. The expected
+    /// values are an independent copy: a change to either listing breaks the pairing.
+    #[test]
+    fn base_sampler_respects_every_rcdt_threshold_boundary() {
+        const RCDT_PIN: [u128; 18] = [
+            3024686241123004913666,
+            1564742784480091954050,
+            636254429462080897535,
+            199560484645026482916,
+            47667343854657281903,
+            8595902006365044063,
+            1163297957344668388,
+            117656387352093658,
+            8867391802663976,
+            496969357462633,
+            20680885154299,
+            638331848991,
+            14602316184,
+            247426747,
+            3104126,
+            28824,
+            198,
+            1,
+        ];
+
+        let draw = |u: u128| {
+            let mut bytes = [0u8; 9];
+            bytes.copy_from_slice(&u.to_le_bytes()[..9]);
+            base_sampler(bytes)
+        };
+
+        assert_eq!(draw(0), 18, "u = 0 lies below every threshold");
+        assert_eq!(draw((1u128 << 72) - 1), 0, "the maximal draw lies above every threshold");
+        for (k, threshold) in RCDT_PIN.into_iter().enumerate() {
+            assert_eq!(draw(threshold), k as i16, "u = RCDT[{k}] must sample {k}");
+            assert_eq!(draw(threshold - 1), k as i16 + 1, "u = RCDT[{k}] - 1 must sample {k}+1");
+        }
+    }
+
+    /// Known-answer vectors for SamplerZ from the Falcon reference material
+    /// (tprest/falcon.py, `scripts/samplerz_KAT512.py`, mirroring the vectors accompanying the
+    /// specification). `octets` is the upstream KAT serialization of the randomness consumed
+    /// across all rejection iterations (big-endian per 72-bit base draw); the replay applies the
+    /// same per-draw reversal the upstream harness does, so this pins the base-sampler
+    /// thresholds it reaches, the first-byte acceptance decisions, and the byte-consumption
+    /// order in one check. (Every vector decides on ber_exp's first comparison byte; the depth
+    /// test below covers the deeper comparisons.)
+    #[test]
+    fn sampler_z_matches_reference_known_answers() {
+        #[rustfmt::skip]
+        let kats: [(f64, f64, f64, &str, i16); 8] = [
+            (-91.90471153063714, 1.7037990414754918, 1.2778336969128337,
+             "0FC5442FF043D66E91D1EACAC64EA5450A22941EDC6C", -92),
+            (-8.322564895434937, 1.7037990414754918, 1.2778336969128337,
+             "F4DA0F8D8444D1A77265C2EF6F98BBBB4BEE7DB8D9B3", -8),
+            (-19.096516109216804, 1.7035823083824078, 1.2778336969128334,
+             "DB47F6D7FB9B19F25C36D6B9334D477A8BC0BE68145D", -20),
+            (-11.335543982423326, 1.7035823083824078, 1.2778336969128334,
+             "AE41B4F5209665C74D00DCC1A8168A7BB516B3190CB42C1DED26CD52AED770ECA7DD334E0547BCC3C163CE0B", -12),
+            (7.9386734193997555, 1.6984647769450156, 1.2778336969128337,
+             "31054166C1012780C603AE9B833CEC73F2F41CA5807CC89C92158834632F9B1555", 8),
+            (-28.990850086867255, 1.6984647769450156, 1.2778336969128337,
+             "737E9D68A50A06DBBC6477", -30),
+            (-9.071257914091655, 1.6980782114808988, 1.2778336969128339,
+             "A98DDD14BF0BF22061D632", -10),
+            (-43.88754568839566, 1.6980782114808988, 1.2778336969128339,
+             "3CBF6818A68F7AB9991514", -41),
+        ];
+
+        for (mu, sigma, sigma_min, octets, expected_z) in kats {
+            let mut rng = ReplayRng::new(octets);
+            let z = sampler_z(mu, sigma, sigma_min, &mut rng);
+            assert_eq!(z, expected_z, "wrong sample for mu = {mu}");
+            assert_eq!(rng.cursor, rng.bytes.len(), "sampler left unused KAT bytes for mu = {mu}");
+        }
+    }
 
     #[test]
     fn test_approx_exp() {

--- a/crates/crypto/src/dsa/falcon512_poseidon2/math/samplerz.rs
+++ b/crates/crypto/src/dsa/falcon512_poseidon2/math/samplerz.rs
@@ -153,11 +153,7 @@ mod test {
         }
 
         fn new(hex: &str) -> Self {
-            assert!(hex.len().is_multiple_of(2));
-            let bytes = (0..hex.len())
-                .step_by(2)
-                .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
-                .collect();
+            let bytes = hex::decode(hex).expect("KAT randomness must be valid hexadecimal");
             Self { bytes, cursor: 0 }
         }
 
@@ -206,7 +202,7 @@ mod test {
         // silently weakening the test.
         let (x, ccs) = (0.3f64, 0.7f64);
         let z = (approx_exp(x, ccs) << 1) - 1;
-        let z_bytes: Vec<u8> = (0..8).map(|j| ((z >> (56 - 8 * j)) & 0xff) as u8).collect();
+        let z_bytes = z.to_be_bytes().to_vec();
         assert!(
             z_bytes.iter().all(|&b| b > 0x00 && b < 0xff),
             "test parameters must give interior comparison bytes: {z_bytes:?}"


### PR DESCRIPTION
Closes #3487.

**Breaking:** `Polynomial::karatsuba` now rejects unequal, empty, and unsupported recursive operand shapes with documented panics. Some unequal operands at the old base case previously happened to work.

Documents the Falcon `math` module and adds oracle-style test coverage throughout (module tests 19 -> 54): SamplerZ reference known-answer vectors, RCDT threshold boundaries, FFT table self-derivation and convolution checks, and NTRU equation checks.

Writing these surfaced a few edge-case defects, now fixed: `FalconFelt::new` canonicalization for negative multiples of q, `Polynomial::div` non-termination when a division step fails to cancel the leading term, unenforced `karatsuba`/FFT size preconditions, and several incorrect doc comments (e.g. `galois_adjoint` computes `f(-x)`, not `f(x^2)`). None of the fixes change behavior on live Falcon signing/keygen paths.