### PR TITLE
fix(cli): emit runnable package from compile

### DIFF
--- a/miden-vm/src/cli/compile.rs
+++ b/miden-vm/src/cli/compile.rs
@@ -33,22 +33,23 @@ impl CompileCmd {
 
         // compile the program
         // Note: assembler debug mode is always enabled (issue #1821)
-        let compiled_program = program.compile(libraries.libraries.iter().cloned())?;
+        let compiled_package = program.compile_package(libraries.libraries.iter().cloned())?;
+        let compiled_program = compiled_package.unwrap_program();
 
         // report program hash to user
         let program_hash: [u8; 32] = compiled_program.hash().into();
         println!("program hash is {}", hex::encode(program_hash));
 
-        // write the compiled program into the specified path if one is provided; if the path is
+        // write the compiled package into the specified path if one is provided; if the path is
         // not provided, writes the file into the same directory as the source file, but with
-        // `.masb` extension.
+        // `.masp` extension.
         let out_path = self.output_file.clone().unwrap_or_else(|| {
             let mut out_file = self.assembly_file.clone();
-            out_file.set_extension("masb");
+            out_file.set_extension("masp");
             out_file
         });
 
-        compiled_program
+        compiled_package
             .write_to_file(out_path)
             .into_diagnostic()
             .wrap_err("Failed to write the compiled file")

--- a/miden-vm/tests/integration/cli/cli_test.rs
+++ b/miden-vm/tests/integration/cli/cli_test.rs
@@ -47,6 +47,33 @@ fn cli_run() {
 }
 
 #[test]
+fn compiled_program_can_be_run() {
+    let working_dir = TempDir::new().unwrap();
+    let assembly_path = working_dir.path().join("fib.masm");
+    fs::copy(fixture("masm-examples/fib/fib.masm"), &assembly_path).unwrap();
+
+    let mut cmd = bin_under_test(working_dir.path());
+    cmd.arg("compile").arg("--assembly").arg(&assembly_path);
+    cmd.assert().success();
+
+    let package_path = assembly_path.with_extension("masp");
+    assert!(package_path.exists());
+
+    let mut cmd = bin_under_test(working_dir.path());
+    cmd.arg("run")
+        .arg(&package_path)
+        .arg("--input")
+        .arg(fixture("masm-examples/fib/fib.inputs"))
+        .arg("-n")
+        .arg("1")
+        .arg("-m")
+        .arg("8192")
+        .arg("-e")
+        .arg("8192");
+    cmd.assert().success();
+}
+
+#[test]
 fn run_rejects_missing_inferred_inputs_file() {
     let working_dir = TempDir::new().unwrap();
     let program_path = working_dir.path().join("miden-vm-cli-missing-run-inputs-test.masm");


### PR DESCRIPTION
## Summary

- keep the executable `Package` produced by the assembler instead of serializing the legacy `Program`
- change the default `compile` artifact extension from `.masb` to `.masp`
- preserve the existing program hash output
- add an integration regression test that compiles a program and then runs the generated package

Fixes #3660

## Testing

Added `compiled_program_can_be_run`, which compiles the Fibonacci fixture into the default `.masp` artifact and executes that artifact with the existing fixture inputs.

The repository Actions runs are currently waiting for maintainer approval for this fork contribution (`action_required` with no jobs started). The patch has been re-reviewed against the current `next` branch and the PR is ready for review once CI is approved.