### PR TITLE
feat(debug): support the `@source_name` procedure attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Added the `ProgramExecutor` trait to `miden-processor`, with `FastProcessor` as the default implementation, so alternative execution engines can be plugged in without changing the surrounding executor wiring ([#3540](https://github.com/0xMiden/miden-vm/pull/3540)).
 - Added `LinkMode::Analysis` and `Linker::link_analysis`, which commit resolved modules and call edges and report a static recursion cycle as a nonfatal diagnostic (`LinkAnalysis`) instead of rejecting it. Strict linking is unchanged: it still rejects cycles before MAST is built and rolls back on failure ([#3535](https://github.com/0xMiden/miden-vm/pull/3535)).
 - Added `AdviceMutation::extend_advice_stack_with`, which takes an `IntoIterator<Item = Felt>` so that small host replies no longer have to build an `AdviceStack` first ([#3543](https://github.com/0xMiden/miden-vm/pull/3543)).
+- Added the `@source_name("...")` procedure attribute for preserving source-level function names in package debug information while recording distinct assembler procedure paths as linkage names ([#3716](https://github.com/0xMiden/miden-vm/pull/3716)).
+
 
 #### Changes
 

--- a/crates/assembly/src/assembler.rs
+++ b/crates/assembly/src/assembler.rs
@@ -680,7 +680,8 @@ impl Assembler {
                     signature.clone(),
                     module_kind.is_kernel(),
                     self.source_manager.clone(),
-                );
+                )
+                .with_attributes(attributes.clone());
 
                 let procedure = pctx.into_procedure(digest, node);
                 self.linker.register_procedure_root(gid, digest);
@@ -1242,6 +1243,7 @@ impl Assembler {
                         self.source_manager.clone(),
                     )
                     .with_span(proc.span())
+                    .with_attributes(proc.attributes().clone())
                     .with_num_locals(num_locals)?;
 
                     // Compile this procedure

--- a/crates/assembly/src/assembler/error.rs
+++ b/crates/assembly/src/assembler/error.rs
@@ -20,6 +20,16 @@ pub(crate) enum AssemblerError {
     #[error("duplicate definition found for export path '{path}'")]
     #[diagnostic()]
     DuplicateExportPath { path: Arc<Path> },
+    #[error("invalid `@source_name` procedure attribute")]
+    #[diagnostic(help(
+        "expected exactly one quoted string, e.g. `@source_name(\"original name\")`"
+    ))]
+    InvalidSourceNameAttribute {
+        #[label("this attribute does not have the form `@source_name(\"...\")`")]
+        span: SourceSpan,
+        #[source_code]
+        source_file: Option<Arc<SourceFile>>,
+    },
     #[error("number of procedure locals {num_locals} exceeds the maximum {max_locals}")]
     #[diagnostic(help(
         "number of procedure locals {num_locals} exceeds the maximum of {max_locals}"

--- a/crates/assembly/src/mast_forest_builder.rs
+++ b/crates/assembly/src/mast_forest_builder.rs
@@ -1149,10 +1149,19 @@ impl MastForestBuilder {
     ) -> Result<(), Report> {
         use miden_assembly_syntax::ast::types::Type;
 
+        let source_name = procedure.source_name_fully_qualified(source_manager)?;
         if let Ok(file_line_col) = source_manager.file_line_col(*procedure.span()) {
             let source_ref = Some(procedure.body_source_ref());
             let file_idx = self.debug_info.add_file(file_line_col.uri.clone(), None);
-            let name_idx = self.debug_info.add_string(procedure.path().as_str());
+            let linkage_name = procedure.path().as_str();
+            let name_idx = self
+                .debug_info
+                .add_string(source_name.as_ref().map_or(linkage_name, |name| name.as_str()));
+            let linkage_name_idx = if source_name.is_some() {
+                Some(self.debug_info.add_string(linkage_name))
+            } else {
+                None
+            };
             let type_idx = if let Some(signature) = procedure.signature() {
                 Some(self.debug_info.register_debug_type(
                     Some(name_idx),
@@ -1162,7 +1171,7 @@ impl MastForestBuilder {
             } else {
                 None
             };
-            let func_info = FunctionInfo::new(
+            let mut func_info = FunctionInfo::new(
                 source_ref,
                 name_idx,
                 file_idx,
@@ -1170,11 +1179,12 @@ impl MastForestBuilder {
                 file_line_col.column,
                 procedure.mast_root(),
             );
-            let func_info = if let Some(type_idx) = type_idx {
-                func_info.with_type(type_idx)
-            } else {
-                func_info
-            };
+            if let Some(linkage_name_idx) = linkage_name_idx {
+                func_info = func_info.with_linkage_name(linkage_name_idx);
+            }
+            if let Some(type_idx) = type_idx {
+                func_info = func_info.with_type(type_idx);
+            }
             self.debug_info.add_function(func_info);
         }
 

--- a/crates/assembly/src/procedure.rs
+++ b/crates/assembly/src/procedure.rs
@@ -1,7 +1,7 @@
 use alloc::sync::Arc;
 
 use miden_assembly_syntax::{
-    ast::{Path, Visibility, types::FunctionType},
+    ast::{Attribute, AttributeSet, MetaExpr, Path, PathBuf, Visibility, types::FunctionType},
     debuginfo::{SourceManager, SourceSpan, Spanned},
     diagnostics::Report,
 };
@@ -24,6 +24,7 @@ pub struct ProcedureContext {
     span: SourceSpan,
     path: Arc<Path>,
     signature: Option<Arc<FunctionType>>,
+    attributes: AttributeSet,
     visibility: Visibility,
     is_kernel: bool,
     num_locals: u16,
@@ -49,6 +50,7 @@ impl ProcedureContext {
             path,
             visibility,
             signature,
+            attributes: Default::default(),
             is_kernel,
             num_locals: 0,
         }
@@ -78,6 +80,12 @@ impl ProcedureContext {
 
     pub fn with_span(mut self, span: SourceSpan) -> Self {
         self.span = span;
+        self
+    }
+
+    /// Sets the attributes attached to this procedure.
+    pub fn with_attributes(mut self, attributes: AttributeSet) -> Self {
+        self.attributes = attributes;
         self
     }
 }
@@ -142,6 +150,7 @@ impl ProcedureContext {
             self.path,
             self.visibility,
             self.signature,
+            self.attributes,
             is_syscall,
             self.num_locals as u32,
             mast_root,
@@ -167,6 +176,7 @@ impl Spanned for ProcedureContext {
 /// - Fully-qualified path of the procedure in Miden Assembly (if known).
 /// - Number of procedure locals to allocate.
 /// - The visibility of the procedure (e.g. public/private/syscall)
+/// - The attributes attached to the procedure.
 /// - The set of MAST roots invoked by this procedure.
 /// - The original source span and file of the procedure (if available).
 #[derive(Clone, Debug)]
@@ -174,6 +184,7 @@ pub struct Procedure {
     span: SourceSpan,
     path: Arc<Path>,
     signature: Option<Arc<FunctionType>>,
+    attributes: AttributeSet,
     visibility: Visibility,
     is_syscall: bool,
     num_locals: u32,
@@ -192,6 +203,7 @@ impl Procedure {
         path: Arc<Path>,
         visibility: Visibility,
         signature: Option<Arc<FunctionType>>,
+        attributes: AttributeSet,
         is_syscall: bool,
         num_locals: u32,
         mast_root: Word,
@@ -202,6 +214,7 @@ impl Procedure {
             path,
             visibility,
             signature,
+            attributes,
             is_syscall,
             num_locals,
             mast_root,
@@ -250,6 +263,60 @@ impl Procedure {
         self.signature.clone()
     }
 
+    /// Returns the attributes attached to this procedure.
+    pub fn attributes(&self) -> &AttributeSet {
+        &self.attributes
+    }
+
+    /// Returns the fully-qualified `@source_name`, if present.
+    ///
+    /// The returned path is formed by joining the procedure's module path and `@source_name`.
+    ///
+    /// # `@source_name` specification
+    ///
+    /// The attribute must contain exactly one quoted string.
+    ///
+    /// `@source_name` allows a producer to preserve a source-level function name while giving the
+    /// emitted Miden Assembly procedure a distinct symbol. This is useful when multiple source
+    /// functions share a name but require unique assembler symbols.
+    ///
+    /// Producers emitting this attribute must respect these requirements:
+    ///
+    /// - Give every emitted procedure whose source-level name is duplicated a distinct,
+    ///   deterministic assembler symbol.
+    /// - Attach `@source_name("original name")` to every such procedure, using the original
+    ///   source-level name.
+    /// - Do not attach `@source_name` to procedures with a unique source-level name or without a
+    ///   source-level name.
+    ///
+    /// Duplicate `@source_name` values are valid. They identify the source-facing name; the
+    /// separately recorded unique linkage name identifies the corresponding assembler procedure.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a `@source_name` attribute is present, but is not of the form
+    /// `@source_name("...")`.
+    pub fn source_name_fully_qualified(
+        &self,
+        source_manager: &dyn SourceManager,
+    ) -> Result<Option<PathBuf>, Report> {
+        let Some(attribute) = self.attributes.get("source_name") else {
+            return Ok(None);
+        };
+
+        if let Attribute::List(list) = attribute
+            && let [MetaExpr::String(name)] = list.as_slice()
+        {
+            return Ok(Some(self.path.parent().unwrap().join(name)));
+        }
+
+        let span = attribute.span();
+        Err(Report::new(AssemblerError::InvalidSourceNameAttribute {
+            span,
+            source_file: source_manager.get(span.source_id()).ok(),
+        }))
+    }
+
     /// Returns the number of memory locals reserved by the procedure.
     pub fn num_locals(&self) -> u32 {
         self.num_locals
@@ -277,5 +344,102 @@ impl Procedure {
 impl Spanned for Procedure {
     fn span(&self) -> SourceSpan {
         self.span
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{sync::Arc, vec};
+
+    use miden_assembly_syntax::{
+        PathBuf,
+        ast::{Attribute, Ident, MetaExpr},
+        debuginfo::{DefaultSourceManager, SourceLanguage, Uri},
+    };
+
+    use super::*;
+
+    /// Constructs a [Procedure] with `attrs` attached, for testing attribute accessors.
+    fn procedure_with_attributes(attrs: vec::IntoIter<Attribute>) -> Procedure {
+        Procedure::new(
+            Arc::from(PathBuf::new("::test::module::foo").unwrap()),
+            Visibility::Private,
+            None,
+            AttributeSet::new(attrs),
+            false,
+            0,
+            Word::default(),
+            MastNodeUse::new(MastNodeRef::from(0), SourceNodeRef::from(0)),
+        )
+    }
+
+    #[test]
+    fn source_name_fully_qualified_is_none_without_attribute() {
+        let source_manager = DefaultSourceManager::default();
+        let procedure = procedure_with_attributes(vec![].into_iter());
+
+        assert_eq!(procedure.source_name_fully_qualified(&source_manager).unwrap(), None);
+    }
+
+    #[test]
+    fn source_name_fully_qualified_returns_quoted_string_joined_to_module_path() {
+        let source_manager = DefaultSourceManager::default();
+        let attribute = Attribute::from_iter(
+            Ident::new("source_name").unwrap(),
+            [MetaExpr::String(Ident::new("bar").unwrap())],
+        );
+        let procedure = procedure_with_attributes(vec![attribute].into_iter());
+
+        assert_eq!(
+            procedure.source_name_fully_qualified(&source_manager).unwrap(),
+            Some(PathBuf::new("::test::module::bar").unwrap()),
+        );
+    }
+
+    #[test]
+    fn malformed_source_name_attributes_are_rejected() {
+        let source_manager = DefaultSourceManager::default();
+        let file = source_manager.load(
+            SourceLanguage::Masm,
+            Uri::new("test.masm"),
+            "@source_name(unquoted)".into(),
+        );
+        let span = SourceSpan::new(file.id(), 0..19);
+
+        // Generate some malformed `@source_name` attributes
+        let malformed = vec![
+            Attribute::Marker(Ident::new("source_name").unwrap()),
+            // `@source_name(unquoted)`
+            Attribute::from_iter(
+                Ident::new("source_name").unwrap(),
+                [MetaExpr::Ident(Ident::new("unquoted").unwrap())],
+            ),
+            // `@source_name("one", "two")`
+            Attribute::from_iter(
+                Ident::new("source_name").unwrap(),
+                [
+                    MetaExpr::String(Ident::new("one").unwrap()),
+                    MetaExpr::String(Ident::new("two").unwrap()),
+                ],
+            ),
+            // `@source_name(value = "named")`
+            Attribute::from_iter(
+                Ident::new("source_name").unwrap(),
+                [(Ident::new("value").unwrap(), MetaExpr::String(Ident::new("named").unwrap()))],
+            ),
+        ];
+
+        for attribute in malformed {
+            let procedure = procedure_with_attributes(vec![attribute.with_span(span)].into_iter());
+            let error = procedure.source_name_fully_qualified(&source_manager).unwrap_err();
+
+            match error.downcast_ref::<AssemblerError>() {
+                Some(AssemblerError::InvalidSourceNameAttribute { source_file, .. }) => {
+                    // The error must be attributed to the file in which the attribute occurred
+                    assert_eq!(source_file.as_ref(), Some(&file));
+                },
+                unexpected => panic!("expected InvalidSourceNameAttribute, got {unexpected:?}"),
+            }
+        }
     }
 }

--- a/crates/assembly/src/tests.rs
+++ b/crates/assembly/src/tests.rs
@@ -6753,6 +6753,114 @@ fn test_assembler_debug_info_present() {
 }
 
 #[test]
+fn source_name_attribute_sets_debug_name_and_linkage_name() -> TestResult {
+    let context = TestContext::default();
+    let module = context.parse_module(source_file!(
+        &context,
+        r#"
+        namespace debug::names
+
+        @source_name("duplicate")
+        pub proc first
+            push.1
+        end
+
+        @source_name("duplicate")
+        pub proc second
+            push.2
+        end
+
+        pub proc normal
+            push.3
+        end
+        "#
+    ))?;
+    let package = Assembler::new(context.source_manager()).assemble_library(
+        "debug-names",
+        module,
+        None::<Box<Module>>,
+    )?;
+
+    let assert_function_names = |package: &Package| {
+        let debug_info = package
+            .debug_info()
+            .expect("package debug info should decode")
+            .expect("package should contain debug info");
+        let duplicate_functions = debug_info
+            .functions()
+            .iter()
+            .filter(|function| {
+                debug_info[function.name_idx].as_ref() == "::debug::names::duplicate"
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(duplicate_functions.len(), 2);
+        assert_eq!(duplicate_functions[0].name_idx, duplicate_functions[1].name_idx);
+        let linkage_names = duplicate_functions
+            .iter()
+            .map(|function| {
+                let linkage_name_idx = function
+                    .linkage_name_idx
+                    .into_option()
+                    .expect("source-named function should have a linkage name");
+                debug_info[linkage_name_idx].to_string()
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(linkage_names.len(), 2);
+        assert!(linkage_names.iter().any(|name| name.ends_with("::first")));
+        assert!(linkage_names.iter().any(|name| name.ends_with("::second")));
+
+        let normal = debug_info
+            .functions()
+            .iter()
+            .find(|function| debug_info[function.name_idx].ends_with("::normal"))
+            .expect("normal function should retain its assembler path as its name");
+        assert_eq!(normal.linkage_name_idx.into_option(), None);
+    };
+
+    assert_function_names(&package);
+    let round_tripped = Package::read_from_bytes(&package.to_bytes())
+        .expect("package with source-named functions should round trip");
+    assert_function_names(&round_tripped);
+
+    Ok(())
+}
+
+#[test]
+fn malformed_source_name_attributes_are_rejected() -> TestResult {
+    let context = TestContext::default();
+
+    for attribute in [
+        "@source_name",
+        "@source_name(unquoted)",
+        "@source_name(\"one\", \"two\")",
+        "@source_name(value = \"named\")",
+    ] {
+        let source = source_file!(
+            &context,
+            format!(
+                r#"
+                namespace debug::invalid
+
+                {attribute}
+                pub proc test
+                    nop
+                end
+                "#
+            )
+        );
+        let module = context.parse_module(source)?;
+        let error = Assembler::new(context.source_manager())
+            .assemble_library("invalid-source-name", module, None::<Box<Module>>)
+            .expect_err("malformed @source_name should be rejected");
+        assert_diagnostic!(&error, "invalid `@source_name` procedure attribute");
+        assert_diagnostic!(&error, "expected exactly one quoted string");
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_cross_module_constant_resolution() -> TestResult {
     let context = TestContext::default();
 

--- a/crates/mast-package/src/debug_info/builder.rs
+++ b/crates/mast-package/src/debug_info/builder.rs
@@ -335,17 +335,27 @@ impl<Exec: Idx, Src: Idx> DebugInfoBuilder<Exec, Src> {
 // ================================================================================================
 
 impl<Exec: Idx, Src: Idx> DebugInfoBuilder<Exec, Src> {
-    /// Look up the index of a function info record by it's [`miden_assembly_syntax::Path`].
+    /// Look up the index of a function info record by its [`miden_assembly_syntax::Path`].
+    ///
+    /// The path is matched against both the linkage name and the source name of each function.
+    /// Linkage name matches take precedence over source name matches.
     pub fn get_function_index_by_path(
         &self,
         path: &miden_assembly_syntax::Path,
     ) -> Option<DebugFunctionIdx> {
         let path = path.as_str();
-        self.debug_info
-            .functions
-            .iter()
-            .position(|f| self.debug_info[f.name_idx].as_ref() == path)
-            .map(|pos| DebugFunctionIdx::from(pos as u32))
+        let mut name_match = None;
+        for (pos, f) in self.debug_info.functions.iter().enumerate() {
+            if let Some(linkage_name_idx) = f.linkage_name_idx.into_option()
+                && self.debug_info[linkage_name_idx].as_ref() == path
+            {
+                return Some(DebugFunctionIdx::from(pos as u32));
+            }
+            if name_match.is_none() && self.debug_info[f.name_idx].as_ref() == path {
+                name_match = Some(pos);
+            }
+        }
+        name_match.map(|pos| DebugFunctionIdx::from(pos as u32))
     }
 
     /// Adds a function to the function table.
@@ -649,9 +659,12 @@ fn declared_type_name(
 mod tests {
     use alloc::sync::Arc;
 
-    use miden_assembly_syntax::ast::types::{
-        CallConv, EnumType, FunctionType, StructType, Type, Variant,
+    use miden_assembly_syntax::{
+        Path,
+        ast::types::{CallConv, EnumType, FunctionType, StructType, Type, Variant},
     };
+    use miden_core::Word;
+    use miden_debug_types::{ColumnNumber, LineNumber, Uri};
     use miden_utils_indexing::Idx;
 
     use super::*;
@@ -807,5 +820,84 @@ mod tests {
         assert_eq!(idx3.to_usize(), 0); // Should return same index
         assert_eq!(builder.string_indices.len(), 2);
         assert_eq!(builder.debug_info.strings.len(), 2);
+    }
+
+    fn add_test_function(
+        builder: &mut PackageDebugInfoBuilder,
+        name: &str,
+        linkage_name: Option<&str>,
+    ) -> DebugFunctionIdx {
+        let file_idx = builder.add_file(Uri::new("test.masm"), None);
+        let line = LineNumber::new(1).unwrap();
+        let column = ColumnNumber::new(1).unwrap();
+        let name_idx = builder.add_string(name);
+        let func = FunctionInfo::new(None, name_idx, file_idx, line, column, Word::default());
+        let func = match linkage_name {
+            Some(linkage_name) => {
+                let linkage_name_idx = builder.add_string(linkage_name);
+                func.with_linkage_name(linkage_name_idx)
+            },
+            None => func,
+        };
+        builder.add_function(func)
+    }
+
+    #[test]
+    fn function_path_lookup_no_match() {
+        let mut builder = PackageDebugInfoBuilder::default();
+        add_test_function(&mut builder, "::module::plain", None);
+        add_test_function(&mut builder, "duplicate", Some("::module::linked"));
+
+        assert_eq!(builder.get_function_index_by_path(Path::new("::module::missing")), None);
+    }
+
+    #[test]
+    fn function_path_lookup_matches_name() {
+        let mut builder = PackageDebugInfoBuilder::default();
+        let plain_function_idx = add_test_function(&mut builder, "::module::plain", None);
+
+        assert_eq!(
+            builder.get_function_index_by_path(Path::new("::module::plain")),
+            Some(plain_function_idx),
+        );
+    }
+
+    #[test]
+    fn function_path_lookup_matches_linkage_name() {
+        let mut builder = PackageDebugInfoBuilder::default();
+        let linked_function_idx =
+            add_test_function(&mut builder, "duplicate", Some("::module::linked"));
+
+        assert_eq!(
+            builder.get_function_index_by_path(Path::new("::module::linked")),
+            Some(linked_function_idx),
+        );
+    }
+
+    #[test]
+    fn function_path_lookup_matches_source_name_of_linked_function() {
+        let mut builder = PackageDebugInfoBuilder::default();
+        let linked_function_idx =
+            add_test_function(&mut builder, "::module::source", Some("::module::linked"));
+
+        assert_eq!(
+            builder.get_function_index_by_path(Path::new("::module::source")),
+            Some(linked_function_idx),
+        );
+    }
+
+    #[test]
+    fn function_path_lookup_prefers_linkage_name() {
+        let mut builder = PackageDebugInfoBuilder::default();
+        // The name-matching function comes first in the table, but the linkage name match must
+        // still take precedence.
+        add_test_function(&mut builder, "::module::shared", None);
+        let linked_function_idx =
+            add_test_function(&mut builder, "duplicate", Some("::module::shared"));
+
+        assert_eq!(
+            builder.get_function_index_by_path(Path::new("::module::shared")),
+            Some(linked_function_idx),
+        );
     }
 }

--- a/crates/mast-package/src/debug_info/types.rs
+++ b/crates/mast-package/src/debug_info/types.rs
@@ -1188,9 +1188,14 @@ pub struct FunctionInfo<N: Idx> {
     pub source_node: OptionalIndex<N>,
     /// Type signature of this function (index into type table, optional)
     pub type_idx: OptionalIndex<DebugTypeIdx>,
-    /// Linkage name / mangled name (index into string table, optional)
+    /// Assembler/linker-visible name (index into string table, optional).
+    ///
+    /// Set when the name known to the linker differs from the name as written in the source code
+    /// (which is tracked by name_idx).
     pub linkage_name_idx: OptionalIndex<DebugStringIdx>,
-    /// Name of the function (index into string table)
+    /// Name of the function (index into string table).
+    ///
+    /// When `linkage_name_idx` is unset, this is also the assembler/linker-visible name.
     pub name_idx: DebugStringIdx,
     /// File containing this function (index into file table)
     pub file_idx: DebugFileIdx,

--- a/docs/src/user_docs/assembly/code_organization.md
+++ b/docs/src/user_docs/assembly/code_organization.md
@@ -13,7 +13,7 @@ Miden assembly programs are organized into procedures. Procedures, in turn, can 
 ### Procedures
 A *procedure* can be used to encapsulate a frequently-used sequence of instructions which can later be invoked via a label. A procedure is introduced using the `proc` keyword. Procedure definitions consist of the following parts, in the order they appear:
 
-* Zero or more attributes which modify the procedure definition, or annotate it in some way. These can be user-defined, but there are also built-in attributes that modify the procedure itself. Currently, the only built-in attribute is `@locals(N)`, which specifies the number of procedure locals allocated for the procedure. See the [Procedure Attributes](#procedure-attributes) section for more on their syntax and semantics.
+* Zero or more attributes which modify the procedure definition, or annotate it in some way. These can be user-defined, but there are also built-in attributes interpreted by the assembler. For example, `@locals(N)` specifies the number of procedure locals allocated for the procedure. See the [Procedure Attributes](#procedure-attributes) section for more on their syntax and semantics.
 * An optional visibility modifier, i.e. `pub` if the procedure is to be exported from the containing module.
 * The `proc` keyword
 * The procedure name/label
@@ -92,6 +92,8 @@ Procedure attributes (also called annotations) provide a mechanism to attach arb
 The set of built-in attributes is listed below:
 
 - `@locals(N)`, specifies that the assembler should allocate `N` elements of procedure local storage, which can then be accessed using procedure-local memory operations, e.g. `loc_load`
+- `@source_name(..)`, reserved for internal use by the Miden compiler.
+
 
 #### Attribute syntax
 


### PR DESCRIPTION
Context [compiler1341](https://github.com/0xMiden/compiler/issues/1341): For debug builds with panic strategy `abort`, rustc can emit duplicate (mangled) function names in the name section. Our plan is to make duplicate names unique and add the original name as `@source_name` procedure attribute.

This PR adds vm-side support for this as discussed earlier today:

- `@source_name` is to be added only for functions with duplicate names
- if a procedure does not have `@source_name`, proceed as before
- if a procedure has `@source_name`
  - use the (unique) path as `linkage_name_idx`
  - use the value of `@source_name` as `name_idx`
