### PR TITLE
fix(assembly): reject deeply nested control flow during parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 #### Fixes
 
+- [BREAKING] Fixed stack overflows when parsing deeply nested MASM control flow by rejecting nesting beyond 256 levels ([#3674](https://github.com/0xMiden/miden-vm/pull/3674)).
 - [BREAKING] Fixed `U32DIV` AIR constraints by directly range-checking the quotient and remainder ([#3604](https://github.com/0xMiden/miden-vm/pull/3604)).
 - [BREAKING] Validated `LeafIndex` on deserialization: `LeafIndex::read_from()` now routes through `TryFrom<NodeIndex>`, and the bypassing `serde` derives were removed from `LeafIndex`, `SmtLeaf`, `Smt`, and `PartialSmt` ([#3559](https://github.com/0xMiden/miden-vm/issues/3559)).
 - Fixed `Polynomial::div` panicking when the numerator is zero by adding the missing `return` keyword ([#3534](https://github.com/0xMiden/miden-vm/issues/3534)).

--- a/crates/assembly-syntax-cst/src/lib.rs
+++ b/crates/assembly-syntax-cst/src/lib.rs
@@ -27,3 +27,9 @@ pub use self::{
     parser::{Parse, parse_inline_masm, parse_source_file, parse_text},
     syntax::{MasmLanguage, SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken},
 };
+
+/// Maximum allowed nesting of control-flow blocks.
+///
+/// This limit prevents stack overflows while parsing or compiling maliciously deep block nesting,
+/// while remaining far above typical program structure depth.
+pub const MAX_CONTROL_FLOW_NESTING: usize = 256;

--- a/crates/assembly-syntax-cst/src/parser.rs
+++ b/crates/assembly-syntax-cst/src/parser.rs
@@ -4,7 +4,7 @@ use miden_debug_types::{SourceFile, SourceId, SourceLanguage, SourceSpan, Uri};
 use rowan::{GreenNodeBuilder, NodeOrToken, TextRange};
 
 use crate::{
-    MasmLanguage,
+    MAX_CONTROL_FLOW_NESTING, MasmLanguage,
     ast::AstNode,
     diagnostics::{LabeledSpan, Severity, diagnostic, miette::MietteDiagnostic as Diagnostic},
     lexer::{Token, tokenize},
@@ -260,7 +260,7 @@ impl<'input> Parser<'input> {
     }
 
     fn parse_inline_masm(mut self, source: Arc<SourceFile>) -> Parse {
-        match self.parse_block_unterminated() {
+        match self.parse_block_unterminated(0) {
             BlockParseOutcome::ReachedEof => (),
             BlockParseOutcome::FoundTerminator => self.error_here("unexpected 'end'"),
             BlockParseOutcome::RecoveredImplicitEnd => {
@@ -781,7 +781,7 @@ impl<'input> Parser<'input> {
         self.start_node(SyntaxKind::BeginBlock);
         self.expect_keyword("begin", "expected `begin`");
         self.parse_line_tail();
-        if self.parse_block(BlockOwner::Begin, &["end"]) == BlockParseOutcome::FoundTerminator {
+        if self.parse_block(BlockOwner::Begin, &["end"], 0) == BlockParseOutcome::FoundTerminator {
             self.expect_keyword("end", BlockOwner::Begin.missing_end_message());
         }
         self.finish_node();
@@ -822,7 +822,9 @@ impl<'input> Parser<'input> {
         }
 
         self.parse_line_tail();
-        if self.parse_block(BlockOwner::Procedure, &["end"]) == BlockParseOutcome::FoundTerminator {
+        if self.parse_block(BlockOwner::Procedure, &["end"], 0)
+            == BlockParseOutcome::FoundTerminator
+        {
             self.expect_keyword("end", BlockOwner::Procedure.missing_end_message());
         }
         self.finish_node();
@@ -901,7 +903,7 @@ impl<'input> Parser<'input> {
         }
     }
 
-    fn parse_block_unterminated(&mut self) -> BlockParseOutcome {
+    fn parse_block_unterminated(&mut self, nesting_depth: usize) -> BlockParseOutcome {
         self.start_node(SyntaxKind::Block);
         while !self.eof() {
             if self.at_regular_trivia() {
@@ -917,23 +919,30 @@ impl<'input> Parser<'input> {
                 continue;
             }
 
+            if self.at_control_flow_operation()
+                && self.reject_excessive_control_flow_nesting(nesting_depth)
+            {
+                self.finish_node();
+                return BlockParseOutcome::ReachedEof;
+            }
+
             if self.at_keyword("if") {
-                if self.parse_if() {
+                if self.parse_if(nesting_depth + 1) {
                     self.finish_node();
                     return BlockParseOutcome::ReachedEof;
                 }
             } else if self.at_keyword("do") {
-                if self.parse_do_while() {
+                if self.parse_do_while(nesting_depth + 1) {
                     self.finish_node();
                     return BlockParseOutcome::ReachedEof;
                 }
             } else if self.at_keyword("while") {
-                if self.parse_while() {
+                if self.parse_while(nesting_depth + 1) {
                     self.finish_node();
                     return BlockParseOutcome::ReachedEof;
                 }
             } else if self.at_keyword("repeat") {
-                if self.parse_repeat() {
+                if self.parse_repeat(nesting_depth + 1) {
                     self.finish_node();
                     return BlockParseOutcome::ReachedEof;
                 }
@@ -951,7 +960,12 @@ impl<'input> Parser<'input> {
         BlockParseOutcome::ReachedEof
     }
 
-    fn parse_block(&mut self, owner: BlockOwner, terminators: &[&str]) -> BlockParseOutcome {
+    fn parse_block(
+        &mut self,
+        owner: BlockOwner,
+        terminators: &[&str],
+        nesting_depth: usize,
+    ) -> BlockParseOutcome {
         self.start_node(SyntaxKind::Block);
         while !self.eof() {
             if self.at_terminator(terminators) {
@@ -980,23 +994,30 @@ impl<'input> Parser<'input> {
                 continue;
             }
 
+            if self.at_control_flow_operation()
+                && self.reject_excessive_control_flow_nesting(nesting_depth)
+            {
+                self.finish_node();
+                return BlockParseOutcome::ReachedEof;
+            }
+
             if self.at_keyword("if") {
-                if self.parse_if() {
+                if self.parse_if(nesting_depth + 1) {
                     self.finish_node();
                     return BlockParseOutcome::ReachedEof;
                 }
             } else if self.at_keyword("do") {
-                if self.parse_do_while() {
+                if self.parse_do_while(nesting_depth + 1) {
                     self.finish_node();
                     return BlockParseOutcome::ReachedEof;
                 }
             } else if self.at_keyword("while") {
-                if self.parse_while() {
+                if self.parse_while(nesting_depth + 1) {
                     self.finish_node();
                     return BlockParseOutcome::ReachedEof;
                 }
             } else if self.at_keyword("repeat") {
-                if self.parse_repeat() {
+                if self.parse_repeat(nesting_depth + 1) {
                     self.finish_node();
                     return BlockParseOutcome::ReachedEof;
                 }
@@ -1015,12 +1036,12 @@ impl<'input> Parser<'input> {
         BlockParseOutcome::ReachedEof
     }
 
-    fn parse_if(&mut self) -> bool {
+    fn parse_if(&mut self, nesting_depth: usize) -> bool {
         self.start_node(SyntaxKind::IfOp);
         self.expect_keyword("if", "expected `if`");
         self.parse_structured_header_suffixes();
         self.parse_line_tail();
-        let then_outcome = self.parse_block(BlockOwner::If, &["else", "end"]);
+        let then_outcome = self.parse_block(BlockOwner::If, &["else", "end"], nesting_depth);
         if then_outcome == BlockParseOutcome::ReachedEof {
             self.finish_node();
             return true;
@@ -1029,7 +1050,7 @@ impl<'input> Parser<'input> {
         if self.at_keyword("else") {
             self.bump();
             self.parse_line_tail();
-            let else_outcome = self.parse_block(BlockOwner::If, &["end"]);
+            let else_outcome = self.parse_block(BlockOwner::If, &["end"], nesting_depth);
             if else_outcome == BlockParseOutcome::ReachedEof {
                 self.finish_node();
                 return true;
@@ -1043,12 +1064,12 @@ impl<'input> Parser<'input> {
         false
     }
 
-    fn parse_while(&mut self) -> bool {
+    fn parse_while(&mut self, nesting_depth: usize) -> bool {
         self.start_node(SyntaxKind::WhileOp);
         self.expect_keyword("while", "expected `while`");
         self.parse_structured_header_suffixes();
         self.parse_line_tail();
-        let outcome = self.parse_block(BlockOwner::While, &["end"]);
+        let outcome = self.parse_block(BlockOwner::While, &["end"], nesting_depth);
         if outcome == BlockParseOutcome::ReachedEof {
             self.finish_node();
             return true;
@@ -1060,14 +1081,14 @@ impl<'input> Parser<'input> {
         false
     }
 
-    fn parse_do_while(&mut self) -> bool {
+    fn parse_do_while(&mut self, nesting_depth: usize) -> bool {
         self.start_node(SyntaxKind::DoWhileOp);
         self.expect_keyword("do", "expected `do`");
         self.parse_line_tail();
         // The body is terminated by a *bare* `while` (the loop condition). A nested
         // `while.true` loop inside the body carries a `.` suffix and is therefore not treated
         // as the terminator (see `at_terminator`).
-        let body_outcome = self.parse_block(BlockOwner::DoWhileBody, &["while"]);
+        let body_outcome = self.parse_block(BlockOwner::DoWhileBody, &["while"], nesting_depth);
         if body_outcome == BlockParseOutcome::ReachedEof {
             self.finish_node();
             return true;
@@ -1075,7 +1096,7 @@ impl<'input> Parser<'input> {
         if body_outcome == BlockParseOutcome::FoundTerminator {
             self.expect_keyword("while", "expected `while`");
             self.parse_line_tail();
-            let cond_outcome = self.parse_block(BlockOwner::DoWhile, &["end"]);
+            let cond_outcome = self.parse_block(BlockOwner::DoWhile, &["end"], nesting_depth);
             if cond_outcome == BlockParseOutcome::ReachedEof {
                 self.finish_node();
                 return true;
@@ -1088,12 +1109,12 @@ impl<'input> Parser<'input> {
         false
     }
 
-    fn parse_repeat(&mut self) -> bool {
+    fn parse_repeat(&mut self, nesting_depth: usize) -> bool {
         self.start_node(SyntaxKind::RepeatOp);
         self.expect_keyword("repeat", "expected `repeat`");
         self.parse_structured_header_suffixes();
         self.parse_line_tail();
-        let outcome = self.parse_block(BlockOwner::Repeat, &["end"]);
+        let outcome = self.parse_block(BlockOwner::Repeat, &["end"], nesting_depth);
         if outcome == BlockParseOutcome::ReachedEof {
             self.finish_node();
             return true;
@@ -1130,6 +1151,30 @@ impl<'input> Parser<'input> {
                 break;
             }
         }
+    }
+
+    fn at_control_flow_operation(&self) -> bool {
+        self.at_keyword("if")
+            || self.at_keyword("do")
+            || self.at_keyword("while")
+            || self.at_keyword("repeat")
+    }
+
+    /// Consumes the rest of an invalid source without recursing any further.
+    fn reject_excessive_control_flow_nesting(&mut self, nesting_depth: usize) -> bool {
+        if nesting_depth < MAX_CONTROL_FLOW_NESTING {
+            return false;
+        }
+
+        self.start_node(SyntaxKind::Error);
+        self.error_here(format!(
+            "control-flow nesting depth exceeded the maximum depth of {MAX_CONTROL_FLOW_NESTING}"
+        ));
+        while !self.eof() {
+            self.bump();
+        }
+        self.finish_node();
+        true
     }
 
     fn parse_instruction(&mut self) {
@@ -1810,6 +1855,21 @@ adv_map TABLE = [
             .collect()
     }
 
+    fn nested_if_source(depth: usize, terminated: bool) -> String {
+        let mut source = String::from("begin\n");
+        for _ in 0..depth {
+            source.push_str("push.1\nif.true\n");
+        }
+        source.push_str("push.1\n");
+        if terminated {
+            for _ in 0..depth {
+                source.push_str("end\n");
+            }
+            source.push_str("end\n");
+        }
+        source
+    }
+
     fn assert_import_rejected(source: &str, expected_label: &str) {
         let parse = parse_text(source);
         assert!(parse.has_errors(), "expected {source:?} to be rejected");
@@ -1825,6 +1885,22 @@ adv_map TABLE = [
     fn parse_text_is_lossless_for_representative_sources() {
         for (index, source) in representative_round_trip_sources().iter().enumerate() {
             assert_lossless_parse(source, format_args!("representative source {index}"));
+        }
+    }
+
+    #[test]
+    fn rejects_excessive_control_flow_nesting() {
+        for terminated in [true, false] {
+            let source = nested_if_source(1_500, terminated);
+            let parse = parse_text(&source);
+            let labels = diagnostic_labels(&parse);
+
+            assert!(
+                labels.iter().any(|label| label.contains("control-flow nesting depth exceeded")),
+                "expected a nesting-depth diagnostic, got {:?}",
+                parse.diagnostics()
+            );
+            assert_eq!(parse.syntax().text().to_string(), source);
         }
     }
 

--- a/crates/assembly-syntax/src/lib.rs
+++ b/crates/assembly-syntax/src/lib.rs
@@ -25,6 +25,8 @@ pub mod parser;
 pub mod sema;
 pub mod testing;
 
+pub use miden_assembly_syntax_cst::MAX_CONTROL_FLOW_NESTING;
+
 #[doc(hidden)]
 pub use self::{
     ast::{Path, PathBuf, PathComponent, PathError},
@@ -37,12 +39,6 @@ pub use self::{
 
 /// Maximum allowed iteration count for `repeat.<count>` blocks.
 pub const MAX_REPEAT_COUNT: u32 = 1_000_000;
-
-/// Maximum allowed nesting of control-flow blocks.
-///
-/// This limit prevents stack overflows while parsing or compiling maliciously deep block nesting,
-/// while remaining far above typical program structure depth.
-pub const MAX_CONTROL_FLOW_NESTING: usize = 256;
 
 /// The modulus of the Miden field as a raw u64 integer
 pub(crate) const FIELD_MODULUS: u64 = Felt::ORDER_U64;

--- a/crates/assembly-syntax/src/lib.rs
+++ b/crates/assembly-syntax/src/lib.rs
@@ -38,5 +38,11 @@ pub use self::{
 /// Maximum allowed iteration count for `repeat.<count>` blocks.
 pub const MAX_REPEAT_COUNT: u32 = 1_000_000;
 
+/// Maximum allowed nesting of control-flow blocks.
+///
+/// This limit prevents stack overflows while parsing or compiling maliciously deep block nesting,
+/// while remaining far above typical program structure depth.
+pub const MAX_CONTROL_FLOW_NESTING: usize = 256;
+
 /// The modulus of the Miden field as a raw u64 integer
 pub(crate) const FIELD_MODULUS: u64 = Felt::ORDER_U64;

--- a/crates/assembly-syntax/src/parser/cst/blocks.rs
+++ b/crates/assembly-syntax/src/parser/cst/blocks.rs
@@ -15,7 +15,7 @@ use super::{
     context::LoweringContext, fragments::lower_u32_immediate_token,
     instructions::try_lower_instruction,
 };
-use crate::{ast, parser::ParsingError};
+use crate::{MAX_CONTROL_FLOW_NESTING, ast, parser::ParsingError};
 
 /// Lowers `block` and rejects source-level empty bodies using `empty_message`.
 ///
@@ -25,6 +25,7 @@ pub(super) fn lower_required_block(
     context: &mut LoweringContext<'_>,
     block: &CstBlock,
     empty_message: &'static str,
+    nesting_depth: usize,
 ) -> Result<ast::Block, ParsingError> {
     if !has_source_operations(block) {
         return Err(ParsingError::InvalidSyntax {
@@ -33,7 +34,7 @@ pub(super) fn lower_required_block(
         });
     }
 
-    lower_block(context, block)
+    lower_block(context, block, nesting_depth)
 }
 
 /// Lowers a CST block into the AST block representation.
@@ -43,11 +44,12 @@ pub(super) fn lower_required_block(
 pub(super) fn lower_block(
     context: &mut LoweringContext<'_>,
     block: &CstBlock,
+    nesting_depth: usize,
 ) -> Result<ast::Block, ParsingError> {
     let span = context.parse().span_for_node(block.syntax());
     let mut ops = Vec::new();
     for op in block.operations() {
-        ops.extend(lower_operation(context, &op)?);
+        ops.extend(lower_operation(context, &op, nesting_depth)?);
         if ops.len() > u16::MAX as usize {
             return Err(ParsingError::CodeBlockTooBig { span });
         }
@@ -60,21 +62,53 @@ pub(super) fn lower_block(
 fn lower_operation(
     context: &mut LoweringContext<'_>,
     op: &CstOperation,
+    nesting_depth: usize,
 ) -> Result<Vec<ast::Op>, ParsingError> {
     match op {
-        CstOperation::If(op) => Ok(vec![lower_if_op(context, op)?]),
-        CstOperation::While(op) => Ok(vec![lower_while_op(context, op)?]),
-        CstOperation::DoWhile(op) => Ok(vec![lower_do_while_op(context, op)?]),
-        CstOperation::Repeat(op) => Ok(vec![lower_repeat_op(context, op)?]),
+        CstOperation::If(op) => {
+            let span = context.parse().span_for_node(op.syntax());
+            let nesting_depth = enter_control_flow(span, nesting_depth)?;
+            Ok(vec![lower_if_op(context, op, nesting_depth)?])
+        },
+        CstOperation::While(op) => {
+            let span = context.parse().span_for_node(op.syntax());
+            let nesting_depth = enter_control_flow(span, nesting_depth)?;
+            Ok(vec![lower_while_op(context, op, nesting_depth)?])
+        },
+        CstOperation::DoWhile(op) => {
+            let span = context.parse().span_for_node(op.syntax());
+            let nesting_depth = enter_control_flow(span, nesting_depth)?;
+            Ok(vec![lower_do_while_op(context, op, nesting_depth)?])
+        },
+        CstOperation::Repeat(op) => {
+            let span = context.parse().span_for_node(op.syntax());
+            let nesting_depth = enter_control_flow(span, nesting_depth)?;
+            Ok(vec![lower_repeat_op(context, op, nesting_depth)?])
+        },
         CstOperation::Instruction(op) => lower_instruction(context, op),
     }
+}
+
+fn enter_control_flow(span: SourceSpan, nesting_depth: usize) -> Result<usize, ParsingError> {
+    let nesting_depth = nesting_depth + 1;
+    if nesting_depth > MAX_CONTROL_FLOW_NESTING {
+        return Err(ParsingError::ControlFlowNestingDepthExceeded {
+            span,
+            max_depth: MAX_CONTROL_FLOW_NESTING,
+        });
+    }
+    Ok(nesting_depth)
 }
 
 /// Lowers an `if.true` / `if.false` operation.
 ///
 /// Empty source branches are accepted when an `else` branch is present. Missing `else` branches and
 /// accepted empty source branches lower to empty AST blocks.
-fn lower_if_op(context: &mut LoweringContext<'_>, op: &CstIfOp) -> Result<ast::Op, ParsingError> {
+fn lower_if_op(
+    context: &mut LoweringContext<'_>,
+    op: &CstIfOp,
+    nesting_depth: usize,
+) -> Result<ast::Op, ParsingError> {
     let span = context.parse().span_for_node(op.syntax());
     let cond = parse_if_condition(context, op)?;
 
@@ -88,7 +122,7 @@ fn lower_if_op(context: &mut LoweringContext<'_>, op: &CstIfOp) -> Result<ast::O
     let else_has_ops = else_node.as_ref().is_some_and(has_source_operations);
 
     let then_blk = if then_has_ops {
-        lower_block(context, &then_node)?
+        lower_block(context, &then_node, nesting_depth)?
     } else if else_node.is_some() {
         empty_block(span)
     } else {
@@ -103,7 +137,7 @@ fn lower_if_op(context: &mut LoweringContext<'_>, op: &CstIfOp) -> Result<ast::O
             if !else_has_ops {
                 empty_block(span)
             } else {
-                lower_block(context, &else_node)?
+                lower_block(context, &else_node, nesting_depth)?
             }
         },
         None => empty_block(span),
@@ -124,6 +158,7 @@ fn lower_if_op(context: &mut LoweringContext<'_>, op: &CstIfOp) -> Result<ast::O
 fn lower_while_op(
     context: &mut LoweringContext<'_>,
     op: &CstWhileOp,
+    nesting_depth: usize,
 ) -> Result<ast::Op, ParsingError> {
     let span = context.parse().span_for_node(op.syntax());
     parse_while_condition(context, op)?;
@@ -131,7 +166,8 @@ fn lower_while_op(
         span,
         message: "expected a block body for `while`".to_string(),
     })?;
-    let body = lower_required_block(context, &body, "expected a non-empty `while` block")?;
+    let body =
+        lower_required_block(context, &body, "expected a non-empty `while` block", nesting_depth)?;
     Ok(ast::Op::While { span, body })
 }
 
@@ -139,19 +175,25 @@ fn lower_while_op(
 fn lower_do_while_op(
     context: &mut LoweringContext<'_>,
     op: &CstDoWhileOp,
+    nesting_depth: usize,
 ) -> Result<ast::Op, ParsingError> {
     let span = context.parse().span_for_node(op.syntax());
     let body = op.body().ok_or_else(|| ParsingError::InvalidSyntax {
         span,
         message: "expected a block body for `do`".to_string(),
     })?;
-    let body = lower_required_block(context, &body, "expected a non-empty `do` block")?;
+    let body =
+        lower_required_block(context, &body, "expected a non-empty `do` block", nesting_depth)?;
     let condition = op.condition().ok_or_else(|| ParsingError::InvalidSyntax {
         span,
         message: "expected a condition block after `while`".to_string(),
     })?;
-    let condition =
-        lower_required_block(context, &condition, "expected a non-empty `while` condition")?;
+    let condition = lower_required_block(
+        context,
+        &condition,
+        "expected a non-empty `while` condition",
+        nesting_depth,
+    )?;
     Ok(ast::Op::DoWhile { span, body, condition })
 }
 
@@ -159,6 +201,7 @@ fn lower_do_while_op(
 fn lower_repeat_op(
     context: &mut LoweringContext<'_>,
     op: &CstRepeatOp,
+    nesting_depth: usize,
 ) -> Result<ast::Op, ParsingError> {
     let span = context.parse().span_for_node(op.syntax());
     let count = parse_repeat_count(context, op)?;
@@ -166,7 +209,8 @@ fn lower_repeat_op(
         span,
         message: "expected a block body for `repeat`".to_string(),
     })?;
-    let body = lower_required_block(context, &body, "expected a non-empty `repeat` block")?;
+    let body =
+        lower_required_block(context, &body, "expected a non-empty `repeat` block", nesting_depth)?;
     Ok(ast::Op::Repeat { span, count, body })
 }
 

--- a/crates/assembly-syntax/src/parser/cst/forms.rs
+++ b/crates/assembly-syntax/src/parser/cst/forms.rs
@@ -424,7 +424,9 @@ fn lower_begin_block(
 ) -> Result<ast::Form, ParsingError> {
     let span = context.parse().span_for_node(begin.syntax());
     let block = match begin.block() {
-        Some(block) => lower_required_block(context, &block, "expected a non-empty entry block")?,
+        Some(block) => {
+            lower_required_block(context, &block, "expected a non-empty entry block", 0)?
+        },
         None => {
             return Err(ParsingError::InvalidSyntax {
                 span,
@@ -446,7 +448,7 @@ fn lower_procedure(
     let (name, signature) = preflight_procedure_header(context, procedure)?;
     let body = match procedure.block() {
         Some(block) => {
-            lower_required_block(context, &block, "expected a non-empty procedure body")?
+            lower_required_block(context, &block, "expected a non-empty procedure body", 0)?
         },
         None => {
             return Err(ParsingError::InvalidSyntax {

--- a/crates/assembly-syntax/src/parser/cst/mod.rs
+++ b/crates/assembly-syntax/src/parser/cst/mod.rs
@@ -96,7 +96,7 @@ pub fn parse_inline_masm(
         let mut context = LoweringContext::new(parse, interned);
         let cst_block = miden_assembly_syntax_cst::ast::Block::cast(context.parse().syntax())
             .expect("inline masm root kind should always be Block");
-        blocks::lower_block(&mut context, &cst_block)
+        blocks::lower_block(&mut context, &cst_block, 0)
             .map_err(move |err| Report::from(err).with_source_code(source))
     } else {
         Err(Report::from(SyntaxError::from(diagnostics)).with_source_code(source))

--- a/crates/assembly-syntax/src/parser/error.rs
+++ b/crates/assembly-syntax/src/parser/error.rs
@@ -170,6 +170,13 @@ pub enum ParsingError {
         #[label]
         span: SourceSpan,
     },
+    #[error("control-flow nesting depth exceeded")]
+    #[diagnostic(help("control-flow nesting exceeded the maximum depth of {max_depth}"))]
+    ControlFlowNestingDepthExceeded {
+        #[label("control-flow nesting exceeded the configured depth limit here")]
+        span: SourceSpan,
+        max_depth: usize,
+    },
     #[error("invalid constant expression: division by zero")]
     DivisionByZero {
         #[label]

--- a/crates/assembly-syntax/src/parser/tests.rs
+++ b/crates/assembly-syntax/src/parser/tests.rs
@@ -4,7 +4,10 @@ use core::assert_matches;
 use miden_debug_types::{SourceFile, SourceId, SourceLanguage, Uri};
 
 use super::*;
-use crate::ast::{Form, Immediate, Instruction, Op, Visibility};
+use crate::{
+    MAX_CONTROL_FLOW_NESTING,
+    ast::{Form, Immediate, Instruction, Op, Visibility},
+};
 
 fn test_source_file(source: &str) -> Arc<SourceFile> {
     Arc::new(SourceFile::new(
@@ -557,6 +560,23 @@ end
     );
 
     assert_parses(source);
+}
+
+#[test]
+fn control_flow_nesting_depth_exceeded_during_lowering() {
+    let mut source = String::from("begin\n");
+    for _ in 0..=MAX_CONTROL_FLOW_NESTING {
+        source.push_str("push.1\nif.true\n");
+    }
+    source.push_str("push.1\n");
+    for _ in 0..=MAX_CONTROL_FLOW_NESTING {
+        source.push_str("end\n");
+    }
+    source.push_str("end\n");
+
+    let error = parse_forms(test_source_file(&source))
+        .expect_err("lowering should reject control-flow nesting beyond the configured limit");
+    crate::assert_diagnostic!(error, "control-flow nesting depth exceeded");
 }
 
 #[test]

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -12,7 +12,7 @@ use alloc::{
 };
 
 use miden_assembly_syntax::{
-    ExportedTypeUse, MAX_REPEAT_COUNT, Parse, SemanticAnalysisError,
+    ExportedTypeUse, MAX_CONTROL_FLOW_NESTING, MAX_REPEAT_COUNT, Parse, SemanticAnalysisError,
     ast::{
         self, AttributeSet, Ident, InvocationTarget, InvokeKind, ItemIndex, ModuleKind,
         SymbolResolution, Visibility, types::FunctionType,
@@ -47,12 +47,6 @@ use crate::{
     },
     mast_forest_builder::{MastForestBuilder, MastNodeRef, SourceNodeRef, StaticLibrary},
 };
-
-/// Maximum allowed nesting of control-flow blocks during compilation.
-///
-/// This limit is intended to prevent stack overflows from maliciously deep block nesting while
-/// remaining far above typical program structure depth.
-pub(crate) const MAX_CONTROL_FLOW_NESTING: usize = 256;
 
 /// Maximum number of locals a single procedure may allocate.
 ///

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -8,7 +8,7 @@ use core::{assert_matches, fmt::Write, str::FromStr};
 use std::{eprintln, sync::Arc};
 
 use miden_assembly_syntax::{
-    MAX_REPEAT_COUNT,
+    MAX_CONTROL_FLOW_NESTING, MAX_REPEAT_COUNT,
     ast::{Ident, Path},
     diagnostics::WrapErr,
 };
@@ -29,7 +29,7 @@ use miden_project::Linkage;
 
 use crate::{
     Assembler, PathBuf, SourceSpan, Span,
-    assembler::{MAX_CONTROL_FLOW_NESTING, MAX_PROC_LOCALS},
+    assembler::MAX_PROC_LOCALS,
     ast::{
         Block, Instruction, Module, Op, Procedure, ProcedureName, QualifiedProcedureName,
         Visibility,
@@ -2048,7 +2048,7 @@ fn control_flow_nesting_depth_boundary() -> TestResult {
 #[test]
 fn control_flow_nesting_depth_exceeded() {
     let context = TestContext::default();
-    let source = nested_if_source(MAX_CONTROL_FLOW_NESTING + 1);
+    let source = nested_if_source(1_500);
     let source = source_file!(&context, source.as_str());
     let error = context
         .assemble(source)


### PR DESCRIPTION
Deeply nested control flow could overflow the parser stack before the assembler checked its 256-level limit.

The parser now rejects level 257 before making another nested call. Later checks in lowering and compilation stay in place.

Tests cover 1,500 nested `if` blocks, both with and without closing `end` tokens.

Closes #3661.