### PR TITLE
fix(debug-types): treat column as a character index in line_column_to_offset

### DIFF
--- a/crates/debug-types/src/source_file.rs
+++ b/crates/debug-types/src/source_file.rs
@@ -649,10 +649,17 @@ impl SourceContent {
             .content
             .get(line_span.start.to_usize()..line_span.end.to_usize())
             .expect("invalid line boundaries: invalid utf-8");
-        if line_src.len() < column_index {
-            return None;
-        }
-        let (pre, _) = line_src.split_at(column_index);
+        // `column_index` counts characters, not bytes -- see `location`, which derives
+        // it with `chars().count()`. Slicing at the raw byte index would panic when the
+        // column lands inside a multi-byte character, and would otherwise return the
+        // wrong offset for any line containing one.
+        let byte_offset = match line_src.char_indices().nth(column_index) {
+            Some((offset, _)) => offset,
+            // A column one past the last character addresses the end of the line.
+            None if line_src.chars().count() == column_index => line_src.len(),
+            None => return None,
+        };
+        let (pre, _) = line_src.split_at(byte_offset);
         let start = line_span.start;
         Some(start + ByteOffset::from_str_len(pre))
     }
@@ -1515,6 +1522,48 @@ end
                 .byte_slice(content.line_range(LineIndex(3)).expect("invalid line"))
                 .expect("invalid byte range"),
             "line4\n".as_bytes()
+        );
+    }
+
+    #[test]
+    fn line_column_to_offset_counts_characters_not_bytes() {
+        // `é` is two bytes, so byte offsets and character columns diverge after it.
+        const CONTENT: &str = "# héllo\npush.1\n";
+        let content = SourceContent::new("masm", "foo.masm", CONTENT);
+
+        // Columns past the multi-byte character must not land mid-codepoint. On the
+        // byte-indexed implementation this panicked with "byte index 4 is not a char
+        // boundary".
+        assert_eq!(
+            content.line_column_to_offset(LineIndex(0), ColumnIndex(4)),
+            Some(ByteIndex(5)),
+            "column 4 is the character after 'é', at byte 5"
+        );
+
+        // `location` reports columns as character counts, so feeding one back to
+        // `line_column_to_offset` must round-trip to the byte index it came from.
+        let end_of_line = ByteIndex(8);
+        let loc = content.location(end_of_line).expect("location");
+        let column = ColumnIndex::from(loc.column);
+        assert_eq!(
+            content.line_column_to_offset(LineIndex(0), column),
+            Some(end_of_line),
+            "location -> line_column_to_offset must round-trip"
+        );
+
+        // A column one past the last character addresses the end of the line, and
+        // anything beyond that is out of bounds.
+        assert_eq!(
+            content.line_column_to_offset(LineIndex(0), ColumnIndex(8)),
+            Some(ByteIndex(9)),
+            "column 8 is the newline terminator's end"
+        );
+        assert_eq!(content.line_column_to_offset(LineIndex(0), ColumnIndex(9)), None);
+
+        // ASCII lines are unaffected.
+        assert_eq!(
+            content.line_column_to_offset(LineIndex(1), ColumnIndex(4)),
+            Some(ByteIndex(13))
         );
     }
 }


### PR DESCRIPTION
Fixes #3633

## Problem

`SourceContent::line_column_to_offset` is byte-indexed:

```rust
if line_src.len() < column_index {   // byte length
    return None;
}
let (pre, _) = line_src.split_at(column_index);   // byte split
```

But columns in this module are **character** counts — `location`, the inverse operation, derives one with `chars().count()`:

```rust
let column_index = ColumnIndex::from(line_src.chars().count() as u32);
```

The two disagree on any line containing a multi-byte character. Running the two functions verbatim against `"# héllo"` (8 bytes, 7 chars):

```
location() column for end-of-line = 7
  master -> Some(7)
  fixed  -> Some(8)
  (correct byte offset of end-of-line = 8)

column 4 (the char right after 'é'):
  fixed  -> Some(5)
  master -> PANICKED
    byte index 4 is not a char boundary; it is inside 'é' (bytes 3..5) of `# héllo`
```

So two distinct failures:

1. **Panic.** `str::split_at` requires a char boundary. Column 4 is a perfectly ordinary character column, and it aborts.
2. **Wrong offset.** Even when it survives, `location` → `line_column_to_offset` no longer round-trips.

Both reach `SourceContent::update`, which turns an editor selection into a byte range:

```rust
let start = self.line_column_to_offset(range.start.line, range.start.character)...
let end   = self.line_column_to_offset(range.end.line, range.end.character)...
self.content.replace_range(start..end, &text);
```

An incremental document update over a line with a non-ASCII character — a comment, a doc string, a symbol name — either aborts, or splices the replacement at the wrong offset and corrupts the tracked content.

## Fix

Walk `char_indices` instead of slicing at a raw byte index, with a column one past the last character addressing the end of the line:

```rust
let byte_offset = match line_src.char_indices().nth(column_index) {
    Some((offset, _)) => offset,
    None if line_src.chars().count() == column_index => line_src.len(),
    None => return None,
};
let (pre, _) = line_src.split_at(byte_offset);
```

For an ASCII line this is byte-for-byte what the previous code produced — `char_indices().nth(n)` yields `(n, _)`, and the `None` arm yields `len()` exactly where the old bounds check passed — so no existing behaviour changes.

The only caller outside this crate is `crates/project/src/ast/package.rs:175`, which passes column 1.

## Tests

`line_column_to_offset_counts_characters_not_bytes` covers the mid-codepoint column, the `location` round-trip, the end-of-line and out-of-bounds columns, and an ASCII line as a control. With the implementation reverted and the test kept, it fails on the original defect:

```
thread '...' panicked at library/core/src/str/mod.rs:845:21:
end byte index 4 is not a char boundary; it is inside 'é' (bytes 3..5 of string)
```

`cargo test -p miden-debug-types` is green (13 passed), as are `cargo fmt --check` and `cargo clippy --all-targets` for the crate.