### PR TITLE
fix(processor): raise default advice size limit

### DIFF
--- a/processor/src/execution_options.rs
+++ b/processor/src/execution_options.rs
@@ -63,8 +63,8 @@ impl ExecutionOptions {
     /// Default fragment size for core trace generation.
     pub const DEFAULT_CORE_TRACE_FRAGMENT_SIZE: usize = 4096; // 2^12
 
-    /// Default maximum combined logical size of the advice provider. Set to 4 MiB.
-    pub const DEFAULT_MAX_ADVICE_SIZE_BYTES: usize = 4 * 1024 * 1024;
+    /// Default maximum combined logical size of the advice provider. Set to 16 MiB.
+    pub const DEFAULT_MAX_ADVICE_SIZE_BYTES: usize = 16 * 1024 * 1024;
 
     /// Default maximum number of input bytes for a single hash precompile invocation.
     /// Set to 2^20 (1 MB).
@@ -355,6 +355,15 @@ mod tests {
         let opts = ExecutionOptions::new(Some(100), 64, 1024);
         assert!(opts.is_ok());
         assert_eq!(opts.unwrap().expected_cycles(), 64);
+    }
+
+    #[test]
+    fn default_advice_size_limit_covers_protocol_lower_bound() {
+        const PROTOCOL_LOWER_BOUND_BYTES: usize = 8_445_856;
+        let options = ExecutionOptions::default();
+
+        assert!(options.max_advice_size_bytes() > PROTOCOL_LOWER_BOUND_BYTES);
+        assert_eq!(options.max_advice_size_bytes(), 16 * 1024 * 1024);
     }
 
     #[test]

--- a/processor/tests/default_advice_size_limit.rs
+++ b/processor/tests/default_advice_size_limit.rs
@@ -1,0 +1,35 @@
+use miden_processor::{
+    ExecutionOptions, ZERO,
+    advice::{AdviceError, AdviceInputs, AdviceProvider, AdviceStack},
+};
+
+const PROTOCOL_LOWER_BOUND_BYTES: usize = 8_445_856;
+const DEFAULT_MAX_ADVICE_SIZE_BYTES: usize = 16 * 1024 * 1024;
+const FELT_SIZE_BYTES: usize = 8;
+
+fn stack_inputs(stack_bytes: usize) -> AdviceInputs {
+    assert_eq!(stack_bytes % FELT_SIZE_BYTES, 0);
+    AdviceInputs::default().with_stack(AdviceStack::from(vec![
+        ZERO;
+        stack_bytes / FELT_SIZE_BYTES
+    ]))
+}
+
+#[test]
+fn default_options_accept_advice_above_protocol_lower_bound() {
+    let inputs = stack_inputs(PROTOCOL_LOWER_BOUND_BYTES + FELT_SIZE_BYTES);
+
+    AdviceProvider::new(inputs, &ExecutionOptions::default())
+        .expect("default advice budget should accept advice above the Protocol lower bound");
+}
+
+#[test]
+fn default_options_reject_advice_above_16_mib() {
+    let inputs = stack_inputs(DEFAULT_MAX_ADVICE_SIZE_BYTES + FELT_SIZE_BYTES);
+
+    let err = AdviceProvider::new(inputs, &ExecutionOptions::default()).unwrap_err();
+    assert!(matches!(
+        err,
+        AdviceError::SizeBudgetExceeded { max, .. } if max == DEFAULT_MAX_ADVICE_SIZE_BYTES
+    ));
+}


### PR DESCRIPTION
Fixes #3691

Raises `DEFAULT_MAX_ADVICE_SIZE_BYTES` from 4 MiB to 16 MiB so the default exceeds the known 8,445,856-byte Protocol lower bound while keeping the existing runtime override unchanged.

Regression coverage now checks both the configured value and the actual provider behavior requested in #3691:
- default options accept advice above 8,445,856 bytes;
- default options reject advice above 16 MiB with `AdviceError::SizeBudgetExceeded`.

The behavior tests exercise `AdviceProvider::new` through the public processor advice API.