### PR TITLE
fix: prepare v0.29.4 release

### DIFF
--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -22,9 +22,9 @@ on:
         default: ""
         type: string
       allow_existing:
-        description: "Exclude crate versions that already exist on crates.io. Use only to resume a partial publish."
+        description: "Exclude crate versions that already exist on crates.io."
         required: false
-        default: false
+        default: true
         type: boolean
       skip_package_version_gate:
         description: "Skip the package version gate. Use only for manual release recovery after maintainers verify the release plan."
@@ -254,7 +254,7 @@ jobs:
           mode: "publish"
           verify-main-head: "true"
           packages: ${{ github.event.inputs.packages || '' }}
-          allow_existing: ${{ github.event.inputs.allow_existing || 'false' }}
+          allow_existing: ${{ github.event.inputs.allow_existing || 'true' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-constraint-compiler",
  "miden-core",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "insta",
  "miden-ace-codegen",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "env_logger",
  "insta",
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "env_logger",
  "log",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "miden-bench"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "clap",
  "miden-lifted-stark",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "miden-constraint-compiler"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "criterion",
  "derive_more",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "criterion",
  "env_logger",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib-codegen"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-core",
  "miden-precompiles",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "assert_matches",
  "blake3",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-field",
  "quote",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-smt-codspeed-bench"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-crypto",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-wycheproof-tests"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -2354,7 +2354,7 @@ dependencies = [
 
 [[package]]
 name = "miden-format"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "clap",
  "miden-assembly-syntax-cst",
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-field",
  "p3-air",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "criterion",
  "miden-lifted-air",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "hashbrown 0.17.1",
  "log",
@@ -2478,7 +2478,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry-local"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "clap",
  "miden-assembly-syntax",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2519,7 +2519,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles-prover"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "insta",
  "k256",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "hashbrown 0.17.1",
  "insta",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-air",
  "miden-assembly",
@@ -2615,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-bn254",
  "p3-field",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "miden-test-serde-macros"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "proc-macro2",
  "proptest",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "miden-test-utils"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "env_logger",
  "miden-air",
@@ -2677,7 +2677,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-serde-utils",
  "miden-test-serde-macros",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "lock_api",
  "loom",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-blake3-bench"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "clap",
  "codspeed-criterion-compat",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-precompiles-bench"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-core",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-synthetic-bench"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-assembly",
@@ -2805,7 +2805,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ repository = "https://github.com/0xMiden/miden-vm"
 exclude = [".github/"]
 rust-version = "1.96.1"
 # First-party packages on the VM release line inherit this version.
-version = "0.29.3"
+version = "0.29.4"
 
 [profile.optimized]
 inherits = "release"

--- a/crates/lib/core/asm/miden-project.toml
+++ b/crates/lib/core/asm/miden-project.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.29.3"
+version = "0.29.4"
 
 [lib]
 namespace = "miden::core"

--- a/crates/midenc-hir-type/Cargo.toml
+++ b/crates/midenc-hir-type/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-type"
 description = "Type system and utilities for Miden HIR"
-version = "0.10.1"
+version = "0.10.2"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -717,7 +717,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-assembly"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "log",
  "miden-assembly-syntax-cst",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "derive_more",
  "log",
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "blake3",
  "cc",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-air",
  "p3-challenger",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "hashbrown",
  "log",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-field",
  "p3-symmetric",
@@ -1034,7 +1034,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1043,7 +1043,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-serde-utils",
  "proptest",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "lock_api",
  "loom",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",

--- a/tools/miden-crypto-fuzz/Cargo.lock
+++ b/tools/miden-crypto-fuzz/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "blake3",
  "cc",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-air",
  "p3-challenger",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-field",
  "p3-symmetric",

--- a/tools/miden-serde-utils-fuzz/Cargo.lock
+++ b/tools/miden-serde-utils-fuzz/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "p3-field",
  "p3-goldilocks",


### PR DESCRIPTION
Version bump and change publish job to ignore already-published crates by default.