### PR TITLE
refactor(processor): use Rayon's in-place scope for trace building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,8 +117,8 @@
 - Fixed `FastProcessor::execute_and_build_trace_sync` aborting on targets that build a full `std`
   but cannot spawn threads, such as `wasm32-unknown-unknown`. The failed spawn panicked under
   `panic=abort`, trapping the module, which left an in-browser prove hung with no error instead of
-  failed. The builder thread is now spawned fallibly and the trace is built sequentially whenever
-  that spawn is refused ([#3722](https://github.com/0xMiden/miden-vm/pull/3722)).
+  failed. Rayon now schedules the streamed trace builder. Its supported fallback runs the same path
+  sequentially when threads are unavailable ([#3722](https://github.com/0xMiden/miden-vm/pull/3722)).
 
 ## v0.29.3 (2026-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@
 
 #### Changes
 
-- Replaced the synchronous streamed hasher's dedicated thread and fallback execution route with Rayon's in-place scope, preserving native overlap and threadless sequential execution ([#3726](https://github.com/0xMiden/miden-vm/pull/3726)).
+- Replaced the synchronous streamed hasher's dedicated thread with Rayon's in-place scope while
+  retaining compact buffered replay when no worker can overlap execution ([#3726](https://github.com/0xMiden/miden-vm/pull/3726)).
 - Fixed `verify` checking for the proof, input, and output files before validating the `--kernel` file extension, so a malformed `--kernel` path was reported as a missing/invalid proof or input/output file instead of the actual problem (mirrors the same ordering issue already fixed for `prove` in #3587) ([#3656](https://github.com/0xMiden/miden-vm/issues/3656)).
 - Fixed `line_column_to_offset` treating the column index as a raw byte offset instead of a character offset, which returned the wrong offset or panicked for lines containing multi-byte UTF-8 characters ([#3633](https://github.com/0xMiden/miden-vm/issues/3633)).
 - Clarified the ACE circuit trust model and distinguished the order-independent AIR wiring relation from the standard processor's sequential DAG witness construction ([#3683](https://github.com/0xMiden/miden-vm/pull/3683)).
@@ -118,8 +119,8 @@
 - Fixed `FastProcessor::execute_and_build_trace_sync` aborting on targets that build a full `std`
   but cannot spawn threads, such as `wasm32-unknown-unknown`. The failed spawn panicked under
   `panic=abort`, trapping the module, which left an in-browser prove hung with no error instead of
-  failed. Rayon now schedules the streamed trace builder. Its supported fallback runs the same path
-  sequentially when threads are unavailable ([#3722](https://github.com/0xMiden/miden-vm/pull/3722)).
+  failed. Rayon now schedules the streamed trace builder. Targets without a separate worker use
+  compact buffered replay ([#3722](https://github.com/0xMiden/miden-vm/pull/3722)).
 
 ## v0.29.3 (2026-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 #### Changes
 
+- Replaced the synchronous streamed hasher's dedicated thread and fallback execution route with Rayon's in-place scope, preserving native overlap and threadless sequential execution ([#3726](https://github.com/0xMiden/miden-vm/pull/3726)).
 - Fixed `verify` checking for the proof, input, and output files before validating the `--kernel` file extension, so a malformed `--kernel` path was reported as a missing/invalid proof or input/output file instead of the actual problem (mirrors the same ordering issue already fixed for `prove` in #3587) ([#3656](https://github.com/0xMiden/miden-vm/issues/3656)).
 - Fixed `line_column_to_offset` treating the column index as a raw byte offset instead of a character offset, which returned the wrong offset or panicked for lines containing multi-byte UTF-8 characters ([#3633](https://github.com/0xMiden/miden-vm/issues/3633)).
 - Clarified the ACE circuit trust model and distinguished the order-independent AIR wiring relation from the standard processor's sequential DAG witness construction ([#3683](https://github.com/0xMiden/miden-vm/pull/3683)).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ paste           = { version = "1.0", default-features = false }
 proptest        = { version = "1.8", default-features = false, features = ["no_std", "alloc"] }
 proptest-derive = { version = "0.8", default-features = false }
 rand            = { version = "0.10", default-features = false }
-rayon           = { version = "1.10", default-features = false }
+rayon           = { version = "1.11", default-features = false }
 rocksdb         = { version = "0.24", default-features = false }
 seq-macro       = "0.3"
 serde           = { version = "1.0", default-features = false, features = ["alloc", "derive", "rc"] }

--- a/Makefile
+++ b/Makefile
@@ -266,9 +266,9 @@ test-wasm-simd: ## Runs the packed Goldilocks/Poseidon2 vs scalar tests under WA
 	RUSTFLAGS="-C target-feature=+simd128" \
 	cargo test -p miden-field -p miden-crypto --no-default-features --lib --target wasm32-wasip1 -- packed
 
-# wasm32-wasip1 refuses to spawn at runtime, so this runs Rayon's fallback for real. Only the span
-# test is skipped -- it asserts a Rayon worker ran, which cannot hold where threads are unavailable
-# -- so equality tests added later are covered here without touching this target. A
+# wasm32-wasip1 refuses to spawn at runtime, so this runs the compact fallback for real. Only the
+# span test is skipped -- it asserts a Rayon worker ran, which cannot hold where threads are
+# unavailable -- so equality tests added later are covered here without touching this target. A
 # passing run is not enough to trust: libtest exits 0 when a filter selects nothing, so a zero-test
 # run would otherwise leave this green while guarding nothing.
 .PHONY: test-wasm-threadless

--- a/Makefile
+++ b/Makefile
@@ -266,9 +266,9 @@ test-wasm-simd: ## Runs the packed Goldilocks/Poseidon2 vs scalar tests under WA
 	RUSTFLAGS="-C target-feature=+simd128" \
 	cargo test -p miden-field -p miden-crypto --no-default-features --lib --target wasm32-wasip1 -- packed
 
-# wasm32-wasip1 refuses to spawn at runtime, so this is the fallback path running for real. Only
-# the span test is skipped -- it asserts the builder thread ran, which cannot hold where the spawn
-# is refused -- so equality tests added later are covered here without touching this target. A
+# wasm32-wasip1 refuses to spawn at runtime, so this runs Rayon's fallback for real. Only the span
+# test is skipped -- it asserts a Rayon worker ran, which cannot hold where threads are unavailable
+# -- so equality tests added later are covered here without touching this target. A
 # passing run is not enough to trust: libtest exits 0 when a filter selects nothing, so a zero-test
 # run would otherwise leave this green while guarding nothing.
 .PHONY: test-wasm-threadless

--- a/miden-vm/README.md
+++ b/miden-vm/README.md
@@ -124,8 +124,8 @@ function. The FastProcessor-backed `prove_sync(&Prover, ...)` function executes 
 one synchronous call while preserving optimized overlapped execution and trace construction.
 
 `prove_sync()` overlaps execution with hasher-chiplet trace construction when a Rayon worker is
-available. Rayon's supported fallback runs the same path sequentially on targets without threads,
-such as `wasm32-unknown-unknown`.
+available. A caller with no separate Rayon worker uses compact buffered replay, including on
+targets such as `wasm32-unknown-unknown`.
 
 #### Proof generation example
 

--- a/miden-vm/README.md
+++ b/miden-vm/README.md
@@ -123,9 +123,9 @@ with `Verifier::verify`.
 function. The FastProcessor-backed `prove_sync(&Prover, ...)` function executes and fully proves in
 one synchronous call while preserving optimized overlapped execution and trace construction.
 
-`prove_sync()` overlaps execution with hasher-chiplet trace construction where a thread can be
-spawned for it. Targets that report thread spawning as unsupported, such as
-`wasm32-unknown-unknown`, build the same trace sequentially. Other spawn failures return an error.
+`prove_sync()` overlaps execution with hasher-chiplet trace construction when a Rayon worker is
+available. Rayon's supported fallback runs the same path sequentially on targets without threads,
+such as `wasm32-unknown-unknown`.
 
 #### Proof generation example
 

--- a/processor/README.md
+++ b/processor/README.md
@@ -28,8 +28,9 @@ building is parallel when the `concurrent` feature is enabled.
 
 With the `std` feature, `FastProcessor::execute_and_build_trace_sync()` preserves the optimized
 synchronous path that overlaps execution with hasher trace construction. It returns
-`(VmTrace, Option<PrecompileWitness>)`. Targets that report thread spawning as unsupported
-construct the same trace sequentially. Other spawn failures are returned as errors.
+`(VmTrace, Option<PrecompileWitness>)`. Execution stays on the calling thread while Rayon may run
+the hasher builder on a worker. Rayon's supported fallback runs the same path sequentially on
+targets without threads.
 
 ## Processor components
 The processor is separated into two main components: **execution** and **trace generation**.

--- a/processor/README.md
+++ b/processor/README.md
@@ -29,8 +29,8 @@ building is parallel when the `concurrent` feature is enabled.
 With the `std` feature, `FastProcessor::execute_and_build_trace_sync()` preserves the optimized
 synchronous path that overlaps execution with hasher trace construction. It returns
 `(VmTrace, Option<PrecompileWitness>)`. Execution stays on the calling thread while Rayon may run
-the hasher builder on a worker. Rayon's supported fallback runs the same path sequentially on
-targets without threads.
+the hasher builder on a worker. A caller with no separate Rayon worker uses compact buffered replay
+and builds the trace after execution.
 
 ## Processor components
 The processor is separated into two main components: **execution** and **trace generation**.

--- a/processor/src/errors.rs
+++ b/processor/src/errors.rs
@@ -85,10 +85,6 @@ pub enum ExecutionError {
         "estimated prover memory of {estimated_bytes} bytes exceeds the budget of {budget_bytes} bytes"
     )]
     ProverMemoryExceeded { estimated_bytes: u64, budget_bytes: u64 },
-    /// The optimized synchronous trace builder could not create its worker thread.
-    #[cfg(feature = "std")]
-    #[error("failed to spawn the hasher-chiplet trace builder: {0}")]
-    TraceBuilderThreadSpawn(#[source] std::io::Error),
     /// Memory error with source context for diagnostics.
     ///
     /// Use `MemoryResultExt::map_mem_err` to convert `Result<T, MemoryError>` with context.

--- a/processor/src/execution_options.rs
+++ b/processor/src/execution_options.rs
@@ -204,8 +204,8 @@ impl ExecutionOptions {
 
     /// Sets whether the synchronous prover may overlap hasher-chiplet trace building with program
     /// execution (defaults to `true`; ignored on no_std, which always uses the sequential path).
-    /// When enabled, overlap is opportunistic: targets without threading support use Rayon's
-    /// sequential fallback.
+    /// When enabled, overlap is opportunistic. A caller with no separate Rayon worker uses compact
+    /// buffered replay.
     pub fn with_overlapped_trace_build(mut self, overlapped: bool) -> Self {
         self.overlapped_trace_build = overlapped;
         self

--- a/processor/src/execution_options.rs
+++ b/processor/src/execution_options.rs
@@ -15,9 +15,8 @@ pub struct ExecutionOptions {
     core_trace_fragment_size: usize,
     /// Maximum combined logical size, in bytes, of the advice stack, map, and Merkle store.
     max_advice_size_bytes: usize,
-    /// Whether the synchronous prover is asked to overlap hasher-chiplet trace building with
-    /// program execution. The sequential path is used on no_std and when the target reports that
-    /// threads are unsupported.
+    /// Whether the synchronous prover may overlap hasher-chiplet trace building with program
+    /// execution (std-only; the sequential path is used on no_std regardless).
     overlapped_trace_build: bool,
     /// Maximum number of input bytes allowed for a single hash precompile invocation.
     max_hash_len_bytes: usize,
@@ -203,17 +202,16 @@ impl ExecutionOptions {
         self.max_hash_len_bytes
     }
 
-    /// Selects the overlapped synchronous proving route. It defaults to `true`. The route falls
-    /// back to sequential trace building when the target reports that threads are unsupported.
+    /// Sets whether the synchronous prover may overlap hasher-chiplet trace building with program
+    /// execution (defaults to `true`; ignored on no_std, which always uses the sequential path).
+    /// When enabled, overlap is opportunistic: targets without threading support use Rayon's
+    /// sequential fallback.
     pub fn with_overlapped_trace_build(mut self, overlapped: bool) -> Self {
         self.overlapped_trace_build = overlapped;
         self
     }
 
-    /// Returns whether the synchronous prover is asked to overlap trace building with execution.
-    ///
-    /// A target that reports threads as unsupported uses the sequential route even when this
-    /// returns `true`. Other spawn failures are returned as errors.
+    /// Returns whether the synchronous prover may overlap trace building with execution.
     pub fn overlapped_trace_build(&self) -> bool {
         self.overlapped_trace_build
     }

--- a/processor/src/fast/execution_api.rs
+++ b/processor/src/fast/execution_api.rs
@@ -138,14 +138,11 @@ impl FastProcessor {
         .await
     }
 
-    /// Executes the program and builds its execution trace, overlapping the two where the target
-    /// can spawn a thread: the hasher chiplet — the dominant serial part of trace building — is
-    /// built on a second thread from a live stream of requests while execution is still running,
-    /// hiding its cost behind the (inherently sequential) execution itself.
-    ///
-    /// When the target reports that threads are unsupported, the trace is built serially instead.
-    /// Having `std` does not guarantee threads. For example, `wasm32-unknown-unknown` has one
-    /// without the other. Other spawn failures are returned as errors.
+    /// Executes the program and builds its execution trace, overlapping the two when a Rayon worker
+    /// is available. The hasher chiplet — the dominant serial part of trace building — consumes a
+    /// live stream of requests while execution is still running, hiding its cost behind the
+    /// (inherently sequential) execution itself. On targets without threads, Rayon's global
+    /// fallback runs execution and trace building sequentially.
     ///
     /// `max_prover_memory_bytes` bounds the trace the same way
     /// [`crate::trace::build_trace_with_budget`] does; the streamed hasher builds ahead of that
@@ -173,108 +170,62 @@ impl FastProcessor {
             &config::pcs_params(),
         ));
         let (sender, receiver) = std::sync::mpsc::channel();
+        let mut tracer = ExecutionTracer::new_with_streamed_hasher(
+            self.options.core_trace_fragment_size(),
+            self.options.max_stack_depth(),
+            sender,
+        );
 
-        std::thread::scope(|scope| {
-            // Only the receiver crosses threads; execution (and the host) stay on this one.
-            // Spans are thread-local, so the builder thread re-enters this function's span
-            // to keep its work attributed under it in profiling traces.
+        let hasher = std::sync::OnceLock::new();
+        let hasher_slot = &hasher;
+        // Keep `tracer` owned by the scope body. If execution unwinds, dropping the body closes the
+        // stream before Rayon waits for the builder, so the builder cannot remain blocked on input.
+        let execution_output = rayon::in_place_scope(move |scope| {
+            // Execution and the host remain on the calling thread. An idle Rayon worker can steal
+            // only the builder task; if threads are unsupported, Rayon's global fallback runs the
+            // task on this thread after the scope body closes the stream.
             let span = tracing::Span::current();
-            let hasher = std::thread::Builder::new()
-                .name("hasher-chiplet-builder".into())
-                .spawn_scoped(scope, move || {
-                    let _span = span.entered();
-                    build_hasher_chiplet(receiver.into_iter().map(Ok), max_trace_len)
-                });
+            scope.spawn(move |_| {
+                let _span = span.entered();
+                let result = build_hasher_chiplet(receiver.into_iter().map(Ok), max_trace_len);
+                assert!(hasher_slot.set(result).is_ok(), "hasher builder ran more than once");
+            });
 
-            let hasher = match hasher {
-                Ok(hasher) => hasher,
-                Err(err) => {
-                    let can_fallback = Self::can_fallback_after_builder_spawn_error(&err);
-                    Self::log_refused_builder_spawn(&err, cfg!(target_family = "wasm"));
-                    if !can_fallback {
-                        return Err(ExecutionError::TraceBuilderThreadSpawn(err));
-                    }
-                    let (vm_witness, precompiles_witness) =
-                        self.execute_for_proving_sync(program, host)?.into_parts();
-                    let trace =
-                        crate::trace::build_trace_with_budget(vm_witness, max_prover_memory_bytes)?;
-                    return Ok((trace, precompiles_witness));
-                },
-            };
-
-            let mut tracer = ExecutionTracer::new_with_streamed_hasher(
-                self.options.core_trace_fragment_size(),
-                self.options.max_stack_depth(),
-                sender,
-            );
-
-            // Liveness invariant: `tracer` is local to this closure. Any unwind, including a panic
-            // in execution, drops the stream's sender and unblocks the builder before the scope
-            // joins it.
             let execution_output = self.execute_with_tracer_sync(program, host, &mut tracer);
 
-            let (mut vm_witness, precompiles_witness) = match execution_output {
+            match execution_output {
                 Ok(output) => {
-                    Self::execution_witness_from_parts(program, stack_inputs, output, tracer)
-                        .into_parts()
+                    let (mut vm_witness, precompiles_witness) =
+                        Self::execution_witness_from_parts(program, stack_inputs, output, tracer)
+                            .into_parts();
+                    // End the stream before this scope waits for the builder. This is required for
+                    // both the parallel path and Rayon's single-thread fallback.
+                    drop(vm_witness.take_hasher_replay());
+                    Ok((vm_witness, precompiles_witness))
                 },
                 Err(err) => {
-                    // Dropping the tracer drops the stream's sender; the builder then sees
-                    // end-of-input and finishes, letting the scope join it cleanly. The
-                    // execution error is the root cause, so the builder's outcome is only
-                    // logged, not propagated.
+                    // Dropping the tracer closes the stream and lets the builder finish. The
+                    // execution error remains the root cause even if the partial replay also
+                    // failed.
                     drop(tracer);
-                    match hasher.join() {
-                        Ok(Err(builder_err)) => {
-                            tracing::debug!(%builder_err, "hasher builder also failed");
-                        },
-                        Ok(Ok(_)) => (),
-                        Err(panic) => std::panic::resume_unwind(panic),
-                    }
-                    return Err(err);
+                    Err(err)
                 },
-            };
-            // End the stream before joining the builder.
-            drop(vm_witness.take_hasher_replay());
-            let hasher = match hasher.join() {
-                Ok(result) => result?,
-                Err(panic) => std::panic::resume_unwind(panic),
-            };
+            }
+        });
 
-            let trace =
-                build_trace_with_prebuilt_hasher(vm_witness, hasher, max_prover_memory_bytes)?;
-            Ok((trace, precompiles_witness))
-        })
-    }
+        let hasher = hasher.into_inner().expect("hasher builder did not run");
+        let (vm_witness, precompiles_witness) = match execution_output {
+            Ok(output) => output,
+            Err(err) => {
+                if let Err(builder_err) = hasher {
+                    tracing::debug!(%builder_err, "hasher builder also failed");
+                }
+                return Err(err);
+            },
+        };
 
-    /// Records a refused builder-thread spawn at a level matching how expected it is.
-    #[cfg(feature = "std")]
-    fn log_refused_builder_spawn(err: &std::io::Error, target_is_wasm: bool) {
-        let can_fallback = Self::can_fallback_after_builder_spawn_error(err);
-        if target_is_wasm && can_fallback {
-            tracing::debug!(
-                %err,
-                kind = ?err.kind(),
-                "target cannot spawn threads; building the trace serially"
-            );
-        } else if can_fallback {
-            tracing::warn!(
-                %err,
-                kind = ?err.kind(),
-                "target reported threads as unsupported; building the trace serially"
-            );
-        } else {
-            tracing::warn!(
-                %err,
-                kind = ?err.kind(),
-                "could not spawn the hasher-chiplet trace builder; returning an error"
-            );
-        }
-    }
-
-    #[cfg(feature = "std")]
-    fn can_fallback_after_builder_spawn_error(err: &std::io::Error) -> bool {
-        err.kind() == std::io::ErrorKind::Unsupported
+        let trace = build_trace_with_prebuilt_hasher(vm_witness, hasher?, max_prover_memory_bytes)?;
+        Ok((trace, precompiles_witness))
     }
 
     /// Executes the given program synchronously and returns its complete post-execution witness.
@@ -1556,63 +1507,5 @@ impl FastProcessor {
             )
             .await;
         Self::stack_result_from_flow(flow)
-    }
-}
-
-#[cfg(all(test, feature = "std"))]
-mod tests {
-    use std::{
-        io::{Error, ErrorKind},
-        sync::{Arc, Mutex},
-        vec::Vec,
-    };
-
-    use tracing::Level;
-    use tracing_subscriber::{Registry, layer::SubscriberExt};
-
-    use super::FastProcessor;
-
-    struct LevelCapture(Arc<Mutex<Vec<Level>>>);
-
-    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for LevelCapture {
-        fn on_event(
-            &self,
-            event: &tracing::Event<'_>,
-            _ctx: tracing_subscriber::layer::Context<'_, S>,
-        ) {
-            self.0.lock().unwrap().push(*event.metadata().level());
-        }
-    }
-
-    fn level_for(kind: ErrorKind, target_is_wasm: bool) -> Level {
-        let levels = Arc::new(Mutex::new(Vec::new()));
-        let subscriber = Registry::default().with(LevelCapture(Arc::clone(&levels)));
-        tracing::subscriber::with_default(subscriber, || {
-            FastProcessor::log_refused_builder_spawn(&Error::from(kind), target_is_wasm)
-        });
-        let levels = levels.lock().unwrap();
-        assert_eq!(levels.len(), 1, "expected exactly one event, got {levels:?}");
-        levels[0]
-    }
-
-    #[test]
-    fn a_refused_spawn_stays_at_debug_only_on_wasm() {
-        let err = Error::from(ErrorKind::Unsupported);
-        assert!(FastProcessor::can_fallback_after_builder_spawn_error(&err));
-        assert_eq!(level_for(err.kind(), true), Level::DEBUG);
-    }
-
-    #[test]
-    fn a_refused_spawn_warns_on_a_target_that_should_have_threads() {
-        assert_eq!(level_for(ErrorKind::Unsupported, false), Level::WARN);
-        for kind in [ErrorKind::WouldBlock, ErrorKind::OutOfMemory, ErrorKind::PermissionDenied] {
-            assert!(!FastProcessor::can_fallback_after_builder_spawn_error(&Error::from(kind)));
-            assert_eq!(level_for(kind, false), Level::WARN);
-            assert_eq!(
-                level_for(kind, true),
-                Level::WARN,
-                "{kind:?} is a host problem on wasm too"
-            );
-        }
     }
 }

--- a/processor/src/fast/execution_api.rs
+++ b/processor/src/fast/execution_api.rs
@@ -186,8 +186,8 @@ impl FastProcessor {
             sender,
         );
 
-        let hasher = std::sync::OnceLock::new();
-        let hasher_slot = &hasher;
+        let mut hasher = None;
+        let hasher_slot = &mut hasher;
         // Keep `tracer` owned by the scope body. If execution unwinds, dropping the body closes the
         // stream before Rayon waits for the builder, so the builder cannot remain blocked on input.
         let execution_output = rayon::in_place_scope(move |scope| {
@@ -197,7 +197,7 @@ impl FastProcessor {
             scope.spawn(move |_| {
                 let _span = span.entered();
                 let result = build_hasher_chiplet(receiver.into_iter().map(Ok), max_trace_len);
-                assert!(hasher_slot.set(result).is_ok(), "hasher builder ran more than once");
+                *hasher_slot = Some(result);
             });
 
             let execution_output = self.execute_with_tracer_sync(program, host, &mut tracer);
@@ -221,7 +221,7 @@ impl FastProcessor {
             }
         });
 
-        let hasher = hasher.into_inner().expect("hasher builder did not run");
+        let hasher = hasher.expect("hasher builder did not run");
         let (vm_witness, precompiles_witness) = match execution_output {
             Ok(output) => output,
             Err(err) => {

--- a/processor/src/fast/execution_api.rs
+++ b/processor/src/fast/execution_api.rs
@@ -141,8 +141,8 @@ impl FastProcessor {
     /// Executes the program and builds its execution trace, overlapping the two when a Rayon worker
     /// is available. The hasher chiplet — the dominant serial part of trace building — consumes a
     /// live stream of requests while execution is still running, hiding its cost behind the
-    /// (inherently sequential) execution itself. On targets without threads, Rayon's global
-    /// fallback runs execution and trace building sequentially.
+    /// (inherently sequential) execution itself. When the caller is Rayon's only worker, this uses
+    /// compact buffered replay and builds the trace after execution.
     ///
     /// `max_prover_memory_bytes` bounds the trace the same way
     /// [`crate::trace::build_trace_with_budget`] does; the streamed hasher builds ahead of that
@@ -162,7 +162,17 @@ impl FastProcessor {
     ) -> Result<(crate::trace::VmTrace, Option<PrecompileWitness>), ExecutionError> {
         use miden_air::{config, memory};
 
-        use crate::trace::{MAX_TRACE_LEN, build_hasher_chiplet, build_trace_with_prebuilt_hasher};
+        use crate::trace::{
+            MAX_TRACE_LEN, build_hasher_chiplet, build_trace_with_budget,
+            build_trace_with_prebuilt_hasher,
+        };
+
+        if Self::rayon_has_no_parallel_worker() {
+            let (vm_witness, precompiles_witness) =
+                self.execute_for_proving_sync(program, host)?.into_parts();
+            let trace = build_trace_with_budget(vm_witness, max_prover_memory_bytes)?;
+            return Ok((trace, precompiles_witness));
+        }
 
         let stack_inputs = self.initial_stack_inputs();
         let max_trace_len = MAX_TRACE_LEN.min(memory::max_any_height_for_budget(
@@ -182,8 +192,7 @@ impl FastProcessor {
         // stream before Rayon waits for the builder, so the builder cannot remain blocked on input.
         let execution_output = rayon::in_place_scope(move |scope| {
             // Execution and the host remain on the calling thread. An idle Rayon worker can steal
-            // only the builder task; if threads are unsupported, Rayon's global fallback runs the
-            // task on this thread after the scope body closes the stream.
+            // only the builder task.
             let span = tracing::Span::current();
             scope.spawn(move |_| {
                 let _span = span.entered();
@@ -198,8 +207,7 @@ impl FastProcessor {
                     let (mut vm_witness, precompiles_witness) =
                         Self::execution_witness_from_parts(program, stack_inputs, output, tracer)
                             .into_parts();
-                    // End the stream before this scope waits for the builder. This is required for
-                    // both the parallel path and Rayon's single-thread fallback.
+                    // End the stream before this scope waits for the builder.
                     drop(vm_witness.take_hasher_replay());
                     Ok((vm_witness, precompiles_witness))
                 },
@@ -226,6 +234,12 @@ impl FastProcessor {
 
         let trace = build_trace_with_prebuilt_hasher(vm_witness, hasher?, max_prover_memory_bytes)?;
         Ok((trace, precompiles_witness))
+    }
+
+    #[cfg(feature = "std")]
+    fn rayon_has_no_parallel_worker() -> bool {
+        // `current_num_threads` initializes Rayon's global fallback before the thread-index check.
+        rayon::current_num_threads() == 1 && rayon::current_thread_index().is_some()
     }
 
     /// Executes the given program synchronously and returns its complete post-execution witness.
@@ -1507,5 +1521,19 @@ impl FastProcessor {
             )
             .await;
         Self::stack_result_from_flow(flow)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::FastProcessor;
+
+    #[test]
+    fn sole_rayon_worker_requires_buffered_trace_building() {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build()
+            .unwrap()
+            .install(|| assert!(FastProcessor::rayon_has_no_parallel_worker()));
     }
 }

--- a/processor/tests/streamed_hasher.rs
+++ b/processor/tests/streamed_hasher.rs
@@ -1,8 +1,8 @@
 //! The overlapped execute-and-build path must produce exactly the trace the
 //! buffered path produces: same values, byte for byte, in every segment.
 //!
-//! `make test-wasm-threadless` runs the equality tests on Rayon's single-thread
-//! fallback and proves the overlapped entry point returns without trapping.
+//! `make test-wasm-threadless` runs the equality tests through the compact
+//! buffered fallback and proves the entry point returns without trapping.
 
 use miden_assembly::Assembler;
 use miden_processor::{
@@ -31,6 +31,21 @@ begin
     padw padw padw hperm dropw dropw dropw
     repeat.4
         push.11 u32wrapping_add
+    end
+    drop
+end
+";
+
+/// Replays the same large basic block often enough that streaming it without a consumer would
+/// retain many owned request payloads.
+const QUEUE_HEAVY_PROGRAM: &str = "
+begin
+    push.0
+    repeat.1024
+        push.1 add push.1 add push.1 add push.1 add
+        push.1 add push.1 add push.1 add push.1 add
+        push.1 add push.1 add push.1 add push.1 add
+        push.1 add push.1 add push.1 add push.1 add
     end
     drop
 end
@@ -86,6 +101,17 @@ fn assert_overlapped_matches_buffered(program_src: &str, stack: &[u64], advice: 
 #[test]
 fn overlapped_build_matches_buffered() {
     assert_overlapped_matches_buffered(PROGRAM, &[1], &AdviceInputs::default());
+}
+
+#[test]
+fn single_worker_handles_queue_heavy_program() {
+    #[cfg(not(target_family = "wasm"))]
+    rayon::ThreadPoolBuilder::new().num_threads(1).build().unwrap().install(|| {
+        assert_overlapped_matches_buffered(QUEUE_HEAVY_PROGRAM, &[], &AdviceInputs::default());
+    });
+
+    #[cfg(target_family = "wasm")]
+    assert_overlapped_matches_buffered(QUEUE_HEAVY_PROGRAM, &[], &AdviceInputs::default());
 }
 
 /// Covers the two Merkle op kinds in the streamed replay (`BuildMerkleRoot`

--- a/processor/tests/streamed_hasher.rs
+++ b/processor/tests/streamed_hasher.rs
@@ -36,18 +36,6 @@ begin
 end
 ";
 
-/// Keeps the scope body busy long enough for an idle Rayon worker to steal the
-/// hasher task. The shorter equality fixture may finish before a steal occurs.
-const OVERLAP_PROGRAM: &str = "
-begin
-    push.0
-    repeat.10000
-        push.1 add
-    end
-    drop
-end
-";
-
 fn processor(stack: &[u64], advice: AdviceInputs) -> FastProcessor {
     let stack: Vec<Felt> = stack.iter().map(|&v| Felt::new(v).unwrap()).collect();
     FastProcessor::new_with_options(
@@ -139,10 +127,8 @@ fn overlapped_build_matches_buffered_merkle() {
     assert_overlapped_matches_buffered("begin mtree_set end", &set_stack, &advice);
 }
 
-/// The overlap path makes the hasher builder available to Rayon workers. Span
-/// context is thread-local, so the builder re-enters the
-/// `execute_and_build_trace_sync` span to stay attributed under it. This asserts
-/// an idle worker steals the builder under a two-thread pool.
+/// The overlap path makes the hasher builder available to Rayon workers. The caller is an ordinary
+/// test thread, so a second thread entering the span proves a global-pool worker ran the builder.
 #[test]
 fn overlap_builder_thread_enters_the_instrument_span() {
     use std::{
@@ -185,20 +171,17 @@ fn overlap_builder_thread_enters_the_instrument_span() {
     };
     let subscriber = Registry::default().with(layer);
 
-    let program = Assembler::default()
-        .assemble_program("test", OVERLAP_PROGRAM)
-        .unwrap()
-        .unwrap_program();
-    rayon::ThreadPoolBuilder::new().num_threads(2).build().unwrap().install(|| {
-        tracing::subscriber::with_default(subscriber, || {
-            let mut host = DefaultHost::default();
-            processor(&[1], AdviceInputs::default())
-                .execute_and_build_trace_sync(&program, &mut host, DEFAULT_MAX_PROVER_MEMORY_BYTES)
-                .unwrap();
-        });
+    let program = Assembler::default().assemble_program("test", PROGRAM).unwrap().unwrap_program();
+    let caller = std::thread::current().id();
+    tracing::subscriber::with_default(subscriber, || {
+        let mut host = DefaultHost::default();
+        processor(&[1], AdviceInputs::default())
+            .execute_and_build_trace_sync(&program, &mut host, DEFAULT_MAX_PROVER_MEMORY_BYTES)
+            .unwrap();
     });
 
     let threads = threads.lock().unwrap();
+    assert!(threads.contains(&caller), "the caller did not enter the instrument span");
     assert_eq!(
         threads.len(),
         2,

--- a/processor/tests/streamed_hasher.rs
+++ b/processor/tests/streamed_hasher.rs
@@ -1,9 +1,8 @@
 //! The overlapped execute-and-build path must produce exactly the trace the
 //! buffered path produces: same values, byte for byte, in every segment.
 //!
-//! Run under `make test-wasm-threadless`, on a target that genuinely refuses to
-//! spawn, the same equality also pins that the overlapped entry point returns at
-//! all and that what it falls back to is the buffered path.
+//! `make test-wasm-threadless` runs the equality tests on Rayon's single-thread
+//! fallback and proves the overlapped entry point returns without trapping.
 
 use miden_assembly::Assembler;
 use miden_processor::{
@@ -32,6 +31,18 @@ begin
     padw padw padw hperm dropw dropw dropw
     repeat.4
         push.11 u32wrapping_add
+    end
+    drop
+end
+";
+
+/// Keeps the scope body busy long enough for an idle Rayon worker to steal the
+/// hasher task. The shorter equality fixture may finish before a steal occurs.
+const OVERLAP_PROGRAM: &str = "
+begin
+    push.0
+    repeat.10000
+        push.1 add
     end
     drop
 end
@@ -128,15 +139,10 @@ fn overlapped_build_matches_buffered_merkle() {
     assert_overlapped_matches_buffered("begin mtree_set end", &set_stack, &advice);
 }
 
-/// The overlap path spawns the hasher builder on its own thread; span context is
-/// thread-local, so the builder re-enters the `execute_and_build_trace_sync` span
-/// to stay attributed under it. This records which threads enter that span rather
-/// than how many times it is entered, so it cannot be satisfied by one thread
-/// entering twice — the point is that the builder ran somewhere else.
-///
-/// Requires a host that can actually spawn. When the target reports that threads are unsupported,
-/// the serial fallback runs and only the caller enters. That is why `make test-wasm-threadless`
-/// skips this one test and runs everything else in the file.
+/// The overlap path makes the hasher builder available to Rayon workers. Span
+/// context is thread-local, so the builder re-enters the
+/// `execute_and_build_trace_sync` span to stay attributed under it. This asserts
+/// an idle worker steals the builder under a two-thread pool.
 #[test]
 fn overlap_builder_thread_enters_the_instrument_span() {
     use std::{
@@ -179,25 +185,23 @@ fn overlap_builder_thread_enters_the_instrument_span() {
     };
     let subscriber = Registry::default().with(layer);
 
-    let program = Assembler::default().assemble_program("test", PROGRAM).unwrap().unwrap_program();
-    let caller = std::thread::current().id();
-    tracing::subscriber::with_default(subscriber, || {
-        let mut host = DefaultHost::default();
-        processor(&[1], AdviceInputs::default())
-            .execute_and_build_trace_sync(&program, &mut host, DEFAULT_MAX_PROVER_MEMORY_BYTES)
-            .unwrap();
+    let program = Assembler::default()
+        .assemble_program("test", OVERLAP_PROGRAM)
+        .unwrap()
+        .unwrap_program();
+    rayon::ThreadPoolBuilder::new().num_threads(2).build().unwrap().install(|| {
+        tracing::subscriber::with_default(subscriber, || {
+            let mut host = DefaultHost::default();
+            processor(&[1], AdviceInputs::default())
+                .execute_and_build_trace_sync(&program, &mut host, DEFAULT_MAX_PROVER_MEMORY_BYTES)
+                .unwrap();
+        });
     });
 
     let threads = threads.lock().unwrap();
-    assert!(
-        threads.contains(&caller),
-        "the caller's own `#[instrument]` span was never entered"
-    );
     assert_eq!(
         threads.len(),
         2,
-        "the builder thread did not re-enter the span: expected the caller and the builder, but \
-         it was entered by {threads:?} (caller is {caller:?}). Either the builder stopped \
-         re-entering it, or the target reported threads as unsupported and the serial fallback ran"
+        "expected execution and the hasher builder to use separate threads, got {threads:?}"
     );
 }

--- a/prover/README.md
+++ b/prover/README.md
@@ -62,9 +62,9 @@ Transport, hydration, structural validity, and fixed limits are specified in the
 
 The FastProcessor-backed `prove_sync(&Prover, ...)` function is the direct synchronous path for
 executing and fully proving a program. When enabled in `ExecutionOptions`, it overlaps execution
-with hasher trace construction if the target can spawn a builder thread. Targets that report
-threads as unsupported build the same trace sequentially. Other spawn failures return an error.
-Proof generation remains configured on `Prover`.
+with hasher trace construction when a Rayon worker is available. Rayon's supported fallback runs
+the same path sequentially on targets without threads. Proof generation remains configured on
+`Prover`.
 
 ## STARK Backend
 

--- a/prover/README.md
+++ b/prover/README.md
@@ -62,9 +62,8 @@ Transport, hydration, structural validity, and fixed limits are specified in the
 
 The FastProcessor-backed `prove_sync(&Prover, ...)` function is the direct synchronous path for
 executing and fully proving a program. When enabled in `ExecutionOptions`, it overlaps execution
-with hasher trace construction when a Rayon worker is available. Rayon's supported fallback runs
-the same path sequentially on targets without threads. Proof generation remains configured on
-`Prover`.
+with hasher trace construction when a Rayon worker is available. A caller with no separate Rayon
+worker uses compact buffered replay. Proof generation remains configured on `Prover`.
 
 ## STARK Backend
 

--- a/prover/src/prover.rs
+++ b/prover/src/prover.rs
@@ -214,10 +214,10 @@ impl Prover {
 /// This FastProcessor-backed orchestration function preserves the optimized overlapped
 /// execution/trace-building path. Proving policy belongs on [`Prover`].
 ///
-/// When enabled in `execution_options`, the processor tries to build the hasher chiplet alongside
-/// execution. If the target reports that threads are unsupported, it builds the same trace
-/// sequentially. Other spawn failures return an error. Both routes converge at the same private VM
-/// STARK and complete-local packaging implementation.
+/// When enabled in `execution_options`, the processor may build the hasher chiplet alongside
+/// execution. Rayon's supported fallback runs the same path sequentially when threads are
+/// unavailable. Both cases use the same private VM STARK and complete-local packaging
+/// implementation.
 #[tracing::instrument(name = "prove_program_sync", skip_all)]
 pub fn prove_sync(
     prover: &Prover,

--- a/prover/src/prover.rs
+++ b/prover/src/prover.rs
@@ -215,9 +215,8 @@ impl Prover {
 /// execution/trace-building path. Proving policy belongs on [`Prover`].
 ///
 /// When enabled in `execution_options`, the processor may build the hasher chiplet alongside
-/// execution. Rayon's supported fallback runs the same path sequentially when threads are
-/// unavailable. Both cases use the same private VM STARK and complete-local packaging
-/// implementation.
+/// execution. A caller with no separate Rayon worker uses compact buffered replay. Both cases use
+/// the same private VM STARK and complete-local packaging implementation.
 #[tracing::instrument(name = "prove_program_sync", skip_all)]
 pub fn prove_sync(
     prover: &Prover,


### PR DESCRIPTION
PR [#3722](https://github.com/0xMiden/miden-vm/pull/3722) fixed targets without threads. It also added thread startup code and failure handling for the trace builder.

This PR uses Rayon to run the trace builder. Program execution stays on the calling thread. When another worker is free, it builds the hasher trace while the program runs. If there is no other worker, the processor uses the existing buffered path. This keeps memory use bounded. Other failures to start Rayon's workers stop the call.

## Tests

The tests compare the two paths in a Rayon pool with one worker. They also run on WASM without
threads.
