### PR TITLE
docs: fix mislabeled accumulator comments in word::gt and word::lt (#3676)

### DIFF
--- a/crates/lib/core/asm/word.masm
+++ b/crates/lib/core/asm/word.masm
@@ -116,41 +116,41 @@ pub proc gt(rhs: word, lhs: word) -> i1
     # => [l_3, r_3, l_2, r_2, l_1, r_1, l_0, r_0]
 
     push.1.0
-    # => [is_lhs_less, continue, l_3, r_3, l_2, r_2, l_1, r_1, l_0, r_0]
+    # => [is_lhs_greater, continue, l_3, r_3, l_2, r_2, l_1, r_1, l_0, r_0]
 
     repeat.4
         movup.3 movup.3
-        # => [l_x, r_x, is_lhs_less, continue, <remaining_felts>]
+        # => [l_x, r_x, is_lhs_greater, continue, <remaining_felts>]
 
         # check r_x == l_x; if so, we continue
         dup dup.2 eq
-        # => [is_felt_eq, l_x, r_x, is_lhs_less, continue, <remaining_felts>]
+        # => [is_felt_eq, l_x, r_x, is_lhs_greater, continue, <remaining_felts>]
 
         movdn.3
-        # => [l_x, r_x, is_lhs_less, is_felt_eq, continue, <remaining_felts>]
+        # => [l_x, r_x, is_lhs_greater, is_felt_eq, continue, <remaining_felts>]
 
         # check r_x < l_x
         lt
-        # => [is_felt_lt, is_lhs_less, is_felt_eq, continue, <remaining_felts>]
+        # => [is_felt_lt, is_lhs_greater, is_felt_eq, continue, <remaining_felts>]
 
         dup.3 and
-        # => [is_felt_lt_if_continue, is_lhs_less, is_felt_eq, continue, <remaining_felts>]
+        # => [is_felt_lt_if_continue, is_lhs_greater, is_felt_eq, continue, <remaining_felts>]
 
         or movdn.2
-        # => [is_felt_eq, continue, is_lhs_less, <remaining_felts>]
+        # => [is_felt_eq, continue, is_lhs_greater, <remaining_felts>]
 
         # keeps continue at 1 if the felts are equal
         # sets continue to 0 if the felts are not equal
         and
-        # => [continue, is_lhs_less, <remaining_felts>]
+        # => [continue, is_lhs_greater, <remaining_felts>]
 
         swap
-        # => [is_lhs_less, continue, <remaining_felts>]
+        # => [is_lhs_greater, continue, <remaining_felts>]
     end
-    # => [is_lhs_less, continue]
+    # => [is_lhs_greater, continue]
 
     swap drop
-    # => [is_lhs_less]
+    # => [is_lhs_greater]
 end
 
 #! Returns true if LHS is greater than or equal to RHS.
@@ -172,7 +172,7 @@ end
 #! `lt` rather than `gt`. See its docs for details.
 #!
 #! Inputs:  [RHS, LHS]
-#! Outputs: [is_lhs_lesser]
+#! Outputs: [is_lhs_less]
 #!
 #! Cycles: 129
 pub proc lt(rhs: word, lhs: word) -> i1
@@ -182,41 +182,41 @@ pub proc lt(rhs: word, lhs: word) -> i1
     # => [l_3, r_3, l_2, r_2, l_1, r_1, l_0, r_0]
 
     push.1.0
-    # => [is_lhs_greater, continue, l_3, r_3, l_2, r_2, l_1, r_1, l_0, r_0]
+    # => [is_lhs_less, continue, l_3, r_3, l_2, r_2, l_1, r_1, l_0, r_0]
 
     repeat.4
         movup.3 movup.3
-        # => [l_x, r_x, is_lhs_greater, continue, <remaining_felts>]
+        # => [l_x, r_x, is_lhs_less, continue, <remaining_felts>]
 
         # check r_x == l_x; if so, we continue
         dup dup.2 eq
-        # => [is_felt_eq, l_x, r_x, is_lhs_greater, continue, <remaining_felts>]
+        # => [is_felt_eq, l_x, r_x, is_lhs_less, continue, <remaining_felts>]
 
         movdn.3
-        # => [l_x, r_x, is_lhs_greater, is_felt_eq, continue, <remaining_felts>]
+        # => [l_x, r_x, is_lhs_less, is_felt_eq, continue, <remaining_felts>]
 
         # check r_x > l_x
         gt
-        # => [is_felt_gt, is_lhs_greater, is_felt_eq, continue, <remaining_felts>]
+        # => [is_felt_gt, is_lhs_less, is_felt_eq, continue, <remaining_felts>]
 
         dup.3 and
-        # => [is_felt_gt_if_continue, is_lhs_greater, is_felt_eq, continue, <remaining_felts>]
+        # => [is_felt_gt_if_continue, is_lhs_less, is_felt_eq, continue, <remaining_felts>]
 
         or movdn.2
-        # => [is_felt_eq, continue, is_lhs_greater, <remaining_felts>]
+        # => [is_felt_eq, continue, is_lhs_less, <remaining_felts>]
 
         # keeps continue at 1 if the felts are equal
         # sets continue to 0 if the felts are not equal
         and
-        # => [continue, is_lhs_greater, <remaining_felts>]
+        # => [continue, is_lhs_less, <remaining_felts>]
 
         swap
-        # => [is_lhs_greater, continue, <remaining_felts>]
+        # => [is_lhs_less, continue, <remaining_felts>]
     end
-    # => [is_lhs_greater, continue]
+    # => [is_lhs_less, continue]
 
     swap drop
-    # => [is_lhs_greater]
+    # => [is_lhs_less]
 end
 
 #! Returns true if LHS is less than or equal to RHS, false otherwise.


### PR DESCRIPTION
## Describe your changes

Inside `word::gt` and `word::lt` in `crates/lib/core/asm/word.masm`, the internal accumulator comments were previously swapped between the two procedures (`is_lhs_less` in `gt` and `is_lhs_greater` in `lt`), likely due to copy-paste derivation.

This PR fixes the accumulator-tracking comment labels in both procedures:
- `word::gt`: updated inline comments from `is_lhs_less` to `is_lhs_greater`
- `word::lt`: updated inline comments from `is_lhs_greater` to `is_lhs_less`

Closes #3676

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] Relevant issues are linked in the PR description.
- [ ] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
- [ ] Updated `CHANGELOG.md`
