### PR TITLE
fix: make `Debug` of `Felt` on miden target print `u64`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added `ast::types::TypedProcInfo`, a typed view over a procedure signature, with argument encoding and range-checked result decoding ([#3276](https://github.com/0xMiden/miden-vm/pull/3276)).
 
+#### Fixes
+
+- Fixed `Felt`'s `Debug` impl on the `miden` target by formatting the canonical `u64` value instead of the `f32` backing type. The `Debug` output format changed from `Felt { inner: .. }` to `Felt(..)` ([#3693](https://github.com/0xMiden/miden-vm/pull/3693)).
+
 ## v0.29.1 (2026-08-11)
 
 #### Fixes

--- a/air/src/constraints/lookup/miden_air.rs
+++ b/air/src/constraints/lookup/miden_air.rs
@@ -68,7 +68,14 @@ pub(crate) fn emit_chiplets_boundary<B: BoundaryBuilder>(boundary: &mut B) {
     let kernel_digests: Vec<[B::F; 4]> = boundary
         .var_len_public_inputs()
         .first()
-        .map(|felts| felts.chunks_exact(WORD_SIZE).map(|d| [d[0], d[1], d[2], d[3]]).collect())
+        .map(|felts| {
+            felts
+                .as_chunks::<WORD_SIZE>()
+                .0
+                .iter()
+                .map(|d| [d[0], d[1], d[2], d[3]])
+                .collect()
+        })
         .unwrap_or_default();
 
     // Kernel ROM init: one contribution per kernel procedure digest.

--- a/core/src/deferred/node.rs
+++ b/core/src/deferred/node.rs
@@ -367,7 +367,9 @@ impl Node {
         let n_chunks = felts.len().div_ceil(Self::DATA_CHUNK_FELT_LEN).max(1);
         felts.resize(n_chunks * Self::DATA_CHUNK_FELT_LEN, ZERO);
         let chunks = felts
-            .chunks_exact(Self::DATA_CHUNK_FELT_LEN)
+            .as_chunks::<{ Self::DATA_CHUNK_FELT_LEN }>()
+            .0
+            .iter()
             .map(|chunk| core::array::from_fn(|i| chunk[i]))
             .collect::<Vec<_>>();
         Self::chunks(chunks).expect("chunks_from_bytes always creates at least one chunk")

--- a/crates/assembly-syntax/src/ast/ident.rs
+++ b/crates/assembly-syntax/src/ast/ident.rs
@@ -343,8 +343,10 @@ pub mod arbitrary {
     const PREFERRED_RANGES: &[core::ops::RangeInclusive<char>] = &['a'..='z', 'A'..='Z'];
     const EXTRA_RANGES: &[core::ops::RangeInclusive<char>] = &['0'..='9', 'à'..='ö', 'ø'..='ÿ'];
 
-    const PREFERRED_CONSTANT_RANGES: &[core::ops::RangeInclusive<char>] = &['A'..='Z'];
-    const EXTRA_CONSTANT_RANGES: &[core::ops::RangeInclusive<char>] = &['0'..='9'];
+    const PREFERRED_CONSTANT_RANGES: &[core::ops::RangeInclusive<char>] =
+        core::slice::from_ref(&('A'..='Z'));
+    const EXTRA_CONSTANT_RANGES: &[core::ops::RangeInclusive<char>] =
+        core::slice::from_ref(&('0'..='9'));
 
     prop_compose! {
         /// A strategy to produce a random character from a more restricted dictionary for bare
@@ -353,7 +355,7 @@ pub mod arbitrary {
                       (c in CharStrategy::new_borrowed(
                           &['_'],
                           PREFERRED_RANGES,
-                          &['0'..='9']
+                          core::slice::from_ref(&('0'..='9'))
                       )) -> char {
             c
         }

--- a/crates/assembly/src/basic_block_builder.rs
+++ b/crates/assembly/src/basic_block_builder.rs
@@ -244,9 +244,9 @@ impl BasicBlockBuilder<'_> {
     /// epilogue of the builder.
     pub(crate) fn make_basic_block(&mut self) -> Result<Option<MastNodeRef>, Report> {
         if !self.ops.is_empty() {
-            let ops = self.ops.drain(..).collect();
+            let ops = core::mem::take(&mut self.ops);
             let asm_ops = core::mem::take(&mut self.asm_ops);
-            let debug_vars = self.debug_vars.drain(..).collect();
+            let debug_vars = core::mem::take(&mut self.debug_vars);
 
             let basic_block_node_ref = self.mast_forest_builder.ensure_block_ref(
                 ops,

--- a/crates/crypto/src/aead/aead_poseidon2/mod.rs
+++ b/crates/crypto/src/aead/aead_poseidon2/mod.rs
@@ -247,9 +247,9 @@ impl SecretKey {
         // Encrypt the data
         let mut ciphertext = Vec::with_capacity(data.len() + RATE_WIDTH);
         let data = pad(data);
-        let mut data_block_iterator = data.chunks_exact(RATE_WIDTH);
+        let data_blocks = data.as_chunks::<RATE_WIDTH>().0;
 
-        data_block_iterator.by_ref().for_each(|data_block| {
+        data_blocks.iter().for_each(|data_block| {
             let keystream = sponge.duplex_add(data_block);
             for (i, &plaintext_felt) in data_block.iter().enumerate() {
                 ciphertext.push(plaintext_felt + keystream[i]);
@@ -369,8 +369,8 @@ impl SecretKey {
 
         // Decrypt the data
         let mut plaintext = Vec::with_capacity(encrypted_data.ciphertext.len());
-        let mut ciphertext_block_iterator = encrypted_data.ciphertext.chunks_exact(RATE_WIDTH);
-        ciphertext_block_iterator.by_ref().for_each(|ciphertext_data_block| {
+        let ciphertext_blocks = encrypted_data.ciphertext.as_chunks::<RATE_WIDTH>().0;
+        ciphertext_blocks.iter().for_each(|ciphertext_data_block| {
             let keystream = sponge.duplex_add(&[]);
             for (i, &ciphertext_felt) in ciphertext_data_block.iter().enumerate() {
                 let plaintext_felt = ciphertext_felt - keystream[i];
@@ -793,9 +793,8 @@ impl AeadScheme for AeadPoseidon2 {
         }
 
         let mut elements = [ZERO; SECRET_KEY_SIZE];
-        for (i, chunk) in bytes.chunks_exact(Felt::NUM_BYTES).enumerate() {
-            let value =
-                u64::from_le_bytes(chunk.try_into().map_err(|_| EncryptionError::FailedOperation)?);
+        for (i, chunk) in bytes.as_chunks::<{ Felt::NUM_BYTES }>().0.iter().enumerate() {
+            let value = u64::from_le_bytes(*chunk);
             elements[i] = Felt::new_unchecked(value);
         }
         Ok(SecretKey::from_elements(elements))

--- a/crates/crypto/src/merkle/smt/full/leaf.rs
+++ b/crates/crypto/src/merkle/smt/full/leaf.rs
@@ -250,7 +250,7 @@ impl SmtLeaf {
         }
 
         let mut entries = Vec::with_capacity(elements.len() / DOUBLE_WORD_LEN);
-        for entry in elements.chunks_exact(DOUBLE_WORD_LEN) {
+        for entry in elements.as_chunks::<DOUBLE_WORD_LEN>().0 {
             let key = Word::new([entry[0], entry[1], entry[2], entry[3]]);
             let value = Word::new([entry[4], entry[5], entry[6], entry[7]]);
             entries.push((key, value));

--- a/crates/crypto/src/merkle/smt/large/subtree/mod.rs
+++ b/crates/crypto/src/merkle/smt/large/subtree/mod.rs
@@ -403,8 +403,8 @@ impl Subtree {
             let (bits_data, hash_data) = payload.split_at(Self::BITMASK_SIZE);
 
             let mut child_bits = [0u64; 8];
-            for (i, chunk) in bits_data.chunks_exact(8).enumerate() {
-                child_bits[i] = u64::from_le_bytes(chunk.try_into().unwrap());
+            for (i, chunk) in bits_data.as_chunks::<8>().0.iter().enumerate() {
+                child_bits[i] = u64::from_le_bytes(*chunk);
             }
 
             // Bits 510-511 are unused - reject corrupted data where these bits are set.
@@ -422,7 +422,9 @@ impl Subtree {
             }
 
             let hashes: Vec<Word> = hash_data
-                .chunks_exact(Self::HASH_SIZE)
+                .as_chunks::<{ Self::HASH_SIZE }>()
+                .0
+                .iter()
                 .map(|chunk| Word::try_from(chunk).map_err(|_| SubtreeError::InvalidHashData))
                 .collect::<Result<_, _>>()?;
 

--- a/crates/crypto/src/utils/mod.rs
+++ b/crates/crypto/src/utils/mod.rs
@@ -208,11 +208,8 @@ pub fn bytes_to_elements_exact(bytes: &[u8]) -> Option<Vec<Felt>> {
 
     let mut result = Vec::with_capacity(bytes.len() / Felt::NUM_BYTES);
 
-    for chunk in bytes.chunks_exact(Felt::NUM_BYTES) {
-        let chunk_array: [u8; Felt::NUM_BYTES] =
-            chunk.try_into().expect("should succeed given the length check above");
-
-        let value = u64::from_le_bytes(chunk_array);
+    for chunk in bytes.as_chunks::<{ Felt::NUM_BYTES }>().0 {
+        let value = u64::from_le_bytes(*chunk);
 
         // Validate that the value represents a valid field element
         let felt = Felt::from_canonical_checked(value)?;

--- a/crates/field/src/wasm_miden.rs
+++ b/crates/field/src/wasm_miden.rs
@@ -1,7 +1,7 @@
 //! On-chain implementation of [`crate::Felt`].
 
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Default)]
 /// A `Felt` represented as an on-chain felt.
 pub struct Felt {
     /// The backing type is `f32` which will be treated as a felt by the compiler.
@@ -357,6 +357,12 @@ impl core::fmt::Display for Felt {
     #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         core::fmt::Display::fmt(&self.as_canonical_u64(), f)
+    }
+}
+
+impl core::fmt::Debug for Felt {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("Felt").field(&self.as_canonical_u64()).finish()
     }
 }
 

--- a/crates/lib/core/src/handlers/smt_peek.rs
+++ b/crates/lib/core/src/handlers/smt_peek.rs
@@ -108,7 +108,9 @@ fn get_smt_leaf_preimage(
     }
 
     Ok(kv_pairs
-        .chunks_exact(WORD_SIZE * 2)
+        .as_chunks::<{ WORD_SIZE * 2 }>()
+        .0
+        .iter()
         .map(|kv_chunk| {
             let key = [kv_chunk[0], kv_chunk[1], kv_chunk[2], kv_chunk[3]];
             let value = [kv_chunk[4], kv_chunk[5], kv_chunk[6], kv_chunk[7]];

--- a/crates/lib/core/tests/pcs/fri/channel.rs
+++ b/crates/lib/core/tests/pcs/fri/channel.rs
@@ -57,7 +57,7 @@ where
     }
 
     pub fn layer_proofs(&mut self) -> Vec<BatchMerkleProof<H>> {
-        self.layer_proofs.drain(..).collect()
+        core::mem::take(&mut self.layer_proofs)
     }
 
     pub fn layer_queries(&mut self) -> Vec<Vec<E>> {
@@ -65,7 +65,7 @@ where
     }
 
     pub fn read_fri_layer_commitments(&mut self) -> Vec<H::Digest> {
-        self.layer_commitments.drain(..).collect()
+        core::mem::take(&mut self.layer_commitments)
     }
 
     pub fn read_remainder(

--- a/crates/lib/core/tests/stark/mod.rs
+++ b/crates/lib/core/tests/stark/mod.rs
@@ -912,7 +912,9 @@ fn boundary_inputs_and_outer_logup_boundary(#[case] num_kernel_procedures: usize
     };
 
     let kernel_corr = kernel_digest_felts
-        .chunks_exact(WORD_SIZE)
+        .as_chunks::<WORD_SIZE>()
+        .0
+        .iter()
         .map(|digest| alpha + gamma + msg(digest))
         .fold(QuadFelt::ZERO, |acc, term| {
             acc + term.try_inverse().expect("zero kernel ROM denominator")

--- a/crates/lifted-stark/src/prover/quotient.rs
+++ b/crates/lifted-stark/src/prover/quotient.rs
@@ -199,6 +199,9 @@ where
                         };
                         let row_base = row_bases[k];
                         let mut scale = F::ONE;
+                        // `EF::DIMENSION` cannot be used as an `as_chunks_mut` const argument
+                        // while generic const expressions remain unsupported.
+                        #[allow(clippy::chunks_exact_to_as_chunks)]
                         for chunk in row.chunks_exact_mut(EF::DIMENSION) {
                             for val in chunk {
                                 *val *= scale;

--- a/crates/lifted-stark/src/util/packing.rs
+++ b/crates/lifted-stark/src/util/packing.rs
@@ -12,6 +12,9 @@ use p3_field::{ExtensionField, Field};
 /// Reconstruct each EF element: `vᵢ = Σⱼ basisⱼ·row[i·DIM + j]`.
 ///
 /// Returns `None` if `row.len()` is not a multiple of `EF::DIMENSION`.
+// `EF::DIMENSION` cannot be used as an `as_chunks` const argument while generic const
+// expressions remain unsupported.
+#[allow(clippy::chunks_exact_to_as_chunks)]
 pub(crate) fn row_to_packed_ext<F, EF>(row: &[EF]) -> Option<Vec<EF>>
 where
     F: Field,

--- a/crates/precompiles/src/hash/mod.rs
+++ b/crates/precompiles/src/hash/mod.rs
@@ -219,7 +219,12 @@ pub(crate) fn assert_hash_precompile<H: HashFunction>() {
     fn digest_chunks<H: HashFunction>(input: &[u8]) -> Vec<[Felt; 8]> {
         let mut felts = bytes_to_packed_u32_elements(&H::hash(input));
         felts.resize(HashPrecompile::<H>::digest_chunks() * 8, ZERO);
-        felts.chunks_exact(8).map(|c| core::array::from_fn(|i| c[i])).collect()
+        felts
+            .as_chunks::<8>()
+            .0
+            .iter()
+            .map(|c| core::array::from_fn(|i| c[i]))
+            .collect()
     }
 
     let fresh = || {

--- a/processor/src/trace/chiplets/ace/tests/mod.rs
+++ b/processor/src/trace/chiplets/ace/tests/mod.rs
@@ -262,7 +262,7 @@ fn generate_memory(circuit: &EncodedCircuit, inputs: &[QuadFelt]) -> Vec<Word> {
     assert_eq!(inputs.len(), circuit.num_inputs());
 
     // Inputs are store two by two in the fest set of words, followed by the instructions.
-    let mut mem = Vec::with_capacity(2 * inputs.len() + circuit.encoded_circuit().len());
+    let mut mem: Vec<Felt> = Vec::with_capacity(2 * inputs.len() + circuit.encoded_circuit().len());
     // Add inputs
     mem.extend(
         inputs
@@ -273,12 +273,7 @@ fn generate_memory(circuit: &EncodedCircuit, inputs: &[QuadFelt]) -> Vec<Word> {
     mem.extend(circuit.encoded_circuit().iter());
 
     // Convert to words
-    mem.chunks_exact(4)
-        .map(|word| {
-            let result: [Felt; WORD_SIZE] = word.try_into().unwrap();
-            result.into()
-        })
-        .collect()
+    mem.as_chunks::<4>().0.iter().map(|word| Word::new(*word)).collect()
 }
 
 /// Given an EvaluationContext


### PR DESCRIPTION
Closes #3690

This affects the `Felt` type for

```
#[cfg(all(target_family = "wasm", miden))]
```
