### PR TITLE
fix: honor bundle release and version options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Fixes
 
 - Fixed `miden-vm bundle --release` to remove package debug information from library and kernel artifacts while preserving their MAST digests ([#3719](https://github.com/0xMiden/miden-vm/issues/3719)).
+- Fixed `miden-vm bundle --version` to store the requested version in library and kernel packages and reject invalid semantic versions ([#3659](https://github.com/0xMiden/miden-vm/issues/3659)).
 
 ## v0.29.2 (2026-08-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.29.3 (Unreleased)
+
+#### Fixes
+
+- Fixed `miden-vm bundle --release` to remove package debug information from library and kernel artifacts while preserving their MAST digests ([#3719](https://github.com/0xMiden/miden-vm/issues/3719)).
+
 ## v0.29.2 (2026-08-20)
 
 #### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.29.3 (Unreleased)
+## v0.29.3 (2026-08-25)
 
 #### Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-constraint-compiler",
  "miden-core",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "insta",
  "miden-ace-codegen",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "env_logger",
  "insta",
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "env_logger",
  "log",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "miden-bench"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "clap",
  "miden-lifted-stark",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "miden-constraint-compiler"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "criterion",
  "derive_more",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "criterion",
  "env_logger",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib-codegen"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-core",
  "miden-precompiles",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "assert_matches",
  "blake3",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-field",
  "quote",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-smt-codspeed-bench"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-crypto",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-wycheproof-tests"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "miden-format"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "clap",
  "miden-assembly-syntax-cst",
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-field",
  "p3-air",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "criterion",
  "miden-lifted-air",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "hashbrown 0.17.1",
  "log",
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry-local"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "clap",
  "miden-assembly-syntax",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles-prover"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "insta",
  "k256",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "hashbrown 0.17.1",
  "insta",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-air",
  "miden-assembly",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-bn254",
  "p3-field",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "miden-test-serde-macros"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "proc-macro2",
  "proptest",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "miden-test-utils"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "env_logger",
  "miden-air",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-serde-utils",
  "miden-test-serde-macros",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "lock_api",
  "loom",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-blake3-bench"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "clap",
  "codspeed-criterion-compat",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-precompiles-bench"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-core",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-synthetic-bench"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-assembly",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ repository = "https://github.com/0xMiden/miden-vm"
 exclude = [".github/"]
 rust-version = "1.96.1"
 # First-party packages on the VM release line inherit this version.
-version = "0.29.2"
+version = "0.29.3"
 
 [profile.optimized]
 inherits = "release"

--- a/crates/lib/core/asm/miden-project.toml
+++ b/crates/lib/core/asm/miden-project.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.29.2"
+version = "0.29.3"
 
 [lib]
 namespace = "miden::core"

--- a/miden-vm/src/cli/bundle.rs
+++ b/miden-vm/src/cli/bundle.rs
@@ -6,7 +6,11 @@ use miden_assembly::{
     diagnostics::{IntoDiagnostic, Report},
 };
 use miden_core_lib::CoreLibrary;
-use miden_mast_package::Package;
+use miden_mast_package::{Package, Version};
+
+fn parse_version(value: &str) -> Result<Version, String> {
+    value.parse().map_err(|err| format!("invalid package version: {err}"))
+}
 
 #[derive(Debug, Clone, Parser)]
 #[command(
@@ -25,8 +29,8 @@ pub struct BundleCmd {
     #[arg(short, long)]
     namespace: Option<String>,
     /// Version of the library, defaults to `0.1.0`.
-    #[arg(short, long, default_value = "0.1.0")]
-    version: String,
+    #[arg(short, long, default_value = "0.1.0", value_parser = parse_version)]
+    version: Version,
     /// Indicates that the artifact produced is a kernel package.
     ///
     /// This requires that `root` be a path to the root module of the kernel.
@@ -66,6 +70,7 @@ impl BundleCmd {
                 None => ast::Path::KERNEL_PATH,
             };
             let mut library = assembler.assemble_kernel_from_root(namespace, &self.root)?;
+            library.version = self.version.clone();
             if self.release {
                 library.strip_debug_info().into_diagnostic()?;
             }
@@ -79,6 +84,7 @@ impl BundleCmd {
             assembler.link_package(CoreLibrary::default().package(), Linkage::Dynamic)?;
             let mut library =
                 assembler.assemble_library_from_root(&self.root, library_namespace.as_deref())?;
+            library.version = self.version.clone();
             if self.release {
                 library.strip_debug_info().into_diagnostic()?;
             }

--- a/miden-vm/src/cli/bundle.rs
+++ b/miden-vm/src/cli/bundle.rs
@@ -65,7 +65,10 @@ impl BundleCmd {
                 Some(ns) => ns,
                 None => ast::Path::KERNEL_PATH,
             };
-            let library = assembler.assemble_kernel_from_root(namespace, &self.root)?;
+            let mut library = assembler.assemble_kernel_from_root(namespace, &self.root)?;
+            if self.release {
+                library.strip_debug_info().into_diagnostic()?;
+            }
             library.write_to_file(output_file).into_diagnostic()?;
             println!("Built kernel library {} from {}", library.name, self.root.display());
         } else {
@@ -74,8 +77,11 @@ impl BundleCmd {
                 None => None,
             };
             assembler.link_package(CoreLibrary::default().package(), Linkage::Dynamic)?;
-            let library =
+            let mut library =
                 assembler.assemble_library_from_root(&self.root, library_namespace.as_deref())?;
+            if self.release {
+                library.strip_debug_info().into_diagnostic()?;
+            }
             library.write_to_file(output_file).into_diagnostic()?;
             println!("Built package '{}'", library.name);
         }

--- a/miden-vm/tests/integration/cli/cli_test.rs
+++ b/miden-vm/tests/integration/cli/cli_test.rs
@@ -178,6 +178,68 @@ fn cli_bundle_release_strips_debug_info() {
 }
 
 #[test]
+fn cli_bundle_version() {
+    let working_dir = TempDir::new().unwrap();
+    let cases = [
+        (
+            "library",
+            fixture("tests/integration/cli/data/lib/mod.masm"),
+            vec!["--namespace", "lib"],
+        ),
+        (
+            "kernel",
+            fixture("tests/integration/cli/data/kernel_main.masm"),
+            vec!["--kernel"],
+        ),
+    ];
+
+    for (name, source, extra_args) in cases {
+        let requested_output = working_dir.path().join(format!("{name}-versioned.masp"));
+        let default_output = working_dir.path().join(format!("{name}-default-version.masp"));
+
+        let mut cmd = bin_under_test(working_dir.path());
+        cmd.arg("bundle")
+            .arg(&source)
+            .args(&extra_args)
+            .arg("--version")
+            .arg("1.2.3")
+            .arg("--output")
+            .arg(&requested_output);
+        cmd.assert().success();
+
+        let package = Package::deserialize_from_file_trusted(&requested_output).unwrap();
+        assert_eq!(package.version, "1.2.3".parse().unwrap());
+
+        let mut cmd = bin_under_test(working_dir.path());
+        cmd.arg("bundle")
+            .arg(&source)
+            .args(&extra_args)
+            .arg("--output")
+            .arg(&default_output);
+        cmd.assert().success();
+
+        let package = Package::deserialize_from_file_trusted(&default_output).unwrap();
+        assert_eq!(package.version, "0.1.0".parse().unwrap());
+    }
+
+    let invalid_output = working_dir.path().join("invalid-version.masp");
+    let mut cmd = bin_under_test(working_dir.path());
+    cmd.arg("bundle")
+        .arg(fixture("tests/integration/cli/data/lib/mod.masm"))
+        .arg("--namespace")
+        .arg("lib")
+        .arg("--version")
+        .arg("not-a-version")
+        .arg("--output")
+        .arg(&invalid_output);
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value 'not-a-version'"))
+        .stderr(predicate::str::contains("--version <VERSION>"));
+    assert!(!invalid_output.exists());
+}
+
+#[test]
 fn cli_bundle_no_exports() {
     let working_dir = TempDir::new().unwrap();
     let mut cmd = bin_under_test(working_dir.path());

--- a/miden-vm/tests/integration/cli/cli_test.rs
+++ b/miden-vm/tests/integration/cli/cli_test.rs
@@ -104,6 +104,80 @@ fn cli_bundle_debug() {
 }
 
 #[test]
+fn cli_bundle_release_strips_debug_info() {
+    let working_dir = TempDir::new().unwrap();
+    let cases = [
+        (
+            "library",
+            fixture("tests/integration/cli/data/lib/mod.masm"),
+            vec!["--namespace", "lib"],
+        ),
+        (
+            "kernel",
+            fixture("tests/integration/cli/data/kernel_main.masm"),
+            vec!["--kernel"],
+        ),
+    ];
+
+    for (name, source, extra_args) in cases {
+        let debug_output = working_dir.path().join(format!("{name}-debug.masp"));
+        let release_output = working_dir.path().join(format!("{name}-release.masp"));
+
+        let mut cmd = bin_under_test(working_dir.path());
+        cmd.arg("bundle")
+            .arg(&source)
+            .args(&extra_args)
+            .arg("--output")
+            .arg(&debug_output);
+        cmd.assert().success();
+
+        let mut cmd = bin_under_test(working_dir.path());
+        cmd.arg("bundle")
+            .arg(&source)
+            .args(&extra_args)
+            .arg("--release")
+            .arg("--output")
+            .arg(&release_output);
+        cmd.assert().success();
+
+        let debug_bytes = fs::read(&debug_output).unwrap();
+        let release_bytes = fs::read(&release_output).unwrap();
+        let source_path = source.to_string_lossy();
+
+        assert_ne!(debug_bytes, release_bytes, "{name} bundles should differ");
+        assert!(
+            debug_bytes
+                .windows(source_path.len())
+                .any(|bytes| bytes == source_path.as_bytes()),
+            "debug {name} bundle should contain its source path"
+        );
+        assert!(
+            !release_bytes
+                .windows(source_path.len())
+                .any(|bytes| bytes == source_path.as_bytes()),
+            "release {name} bundle should omit its source path"
+        );
+
+        let debug_package = Package::deserialize_from_file_trusted(&debug_output).unwrap();
+        let release_package = Package::deserialize_from_file_trusted(&release_output).unwrap();
+
+        assert!(
+            debug_package.debug_info().unwrap().is_some(),
+            "debug {name} bundle should contain package debug info"
+        );
+        assert!(
+            release_package.debug_info().unwrap().is_none(),
+            "release {name} bundle should omit package debug info"
+        );
+        assert_eq!(
+            debug_package.digest(),
+            release_package.digest(),
+            "release mode should preserve the {name} MAST digest"
+        );
+    }
+}
+
+#[test]
 fn cli_bundle_no_exports() {
     let working_dir = TempDir::new().unwrap();
     let mut cmd = bin_under_test(working_dir.path());

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-assembly"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "log",
  "miden-assembly-syntax-cst",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "derive_more",
  "log",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "blake3",
  "cc",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-air",
  "p3-challenger",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "hashbrown",
  "log",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-field",
  "p3-symmetric",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-serde-utils",
  "proptest",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "lock_api",
  "loom",

--- a/tools/miden-crypto-fuzz/Cargo.lock
+++ b/tools/miden-crypto-fuzz/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "blake3",
  "cc",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-air",
  "p3-challenger",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-field",
  "p3-symmetric",

--- a/tools/miden-serde-utils-fuzz/Cargo.lock
+++ b/tools/miden-serde-utils-fuzz/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "p3-field",
  "p3-goldilocks",


### PR DESCRIPTION
`miden-vm bundle` accepted `--release` and `--version`, but did not apply them to output packages. Release bundles kept debug  information, and every package used version 0.0.0.
This change removes package debug information when `--release` is set. It also stores the requested semantic version in library and kernel packages. Invalid versions fail before an output file is written. The default remains 0.1.0.

This closes #3719 and #3659.