### PR TITLE
fix(crypto): reject out-of-range empty_nodes_mask bits in SparseMerklePath::read_from

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -108,6 +108,7 @@ jobs:
           - merkle_store
           - smt_serde
           - partial_smt
+          - sparse_path
           - mmr
           - crypto
           - aead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - [BREAKING] Reduced the precompile STARK relation from 12 AIRs to 10 by merging the chunk/node/sponge and EC point/group stores ([#3464](https://github.com/0xMiden/miden-vm/pull/3464)).
 
+#### Fixes
+
+- Fixed a panic (`usize` subtraction overflow / out-of-bounds index) reachable by deserializing a malformed `SparseMerklePath` whose `empty_nodes_mask` has a bit set at a position `>= depth`; `Deserializable::read_from` now validates that no such out-of-range bits are present, matching the invariant already enforced by `SparseMerklePath::from_parts`.
+
 ## v0.29.0 (2026-08-04)
 
 #### Changes

--- a/crates/crypto/src/merkle/sparse_path.rs
+++ b/crates/crypto/src/merkle/sparse_path.rs
@@ -265,6 +265,27 @@ impl Deserializable for SparseMerklePath {
             )));
         }
         let empty_nodes_mask = source.read_u64()?;
+
+        // Reject masks with any bit set at a position >= depth. Bit `i` of the mask represents
+        // the (i + 1)-th depth of the path, so only bits `0..depth` are meaningful; a set bit
+        // beyond that range does not correspond to any node in a path of this depth. Without
+        // this check, `empty_nodes_count` (a plain popcount) can be satisfied by out-of-range
+        // bits, silently reducing the number of nodes read below what `depth` requires. This
+        // desyncs `self.depth()` (derived from `nodes.len() + mask.count_ones()`, which stays
+        // consistent) from the *positions* the mask claims are empty, causing
+        // `get_nonempty_index` to underflow (`normal_index - empty_deeper`) and panic - or, with
+        // overflow checks disabled, to wrap into an out-of-bounds `Vec` index and panic there
+        // instead - the first time the path is queried (e.g. via `at_depth`, `compute_root`, or
+        // `verify`). `SparseMerklePath::from_parts` already rejects this shape (its
+        // `min_path_len` is derived from the mask's highest set bit via `leading_zeros`, not from
+        // an externally supplied `depth`), so this brings deserialization in line with it.
+        let valid_mask = if depth == 64 { u64::MAX } else { (1u64 << depth) - 1 };
+        if empty_nodes_mask & !valid_mask != 0 {
+            return Err(DeserializationError::InvalidValue(format!(
+                "SparseMerklePath empty_nodes_mask has bits set beyond its declared depth ({depth}): {empty_nodes_mask:#066b}",
+            )));
+        }
+
         let empty_nodes_count = empty_nodes_mask.count_ones();
         if empty_nodes_count > depth as u32 {
             return Err(DeserializationError::InvalidValue(format!(
@@ -517,7 +538,43 @@ mod tests {
             smt::{LeafIndex, SMT_MAX_DEPTH, SimpleSmt, Smt, SparseMerkleTreeReader},
             sparse_path::path_depth_iter,
         },
+        utils::{ByteWriter, Deserializable, Serializable},
     };
+
+    #[test]
+    fn poc_malformed_mask_bit_beyond_depth_causes_panic_on_at_depth() {
+        // Craft raw bytes for a SparseMerklePath with:
+        //   depth = 4
+        //   empty_nodes_mask = bit 4 set (0b10000) -- a bit position that is OUT OF RANGE
+        //     for a depth-4 path (valid bit positions for depth=4 are bits 0..=3).
+        //   count_ones(mask) = 1, so nodes.len() required = depth - 1 = 3
+        struct RawWriter(Vec<u8>);
+        impl ByteWriter for RawWriter {
+            fn write_bytes(&mut self, bytes: &[u8]) {
+                self.0.extend_from_slice(bytes);
+            }
+        }
+
+        let mut w = RawWriter(Vec::new());
+        w.write_u8(4u8); // depth
+        w.write_u64(0b10000u64); // empty_nodes_mask, bit 4 set (out of range for depth=4)
+        // 3 nodes required (depth=4 - count_ones=1)
+        for i in 0..3u64 {
+            Word::from([Felt::new(i), Felt::new(i), Felt::new(i), Felt::new(i)]).write_into(&mut w);
+        }
+
+        let mut source = w.0.as_slice();
+
+        // With the fix, deserialization must reject this malformed input outright instead of
+        // constructing an inconsistent `SparseMerklePath` that later panics when queried (e.g.
+        // via `at_depth`, `compute_root`, or `verify`).
+        let result = SparseMerklePath::read_from(&mut source);
+        assert!(
+            result.is_err(),
+            "expected out-of-range empty_nodes_mask bit to be rejected during deserialization, \
+             got: {result:?}",
+        );
+    }
 
     fn make_smt(pair_count: u64) -> Smt {
         let entries: Vec<(Word, Word)> = (0..pair_count)

--- a/tools/miden-crypto-fuzz/Cargo.toml
+++ b/tools/miden-crypto-fuzz/Cargo.toml
@@ -57,6 +57,13 @@ name  = "partial_smt"
 path  = "fuzz_targets/partial_smt.rs"
 test  = false
 
+[[bin]]
+bench = false
+doc   = false
+name  = "sparse_path"
+path  = "fuzz_targets/sparse_path.rs"
+test  = false
+
 # MMR structures fuzz target
 [[bin]]
 bench = false

--- a/tools/miden-crypto-fuzz/fuzz_targets/sparse_path.rs
+++ b/tools/miden-crypto-fuzz/fuzz_targets/sparse_path.rs
@@ -1,0 +1,134 @@
+#![no_main]
+
+use core::mem::size_of;
+use core::num::NonZero;
+
+use libfuzzer_sys::fuzz_target;
+use miden_crypto::{
+    Felt, Word,
+    merkle::{SparseMerklePath, smt::SMT_MAX_DEPTH},
+    utils::{Deserializable, Serializable},
+};
+
+fuzz_target!(|data: &[u8]| {
+    // Exercise the public deserializer directly, matching the other serde fuzz targets.
+    let _ = SparseMerklePath::read_from_bytes(data);
+    let _ = Vec::<SparseMerklePath>::read_from_bytes(data);
+    let _ = Option::<SparseMerklePath>::read_from_bytes(data);
+    let _ = <[SparseMerklePath; 1]>::read_from_bytes(data);
+
+    if data.is_empty() {
+        return;
+    }
+
+    // Random bytes essentially never form a well-formed `depth` + `empty_nodes_mask` +
+    // `nodes` triple (the encoding requires `nodes.len() == depth - mask.count_ones()`),
+    // so the raw byte fuzzer above rarely gets past the initial length check. Generate a
+    // structured, parse-valid-shaped encoding instead so the fuzzer can regularly reach
+    // `get_nonempty_index`/`at_depth`/`compute_root` on a value that *did* pass
+    // deserialization - this is exactly the code path where the reviewed
+    // out-of-range-mask-bit panic (empty_nodes_mask bit set at position >= depth) lived,
+    // since it depends on the *relationship* between the mask's bit positions and the
+    // declared depth, not on any single field in isolation.
+    let mut input = StructuredInput::new(data);
+    let (depth, empty_nodes_mask, nodes) = input.sparse_merkle_path_parts();
+
+    let encoded = encode(depth, empty_nodes_mask, &nodes);
+    if let Ok(path) = SparseMerklePath::read_from_bytes(&encoded) {
+        exercise(&path);
+    }
+
+    // Also go through the safe constructor with the same generated parts, and exercise
+    // whatever it accepts. `from_parts` and `read_from`/deserialize are two independent
+    // code paths that are expected to agree on which (mask, nodes) shapes are valid; fuzzing
+    // both with the same generated inputs helps catch future divergence between them.
+    if let Ok(path) = SparseMerklePath::from_parts(empty_nodes_mask, nodes) {
+        exercise(&path);
+    }
+});
+
+/// Exercises every public read-path on a successfully constructed `SparseMerklePath`, so
+/// panics reachable only *after* construction (e.g. depth-dependent indexing) are covered too.
+fn exercise(path: &SparseMerklePath) {
+    let depth = path.depth();
+    let _ = path.serialize_to_bytes();
+
+    if let Some(nz_depth) = NonZero::new(depth) {
+        let _ = path.at_depth(nz_depth);
+        let index_bits = if depth >= 64 { u64::MAX } else { (1u64 << depth) - 1 };
+        let _ = path.compute_root(index_bits, Word::default());
+        let _ = path.verify(index_bits, Word::default(), &Word::default());
+    }
+}
+
+fn encode(depth: u8, empty_nodes_mask: u64, nodes: &[Word]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.push(depth);
+    bytes.extend_from_slice(&empty_nodes_mask.to_le_bytes());
+    for node in nodes {
+        node.write_into(&mut bytes);
+    }
+    bytes
+}
+
+struct StructuredInput<'a> {
+    data: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> StructuredInput<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, cursor: 0 }
+    }
+
+    /// Generates a `(depth, empty_nodes_mask, nodes)` triple. Most of the time `nodes.len()`
+    /// is made consistent with `depth - empty_nodes_mask.count_ones()` (the shape
+    /// `read_from` expects), but the mask's *bit positions* are left free-ranging over the
+    /// full `u64`, independent of `depth` - deliberately including positions `>= depth`,
+    /// which is exactly the malformed-but-previously-accepted shape this target exists to
+    /// keep covered.
+    fn sparse_merkle_path_parts(&mut self) -> (u8, u64, Vec<Word>) {
+        let depth = self.next_u8() % (SMT_MAX_DEPTH + 1);
+        let empty_nodes_mask = self.next_u64();
+
+        let node_count = if self.next_bool() {
+            // Consistent shape: what `read_from` would compute from (depth, mask).
+            (depth as u32).saturating_sub(empty_nodes_mask.count_ones()) as usize
+        } else {
+            // Inconsistent shape, to also cover `from_parts`'s own length validation.
+            self.next_u8() as usize % 8
+        };
+
+        let nodes = (0..node_count).map(|_| self.next_word()).collect();
+        (depth, empty_nodes_mask, nodes)
+    }
+
+    fn next_word(&mut self) -> Word {
+        Word::new([self.next_felt(), self.next_felt(), self.next_felt(), self.next_felt()])
+    }
+
+    fn next_felt(&mut self) -> Felt {
+        Felt::new_unchecked(self.next_u64() % Felt::ORDER)
+    }
+
+    fn next_bool(&mut self) -> bool {
+        self.next_u8() & 1 == 1
+    }
+
+    fn next_u8(&mut self) -> u8 {
+        if self.data.is_empty() {
+            return 0;
+        }
+        let value = self.data[self.cursor % self.data.len()];
+        self.cursor += 1;
+        value
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut bytes = [0; size_of::<u64>()];
+        for byte in &mut bytes {
+            *byte = self.next_u8();
+        }
+        u64::from_le_bytes(bytes)
+    }
+}


### PR DESCRIPTION
### Summary

`SparseMerklePath::read_from` validates only the *count* of set bits in `empty_nodes_mask` against the declared `depth` (`popcount(mask) <= depth`), not their *positions*. A malformed byte stream can set a mask bit at a position `>= depth`, which passes deserialization but produces an inconsistent path: `get_nonempty_index` then underflows (`normal_index - empty_deeper`), panicking the first time the path is queried via `at_depth`/`compute_root`/`verify` - a `usize` subtraction overflow in debug builds, or an out-of-bounds `Vec` index in release.

This brings `read_from` in line with the invariant `from_parts` already enforces (it derives its minimum node count from the mask's highest set bit via `leading_zeros`, not from an externally-supplied `depth`).

Related: #3630 (@memosr) fixes the separate `depth`-narrowing-to-`u8` defect in the same file (#3615); that PR explicitly scopes around this one, so there's no overlap - this PR only touches `Deserializable::read_from`'s mask-bit-position check.

### Changes

- `read_from` now rejects `empty_nodes_mask` values with any bit set at a position `>= depth`, returning `DeserializationError::InvalidValue` instead of silently accepting them.
- Regression test asserting the malformed-mask byte stream from the report above is now rejected at deserialization (previously it would construct successfully and panic on first query).
- CHANGELOG entry.

### Reproduction (pre-fix)

```rust
// depth=4, empty_nodes_mask has bit 4 set (out of range for a depth-4 path)
let bytes = [4u8]
    .into_iter()
    .chain(0b10000u64.to_le_bytes())
    .chain(/* 3 Words */)
    .collect::<Vec<u8>>();
let path = SparseMerklePath::read_from_bytes(&bytes).unwrap(); // succeeds (bug)
path.at_depth(NonZero::new(4).unwrap()); // panics: subtract with overflow
```

I verified the underflow by reproducing the exact arithmetic (`get_nonempty_index`'s population counts, shifts, and the `normal_index - empty_deeper` subtraction) in an isolated Rust program with `overflow-checks=on`: panics with `attempt to subtract with overflow`. With `overflow-checks=off` it instead wraps to `usize::MAX`, which panics as an out-of-bounds `Vec` index on the subsequent access.

Closes #3555.