### PR TITLE
fix(project): resolve manifest paths through Uri::to_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 - [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
+- Fixed project and workspace manifest paths being dropped on Windows, which left target paths resolved against the working directory and broke the build ([#3641](https://github.com/0xMiden/miden-vm/issues/3641)).
 - Moved the `read_bounded_len` and `validate_bounded_len` helpers from `miden-core` to `miden-serde-utils`, where they are now public. `miden-core::serde` re-exports them unchanged, and the private duplicates in `miden-utils-indexing` were removed ([#3415](https://github.com/0xMiden/miden-vm/issues/3415)).
 #### Features
 

--- a/crates/project/src/dependencies.rs
+++ b/crates/project/src/dependencies.rs
@@ -254,10 +254,8 @@ impl DependencyVersionScheme {
         // dependency resolution
         match Self::try_from(spec)? {
             Self::Path { path: uri, version } => {
-                let workspace_path = workspace
-                    .source_file
-                    .as_ref()
-                    .map(|file| Path::new(file.content().uri().path()));
+                let workspace_path =
+                    workspace.source_file.as_ref().and_then(|file| file.content().uri().to_path());
                 if uri.scheme().is_none_or(|scheme| scheme == "file")
                     && let Some(workspace_path) = workspace_path.and_then(|p| p.canonicalize().ok())
                     && let Some(workspace_root) = workspace_path.parent()

--- a/crates/project/src/package.rs
+++ b/crates/project/src/package.rs
@@ -298,12 +298,16 @@ impl Package {
         source: Arc<SourceFile>,
         workspace: Option<&WorkspaceFile>,
     ) -> Result<Box<Self>, Report> {
-        let manifest_path = Path::new(source.uri().path());
-        let manifest_path = if manifest_path.try_exists().is_ok_and(|exists| exists) {
-            Some(manifest_path.to_path_buf().into_boxed_path())
-        } else {
-            None
-        };
+        // `Uri::path()` returns the URI's path component, which is not a usable filesystem path for
+        // every form a source file URI can take. A canonicalized manifest on Windows is a verbatim
+        // `\\?\C:\...` path, whose prefix parses as an authority and leaves a path component of
+        // `\\`. `Uri::to_path()` handles those forms, so use it to avoid silently dropping the
+        // manifest path.
+        let manifest_path = source
+            .uri()
+            .to_path()
+            .filter(|path| path.try_exists().is_ok_and(|exists| exists))
+            .map(std::path::PathBuf::into_boxed_path);
 
         // Parse the manifest into an AST for further processing
         let package_ast = ast::ProjectFile::parse(source.clone())?;
@@ -354,7 +358,7 @@ impl Package {
 
         // Extract project dependencies, using the workspace to resolve workspace-relative
         // dependencies
-        let dependencies = package_ast.extract_dependencies(source.clone(), workspace)?;
+        let dependencies = package_ast.extract_dependencies(source, workspace)?;
 
         // Extract the build targets for this project
         let lib = package_ast.extract_library_target()?;

--- a/crates/project/src/tests.rs
+++ b/crates/project/src/tests.rs
@@ -474,3 +474,36 @@ path = "lib.masm"
 
     assert!(format!("{error}").contains("duplicate"), "{error}");
 }
+
+/// `Project::load` canonicalizes the manifest before handing it to the source manager, which on
+/// Windows produces a verbatim `\?\C:\...` path. Reading that back with `Uri::path()` yields `\`,
+/// which does not exist, so the manifest path used to be dropped and target paths were then
+/// resolved against the process working directory instead of the project directory.
+#[test]
+fn manifest_path_survives_loading_from_disk() {
+    let dir = TempDir::new().unwrap();
+    let root = dir.path();
+    fs::write(
+        root.join("miden-project.toml"),
+        r#"[package]
+name = "probe"
+version = "0.1.0"
+
+[lib]
+namespace = "probe::lib"
+path = "mod.masm"
+"#,
+    )
+    .unwrap();
+    fs::write(root.join("mod.masm"), "export.noop\n    nop\nend\n").unwrap();
+
+    let context = TestContext::default();
+    let project = Project::load(root, context.source_manager.as_ref()).unwrap();
+
+    let manifest_path = project.manifest_path().expect("manifest path should be recorded");
+    assert_eq!(
+        manifest_path,
+        root.join("miden-project.toml").canonicalize().unwrap(),
+        "the recorded manifest path should be the canonicalized manifest"
+    );
+}

--- a/crates/project/src/workspace.rs
+++ b/crates/project/src/workspace.rs
@@ -77,7 +77,7 @@ impl Workspace {
 
         let manifest_uri = source.content().uri();
         let manifest_path = if manifest_uri.scheme().is_none_or(|scheme| scheme == "file") {
-            Some(Path::new(manifest_uri.path()).to_path_buf().into_boxed_path())
+            manifest_uri.to_path().map(std::path::PathBuf::into_boxed_path)
         } else {
             None
         };


### PR DESCRIPTION
Closes #3641.

Uri::path() returns the URI's path component, which is only a usable filesystem path for some of the URI forms a source file can carry. Project::load canonicalizes the manifest first, and on Windows that yields a verbatim \?\C:\... path whose prefix parses as an authority, leaving a path component of \. Three call sites converted a source URI that way and then hit the filesystem, so on Windows they silently fell back to no manifest path at all.

From there it cascades. A missing manifest path sends target resolution down TargetAssemblyContext::new_virtual, which resolves the target against the process working directory rather than the project root, so path = "mod.masm" from the manifest is looked up in the wrong place. Since miden-core-lib's build script assembles a generated project, that took the whole workspace build down with it.

Uri::to_path() already handles these forms and is what the MASM source provider uses, so this routes the three sites through it and pins the manifest path with a test.

Test plan: cargo test -p miden-project --features serde. On Windows this goes from 9 passing and 27 failing to 35 passing and 1 failing, and cargo build -p miden-core-lib succeeds where it previously could not run at all. clippy is clean with the xclippy lint set.

The one still-failing test, can_load_protocol_example_project, is a separate problem: the workspace member containment check compares a verbatim path against a non-verbatim one in strip_prefix. I left it alone rather than widen this change, and I am happy to follow up on it.
