### PR TITLE
fix(project): resolve manifest paths from canonicalized source uris

### DIFF
--- a/crates/project/src/dependencies.rs
+++ b/crates/project/src/dependencies.rs
@@ -254,10 +254,11 @@ impl DependencyVersionScheme {
         // dependency resolution
         match Self::try_from(spec)? {
             Self::Path { path: uri, version } => {
-                let workspace_path = workspace
-                    .source_file
-                    .as_ref()
-                    .map(|file| Path::new(file.content().uri().path()));
+                // `to_path()` handles the Windows verbatim (`\\?\`) prefix a
+                // canonicalized workspace manifest carries; `uri().path()`
+                // would strip the drive and this lookup would silently miss.
+                let workspace_path =
+                    workspace.source_file.as_ref().and_then(|file| file.content().uri().to_path());
                 if uri.scheme().is_none_or(|scheme| scheme == "file")
                     && let Some(workspace_path) = workspace_path.and_then(|p| p.canonicalize().ok())
                     && let Some(workspace_root) = workspace_path.parent()

--- a/crates/project/src/package.rs
+++ b/crates/project/src/package.rs
@@ -3,7 +3,7 @@ use alloc::{
     string::{String, ToString},
 };
 #[cfg(feature = "std")]
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[cfg(all(feature = "std", feature = "serde"))]
 use miden_assembly_syntax::debuginfo::Spanned;
@@ -298,12 +298,15 @@ impl Package {
         source: Arc<SourceFile>,
         workspace: Option<&WorkspaceFile>,
     ) -> Result<Box<Self>, Report> {
-        let manifest_path = Path::new(source.uri().path());
-        let manifest_path = if manifest_path.try_exists().is_ok_and(|exists| exists) {
-            Some(manifest_path.to_path_buf().into_boxed_path())
-        } else {
-            None
-        };
+        // `Uri::to_path` rather than `uri().path()`: on Windows the manifest is
+        // loaded from a canonicalized path, which carries the `\\?\` verbatim
+        // prefix. `path()` reads that prefix as an authority separator and
+        // returns a drive-less remainder that no longer exists on disk, so the
+        // manifest path would be silently dropped and the project would resolve
+        // its targets relative to the process working directory instead.
+        let manifest_path = source.uri().to_path();
+        let manifest_path = manifest_path.filter(|path| path.try_exists().is_ok_and(|e| e));
+        let manifest_path = manifest_path.map(PathBuf::into_boxed_path);
 
         // Parse the manifest into an AST for further processing
         let package_ast = ast::ProjectFile::parse(source.clone())?;

--- a/crates/project/src/tests.rs
+++ b/crates/project/src/tests.rs
@@ -8,7 +8,7 @@ use miden_assembly_syntax::{
 };
 use tempfile::TempDir;
 
-use crate::{DependencyVersionScheme, Linkage, Project, TargetType, Workspace};
+use crate::{DependencyVersionScheme, Linkage, Package, Project, TargetType, Workspace};
 
 struct TestContext {
     pub source_manager: Arc<dyn SourceManager>,
@@ -473,4 +473,48 @@ path = "lib.masm"
         .expect_err("duplicate member package names should be rejected");
 
     assert!(format!("{error}").contains("duplicate"), "{error}");
+}
+
+/// A manifest loaded from a canonicalized path must keep its manifest path.
+///
+/// `Project::load` canonicalizes before loading, which on Windows yields a
+/// verbatim `\\?\C:\...` path. Deriving the manifest path from `Uri::path()`
+/// treats that prefix as an authority separator and returns a drive-less
+/// remainder that no longer exists, so the path is dropped and target
+/// resolution silently falls back to the process working directory — the whole
+/// workspace then fails to build with a bare relative path in the error
+/// (`invalid root module path 'mod.masm'`).
+#[test]
+fn manifest_path_survives_a_canonicalized_source_uri() -> Result<(), Report> {
+    let tempdir = TempDir::new().unwrap();
+    let project_dir = tempdir.path().join("pkg");
+    fs::create_dir_all(&project_dir).unwrap();
+
+    let manifest = project_dir.join("miden-project.toml");
+    fs::write(
+        &manifest,
+        r#"[package]
+name = "pkg"
+version = "0.1.0"
+
+[lib]
+path = "mod.masm"
+"#,
+    )
+    .unwrap();
+    fs::write(project_dir.join("mod.masm"), "export.foo\nend\n").unwrap();
+
+    // Load through the canonicalized path, exactly as `Project::load` does.
+    let canonical_manifest = manifest.canonicalize().unwrap();
+    let context = TestContext::default();
+    let source_file = context.source_manager.load_file(&canonical_manifest).map_err(Report::msg)?;
+    let package = Package::load(source_file)?;
+
+    assert_eq!(
+        package.manifest_path(),
+        Some(canonical_manifest.as_path()),
+        "manifest path was dropped for a canonicalized source uri"
+    );
+
+    Ok(())
 }

--- a/crates/project/src/workspace.rs
+++ b/crates/project/src/workspace.rs
@@ -1,7 +1,10 @@
 #[cfg(all(feature = "std", feature = "serde"))]
 use std::string::{String, ToString};
 #[cfg(feature = "std")]
-use std::{boxed::Box, path::Path};
+use std::{
+    boxed::Box,
+    path::{Path, PathBuf},
+};
 
 #[cfg(all(feature = "std", feature = "serde"))]
 use miden_assembly_syntax::debuginfo::SourceManager;
@@ -76,8 +79,22 @@ impl Workspace {
         let file = ast::WorkspaceFile::parse(source.clone())?;
 
         let manifest_uri = source.content().uri();
+        // `to_path()` rather than `Path::new(uri.path())`: a canonicalized
+        // manifest carries the Windows verbatim `\\?\` prefix, which `path()`
+        // reads as an authority separator and strips the drive from. The
+        // resulting path has no usable parent, so `workspace_root()` returns
+        // `None` and every member load fails as if this were a virtual
+        // manifest.
+        //
+        // Canonicalize here so the root is in the same form as the member
+        // directories, which `absolutize_path` canonicalizes below. Member
+        // lookups compare the two, and a mixed pair (`D:\ws/member` vs
+        // `\\?\D:\ws\member`) never matches.
         let manifest_path = if manifest_uri.scheme().is_none_or(|scheme| scheme == "file") {
-            Some(Path::new(manifest_uri.path()).to_path_buf().into_boxed_path())
+            manifest_uri
+                .to_path()
+                .map(|path| path.canonicalize().unwrap_or(path))
+                .map(PathBuf::into_boxed_path)
         } else {
             None
         };
@@ -108,7 +125,13 @@ impl Workspace {
                     span: Label::new(member.span(), err.to_string()),
                 }
             })?;
-            if member_dir.strip_prefix(workspace_root).is_err() {
+            // `absolutize_path` canonicalizes, which on Windows returns a
+            // verbatim `\\?\` path. The root is canonicalized at construction
+            // for the same reason, but fall back defensively here so a
+            // non-canonical root can still contain its members.
+            let canonical_root =
+                workspace_root.canonicalize().unwrap_or_else(|_| workspace_root.to_path_buf());
+            if member_dir.strip_prefix(&canonical_root).is_err() {
                 return Err(ProjectFileError::LoadWorkspaceMemberFailed {
                     source_file: source.clone(),
                     span: Label::new(


### PR DESCRIPTION
## Problem

On Windows the whole workspace fails to build, because `miden-core-lib`'s build script cannot assemble the generated MASM project:

```text
error: failed to run custom build command for `miden-core-lib v0.29.1`
  Error:   x invalid root module path 'mod.masm': The system cannot find the file specified. (os error 2)
```

This is issue #3641, which was closed as completed but never landed a fix — all three `uri().path()` call sites it identified are still on `next`, and the failure reproduces on current `main`.

## Root cause

Credit to @Dusk1e for the diagnosis in #3641. `Project::load` canonicalizes before loading, which on Windows yields a verbatim `\?\C:\...` path. `Uri::path()` reads the `\?\` prefix as an authority separator and returns a drive-less remainder that no longer exists on disk, so the manifest path is silently dropped:

```text
canonicalize()  -> \?\C:\...\miden-project.toml
  authority()   -> Some("")
  path()        -> "/C:/...\/miden-project.toml"
  try_exists()  -> Err(InvalidFilename)
to_path()       -> \?\C:\...  (try_exists: Ok(true))
```

From there `manifest_path()` is `None`, target resolution goes down `TargetAssemblyContext::new_virtual` instead of `new`, and `path = "mod.masm"` is resolved against the build script's working directory rather than the project directory.

## Changes

Four call sites, two beyond the two in #3641 — found by running the suite rather than by reading:

1. **`package.rs`** — derive the manifest path with `to_path()`.
2. **`dependencies.rs`** (std path only) — same, for the workspace-member lookup.
3. **`workspace.rs`** — same for the workspace manifest, and canonicalize it at construction. `workspace_root()` is `manifest_path()?.parent()`, so a drive-less path left every member load failing as *"cannot load workspace members for virtual workspace manifest"*.
4. **`workspace.rs`** containment check — `absolutize_path` canonicalizes member directories, so comparing them against a non-canonical root made every member look like it escaped the workspace root. The root is now canonical by construction, with a defensive fallback at the check.

The third `uri().path()` site listed in #3641 (`dependencies.rs:300`) is deliberately unchanged: it sits in the `#[cfg(not(feature = "std"))]` branch, `Uri::to_path` is `cfg(feature = "std")`, and no_std has no `canonicalize()` and therefore no verbatim prefix.

## Tests

```text
cargo test --locked -p miden-project --all-features
```

| | failed | passed |
|---|---|---|
| `next` (baseline) | 26 | 11 |
| this branch | **0** | **38** |

No regressions: a `comm` diff of the two failure lists shows nothing that passed on baseline now failing. The 26 baseline failures were all this one bug wearing different masks — `builds_path_dependency_graph`, `path_to_masp_is_leaf`, `resolves_git_dependency_using_local_repo`, and the workspace-member lookups among them.

Added `manifest_path_survives_a_canonicalized_source_uri`, which loads a manifest through a canonicalized path exactly as `Project::load` does and asserts the manifest path is retained. It reproduces the bug on Windows; on Linux there is no verbatim prefix, so it passes either way and stands as a regression guard rather than a cross-platform assertion.

`cargo fmt -p miden-project --check` is clean on the changed files. `Cargo.lock` unchanged.

Fixes #3641.