### PR TITLE
Chore: prepare v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,12 +44,10 @@
 - Fixed `line_column_to_offset` treating the column index as a raw byte offset instead of a character offset, which returned the wrong offset or panicked for lines containing multi-byte UTF-8 characters ([#3633](https://github.com/0xMiden/miden-vm/issues/3633)).
 - Clarified the ACE circuit trust model and distinguished the order-independent AIR wiring relation from the standard processor's sequential DAG witness construction ([#3683](https://github.com/0xMiden/miden-vm/pull/3683)).
 - [BREAKING] Removed the MASM `sys::vm::claim::kernel_commitment` procedure. The recursive verifier now copies and hashes kernel digests from advice in one pass using the new `mem::pipe_words_to_memory_in_domain` procedure. Callers computing a domain-tagged hash over an existing memory region can use `crypto::hashes::poseidon2::hash_elements_in_domain` directly.
-- [BREAKING] Replaced package digests with separate interface, MAST forest, code, artifact, and full package commitments. Dependency records now use the full package commitment ([#3679](https://github.com/0xMiden/miden-vm/pull/3679)).
 - [BREAKING] Replaced package digests with separate interface, MAST forest, code, artifact, dependency, and full package commitments. Dependency commitments exclude optional debug data and opaque custom sections ([#3679](https://github.com/0xMiden/miden-vm/pull/3679)).
 - Documented the `word("...")` and `event("...")` string-derived constant constructors and word
   slicing behavior in the assembly reference ([#2688](https://github.com/0xMiden/miden-vm/issues/2688)).
 - [BREAKING] Added structural and hash-consistency validation to serde deserialization for `MerkleTree`, `Mmr`, `MmrPeaks`, `MmrPath`, `PartialMerkleTree`, and `SimpleSmt`. `Mmr` binary deserialization now applies the same validation, and `PartialMerkleTree::with_leaves` rejects depth-zero leaves ([#3645](https://github.com/0xMiden/miden-vm/pull/3645)).
-- [BREAKING] Replaced the separate advice stack, map, and Merkle store limits with one configurable 4 MiB logical byte budget for the full advice provider ([#3107](https://github.com/0xMiden/miden-vm/issues/3107)).
 - [BREAKING] Replaced the separate advice stack, map, and Merkle store limits with one configurable 4 MiB logical byte budget for the full advice provider ([#3643](https://github.com/0xMiden/miden-vm/pull/3643)).
 - Raised the default maximum logical size of the advice provider from 4 MiB to 16 MiB ([#3699](https://github.com/0xMiden/miden-vm/pull/3699)).
 - [BREAKING] `UniqueNodes` entries are now keyed by tree position, and missing nodes mean canonical empty subtree roots. The `NodeValue` enum was removed ([#3620](https://github.com/0xMiden/miden-vm/pull/3620)).
@@ -71,14 +69,6 @@
 - Made `Mmr::clone()` cheap by storing MMR nodes in chunked, `Arc`-shared storage. Clones share all chunk storage with the original; appending after a clone copies at most one 32 KiB chunk. Public API and serialization formats are unchanged. ([#3562](https://github.com/0xMiden/miden-vm/pull/3562)).
 - The `miden-precompiles` package has been merged into `miden-core`, users should remove any references to `miden-precompiles` and use `miden-core` instead.
 - [BREAKING] Replaced the prover's trace-row cap with a memory budget ([#3706](https://github.com/0xMiden/miden-vm/issues/3706)).
-
-#### Features
-
-- Added `AdviceInputs::new` constructor and `From<AdviceMap>` impl, complementing the existing builder-style accessors for assembling advice inputs from their parts ([#3540](https://github.com/0xMiden/miden-vm/pull/3540)).
-- Added the `ProgramExecutor` trait to `miden-processor`, with `FastProcessor` as the default implementation, so alternative execution engines can be plugged in without changing the surrounding executor wiring ([#3540](https://github.com/0xMiden/miden-vm/pull/3540)).
-
-#### Changes
-
 - [BREAKING] Removed the free `execute()` and `execute_sync()` functions from `miden-vm`/`miden-processor`. Use `FastProcessor::new_with_options(...)` followed by `execute()`/`execute_sync()` instead ([#3540](https://github.com/0xMiden/miden-vm/pull/3540)).
 - [BREAKING] `verify` and `Verifier::verify` now borrow the proof and the claim instead of
   consuming them.
@@ -105,6 +95,8 @@
 - [BREAKING] `miden_assembly_syntax::ast::TypeResolver::get_type` and `get_local_type` now return a `TypeTemplate` rather than a `Type`, and the trait gains a `finalize` method. A declaration cannot be resolved to a concrete type until the whole recursive group it belongs to is known, so resolution produces templates and materializes them at the outermost boundary. `TypeExpr::resolve_type` is replaced by `TypeExpr::resolve_template`; use `TypeResolver::resolve` to obtain a `Type`.
 - Fixed a stack overflow when assembling a module containing a cyclic type declaration. `type A = B` with `type B = A`, or a type defined in terms of itself, previously aborted the process, because resolving a type reference re-entered declaration resolution with a fresh nesting budget. A cycle between type aliases alone is now reported as a `recursive type definition` diagnostic, while a cycle that passes through an aggregate whose field goes via a pointer is finite and resolves. Resolved type declarations are also cached now, where the cache was previously populated but never consulted.
 - [BREAKING] The MAST package format version is now 7. Package type serialization gained a tag for recursive aggregates, which encodes a definition group and the index of the selected definition; existing type tags keep their meanings. The reader accepts exactly one version, so version 6 packages are rejected.
+- Adopted cargo-fixit, aligned clippy lints with crypto, and cleared cargo-shear warnings ([#3479](https://github.com/0xMiden/miden-vm/pull/3479)).
+- Validated and retained `DebugInfo` when reading untrusted packages, with bounded decoding for hostile data and an explicit unmetered decoder for analysis ([#3460](https://github.com/0xMiden/miden-vm/pull/3460)).
 
 #### Fixes
 
@@ -151,11 +143,6 @@
 #### Fixes
 
 - Fixed `Felt`'s `Debug` impl on the `miden` target by formatting the canonical `u64` value instead of the `f32` backing type. The `Debug` output format changed from `Felt { inner: .. }` to `Felt(..)` ([#3693](https://github.com/0xMiden/miden-vm/pull/3693)).
-## v0.29.2 (Unreleased)
-
-#### Changes
-
-- Added explicit unavailable and tagged Miden frame-base debug variable locations, plus a structured Miden-runtime expression fallback for compound locations. This replaces private compiler/debugger expression encodings for new packages and bumps the package debug-info wire format to version 3.
 
 ## v0.29.1 (2026-08-11)
 
@@ -165,22 +152,18 @@
 - Added `ecdsa_k256_keccak::verify_bytes` for verifying signatures over variable-length Keccak256 message bytes stored in VM memory ([#3563](https://github.com/0xMiden/miden-vm/pull/3563)).
 - Fixed persistent `LargeSmtForest::entries()` iteration, including snapshot-backed readers, by bounding RocksDB scans to the requested lineage prefix instead of scanning subsequent lineages ([#3576](https://github.com/0xMiden/miden-vm/pull/3576)).
 - Keccak-256 wrapper preimages may now cover memory that was never written to, matching the in-VM rule that unwritten memory reads as zero ([#3537](https://github.com/0xMiden/miden-vm/issues/3537)).
+
 ## v0.29.0 (2026-08-04)
 
 #### Changes
 
 - [BREAKING] Recursive MASM verification now accepts a claim commitment and authenticates the advice-supplied claim and kernel witness. Rust callers construct request-addressed inputs with `RecursiveVerifierInputs::for_request` ([#3447](https://github.com/0xMiden/miden-vm/pull/3447)).
-- Adopted cargo-fixit, aligned clippy lints with crypto, cleared cargo-shear warnings ([#3479](https://github.com/0xMiden/miden-vm/pull/3479))
 
 #### Fixes
 
 - [BREAKING] Fixed collisions between empty input and full rate blocks in domain-separated field-element hashing by marking nonzero-domain empty input in capacity. This changes empty domain-separated commitments ([#3447](https://github.com/0xMiden/miden-vm/pull/3447)).
 - [BREAKING] Split the synthetic core MASM package into separate `miden-core` and `miden-precompiles` packages, leaving the bare `miden` namespace available for sibling packages such as `miden-protocol` ([#3459](https://github.com/0xMiden/miden-vm/pull/3459)).
 - Moved the `miden-precompiles` and `miden-precompiles-prover` crate sources from the repository root into `crates/`, aligning them with the rest of the workspace layout ([#3462](https://github.com/0xMiden/miden-vm/pull/3462)).
-
-#### Changes
-
-- Validated and retained `DebugInfo` when reading untrusted packages, with bounded decoding for hostile data and an explicit unmetered decoder for analysis ([#3460](https://github.com/0xMiden/miden-vm/pull/3460)).
 
 ## v0.28.0 (2026-08-01)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,7 +2813,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-constraint-compiler",
  "miden-core",
@@ -2065,7 +2065,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "insta",
  "miden-ace-codegen",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "env_logger",
  "insta",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "env_logger",
  "log",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "miden-bench"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "clap",
  "miden-lifted-stark",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "miden-constraint-compiler"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "criterion",
  "derive_more",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "criterion",
  "env_logger",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib-codegen"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-core",
  "miden-precompiles",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "assert_matches",
  "blake3",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-field",
  "quote",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-smt-codspeed-bench"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-crypto",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-wycheproof-tests"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "miden-format"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "clap",
  "miden-assembly-syntax-cst",
@@ -2387,7 +2387,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-field",
  "p3-air 0.6.3",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "criterion",
  "miden-lifted-air",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "codspeed-criterion-compat",
  "hashbrown 0.17.1",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry-local"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "clap",
  "miden-assembly-syntax",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles-prover"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "insta",
  "k256",
@@ -2552,7 +2552,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "hashbrown 0.17.1",
  "insta",
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-air",
  "miden-assembly",
@@ -2628,7 +2628,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-field 0.6.3",
  "p3-goldilocks",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-challenger",
  "p3-field 0.6.3",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-bn254",
  "p3-field 0.6.3",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "miden-test-serialization-macros"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "proc-macro2",
  "proptest",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "miden-test-utils"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "env_logger",
  "miden-air",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-serde-utils",
  "miden-test-serialization-macros",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "lock_api",
  "loom",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-blake3-bench"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "clap",
  "codspeed-criterion-compat",
@@ -2784,7 +2784,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-precompiles-bench"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-core",
@@ -2796,7 +2796,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-synthetic-bench"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-assembly",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ miden-core-lib          = { path = "./crates/lib/core", version = "0.31", defaul
 miden-serde-utils       = { path = "./crates/serde-utils", version = "0.31", default-features = false }
 miden-stark-transcript  = { path = "./crates/stark-transcript", version = "0.31", default-features = false }
 miden-stateful-hasher   = { path = "./crates/stateful-hasher", version = "0.31", default-features = false }
-midenc-hir-type         = { path = "./crates/midenc-hir-type", version = "0.12", default-features = false }
+midenc-hir-type         = { path = "./crates/midenc-hir-type", version = "0.13", default-features = false }
 miden-utils-core-derive = { path = "./crates/utils-core-derive", version = "0.31", default-features = false }
 miden-utils-diagnostics = { path = "./crates/utils-diagnostics", version = "0.31", default-features = false }
 miden-utils-indexing    = { path = "./crates/utils-indexing", version = "0.31", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ rust-version = "1.96.1"
 # Private workspace members inherit this version. Publishable crates keep their
 # own package versions so release tooling can publish only the crates selected
 # for a release.
-version = "0.30.0"
+version = "0.31.0"
 
 [profile.optimized]
 inherits = "release"
@@ -81,39 +81,39 @@ opt-level = 0
 
 [workspace.dependencies]
 # Workspace crates
-miden-ace-codegen       = { path = "./crates/ace-codegen", version = "0.30", default-features = false }
-miden-air               = { path = "./air", version = "0.30", default-features = false }
-miden-assembly          = { path = "./crates/assembly", version = "0.30", default-features = false }
-miden-assembly-syntax   = { path = "./crates/assembly-syntax", version = "0.30", default-features = false }
-miden-assembly-syntax-cst = { path = "./crates/assembly-syntax-cst", version = "0.30", default-features = false }
-miden-constraint-compiler = { path = "./crates/miden-constraint-compiler", version = "0.30", default-features = false }
-miden-core              = { path = "./core", version = "0.30", default-features = false }
-miden-crypto            = { path = "./crates/crypto", version = "0.30", default-features = false }
-miden-crypto-derive     = { path = "./crates/crypto-derive", version = "0.30", default-features = false }
-miden-debug-types       = { path = "./crates/debug-types", version = "0.30", default-features = false }
-miden-field             = { path = "./crates/field", version = "0.30", default-features = false }
-miden-lifted-air        = { path = "./crates/lifted-air", version = "0.30", default-features = false }
-miden-lifted-stark      = { path = "./crates/lifted-stark", version = "0.30", default-features = false }
-miden-mast-package      = { path = "./crates/mast-package", version = "0.30", default-features = false }
-miden-package-registry  = { path = "./crates/package-registry", version = "0.30", default-features = false }
-miden-precompiles       = { path = "./crates/precompiles", version = "0.30", default-features = false }
-miden-precompiles-prover = { path = "./crates/precompiles-prover", version = "0.30", default-features = false }
-miden-core-lib-codegen  = { path = "./crates/lib/core/codegen", version = "0.30", default-features = false }
-miden-processor         = { path = "./processor", version = "0.30", default-features = false }
+miden-ace-codegen       = { path = "./crates/ace-codegen", version = "0.31", default-features = false }
+miden-air               = { path = "./air", version = "0.31", default-features = false }
+miden-assembly          = { path = "./crates/assembly", version = "0.31", default-features = false }
+miden-assembly-syntax   = { path = "./crates/assembly-syntax", version = "0.31", default-features = false }
+miden-assembly-syntax-cst = { path = "./crates/assembly-syntax-cst", version = "0.31", default-features = false }
+miden-constraint-compiler = { path = "./crates/miden-constraint-compiler", version = "0.31", default-features = false }
+miden-core              = { path = "./core", version = "0.31", default-features = false }
+miden-crypto            = { path = "./crates/crypto", version = "0.31", default-features = false }
+miden-crypto-derive     = { path = "./crates/crypto-derive", version = "0.31", default-features = false }
+miden-debug-types       = { path = "./crates/debug-types", version = "0.31", default-features = false }
+miden-field             = { path = "./crates/field", version = "0.31", default-features = false }
+miden-lifted-air        = { path = "./crates/lifted-air", version = "0.31", default-features = false }
+miden-lifted-stark      = { path = "./crates/lifted-stark", version = "0.31", default-features = false }
+miden-mast-package      = { path = "./crates/mast-package", version = "0.31", default-features = false }
+miden-package-registry  = { path = "./crates/package-registry", version = "0.31", default-features = false }
+miden-precompiles       = { path = "./crates/precompiles", version = "0.31", default-features = false }
+miden-precompiles-prover = { path = "./crates/precompiles-prover", version = "0.31", default-features = false }
+miden-core-lib-codegen  = { path = "./crates/lib/core/codegen", version = "0.31", default-features = false }
+miden-processor         = { path = "./processor", version = "0.31", default-features = false }
 miden-test-serialization-macros = { path = "./crates/test-serialization-macros", default-features = false }
-miden-project           = { path = "./crates/project", version = "0.30", default-features = false }
-miden-prover            = { path = "./prover", version = "0.30", default-features = false }
-miden-core-lib          = { path = "./crates/lib/core", version = "0.30", default-features = false }
-miden-serde-utils       = { path = "./crates/serde-utils", version = "0.30", default-features = false }
-miden-stark-transcript  = { path = "./crates/stark-transcript", version = "0.30", default-features = false }
-miden-stateful-hasher   = { path = "./crates/stateful-hasher", version = "0.30", default-features = false }
+miden-project           = { path = "./crates/project", version = "0.31", default-features = false }
+miden-prover            = { path = "./prover", version = "0.31", default-features = false }
+miden-core-lib          = { path = "./crates/lib/core", version = "0.31", default-features = false }
+miden-serde-utils       = { path = "./crates/serde-utils", version = "0.31", default-features = false }
+miden-stark-transcript  = { path = "./crates/stark-transcript", version = "0.31", default-features = false }
+miden-stateful-hasher   = { path = "./crates/stateful-hasher", version = "0.31", default-features = false }
 midenc-hir-type         = { path = "./crates/midenc-hir-type", version = "0.12", default-features = false }
-miden-utils-core-derive = { path = "./crates/utils-core-derive", version = "0.30", default-features = false }
-miden-utils-diagnostics = { path = "./crates/utils-diagnostics", version = "0.30", default-features = false }
-miden-utils-indexing    = { path = "./crates/utils-indexing", version = "0.30", default-features = false }
-miden-utils-sync        = { path = "./crates/utils-sync", version = "0.30", default-features = false }
+miden-utils-core-derive = { path = "./crates/utils-core-derive", version = "0.31", default-features = false }
+miden-utils-diagnostics = { path = "./crates/utils-diagnostics", version = "0.31", default-features = false }
+miden-utils-indexing    = { path = "./crates/utils-indexing", version = "0.31", default-features = false }
+miden-utils-sync        = { path = "./crates/utils-sync", version = "0.31", default-features = false }
 miden-utils-testing     = { path = "./crates/test-utils", package = "miden-test-utils" }
-miden-verifier          = { path = "./verifier", version = "0.30", default-features = false }
+miden-verifier          = { path = "./verifier", version = "0.31", default-features = false }
 
 # Miden crates
 miden-formatting = { version = "0.1", default-features = false }

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-air"
-version = "0.30.0"
+version = "0.31.0"
 description = "Algebraic intermediate representation of Miden VM processor"
 documentation = "https://docs.rs/miden-air"
 readme = "README.md"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.30.0"
+version = "0.31.0"
 description = "Miden VM core components"
 documentation = "https://docs.rs/miden-core"
 readme = "README.md"

--- a/crates/ace-codegen/Cargo.toml
+++ b/crates/ace-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-ace-codegen"
-version = "0.30.0"
+version = "0.31.0"
 description = "ACE circuit codegen for Plonky3-based Miden AIRs."
 documentation = "https://docs.rs/miden-ace-codegen"
 readme = "README.md"

--- a/crates/assembly-syntax-cst/Cargo.toml
+++ b/crates/assembly-syntax-cst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax-cst"
-version = "0.30.0"
+version = "0.31.0"
 description = "Lossless concrete syntax tree support for the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax-cst"
 readme = "README.md"

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax"
-version = "0.30.0"
+version = "0.31.0"
 description = "Parsing and semantic analysis of the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax"
 readme = "README.md"

--- a/crates/assembly/Cargo.toml
+++ b/crates/assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly"
-version = "0.30.0"
+version = "0.31.0"
 description = "Miden VM assembly language"
 documentation = "https://docs.rs/miden-assembly"
 readme = "README.md"

--- a/crates/crypto-derive/Cargo.toml
+++ b/crates/crypto-derive/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "miden-crypto-derive"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.30.0"
+version = "0.31.0"
 
 [lib]
 doctest    = false

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-crypto"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.30.0"
+version = "0.31.0"
 
 [[bin]]
 bench             = false

--- a/crates/debug-types/Cargo.toml
+++ b/crates/debug-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-debug-types"
-version = "0.30.0"
+version = "0.31.0"
 description = "Core source-level debugging information types used throughout the Miden toolchain"
 documentation = "https://docs.rs/miden-debug-types"
 readme = "README.md"

--- a/crates/field/Cargo.toml
+++ b/crates/field/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-field"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.30.0"
+version = "0.31.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core-lib"
-version = "0.30.0"
+version = "0.31.0"
 description = "Miden VM core library"
 documentation = "https://docs.rs/miden-core-lib"
 readme = "README.md"

--- a/crates/lib/core/asm/miden-project.toml
+++ b/crates/lib/core/asm/miden-project.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.30.0"
+version = "0.31.0"
 
 [lib]
 namespace = "miden::core"

--- a/crates/lifted-air/Cargo.toml
+++ b/crates/lifted-air/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-lifted-air"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.30.0"
+version = "0.31.0"
 
 [lib]
 doctest = true

--- a/crates/lifted-stark/Cargo.toml
+++ b/crates/lifted-stark/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-lifted-stark"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.30.0"
+version = "0.31.0"
 
 [lib]
 doctest = false

--- a/crates/mast-package/Cargo.toml
+++ b/crates/mast-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-mast-package"
-version = "0.30.0"
+version = "0.31.0"
 description = "Package containing a compiled Miden MAST artifact with declared dependencies and exports"
 documentation = "https://docs.rs/miden-mast-package"
 readme = "README.md"

--- a/crates/miden-constraint-compiler/Cargo.toml
+++ b/crates/miden-constraint-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-constraint-compiler"
-version = "0.30.0"
+version = "0.31.0"
 description = "Constraint compiler for Plonky3-based Miden AIRs."
 documentation = "https://docs.rs/miden-constraint-compiler"
 readme = "README.md"

--- a/crates/miden-format/Cargo.toml
+++ b/crates/miden-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-format"
-version = "0.30.0"
+version = "0.31.0"
 description = "Formatter for the Miden Assembly language"
 documentation = "https://docs.rs/miden-format"
 readme = "README.md"

--- a/crates/midenc-hir-type/Cargo.toml
+++ b/crates/midenc-hir-type/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-type"
 description = "Type system and utilities for Miden HIR"
-version = "0.12.0"
+version = "0.13.0"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/package-registry-local/Cargo.toml
+++ b/crates/package-registry-local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry-local"
-version = "0.30.0"
+version = "0.31.0"
 description = "Filesystem-backed local package registry for Miden packages"
 documentation = "https://docs.rs/miden-package-registry-local"
 readme = "README.md"

--- a/crates/package-registry/Cargo.toml
+++ b/crates/package-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry"
-version = "0.30.0"
+version = "0.31.0"
 description = "Package registry interfaces and dependency resolution for Miden packages"
 documentation = "https://docs.rs/miden-package-registry"
 readme = "README.md"

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-project"
-version = "0.30.0"
+version = "0.31.0"
 description = "Interface for working with Miden projects"
 documentation = "https://docs.rs/miden-project"
 readme = "README.md"

--- a/crates/serde-utils/Cargo.toml
+++ b/crates/serde-utils/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-serde-utils"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.30.0"
+version = "0.31.0"
 
 [features]
 default = ["std"]

--- a/crates/stark-transcript/Cargo.toml
+++ b/crates/stark-transcript/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-stark-transcript"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.30.0"
+version = "0.31.0"
 
 [lib]
 doctest = false

--- a/crates/stateful-hasher/Cargo.toml
+++ b/crates/stateful-hasher/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-stateful-hasher"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.30.0"
+version = "0.31.0"
 
 [lib]
 doctest = false

--- a/crates/test-serialization-macros/Cargo.toml
+++ b/crates/test-serialization-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-test-serialization-macros"
-version = "0.30.0"
+version = "0.31.0"
 description = "Proc macros for serialization round-trip testing in Miden VM"
 readme = "README.md"
 categories = ["development-tools::testing", "no-std"]

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-test-utils"
-version = "0.30.0"
+version = "0.31.0"
 description = "Test utilities for Miden VM programs"
 readme = "README.md"
 categories = ["development-tools::testing", "no-std"]

--- a/crates/utils-core-derive/Cargo.toml
+++ b/crates/utils-core-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-core-derive"
-version = "0.30.0"
+version = "0.31.0"
 description = "Proc macro to derive enum dispatch trait implementations on miden-core structs"
 readme = "README.md"
 categories = ["development-tools::procedural-macro-helpers", "no-std"]

--- a/crates/utils-diagnostics/Cargo.toml
+++ b/crates/utils-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-diagnostics"
-version = "0.30.0"
+version = "0.31.0"
 description = "Diagnostic infrastructure used in the Miden assembler and VM"
 documentation = "https://docs.rs/miden-utils-diagnostics"
 readme = "README.md"

--- a/crates/utils-indexing/Cargo.toml
+++ b/crates/utils-indexing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-indexing"
-version = "0.30.0"
+version = "0.31.0"
 description = "Type-safe u32-indexed vector utilities for Miden"
 readme = "README.md"
 categories = ["development-tools", "no-std"]

--- a/crates/utils-sync/Cargo.toml
+++ b/crates/utils-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-sync"
-version = "0.30.0"
+version = "0.31.0"
 description = "no-std compatible locking primitives for the Miden project"
 documentation = "https://docs.rs/miden-utils-sync"
 readme = "README.md"

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-vm"
-version = "0.30.0"
+version = "0.31.0"
 description = "Miden virtual machine"
 documentation = "https://docs.rs/miden-vm"
 readme = "README.md"

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-processor"
-version = "0.30.0"
+version = "0.31.0"
 description = "Miden VM processor"
 documentation = "https://docs.rs/miden-processor"
 readme = "README.md"

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-prover"
-version = "0.30.0"
+version = "0.31.0"
 description = "Miden VM prover"
 documentation = "https://docs.rs/miden-prover"
 readme = "README.md"

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -742,7 +742,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-constraint-compiler",
  "miden-core",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-ace-codegen",
  "miden-core",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "log",
  "miden-assembly-syntax-cst",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "miden-constraint-compiler"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "derive_more",
  "log",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "blake3",
  "cc",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-air 0.6.3",
  "p3-challenger",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "hashbrown",
  "miden-assembly-syntax",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "hashbrown",
  "itertools",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-field 0.6.3",
  "p3-goldilocks",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-challenger",
  "p3-field 0.6.3",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-field 0.6.3",
  "p3-symmetric",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-serde-utils",
  "proptest",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "lock_api",
  "loom",

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",

--- a/tools/miden-crypto-fuzz/Cargo.lock
+++ b/tools/miden-crypto-fuzz/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "blake3",
  "cc",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-air",
  "p3-challenger",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-field",
  "p3-symmetric",

--- a/tools/miden-serde-utils-fuzz/Cargo.lock
+++ b/tools/miden-serde-utils-fuzz/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "p3-field",
  "p3-goldilocks",

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-verifier"
-version = "0.30.0"
+version = "0.31.0"
 description = "Miden VM execution verifier"
 documentation = "https://docs.rs/miden-verifier"
 readme = "README.md"


### PR DESCRIPTION
Prepares v0.31.0 and stands as pre-requisite to opening the tracking PR for it.

There are non trivial CHANGELOG cleanups.