### PR TITLE
fix(processor): allow crypto_stream at upper memory boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 - [BREAKING] Fixed stack overflows when parsing deeply nested MASM control flow by rejecting nesting beyond 256 levels ([#3674](https://github.com/0xMiden/miden-vm/pull/3674)).
 - [BREAKING] Fixed `U32DIV` AIR constraints by directly range-checking the quotient and remainder ([#3604](https://github.com/0xMiden/miden-vm/pull/3604)).
 - [BREAKING] Constrained `MPVERIFY` and `MRUPDATE` depths to `[1, 64]` and canonicalized reconstructed Merkle-path indices, preventing depth-64 paths from authenticating different leaves at the same field-valued index. Execution rejects out-of-range depths with the new public `OperationError::MerkleDepthOutOfRange` variant ([#3671](https://github.com/0xMiden/miden-vm/pull/3671)).
+- Fixed `crypto_stream` rejecting double-word memory ranges ending exactly at `2^32`, even though
+  every address in the range is valid ([#3632](https://github.com/0xMiden/miden-vm/issues/3632)).
 - [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
 - Moved the `read_bounded_len` and `validate_bounded_len` helpers from `miden-core` to `miden-serde-utils`, where they are now public. `miden-core::serde` re-exports them unchanged, and the private duplicates in `miden-utils-indexing` were removed ([#3415](https://github.com/0xMiden/miden-vm/issues/3415)).

--- a/miden-vm/tests/integration/operations/crypto_ops.rs
+++ b/miden-vm/tests/integration/operations/crypto_ops.rs
@@ -2,11 +2,9 @@
 use miden_core::field::{BasedVectorSpace, QuadFelt};
 use miden_processor::{ExecutionError, MemoryError};
 #[cfg(feature = "arbitrary")]
-use miden_utils_testing::build_test;
-#[cfg(feature = "arbitrary")]
 use miden_utils_testing::proptest::prelude::*;
 use miden_utils_testing::{
-    Felt, build_expected_hash, build_expected_perm, build_op_test,
+    Felt, build_expected_hash, build_expected_perm, build_op_test, build_test,
     crypto::{MerkleTree, NodeIndex, init_merkle_leaf, init_merkle_store},
 };
 
@@ -489,6 +487,33 @@ fn crypto_stream_rejects_dst_range_overflow() {
             ..
         }
     ));
+}
+
+#[test]
+fn crypto_stream_allows_range_ending_at_memory_limit() {
+    const LAST_DOUBLE_WORD_ADDR: u64 = (u32::MAX as u64) + 1 - 8;
+
+    // The range [LAST_DOUBLE_WORD_ADDR, 2^32) contains the final eight valid memory addresses.
+    for (src_addr, dst_addr) in [(LAST_DOUBLE_WORD_ADDR, 0), (0, LAST_DOUBLE_WORD_ADDR)] {
+        let source = format!(
+            "
+            begin
+                push.{dst_addr}              # dst_ptr
+                push.{src_addr}              # src_ptr
+                padw                         # capacity
+                push.1.2.3.4                 # rate[0-3]
+                push.5.6.7.8                 # rate[4-7]
+
+                crypto_stream
+                # Keep cleanup stack-only: the destination case overwrites the word containing
+                # FMP_ADDR, so a local-memory-based cleanup would observe the new value.
+                dropw dropw dropw drop drop
+            end
+            "
+        );
+
+        build_test!(&source, &[]).check_constraints();
+    }
 }
 
 #[test]

--- a/processor/src/execution/operations/crypto_ops/mod.rs
+++ b/processor/src/execution/operations/crypto_ops/mod.rs
@@ -611,7 +611,7 @@ pub(super) fn op_crypto_stream<P: Processor, T: Tracer>(
 // function
 
 /// Validates that two 2-word (8-element) memory ranges starting at `src_addr` and `dst_addr`
-/// are within u32 bounds and do not overlap in the same cycle.
+/// are within the 32-bit memory address space and do not overlap in the same cycle.
 ///
 /// Uses half-open intervals: [addr, addr+8). If ranges overlap, returns an IllegalMemoryAccess
 /// error pointing at the first destination word that would be written.
@@ -622,27 +622,31 @@ fn validate_dual_word_stream_addrs(
     ctx: ContextId,
     clk: RowIndex,
 ) -> Result<(), MemoryError> {
-    // Convert to u32 and check end-exclusive bounds
+    // Convert the start addresses to u32, but keep the end-exclusive addresses as u64 so that
+    // 2^32 can represent the end of the final valid memory range.
     let src_addr_u64 = src_addr.as_canonical_u64();
     let dst_addr_u64 = dst_addr.as_canonical_u64();
+    const MEMORY_SIZE: u64 = (u32::MAX as u64) + 1;
 
     let src_addr_u32 = u32::try_from(src_addr_u64)
         .map_err(|_| MemoryError::AddressOutOfBounds { addr: src_addr_u64 })?;
-    let src_end = src_addr_u32
-        .checked_add(8)
-        .ok_or(MemoryError::AddressOutOfBounds { addr: src_addr_u64 })?;
+    let src_end = src_addr_u64 + 8;
+    if src_end > MEMORY_SIZE {
+        return Err(MemoryError::AddressOutOfBounds { addr: src_addr_u64 });
+    }
 
     let dst_addr_u32 = u32::try_from(dst_addr_u64)
         .map_err(|_| MemoryError::AddressOutOfBounds { addr: dst_addr_u64 })?;
-    let dst_end = dst_addr_u32
-        .checked_add(8)
-        .ok_or(MemoryError::AddressOutOfBounds { addr: dst_addr_u64 })?;
+    let dst_end = dst_addr_u64 + 8;
+    if dst_end > MEMORY_SIZE {
+        return Err(MemoryError::AddressOutOfBounds { addr: dst_addr_u64 });
+    }
 
     // Check for overlap between [src, src+8) and [dst, dst+8)
-    if src_addr_u32 < dst_end && dst_addr_u32 < src_end {
+    if src_addr_u64 < dst_end && dst_addr_u64 < src_end {
         let dst_word2 = dst_addr_u32 + 4; // safe since dst_end computed above
         // We write dst first, then dst+4. Use the first that overlaps.
-        let overlap_first = (dst_addr_u32 >= src_addr_u32) && (dst_addr_u32 < src_end);
+        let overlap_first = (dst_addr_u32 >= src_addr_u32) && (dst_addr_u64 < src_end);
         let offending_addr = if overlap_first { dst_addr_u32 } else { dst_word2 };
         return Err(MemoryError::IllegalMemoryAccess {
             ctx,


### PR DESCRIPTION
## Describe your changes

Fixes #3632

### Problem

`crypto_stream` rejects a source or destination double-word range starting at `2^32 - 8`.
The half-open range `[2^32 - 8, 2^32)` contains only valid 32-bit memory addresses, so the
operation should accept it. Instead, execution returns `MemoryError::AddressOutOfBounds` before
accessing memory.

### Rationale\n\nThe VM uses a 32-bit memory address space, so `2^32` is a valid exclusive endpoint even though it is not itself an address. Rejecting `[2^32 - 8, 2^32)` prevents `crypto_stream` from accessing the final valid double-word range and is inconsistent with the intended memory model.\n\n### Root cause

`validate_dual_word_stream_addrs` validates each start address as a `u32`, then calculates the
end-exclusive address with `u32::checked_add(8)`. The valid endpoint `2^32` cannot be represented
as a `u32`, so the final valid double-word is mistaken for an overflowing range.

### Impact

This is a VM execution correctness issue: valid `crypto_stream` executions at the exact upper
memory boundary are rejected. Existing invalid ranges, unaligned accesses, and overlapping ranges
remain rejected. There is no compatibility or performance impact for other addresses, and no
invalid execution or proof acceptance was identified.

### Fix

Keep validating the actual source and destination addresses as `u32`, but calculate and compare
the half-open endpoints as `u64`. This represents the exclusive endpoint `2^32` while still
rejecting any endpoint greater than the memory size and preserving the existing overlap invariant.

### Regression test

The new test uses the final valid double-word as both the source and destination in separate
executions and calls `check_constraints()`, covering execution, trace construction, and AIR
constraint evaluation. It fails before the fix with `AddressOutOfBounds { addr: 4294967288 }` and
passes afterward. Existing tests continue to cover genuine range overflow, alignment, adjacency,
in-place access, and partial overlap.

### Verification

```text
cargo test -p miden-vm --test miden-cli crypto_stream -- --nocapture
  10 passed, 0 failed

cargo test -p miden-processor --quiet
  1,614 passed, 0 failed, 1 ignored across test binaries

cargo test -p miden-vm --features executable --quiet
  287 passed, 0 failed

cargo clippy -p miden-processor -p miden-vm --all-targets --all-features -- -D warnings
  passed

cargo fmt --all --check
  passed (stable rustfmt reported warnings for nightly-only repository settings)

git diff --check
  passed
```

## Checklist before requesting a review

- [x] Repo forked and branch created from latest `next` according to the naming convention.
- [x] Commit message and codestyle follow repository conventions.
- [x] The commit is signed and marked Verified by GitHub.
- [x] Relevant issue linked in the PR description.
- [x] Regression test added for the changed behavior.
- [x] The non-obvious endpoint invariant is documented in code.
- [x] `CHANGELOG.md` updated.
- [x] Issue #3632 is assigned to `dieutx`.
