### PR TITLE
fix: distinguish deferred MSM claims during interning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@
 
 #### Fixes
 
+- Fixed deferred MSM session lowering so structurally distinct claims with the same canonical
+  expression retain their own hashes, while exact repeats reuse one balanced eval row
+  ([#3689](https://github.com/0xMiden/miden-vm/issues/3689)).
 - Added u32 checks before sorted array pointers from advice are used in arithmetic or memory access, and corrected the `sys::drop_stack_top` MASM signature ([#3711](https://github.com/0xMiden/miden-vm/pull/3711)).
 - [BREAKING] Fixed stack overflows when parsing deeply nested MASM control flow by rejecting nesting beyond 256 levels ([#3674](https://github.com/0xMiden/miden-vm/pull/3674)).
 - [BREAKING] Constrained the stack overflow pointer on every VM transition, preventing forged traces from consuming overflow rows out of order ([#3684](https://github.com/0xMiden/miden-vm/pull/3684)).

--- a/crates/precompiles-prover/src/session/mod.rs
+++ b/crates/precompiles-prover/src/session/mod.rs
@@ -392,7 +392,7 @@ impl Session {
             );
         }
 
-        let value = self.eval.record_ec_msm(
+        let (value, is_new) = self.eval.record_ec_msm(
             expr.addr(),
             group.addr(),
             val,
@@ -400,7 +400,9 @@ impl Session {
             terms,
             &mut self.p2,
         );
-        self.msm.consume_claim(expr, 1);
+        if is_new {
+            self.msm.consume_claim(expr, 1);
+        }
         value
     }
 

--- a/crates/precompiles-prover/src/session/mod.rs
+++ b/crates/precompiles-prover/src/session/mod.rs
@@ -361,49 +361,13 @@ impl Session {
     /// the chiplet's internal `idx` storage order (hence not of the
     /// addition-chain strategy). The caller's pairing is validated against the
     /// expression by the bus; each scalar node must be stored under the group's
-    /// scalar bound. Bumps the resolve use count.
+    /// scalar bound. Bumps the resolve use count on a new eval row.
     ///
     /// Panics unless the claim is **fully merged** — distinct bases, exactly
     /// one pair per term — the canonical form that makes the root well-defined
     /// (an unmerged `P×a, P×b` would hash differently from `P×(a+b)`).
     pub fn ec_msm(&mut self, expr: EcExprPtr, terms: &[(EcNode, UintNode)]) -> EcNode {
-        let group = self.msm.group(expr);
-        let sbound = self.msm.sbound(expr);
-        let val = self.msm.value(expr);
-        let chiplet = self.msm.terms(expr);
-
-        // Fully-merged claim: one pair per chiplet term, distinct bases, each
-        // pair a real term of `expr`. With distinct bases + matching count +
-        // each-pair-a-term, the pairs *are* the chiplet's term set — so the
-        // seam's set match is well-defined and the root tracks the term set,
-        // not an unmerged split.
-        assert_eq!(
-            terms.len(),
-            chiplet.len(),
-            "ec_msm needs exactly one (base, scalar) pair per claim term",
-        );
-        for i in 0..terms.len() {
-            for j in (i + 1)..terms.len() {
-                assert_ne!(terms[i].0.point, terms[j].0.point, "duplicate base in ec_msm claim");
-            }
-            assert!(
-                chiplet.iter().any(|&(b, s)| b == terms[i].0.point && s == terms[i].1.ptr),
-                "(base, scalar) pair is not a term of this MSM expression",
-            );
-        }
-
-        let (value, is_new) = self.eval.record_ec_msm(
-            expr.addr(),
-            group.addr(),
-            val,
-            sbound.addr(),
-            terms,
-            &mut self.p2,
-        );
-        if is_new {
-            self.msm.consume_claim(expr, 1);
-        }
-        value
+        self.eval.record_ec_msm(expr, terms, &mut self.msm, &mut self.p2)
     }
 
     /// Number of MSM expressions laid so far (intros + combines + negs) — a

--- a/crates/precompiles-prover/src/tests/deferred_session.rs
+++ b/crates/precompiles-prover/src/tests/deferred_session.rs
@@ -3,7 +3,7 @@ use alloc::{sync::Arc, vec, vec::Vec};
 use miden_core::deferred::{DeferredState, Node};
 use miden_precompiles::{CurveId, CurvePoint, CurvePrecompile, UintDomain, UintPrecompile};
 
-use crate::deferred::session_from_deferred_state;
+use crate::deferred::{DeferredSession, session_from_deferred_state};
 
 fn state() -> DeferredState {
     DeferredState::new(Arc::new(miden_precompiles::registry()))
@@ -78,6 +78,43 @@ fn curve_msm_node(pairs: Vec<(Node, Node)>) -> Node {
     let pairs = pairs.into_iter().map(|(point, scalar)| (point.digest(), scalar.digest()));
     let pairs = pairs.collect::<Vec<_>>();
     Node::try_pair_list(CurvePrecompile::msm_tag(), pairs).expect("tag is curve-owned")
+}
+
+#[test]
+fn deferred_session_lowers_nested_one_term_msm() {
+    let mut state = state();
+    let curve = CurveId::Secp256k1;
+    let generator = CurvePrecompile::generator_node(curve);
+    let one = UintPrecompile::value_node(curve.scalar_domain(), limbs(1));
+    state.register(generator.clone()).expect("generator must register");
+    state.register(one.clone()).expect("scalar must register");
+
+    let inner = curve_msm_node(vec![(generator.clone(), one.clone())]);
+    state.register(inner.clone()).expect("inner MSM must register");
+    let outer = curve_msm_node(vec![(inner, one)]);
+    state.register(outer.clone()).expect("outer MSM must register");
+    register_curve_equality(&mut state, outer, generator);
+
+    let DeferredSession { session, root } =
+        session_from_deferred_state(&state).expect("nested MSM claims should lower");
+    session.finish(root).check();
+}
+
+#[test]
+fn deferred_session_reuses_identical_msm_claim_in_trace() {
+    let mut state = state();
+    let curve = CurveId::Secp256k1;
+    let generator = CurvePrecompile::generator_node(curve);
+    let one = UintPrecompile::value_node(curve.scalar_domain(), limbs(1));
+    state.register(generator.clone()).expect("generator must register");
+    state.register(one.clone()).expect("scalar must register");
+
+    let msm = curve_msm_node(vec![(generator, one)]);
+    register_curve_equality(&mut state, msm.clone(), msm);
+
+    let DeferredSession { session, root } =
+        session_from_deferred_state(&state).expect("repeated MSM claim should lower");
+    session.finish(root).check();
 }
 
 fn register_affine_curve_value(

--- a/crates/precompiles-prover/src/transcript/eval/trace.rs
+++ b/crates/precompiles-prover/src/transcript/eval/trace.rs
@@ -60,6 +60,7 @@ use miden_precompiles::CurvePrecompile;
 use crate::{
     ec::{
         EcRequire,
+        msm::trace::{EcExprPtr, EcMsmRequires},
         trace::{EcGroupPtr, EcPointPtr},
     },
     logup::build_logup_aux_trace,
@@ -79,8 +80,7 @@ use crate::{
         nodes::{EcOpId, UintOpId},
         poseidon2::{
             P2Cap, P2Digest,
-            math::STATE_WIDTH,
-            trace::{PermSeqId, Poseidon2Requires, apply_permutation},
+            trace::{PermSeqId, Poseidon2Requires},
         },
     },
     uint::{
@@ -752,24 +752,46 @@ impl TranscriptEvalRequires {
     /// digest is `h_claim` and it binds `(h_claim, Group, val)`. Consumes each
     /// term's child `Group`/`Uint` binding (their `out_mult`);
     /// the absorb rows additionally consume `MsmClaimTerm` and the boundary
-    /// `MsmExpr` over the bus (laid by the AIR). Dedups by `(expr, h_claim)`. Returns the value's
-    /// shared-use [`EcNode`] and whether a new eval row was recorded.
+    /// `MsmExpr` over the bus (laid by the AIR). Dedups by `(expr, h_claim)` and bumps the MSM
+    /// resolve use count only for a new row. Returns the value's shared-use [`EcNode`].
     pub fn record_ec_msm(
         &mut self,
-        expr: u32,
-        group: u32,
-        val: EcPointPtr,
-        bound: u32,
+        expr: EcExprPtr,
         terms: &[(EcNode, UintNode)],
+        msm: &mut EcMsmRequires,
         p2: &mut Poseidon2Requires,
-    ) -> (EcNode, bool) {
+    ) -> EcNode {
         assert!(!terms.is_empty(), "an MSM claim needs at least one term");
+        let group = msm.group(expr);
+        let bound = msm.sbound(expr);
+        let val = msm.value(expr);
+        let chiplet = msm.terms(expr);
+
+        // Fully-merged claim: one pair per chiplet term, distinct bases, each
+        // pair a real term of `expr`. With distinct bases + matching count +
+        // each-pair-a-term, the pairs *are* the chiplet's term set — so the
+        // seam's set match is well-defined and the root tracks the term set,
+        // not an unmerged split.
+        assert_eq!(
+            terms.len(),
+            chiplet.len(),
+            "ec_msm needs exactly one (base, scalar) pair per claim term",
+        );
+        for i in 0..terms.len() {
+            for j in (i + 1)..terms.len() {
+                assert_ne!(terms[i].0.point, terms[j].0.point, "duplicate base in ec_msm claim");
+            }
+            assert!(
+                chiplet.iter().any(|&(b, s)| b == terms[i].0.point && s == terms[i].1.ptr),
+                "(base, scalar) pair is not a term of this MSM expression",
+            );
+        }
+
         let blocks: Vec<_> = terms
             .iter()
             .map(|(base, scalar)| {
                 assert_eq!(
-                    scalar.bound_ptr.addr(),
-                    bound,
+                    scalar.bound_ptr, bound,
                     "term scalar must be stored under the claim's scalar bound",
                 );
                 (base.hash.as_array(), scalar.hash.as_array())
@@ -777,29 +799,19 @@ impl TranscriptEvalRequires {
             .collect();
 
         let initial_cap = P2Cap::ec_msm_iv();
-        let h_claim = Poseidon2Requires::digest_of(initial_cap, &blocks);
-        let key = EcKey::Msm(expr, h_claim);
+        let prepared = Poseidon2Requires::prepare_absorption(initial_cap, blocks);
+        let h_claim = prepared.digest();
+        let key = EcKey::Msm(expr.addr(), h_claim);
         if let Some(&node) = self.ec_dedup.get(&key) {
-            return (node, false);
+            return node;
         }
 
-        let absorption = p2.require_absorption(initial_cap, blocks.iter().copied());
-        let _ = p2.require_digest(absorption.digest);
-        debug_assert_eq!(absorption.digest, h_claim);
+        let (absorption, digests) = p2.require_prepared_absorption(prepared);
+        let _ = p2.require_digest(h_claim);
 
         let mut absorbs = Vec::with_capacity(terms.len());
-        let mut cap = initial_cap.as_array();
         let span_head = absorption.head().seq();
-        for (idx, ((base, scalar), &(rate0, rate1))) in terms.iter().zip(blocks.iter()).enumerate()
-        {
-            let mut state = [Felt::ZERO; STATE_WIDTH];
-            state[0..4].copy_from_slice(&rate0);
-            state[4..8].copy_from_slice(&rate1);
-            state[8..12].copy_from_slice(&cap);
-            let state_out = apply_permutation(state);
-            let digest = P2Digest([state_out[0], state_out[1], state_out[2], state_out[3]]);
-            cap = [state_out[8], state_out[9], state_out[10], state_out[11]];
-
+        for (idx, ((base, scalar), digest)) in terms.iter().zip(digests).enumerate() {
             absorbs.push(MsmAbsorb {
                 base_hash: base.hash,
                 scalar_hash: scalar.hash,
@@ -811,7 +823,6 @@ impl TranscriptEvalRequires {
             self.consume_ec(base);
             self.consume_uint(scalar);
         }
-        debug_assert_eq!(absorbs.last().expect("non-empty MSM").digest, h_claim);
         let id = self.next_id;
         self.next_id += 1;
         self.nodes.push(EvalNode {
@@ -819,16 +830,17 @@ impl TranscriptEvalRequires {
             absorbed: None, // per-row perms / digests live in `absorbs`
             kind: NodeKind::EcMsm {
                 absorbs,
-                expr,
-                group,
+                expr: expr.addr(),
+                group: group.addr(),
                 val: val.addr(),
-                bound,
+                bound: bound.addr(),
             },
         });
         self.node_consumers.insert(id, 0);
         let node = EcNode { id, hash: h_claim, point: val };
         self.ec_dedup.insert(key, node);
-        (node, true)
+        msm.consume_claim(expr, 1);
+        node
     }
 
     fn consume_ec(&mut self, node: &EcNode) {

--- a/crates/precompiles-prover/src/transcript/eval/trace.rs
+++ b/crates/precompiles-prover/src/transcript/eval/trace.rs
@@ -280,12 +280,12 @@ enum UintKey {
 /// `group_ptr` + coord hashes (the group rides the cap not the children, so
 /// identical coords on distinct groups stay distinct; ∞ uses the zero coord
 /// hashes), an `Op` by `(op, P hash, Q hash)`, an `Msm` claim by its
-/// `expr_ptr` (one node per expression; its hash chains the whole term run).
+/// `(expr_ptr, claim hash)` (one node per structural claim; its hash chains the whole term run).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum EcKey {
     Create(u32, P2Digest, P2Digest),
     Op(EcOpId, P2Digest, P2Digest),
-    Msm(u32),
+    Msm(u32, P2Digest),
 }
 
 /// `*Requires`-pattern accumulator for the eval chip, built from explicit
@@ -752,8 +752,8 @@ impl TranscriptEvalRequires {
     /// digest is `h_claim` and it binds `(h_claim, Group, val)`. Consumes each
     /// term's child `Group`/`Uint` binding (their `out_mult`);
     /// the absorb rows additionally consume `MsmClaimTerm` and the boundary
-    /// `MsmExpr` over the bus (laid by the AIR). Dedups by `expr`. Returns
-    /// the value's shared-use [`EcNode`].
+    /// `MsmExpr` over the bus (laid by the AIR). Dedups by `(expr, h_claim)`. Returns the value's
+    /// shared-use [`EcNode`] and whether a new eval row was recorded.
     pub fn record_ec_msm(
         &mut self,
         expr: u32,
@@ -762,10 +762,7 @@ impl TranscriptEvalRequires {
         bound: u32,
         terms: &[(EcNode, UintNode)],
         p2: &mut Poseidon2Requires,
-    ) -> EcNode {
-        if let Some(&node) = self.ec_dedup.get(&EcKey::Msm(expr)) {
-            return node;
-        }
+    ) -> (EcNode, bool) {
         assert!(!terms.is_empty(), "an MSM claim needs at least one term");
         let blocks: Vec<_> = terms
             .iter()
@@ -780,9 +777,15 @@ impl TranscriptEvalRequires {
             .collect();
 
         let initial_cap = P2Cap::ec_msm_iv();
+        let h_claim = Poseidon2Requires::digest_of(initial_cap, &blocks);
+        let key = EcKey::Msm(expr, h_claim);
+        if let Some(&node) = self.ec_dedup.get(&key) {
+            return (node, false);
+        }
+
         let absorption = p2.require_absorption(initial_cap, blocks.iter().copied());
         let _ = p2.require_digest(absorption.digest);
-        let h_claim = absorption.digest;
+        debug_assert_eq!(absorption.digest, h_claim);
 
         let mut absorbs = Vec::with_capacity(terms.len());
         let mut cap = initial_cap.as_array();
@@ -824,8 +827,8 @@ impl TranscriptEvalRequires {
         });
         self.node_consumers.insert(id, 0);
         let node = EcNode { id, hash: h_claim, point: val };
-        self.ec_dedup.insert(EcKey::Msm(expr), node);
-        node
+        self.ec_dedup.insert(key, node);
+        (node, true)
     }
 
     fn consume_ec(&mut self, node: &EcNode) {

--- a/crates/precompiles-prover/src/transcript/poseidon2/trace.rs
+++ b/crates/precompiles-prover/src/transcript/poseidon2/trace.rs
@@ -143,6 +143,32 @@ pub fn apply_permutation(state_in: [Felt; STATE_WIDTH]) -> [Felt; STATE_WIDTH] {
     state
 }
 
+/// A multi-block absorption computed once before its caller checks a higher-level intern table.
+#[derive(Debug)]
+pub(crate) struct PreparedAbsorption {
+    cap: P2Cap,
+    blocks: Vec<([Felt; 4], [Felt; 4])>,
+    digests: Vec<P2Digest>,
+}
+
+impl PreparedAbsorption {
+    fn new(cap: P2Cap, blocks: Vec<([Felt; 4], [Felt; 4])>) -> Self {
+        assert!(!blocks.is_empty(), "absorption needs at least one block");
+        let mut current_cap = cap.as_array();
+        let mut digests = Vec::with_capacity(blocks.len());
+        for &(rate0, rate1) in &blocks {
+            let state_out = apply_permutation(state_from_chunks(rate0, rate1, current_cap));
+            digests.push(P2Digest(chunk_from_state(&state_out, 0)));
+            current_cap = chunk_from_state(&state_out, 8);
+        }
+        Self { cap, blocks, digests }
+    }
+
+    pub(crate) fn digest(&self) -> P2Digest {
+        *self.digests.last().expect("prepared absorption is non-empty")
+    }
+}
+
 /// Run the absorption oracle on `(cap, blocks)`: returns the digest =
 /// `state[0..4]` after the last block's permutation. Capacity is
 /// threaded across blocks (cycle K+1's `state[8..12]` = cycle K's
@@ -211,6 +237,27 @@ impl Poseidon2Requires {
         absorb_oracle(cap, blocks)
     }
 
+    /// Prepare a multi-block absorption for a caller that must inspect its digest before deciding
+    /// whether to record it.
+    pub(crate) fn prepare_absorption(
+        cap: P2Cap,
+        blocks: Vec<([Felt; 4], [Felt; 4])>,
+    ) -> PreparedAbsorption {
+        PreparedAbsorption::new(cap, blocks)
+    }
+
+    /// Record an absorption that was prepared by [`Self::prepare_absorption`] without running the
+    /// permutation oracle again. Returns each cycle's digest with the normal absorption output.
+    pub(crate) fn require_prepared_absorption(
+        &mut self,
+        prepared: PreparedAbsorption,
+    ) -> (AbsorptionOutput, Vec<P2Digest>) {
+        let PreparedAbsorption { cap, blocks, digests } = prepared;
+        let digest = *digests.last().expect("prepared absorption is non-empty");
+        let output = self.require_absorption_with_digest(cap, blocks, digest);
+        (output, digests)
+    }
+
     /// Register an absorption `(cap, blocks)`. Interns by digest: a hit
     /// bumps the open span's `in_mult` and returns its range; a miss
     /// lays a fresh span. Returns the digest + range. (`in_mult` is a
@@ -224,6 +271,15 @@ impl Poseidon2Requires {
         assert!(!blocks.is_empty(), "absorption needs at least one block");
         let digest = absorb_oracle(cap, &blocks);
 
+        self.require_absorption_with_digest(cap, blocks, digest)
+    }
+
+    fn require_absorption_with_digest(
+        &mut self,
+        cap: P2Cap,
+        blocks: Vec<([Felt; 4], [Felt; 4])>,
+        digest: P2Digest,
+    ) -> AbsorptionOutput {
         if let Some(&idx) = self.by_digest.get(&digest) {
             let rec = &mut self.absorptions[idx];
             rec.in_mult += 1;


### PR DESCRIPTION
Deferred MSM lowering used the canonical expression as the eval row key. Nested one-term MSM claims can share that expression while having different claim digests. As a result, an outer claim could reuse a node that carried the inner claim's hash.

The interning key now consists of the expression and structural claim digest. `Session::ec_msm` increments claim multiplicity only when it creates an eval row. Exact repeated claims still reuse one balanced row.

Closes #3689.