### PR TITLE
refactor(precompiles-prover): drop the dead point-at-infinity path in GLV MSM lowering

### DIFF
--- a/crates/precompiles-prover/src/deferred/session.rs
+++ b/crates/precompiles-prover/src/deferred/session.rs
@@ -329,23 +329,18 @@ impl<'a> DeferredSessionBuilder<'a> {
         // table once); sign rides the digit selection inside
         // `glv_joint_wnaf_with_tables`, not the table's seed, so a shared
         // base's tables serve every claim's GLV split regardless of sign.
-        //
-        // A base at infinity has no endomorphism image, so it skips the
-        // endo table and rides `glv_joint_wnaf_with_tables`'s plain-only
-        // leg instead of a GLV split.
         let expr = if curve.endomorphism().is_some() {
             for (base, _) in &expr_terms {
                 self.ensure_wnaf_table(base, MSM_WNAF_WINDOW);
-                if !self.session.is_pai(base) {
-                    self.ensure_wnaf_table_endo(base, MSM_WNAF_WINDOW);
-                }
+                self.ensure_wnaf_table_endo(base, MSM_WNAF_WINDOW);
             }
-            let table_terms: Vec<(&strategies::WnafTable, Option<&strategies::WnafTable>, U256)> =
+            let table_terms: Vec<(&strategies::WnafTable, &strategies::WnafTable, U256)> =
                 expr_terms
                     .iter()
                     .map(|(base, scalar)| {
                         let plain = self.wnaf_tables.get(&(base.point, MSM_WNAF_WINDOW)).unwrap();
-                        let endo = self.glv_endo_tables.get(&(base.point, MSM_WNAF_WINDOW));
+                        let endo =
+                            self.glv_endo_tables.get(&(base.point, MSM_WNAF_WINDOW)).unwrap();
                         (plain, endo, *scalar)
                     })
                     .collect();

--- a/crates/precompiles-prover/src/session/strategies.rs
+++ b/crates/precompiles-prover/src/session/strategies.rs
@@ -370,28 +370,22 @@ pub fn joint_wnaf_with_signed_tables(
 /// ([`glv_decompose`]) since the split (and its signs) is scalar-specific; only the tables — which
 /// depend on the base alone — are shared.
 ///
-/// `terms` pairs each base's `(plain_table, endo_table, scalar)`. `endo_table` is `None` for a
-/// base with no endomorphism image — the point at infinity, whose GLV split is undefined by the
-/// `φ` coordinate formula — in which case the term rides its plain leg alone at the scalar's full
-/// (undecomposed) magnitude instead of a split half. Returns the combined MSM expression. Panics
-/// if `terms` is empty or any scalar is zero.
+/// `terms` pairs each base's `(plain_table, endo_table, scalar)`. Every base needs an endomorphism
+/// table: the point at infinity has no `φ` image, but a caller cannot reach here with one because an
+/// identity base has no MSM claim to lower in the first place. Returns the combined MSM expression.
+/// Panics if `terms` is empty or any scalar is zero.
 pub fn glv_joint_wnaf_with_tables(
     session: &mut Session,
-    terms: &[(&WnafTable, Option<&WnafTable>, U256)],
+    terms: &[(&WnafTable, &WnafTable, U256)],
 ) -> EcExprPtr {
     assert!(!terms.is_empty(), "an MSM needs at least one base");
 
     let mut signed_terms: Vec<(&WnafTable, U256, bool)> = Vec::with_capacity(terms.len() * 2);
     for &(plain, endo, k) in terms {
         assert_ne!(k, U256::ZERO, "glv_joint_wnaf_with_tables terms must have a nonzero scalar");
-        match endo {
-            Some(endo) => {
-                let [(a_neg, a_mag), (b_neg, b_mag)] = glv_decompose(to_limbs32(k));
-                signed_terms.push((plain, from_limbs32(&a_mag), a_neg));
-                signed_terms.push((endo, from_limbs32(&b_mag), b_neg));
-            },
-            None => signed_terms.push((plain, k, false)),
-        }
+        let [(a_neg, a_mag), (b_neg, b_mag)] = glv_decompose(to_limbs32(k));
+        signed_terms.push((plain, from_limbs32(&a_mag), a_neg));
+        signed_terms.push((endo, from_limbs32(&b_mag), b_neg));
     }
     joint_wnaf_with_signed_tables(session, &signed_terms)
 }

--- a/crates/precompiles-prover/src/tests/ec_msm.rs
+++ b/crates/precompiles-prover/src/tests/ec_msm.rs
@@ -249,7 +249,7 @@ fn glv_joint_wnaf_value_matches_native_mul_scalar() {
     let g_pt = create(&mut s, gx, gy);
     let plain = wnaf_table(&mut s, &g_pt, 5);
     let endo = wnaf_table_endo(&mut s, &g_pt, 5);
-    let expr = glv_joint_wnaf_with_tables(&mut s, &[(&plain, Some(&endo), u)]);
+    let expr = glv_joint_wnaf_with_tables(&mut s, &[(&plain, &endo, u)]);
     let (x, y) = s.msm_value_coords(expr);
 
     let expected = curve
@@ -285,7 +285,7 @@ fn glv_joint_wnaf_with_tables_reused_across_scalars() {
         from_hex("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
         from_hex("123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde"),
     ] {
-        let expr = glv_joint_wnaf_with_tables(&mut s, &[(&plain, Some(&endo), u)]);
+        let expr = glv_joint_wnaf_with_tables(&mut s, &[(&plain, &endo, u)]);
         let (x, y) = s.msm_value_coords(expr);
         let expected =
             curve.mul_scalar(curve.generator(), to_limbs32(u)).expect("valid scalar mul");


### PR DESCRIPTION
translate_ec_msm rejects an identity base before any wNAF table is laid, so the is_pai guard around the endomorphism table below it can never be false and glv_joint_wnaf_with_tables never sees a None endo table. This builds the endo table unconditionally, takes it by reference so the invariant reads the same way the plain table's unwrap already does, and drops the comments describing the unreachable plain-only fallback.

No behaviour change.