### PR TITLE
fix(package-registry-local): hash index.toml with ASCII trim on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - Moved the `read_bounded_len` and `validate_bounded_len` helpers from `miden-core` to `miden-serde-utils`, where they are now public. `miden-core::serde` re-exports them unchanged, and the private duplicates in `miden-utils-indexing` were removed ([#3415](https://github.com/0xMiden/miden-vm/issues/3415)).
 - Fixed `miden-vm prove` so unsupported program extensions are rejected before inferred input files are loaded ([#3587](https://github.com/0xMiden/miden-vm/issues/3587)).
 - Rejected MAST basic block payloads whose batch metadata does not cover every serialized operation, instead of silently dropping the trailing operations during deserialization ([#3594](https://github.com/0xMiden/miden-vm/issues/3594)).
+- Hashed the local registry `index.toml` with ASCII trim on load, matching the write-path staleness check, so a leading NBSP or vertical tab no longer makes every write fail with `WriteToStaleIndex` ([#3651](https://github.com/0xMiden/miden-vm/issues/3651)).
 #### Features
 
 - Added `LinkMode::Analysis` and `Linker::link_analysis`, which commit resolved modules and call edges and report a static recursion cycle as a nonfatal diagnostic (`LinkAnalysis`) instead of rejecting it. Strict linking is unchanged: it still rejects cycles before MAST is built and rolls back on failure ([#3535](https://github.com/0xMiden/miden-vm/pull/3535)).

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -189,13 +189,9 @@ impl LocalPackageRegistry {
                     fs::File::open(&index_path).map_err(LocalRegistryError::IndexRead)?;
                 file.read_to_string(&mut contents).map_err(LocalRegistryError::IndexRead)?;
             }
-            // Hash with the same ASCII trim used by save_with_locked_operation. Unicode `trim()`
-            // strips more (e.g. NBSP, vertical tab), which would make later writes fail with
-            // WriteToStaleIndex even though the file was not modified. Parsing still uses `trim()`
-            // so a leading NBSP does not turn a valid index into a TOML error.
-            index_checksum =
-                *miden_core::crypto::hash::Sha256::hash(contents.trim_ascii().as_bytes())
-                    .as_bytes();
+            // Checksum uses ASCII trim via `hash_index_contents`. Parsing still uses Unicode
+            // `trim()` so a leading NBSP does not turn a valid index into a TOML error.
+            index_checksum = hash_index_contents(contents.as_bytes());
             let contents = contents.trim();
             if contents.is_empty() {
                 InMemoryPackageRegistry::default()
@@ -204,7 +200,7 @@ impl LocalPackageRegistry {
                 InMemoryPackageRegistry::from_packages(persisted.packages)
             }
         } else {
-            index_checksum = *miden_core::crypto::hash::Sha256::hash(&[]).as_bytes();
+            index_checksum = hash_index_contents(&[]);
             InMemoryPackageRegistry::default()
         };
 
@@ -390,8 +386,7 @@ impl LocalPackageRegistry {
             Err(error) if error.kind() == io::ErrorKind::NotFound => Vec::new(),
             Err(error) => return Err(LocalRegistryError::IndexRead(error)),
         };
-        let checksum = miden_core::crypto::hash::Sha256::hash(prev_contents.trim_ascii());
-        if &self.index_checksum != checksum.as_bytes() {
+        if self.index_checksum != hash_index_contents(&prev_contents) {
             return Err(LocalRegistryError::WriteToStaleIndex);
         }
 
@@ -399,13 +394,13 @@ impl LocalPackageRegistry {
 
         // Compute the new checksum of the updated index contents before we write, but do not
         // update the in-memory state until we've successfully persisted the index
-        let new_checksum = miden_core::crypto::hash::Sha256::hash(contents.as_bytes().trim_ascii());
+        let new_checksum = hash_index_contents(contents.as_bytes());
 
         write_file_atomically(&self.index_path, contents.as_bytes())
             .map_err(LocalRegistryError::IndexWrite)?;
 
         // Update the index checksum for the next write
-        self.index_checksum = *new_checksum.as_bytes();
+        self.index_checksum = new_checksum;
 
         Ok(())
     }
@@ -667,6 +662,10 @@ impl LocalPackageRegistry {
             artifact_path,
         })
     }
+}
+
+fn hash_index_contents(contents: &[u8]) -> [u8; 32] {
+    *miden_core::crypto::hash::Sha256::hash(contents.trim_ascii()).as_bytes()
 }
 
 fn lock_path_for_index(index_path: &Path) -> PathBuf {

--- a/crates/package-registry-local/src/lib.rs
+++ b/crates/package-registry-local/src/lib.rs
@@ -189,9 +189,14 @@ impl LocalPackageRegistry {
                     fs::File::open(&index_path).map_err(LocalRegistryError::IndexRead)?;
                 file.read_to_string(&mut contents).map_err(LocalRegistryError::IndexRead)?;
             }
-            let contents = contents.trim();
+            // Hash with the same ASCII trim used by save_with_locked_operation. Unicode `trim()`
+            // strips more (e.g. NBSP, vertical tab), which would make later writes fail with
+            // WriteToStaleIndex even though the file was not modified. Parsing still uses `trim()`
+            // so a leading NBSP does not turn a valid index into a TOML error.
             index_checksum =
-                *miden_core::crypto::hash::Sha256::hash(contents.as_bytes()).as_bytes();
+                *miden_core::crypto::hash::Sha256::hash(contents.trim_ascii().as_bytes())
+                    .as_bytes();
+            let contents = contents.trim();
             if contents.is_empty() {
                 InMemoryPackageRegistry::default()
             } else {
@@ -1276,6 +1281,37 @@ mod tests {
             .expect_err("stale publish should fail before writing artifact bytes");
         assert!(matches!(error, LocalRegistryError::WriteToStaleIndex));
         assert_eq!(fs::read(&published.artifact_path).unwrap(), original_bytes);
+    }
+
+    #[test]
+    fn publish_succeeds_when_index_has_leading_trim_mismatch_whitespace() {
+        // `str::trim` removes these; `trim_ascii` does not. Before the checksums used the same
+        // trim, a reload followed by publish failed with WriteToStaleIndex.
+        for prefix in ["\u{00A0}".as_bytes(), b"\x0B"] {
+            let tempdir = TempDir::new().unwrap();
+            let mut registry = load_registry(&tempdir);
+
+            let package_path = tempdir.path().join("pkg.masp");
+            build_package("pkg", "1.0.0", []).write_to_file(&package_path).unwrap();
+            registry.publish(&package_path).unwrap();
+
+            let index_path = tempdir.path().join("midenup").join("registry").join("index.toml");
+            let original = fs::read(&index_path).unwrap();
+            let mut padded = prefix.to_vec();
+            padded.extend_from_slice(&original);
+            fs::write(&index_path, padded).unwrap();
+
+            let mut registry = load_registry(&tempdir);
+            let other_path = tempdir.path().join("other.masp");
+            build_package("other", "1.0.0", []).write_to_file(&other_path).unwrap();
+            let published = registry
+                .publish(&other_path)
+                .expect("index whitespace must not look like a stale write");
+
+            let loaded =
+                registry.load_package(&PackageId::from("other"), &published.version).unwrap();
+            assert_eq!(loaded.name, PackageId::from("other"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Rationale

`LocalPackageRegistry` rejects writes when `index.toml` does not match the checksum recorded at load. Load hashed `str::trim()` bytes; the write-path staleness check hashed `trim_ascii()` bytes. Those are not the same set of whitespace, so a leading NBSP or vertical tab made every later write fail with `WriteToStaleIndex` even though nobody modified the file.

Closes #3651.

This replaces #3652, which the bot closed before the issue was assigned.

## Changes

- Hash the loaded index with `trim_ascii()`, matching `save_with_locked_operation`.
- Keep Unicode `trim()` for TOML parsing so a leading NBSP does not become a parse error.
- Regression test covering `U+00A0` and `U+000B`.
- CHANGELOG entry.

## Test plan

```
cargo test -p miden-package-registry-local --lib publish_succeeds_when_index_has_leading_trim_mismatch_whitespace
```