### PR TITLE
fix(crypto): guard empty forest index lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 
 #### Fixes
 
+- Fixed `Forest::root_in_order_index` and `Forest::rightmost_in_order_index` underflowing on
+  empty forests by documenting and enforcing their non-empty precondition ([#3624](https://github.com/0xMiden/miden-vm/issues/3624)).
 - [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).
 - Moved the `read_bounded_len` and `validate_bounded_len` helpers from `miden-core` to `miden-serde-utils`, where they are now public. `miden-core::serde` re-exports them unchanged, and the private duplicates in `miden-utils-indexing` were removed ([#3415](https://github.com/0xMiden/miden-vm/issues/3415)).

--- a/crates/crypto/src/merkle/mmr/forest.rs
+++ b/crates/crypto/src/merkle/mmr/forest.rs
@@ -321,7 +321,13 @@ impl Forest {
     /// This function takes the smallest tree in this forest, "pretends" that it is a subtree of a
     /// fully balanced binary tree, and returns the the in-order index of that balanced tree's root
     /// node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the forest is empty.
     pub fn root_in_order_index(&self) -> InOrderIndex {
+        assert!(!self.is_empty(), "forest must not be empty");
+
         // Count total size of all trees in the forest.
         let nodes = self.num_nodes();
 
@@ -339,7 +345,13 @@ impl Forest {
     }
 
     /// Returns the in-order index of the rightmost element (the smallest tree).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the forest is empty.
     pub fn rightmost_in_order_index(&self) -> InOrderIndex {
+        assert!(!self.is_empty(), "forest must not be empty");
+
         // Count total size of all trees in the forest.
         let nodes = self.num_nodes();
 

--- a/crates/crypto/src/merkle/mmr/tests.rs
+++ b/crates/crypto/src/merkle/mmr/tests.rs
@@ -355,6 +355,12 @@ fn test_forest_to_root_index() {
 }
 
 #[test]
+#[should_panic(expected = "forest must not be empty")]
+fn test_forest_to_root_index_panics_for_empty_forest() {
+    Forest::empty().root_in_order_index();
+}
+
+#[test]
 fn test_forest_to_rightmost_index() {
     fn idx(pos: usize) -> InOrderIndex {
         InOrderIndex::new(pos.try_into().unwrap())
@@ -382,6 +388,12 @@ fn test_forest_to_rightmost_index() {
     assert_eq!(Forest::new(0b1101).unwrap().rightmost_in_order_index(), idx(25));
     assert_eq!(Forest::new(0b1110).unwrap().rightmost_in_order_index(), idx(27));
     assert_eq!(Forest::new(0b1111).unwrap().rightmost_in_order_index(), idx(29));
+}
+
+#[test]
+#[should_panic(expected = "forest must not be empty")]
+fn test_forest_to_rightmost_index_panics_for_empty_forest() {
+    Forest::empty().rightmost_in_order_index();
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`Forest::root_in_order_index` and `rightmost_in_order_index` underflow when called on an empty forest. The empty case should fail at the helper's precondition instead of reaching the index calculation.

## Fix

Both helpers now assert that the forest is non-empty before calculating the index. I also documented the panic condition and added regression tests for both methods.

Closes #3624

## Testing

- `cargo +nightly fmt --all --check`
- `cargo test -p miden-crypto forest_to_`
- `cargo test -p miden-crypto --lib`
- `cargo clippy -p miden-crypto --all-targets --all-features -- -D warnings`
- `git diff --check`
