### PR TITLE
fix(precompiles): bound deferred translation work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 #### Fixes
 
+- Added a default limit of 65,536 work units for deferred precompile translation. The prover rejects shared DAGs that would exceed the limit. Callers can set the limit through `Prover::with_max_precompile_expansion_work` or `prove_deferred_state_with_budget` ([#3731](https://github.com/0xMiden/miden-vm/pull/3731)).
 - [BREAKING] Limited bare `exp` to 63 exponent bits. It now lowers to `exp.u63` (72 cycles) and fails for exponents greater than or equal to `2^63`. Existing MAST artifacts containing the previous bare-`exp` lowering must be reassembled to use the new bound ([#3712](https://github.com/0xMiden/miden-vm/pull/3712)).
 
 ## v0.30.0 (2026-08-26)

--- a/crates/precompiles-prover/src/deferred/mod.rs
+++ b/crates/precompiles-prover/src/deferred/mod.rs
@@ -2,4 +2,7 @@
 mod session;
 
 #[allow(unused_imports)]
-pub(crate) use session::{DeferredSession, DeferredSessionError, session_from_deferred_state};
+pub(crate) use session::{
+    DeferredSession, DeferredSessionError, session_from_deferred_state,
+    session_from_deferred_state_with_budget,
+};

--- a/crates/precompiles-prover/src/deferred/session.rs
+++ b/crates/precompiles-prover/src/deferred/session.rs
@@ -1,5 +1,6 @@
 use alloc::{
     collections::{BTreeMap, BTreeSet, btree_map::Entry},
+    vec,
     vec::Vec,
 };
 
@@ -10,6 +11,7 @@ use miden_precompiles::{
 };
 
 use crate::{
+    DEFAULT_MAX_DEFERRED_EXPANSION_WORK, MAX_DEFERRED_TRANSLATION_DEPTH,
     ec::trace::EcPointPtr,
     math::{U256, from_limbs32},
     session::{EcNode, Session, Truthy, UintNode, strategies},
@@ -49,11 +51,29 @@ pub(crate) enum DeferredSessionError {
 
     #[error("deferred MSM node {digest:?} has no nonzero scalar")]
     UnsupportedMsmAllZeroScalars { digest: Digest },
+
+    #[error("deferred translation expansion exceeds the limit of {max} work units")]
+    TranslationBudgetExceeded { max: usize },
+
+    #[error("deferred translation expansion node count overflowed usize")]
+    TranslationCountOverflow,
+
+    #[error("deferred translation depth exceeds the limit of {max}")]
+    TranslationDepthExceeded { max: usize },
 }
 
 pub(crate) fn session_from_deferred_state(
     state: &DeferredState,
 ) -> Result<DeferredSession, DeferredSessionError> {
+    session_from_deferred_state_with_budget(state, DEFAULT_MAX_DEFERRED_EXPANSION_WORK)
+}
+
+pub(crate) fn session_from_deferred_state_with_budget(
+    state: &DeferredState,
+    max_expansion_work: usize,
+) -> Result<DeferredSession, DeferredSessionError> {
+    validate_translation_expansion(state, max_expansion_work)?;
+
     let mut builder = DeferredSessionBuilder {
         state,
         session: Session::new(),
@@ -69,6 +89,280 @@ pub(crate) fn session_from_deferred_state(
     }
 
     Ok(DeferredSession { session: builder.session, root })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum TranslationKind {
+    Truthy,
+    Uint,
+    Ec,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct TranslationKey {
+    kind: TranslationKind,
+    digest: Digest,
+}
+
+impl TranslationKey {
+    const fn new(kind: TranslationKind, digest: Digest) -> Self {
+        Self { kind, digest }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TranslationMetrics {
+    work: usize,
+    depth: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TranslationChild {
+    key: TranslationKey,
+    recursive: bool,
+}
+
+#[derive(Debug, Clone)]
+struct TranslationNode {
+    work: usize,
+    children: Vec<TranslationChild>,
+}
+
+impl TranslationNode {
+    fn leaf() -> Self {
+        Self { work: 1, children: Vec::new() }
+    }
+
+    fn with_children(children: Vec<TranslationChild>) -> Self {
+        Self { work: 1, children }
+    }
+}
+
+#[derive(Debug)]
+enum ExpansionFrame {
+    Visit(TranslationKey),
+    Complete {
+        key: TranslationKey,
+        node: TranslationNode,
+    },
+}
+
+/// Counts root-reachable translation calls without constructing any session rows.
+///
+/// Metrics are memoized by translation kind and digest, but a parent's count includes each child
+/// occurrence. Thus a shared child is fully charged for every recursive visit while the preflight
+/// itself remains linear in the number of unique typed nodes.
+fn validate_translation_expansion(
+    state: &DeferredState,
+    max_work: usize,
+) -> Result<(), DeferredSessionError> {
+    let mut metrics = BTreeMap::<TranslationKey, TranslationMetrics>::new();
+    let mut visiting = BTreeSet::<TranslationKey>::new();
+    let mut stack = Vec::new();
+    stack.push(ExpansionFrame::Visit(TranslationKey::new(
+        TranslationKind::Truthy,
+        state.root(),
+    )));
+
+    while let Some(frame) = stack.pop() {
+        match frame {
+            ExpansionFrame::Visit(key) => {
+                if metrics.contains_key(&key) {
+                    continue;
+                }
+                if !visiting.insert(key) {
+                    return Err(DeferredSessionError::MalformedNode(key.digest));
+                }
+
+                let node = translation_node(state, key)?;
+                if node.children.is_empty() {
+                    validate_translation_metrics(
+                        TranslationMetrics { work: node.work, depth: 1 },
+                        max_work,
+                    )?;
+                    metrics.insert(key, TranslationMetrics { work: node.work, depth: 1 });
+                    visiting.remove(&key);
+                } else {
+                    let children = node.children.clone();
+                    stack.push(ExpansionFrame::Complete { key, node });
+                    for child in children.iter().rev() {
+                        stack.push(ExpansionFrame::Visit(child.key));
+                    }
+                }
+            },
+            ExpansionFrame::Complete { key, node } => {
+                let mut combined = TranslationMetrics { work: node.work, depth: 1 };
+                for child in node.children {
+                    let child_metrics = metrics[&child.key];
+                    combined.work = combined
+                        .work
+                        .checked_add(child_metrics.work)
+                        .ok_or(DeferredSessionError::TranslationCountOverflow)?;
+                    combined.depth = combined.depth.max(
+                        child_metrics
+                            .depth
+                            .checked_add(usize::from(child.recursive))
+                            .ok_or(DeferredSessionError::TranslationCountOverflow)?,
+                    );
+                }
+                validate_translation_metrics(combined, max_work)?;
+                metrics.insert(key, combined);
+                visiting.remove(&key);
+            },
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_translation_metrics(
+    metrics: TranslationMetrics,
+    max_work: usize,
+) -> Result<(), DeferredSessionError> {
+    if metrics.work > max_work {
+        return Err(DeferredSessionError::TranslationBudgetExceeded { max: max_work });
+    }
+    if metrics.depth > MAX_DEFERRED_TRANSLATION_DEPTH {
+        return Err(DeferredSessionError::TranslationDepthExceeded {
+            max: MAX_DEFERRED_TRANSLATION_DEPTH,
+        });
+    }
+    Ok(())
+}
+
+fn translation_node(
+    state: &DeferredState,
+    key: TranslationKey,
+) -> Result<TranslationNode, DeferredSessionError> {
+    let node = state
+        .get_node(&key.digest)
+        .ok_or(DeferredSessionError::MissingNode(key.digest))?;
+
+    match key.kind {
+        TranslationKind::Truthy => {
+            if key.digest == TRUE_DIGEST {
+                return Ok(TranslationNode::leaf());
+            }
+            if node.tag() == Tag::AND {
+                let (lhs, rhs) = node
+                    .payload()
+                    .as_join()
+                    .map_err(|_| DeferredSessionError::MalformedNode(key.digest))?;
+                return Ok(TranslationNode::with_children(vec![
+                    translation_child(TranslationKind::Truthy, lhs, false),
+                    translation_child(TranslationKind::Truthy, rhs, false),
+                ]));
+            }
+            if let Some(assertion) = Keccak256Precompile::decode_assert_node(node)
+                .map_err(|_| DeferredSessionError::MalformedNode(key.digest))?
+            {
+                let input_chunks = usize::try_from(n_chunks(assertion.n_bytes).get())
+                    .map_err(|_| DeferredSessionError::TranslationCountOverflow)?;
+                let work = input_chunks
+                    .checked_add(1)
+                    .ok_or(DeferredSessionError::TranslationCountOverflow)?;
+                return Ok(TranslationNode { work, children: Vec::new() });
+            }
+            match UintPrecompile::decode_node(node)
+                .map_err(|_| DeferredSessionError::MalformedNode(key.digest))?
+            {
+                Some(UintNodeRef::Eq { lhs, rhs }) => {
+                    return Ok(TranslationNode::with_children(vec![
+                        translation_child(TranslationKind::Uint, lhs, true),
+                        translation_child(TranslationKind::Uint, rhs, true),
+                    ]));
+                },
+                Some(_) => {
+                    return Err(DeferredSessionError::TypeMismatch {
+                        digest: key.digest,
+                        expected: "truthy deferred node",
+                    });
+                },
+                None => {},
+            }
+            match CurvePrecompile::decode_node(node)
+                .map_err(|_| DeferredSessionError::MalformedNode(key.digest))?
+            {
+                Some(CurveNodeRef::Eq { lhs, rhs }) => Ok(TranslationNode::with_children(vec![
+                    translation_child(TranslationKind::Ec, lhs, true),
+                    translation_child(TranslationKind::Ec, rhs, true),
+                ])),
+                Some(_) | None => Err(DeferredSessionError::TypeMismatch {
+                    digest: key.digest,
+                    expected: "truthy deferred node",
+                }),
+            }
+        },
+        TranslationKind::Uint => {
+            match UintPrecompile::decode_node(node)
+                .map_err(|_| DeferredSessionError::MalformedNode(key.digest))?
+            {
+                Some(UintNodeRef::Value { .. }) => Ok(TranslationNode::leaf()),
+                Some(
+                    UintNodeRef::Add { lhs, rhs }
+                    | UintNodeRef::Sub { lhs, rhs }
+                    | UintNodeRef::Mul { lhs, rhs },
+                ) => Ok(TranslationNode::with_children(vec![
+                    translation_child(TranslationKind::Uint, lhs, true),
+                    translation_child(TranslationKind::Uint, rhs, true),
+                ])),
+                Some(UintNodeRef::Eq { .. }) | None => Err(DeferredSessionError::TypeMismatch {
+                    digest: key.digest,
+                    expected: "uint value",
+                }),
+            }
+        },
+        TranslationKind::Ec => {
+            match CurvePrecompile::decode_node(node)
+                .map_err(|_| DeferredSessionError::MalformedNode(key.digest))?
+            {
+                Some(CurveNodeRef::Value { x, y, .. }) => {
+                    match (x == TRUE_DIGEST, y == TRUE_DIGEST) {
+                        (true, true) => Ok(TranslationNode::leaf()),
+                        (false, false) => Ok(TranslationNode::with_children(vec![
+                            translation_child(TranslationKind::Uint, x, true),
+                            translation_child(TranslationKind::Uint, y, true),
+                        ])),
+                        (true, false) | (false, true) => {
+                            Err(DeferredSessionError::MalformedNode(key.digest))
+                        },
+                    }
+                },
+                Some(CurveNodeRef::Add { lhs, rhs } | CurveNodeRef::Sub { lhs, rhs }) => {
+                    Ok(TranslationNode::with_children(vec![
+                        translation_child(TranslationKind::Ec, lhs, true),
+                        translation_child(TranslationKind::Ec, rhs, true),
+                    ]))
+                },
+                Some(CurveNodeRef::Msm { pairs }) => Ok(TranslationNode::with_children(
+                    pairs
+                        .into_iter()
+                        .flat_map(|(point, scalar)| {
+                            [
+                                translation_child(TranslationKind::Ec, point, true),
+                                translation_child(TranslationKind::Uint, scalar, true),
+                            ]
+                        })
+                        .collect(),
+                )),
+                Some(CurveNodeRef::Eq { .. }) | None => Err(DeferredSessionError::TypeMismatch {
+                    digest: key.digest,
+                    expected: "curve value",
+                }),
+            }
+        },
+    }
+}
+
+const fn translation_child(
+    kind: TranslationKind,
+    digest: Digest,
+    recursive: bool,
+) -> TranslationChild {
+    TranslationChild {
+        key: TranslationKey::new(kind, digest),
+        recursive,
+    }
 }
 
 // TODO: Add translator-level value caches if repeated traversal becomes measurable. Truthy
@@ -102,24 +396,54 @@ struct TranslatedEc {
     curve: CurveId,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum TruthyFrame {
+    Visit(Digest),
+    CompleteAnd(Digest),
+}
+
 impl<'a> DeferredSessionBuilder<'a> {
     fn translate_truthy(&mut self, digest: Digest) -> Result<Truthy, DeferredSessionError> {
-        self.require_truthy_metadata(digest)?;
+        let mut frames = Vec::new();
+        let mut values = Vec::new();
+        frames.push(TruthyFrame::Visit(digest));
 
-        if digest == TRUE_DIGEST {
-            return Ok(self.session.zero());
+        while let Some(frame) = frames.pop() {
+            match frame {
+                TruthyFrame::Visit(digest) => {
+                    self.require_truthy_metadata(digest)?;
+                    if digest == TRUE_DIGEST {
+                        values.push(self.session.zero());
+                        continue;
+                    }
+
+                    if self.node_tag(digest)? == Tag::AND {
+                        let (lhs, rhs) = self.join_payload(digest)?;
+                        frames.push(TruthyFrame::CompleteAnd(digest));
+                        frames.push(TruthyFrame::Visit(rhs));
+                        frames.push(TruthyFrame::Visit(lhs));
+                    } else {
+                        values.push(self.translate_truthy_leaf(digest)?);
+                    }
+                },
+                TruthyFrame::CompleteAnd(digest) => {
+                    let rhs = values.pop().ok_or(DeferredSessionError::MalformedNode(digest))?;
+                    let lhs = values.pop().ok_or(DeferredSessionError::MalformedNode(digest))?;
+                    let node = self.session.assert_and(lhs, rhs);
+                    debug_assert_eq!(node.hash(), P2Digest::from(digest));
+                    values.push(node);
+                },
+            }
         }
 
-        let tag = self.node_tag(digest)?;
-        if tag == Tag::AND {
-            let (lhs, rhs) = self.join_payload(digest)?;
-            let lhs = self.translate_truthy(lhs)?;
-            let rhs = self.translate_truthy(rhs)?;
-            let node = self.session.assert_and(lhs, rhs);
-            debug_assert_eq!(node.hash(), P2Digest::from(digest));
-            return Ok(node);
+        if values.len() == 1 {
+            Ok(values.pop().expect("length checked above"))
+        } else {
+            Err(DeferredSessionError::MalformedNode(digest))
         }
+    }
 
+    fn translate_truthy_leaf(&mut self, digest: Digest) -> Result<Truthy, DeferredSessionError> {
         if let Some(assertion) = Keccak256Precompile::decode_assert_node(self.node(digest)?)
             .map_err(|_| DeferredSessionError::MalformedNode(digest))?
         {

--- a/crates/precompiles-prover/src/lib.rs
+++ b/crates/precompiles-prover/src/lib.rs
@@ -19,6 +19,25 @@ pub use miden_core::{
 };
 pub use session::VerifyError;
 
+/// Default maximum amount of recursive translation work for one deferred root.
+///
+/// Deferred state is a content-addressed DAG, so its unique-node storage budget does not bound the
+/// number or cost of paths that the precompile prover must lower. One work unit represents a node
+/// translation or one 32-byte Keccak input chunk. Callers that accept untrusted deferred witnesses
+/// should select a limit appropriate for their worker policy with
+/// [`prove_deferred_state_with_budget`].
+///
+/// The default admits the maximum supported merged-root count while rejecting compact DAGs that
+/// would expand beyond 65,536 units of translation work.
+pub const DEFAULT_MAX_DEFERRED_EXPANSION_WORK: usize = 1 << 16;
+
+/// Hard safety ceiling for recursive deferred translation.
+///
+/// Translation currently follows truthy, uint, and EC dependencies recursively. Preflight rejects
+/// deeper inputs before entering that recursion so untrusted witnesses cannot exhaust the thread
+/// stack.
+pub const MAX_DEFERRED_TRANSLATION_DEPTH: usize = 256;
+
 #[cfg(any(test, feature = "std"))]
 pub(crate) mod ace;
 pub(crate) mod ace_registry;
@@ -44,9 +63,22 @@ pub fn prove_deferred_state(
     state: &DeferredState,
     hash_fn: HashFunction,
 ) -> Result<StarkProof, ProveDeferredStateError> {
+    prove_deferred_state_with_budget(state, hash_fn, DEFAULT_MAX_DEFERRED_EXPANSION_WORK)
+}
+
+/// Proves the precompile claims in `state` while limiting recursive translation expansion.
+///
+/// Truthy, uint, and EC dependencies are counted with checked arithmetic before session rows are
+/// constructed. A shared child is charged once per occurrence in the expanded translation tree,
+/// matching the current lowering behavior.
+pub fn prove_deferred_state_with_budget(
+    state: &DeferredState,
+    hash_fn: HashFunction,
+    max_expansion_work: usize,
+) -> Result<StarkProof, ProveDeferredStateError> {
     let deferred = {
         let _span = tracing::info_span!("build_session").entered();
-        deferred::session_from_deferred_state(state)?
+        deferred::session_from_deferred_state_with_budget(state, max_expansion_work)?
     };
     let traces = {
         let _span = tracing::info_span!("build_trace").entered();

--- a/crates/precompiles-prover/src/tests/deferred_session.rs
+++ b/crates/precompiles-prover/src/tests/deferred_session.rs
@@ -1,13 +1,184 @@
 use alloc::{sync::Arc, vec, vec::Vec};
 
-use miden_core::deferred::{DeferredState, Node};
-use miden_precompiles::{CurveId, CurvePoint, CurvePrecompile, UintDomain, UintPrecompile};
+use miden_core::{
+    Felt,
+    deferred::{
+        DeferredState, MAX_PRECOMPILE_ROOTS, Node, PrecompileRegistry, PrecompileWitness,
+        TRUE_DIGEST,
+    },
+};
+use miden_precompiles::{
+    CurveId, CurvePoint, CurvePrecompile, Keccak256Precompile, UintDomain, UintPrecompile,
+};
 
-use crate::deferred::{DeferredSession, session_from_deferred_state};
+use crate::{
+    DEFAULT_MAX_DEFERRED_EXPANSION_WORK, MAX_DEFERRED_TRANSLATION_DEPTH,
+    deferred::{
+        DeferredSession, DeferredSessionError, session_from_deferred_state,
+        session_from_deferred_state_with_budget,
+    },
+    hash::keccak::sponge::trace::keccak_oracle,
+};
 
 fn state() -> DeferredState {
     DeferredState::new(Arc::new(miden_precompiles::registry()))
         .expect("precompile init must succeed")
+}
+
+fn shared_and_state(depth: u32) -> DeferredState {
+    let mut state = DeferredState::new(Arc::new(PrecompileRegistry::new()))
+        .expect("empty registry must initialize");
+    for _ in 0..depth {
+        let root = state.root();
+        state.log_statement(root).expect("current root must log as a true statement");
+    }
+    state
+}
+
+fn linear_and_state(depth: u32) -> DeferredState {
+    let mut state = DeferredState::new(Arc::new(PrecompileRegistry::new()))
+        .expect("empty registry must initialize");
+    for _ in 0..depth {
+        state.log_statement(TRUE_DIGEST).expect("TRUE must log as a true statement");
+    }
+    state
+}
+
+fn shared_uint_state(depth: u32) -> DeferredState {
+    let mut state = state();
+    let value = UintPrecompile::value_node(UintDomain::U256, limbs(1));
+    let mut value = state.register(value).expect("value must register");
+    for _ in 0..depth {
+        let sum = Node::join(UintPrecompile::op_tag(UintPrecompile::ADD_OP_ID), value, value)
+            .expect("tag is uint-owned");
+        value = state.register(sum).expect("sum must register");
+    }
+    let eq = Node::join(UintPrecompile::op_tag(UintPrecompile::EQ_OP_ID), value, value)
+        .expect("tag is uint-owned");
+    let eq = state.register(eq).expect("equality must register");
+    state.log_statement(eq).expect("equality must log");
+    state
+}
+
+fn linear_uint_state(depth: u32) -> DeferredState {
+    let mut state = state();
+    let one = UintPrecompile::value_node(UintDomain::U256, limbs(1));
+    let one = state.register(one).expect("value must register");
+    let mut value = one;
+    for _ in 0..depth {
+        let sum = Node::join(UintPrecompile::op_tag(UintPrecompile::ADD_OP_ID), value, one)
+            .expect("tag is uint-owned");
+        value = state.register(sum).expect("sum must register");
+    }
+    let eq = Node::join(UintPrecompile::op_tag(UintPrecompile::EQ_OP_ID), value, value)
+        .expect("tag is uint-owned");
+    let eq = state.register(eq).expect("equality must register");
+    state.log_statement(eq).expect("equality must log");
+    state
+}
+
+fn keccak_state(input: &[u8]) -> DeferredState {
+    let registry =
+        Arc::new(PrecompileRegistry::new().with_precompile(Keccak256Precompile::default()));
+    let mut state = DeferredState::new(registry).expect("Keccak registry must initialize");
+    let input_digest = state
+        .register(Node::chunks_from_bytes(input))
+        .expect("input chunks must register");
+    let expected = vec![keccak_oracle(input).to_u32s().map(Felt::from_u32)];
+    let expected_digest = state
+        .register(Node::chunks(expected).expect("digest chunks are nonempty"))
+        .expect("expected digest must register");
+    let assertion = state
+        .register(Keccak256Precompile::assert_node(
+            input.len().try_into().expect("test input length fits u32"),
+            input_digest,
+            expected_digest,
+        ))
+        .expect("matching Keccak assertion must register");
+    state.log_statement(assertion).expect("matching assertion must log");
+    state
+}
+
+#[test]
+fn deferred_session_truthy_expansion_budget_has_an_exact_boundary() {
+    let state = shared_and_state(5);
+
+    session_from_deferred_state_with_budget(&state, 63)
+        .expect("a depth-five shared AND has exactly 63 truthy occurrences");
+    assert!(matches!(
+        session_from_deferred_state_with_budget(&state, 62),
+        Err(DeferredSessionError::TranslationBudgetExceeded { max: 62 })
+    ));
+}
+
+#[test]
+fn deferred_session_expansion_budget_includes_shared_uint_dependencies() {
+    let state = shared_uint_state(5);
+
+    session_from_deferred_state_with_budget(&state, 129)
+        .expect("the shared uint expression has exactly 129 translation occurrences");
+    assert!(matches!(
+        session_from_deferred_state_with_budget(&state, 128),
+        Err(DeferredSessionError::TranslationBudgetExceeded { max: 128 })
+    ));
+}
+
+#[test]
+fn deferred_session_expansion_budget_charges_keccak_input_chunks() {
+    let state = keccak_state(&[42; 64]);
+
+    session_from_deferred_state_with_budget(&state, 5)
+        .expect("the root, TRUE leaf, assertion, and two input chunks cost five units");
+    assert!(matches!(
+        session_from_deferred_state_with_budget(&state, 4),
+        Err(DeferredSessionError::TranslationBudgetExceeded { max: 4 })
+    ));
+}
+
+#[test]
+fn deferred_session_accepts_supported_merged_root_depth() {
+    let witnesses = (0..MAX_PRECOMPILE_ROOTS)
+        .map(|_| {
+            PrecompileWitness::new(linear_and_state(1))
+                .expect("one logged statement must form a witness")
+        })
+        .collect();
+    let merged = PrecompileWitness::merge(witnesses).expect("root count is supported");
+
+    session_from_deferred_state(merged.state()).expect("supported root merges must lower");
+}
+
+#[test]
+fn deferred_session_rejects_translation_depth_above_the_safe_limit() {
+    session_from_deferred_state(&linear_uint_state(MAX_DEFERRED_TRANSLATION_DEPTH as u32 - 2))
+        .expect("the exact translation depth limit must be accepted");
+    assert!(matches!(
+        session_from_deferred_state(&linear_uint_state(MAX_DEFERRED_TRANSLATION_DEPTH as u32 - 1)),
+        Err(DeferredSessionError::TranslationDepthExceeded { max: MAX_DEFERRED_TRANSLATION_DEPTH })
+    ));
+}
+
+#[test]
+fn deferred_session_truthy_expansion_count_rejects_overflow() {
+    let state = shared_and_state(usize::BITS);
+
+    assert!(matches!(
+        session_from_deferred_state_with_budget(&state, usize::MAX),
+        Err(DeferredSessionError::TranslationCountOverflow)
+    ));
+}
+
+#[test]
+fn deferred_session_rejects_truthy_expansion_above_the_default_budget() {
+    let depth = DEFAULT_MAX_DEFERRED_EXPANSION_WORK.ilog2();
+    let state = shared_and_state(depth);
+
+    assert!(matches!(
+        session_from_deferred_state(&state),
+        Err(DeferredSessionError::TranslationBudgetExceeded {
+            max: DEFAULT_MAX_DEFERRED_EXPANSION_WORK,
+        })
+    ));
 }
 
 fn limbs(value: u32) -> [u32; 8] {

--- a/prover/src/prover.rs
+++ b/prover/src/prover.rs
@@ -19,6 +19,7 @@ use crate::{config, prove_stark};
 pub struct Prover {
     hash_fn: HashFunction,
     max_prover_memory_bytes: u64,
+    max_precompile_expansion_work: usize,
 }
 
 impl Prover {
@@ -29,11 +30,16 @@ impl Prover {
     /// not cover the precompile prover's memory footprint.
     pub const DEFAULT_MAX_PROVER_MEMORY_BYTES: u64 = trace::DEFAULT_MAX_PROVER_MEMORY_BYTES;
 
+    /// Default maximum amount of recursive translation work for one deferred precompile root.
+    pub const DEFAULT_MAX_PRECOMPILE_EXPANSION_WORK: usize =
+        miden_precompiles_prover::DEFAULT_MAX_DEFERRED_EXPANSION_WORK;
+
     /// Creates a prover with the canonical proof-generation configuration.
     pub const fn new() -> Self {
         Self {
             hash_fn: HashFunction::Blake3_256,
             max_prover_memory_bytes: Self::DEFAULT_MAX_PROVER_MEMORY_BYTES,
+            max_precompile_expansion_work: Self::DEFAULT_MAX_PRECOMPILE_EXPANSION_WORK,
         }
     }
 
@@ -56,6 +62,21 @@ impl Prover {
     /// over a VM execution trace.
     pub const fn max_prover_memory_bytes(&self) -> u64 {
         self.max_prover_memory_bytes
+    }
+
+    /// Sets the maximum amount of recursive translation work for one deferred precompile root.
+    #[must_use]
+    pub const fn with_max_precompile_expansion_work(
+        mut self,
+        max_precompile_expansion_work: usize,
+    ) -> Self {
+        self.max_precompile_expansion_work = max_precompile_expansion_work;
+        self
+    }
+
+    /// Returns the maximum amount of recursive translation work for one deferred precompile root.
+    pub const fn max_precompile_expansion_work(&self) -> usize {
+        self.max_precompile_expansion_work
     }
 
     /// Proves only the VM portion of an execution witness.
@@ -105,8 +126,12 @@ impl Prover {
         &self,
         witness: &PrecompileWitness,
     ) -> Result<PrecompileProof, ProverError> {
-        let proof = miden_precompiles_prover::prove_deferred_state(witness.state(), self.hash_fn)
-            .map_err(ProverError::PrecompileProofGeneration)?;
+        let proof = miden_precompiles_prover::prove_deferred_state_with_budget(
+            witness.state(),
+            self.hash_fn,
+            self.max_precompile_expansion_work,
+        )
+        .map_err(ProverError::PrecompileProofGeneration)?;
         Ok(PrecompileProof { proof, roots: witness.roots().to_vec() })
     }
 
@@ -291,6 +316,8 @@ impl ProverError {
 
 #[cfg(test)]
 mod tests {
+    use miden_core::deferred::{DeferredState, PrecompileWitness};
+
     use super::*;
 
     #[test]
@@ -306,8 +333,37 @@ mod tests {
     fn prover_uses_canonical_memory_budget_and_allows_override() {
         let prover = Prover::new();
         assert_eq!(prover.max_prover_memory_bytes(), Prover::DEFAULT_MAX_PROVER_MEMORY_BYTES);
+        assert_eq!(
+            prover.max_precompile_expansion_work(),
+            Prover::DEFAULT_MAX_PRECOMPILE_EXPANSION_WORK
+        );
 
-        let prover = prover.with_max_prover_memory_bytes(1 << 20);
+        let prover = prover
+            .with_max_prover_memory_bytes(1 << 20)
+            .with_max_precompile_expansion_work(63);
         assert_eq!(prover.max_prover_memory_bytes(), 1 << 20);
+        assert_eq!(prover.max_precompile_expansion_work(), 63);
+    }
+
+    #[test]
+    fn prover_rejects_precompile_expansion_above_its_budget() {
+        let mut state = DeferredState::default();
+        for _ in 0..5 {
+            let root = state.root();
+            state.log_statement(root).expect("current root must log as a true statement");
+        }
+        let witness = PrecompileWitness::new(state).expect("nonempty state must form a witness");
+
+        let error = Prover::new()
+            .with_max_precompile_expansion_work(62)
+            .prove_precompile(&witness)
+            .expect_err("a depth-five shared AND expands to 63 nodes");
+
+        assert!(matches!(
+            error,
+            ProverError::PrecompileProofGeneration(
+                miden_precompiles_prover::ProveDeferredStateError::Translation(message)
+            ) if message.contains("exceeds the limit of 62 work units")
+        ));
     }
 }


### PR DESCRIPTION
Fixes [0xMiden/security-issues#40](https://github.com/0xMiden/security-issues/issues/40).

A deferred state has one copy of each shared node, but the precompile prover may visit the same node many times. Each AND level can double the work. A small state can use too much CPU time and stack space.

The prover now counts translation work before it builds the proving session. It returns an error when the count exceeds the limit. The default is 65,536 work units, and callers can set it through `Prover`.

Each node visit counts as one unit. Each 32 byte Keccak input chunk also counts as one unit. The translator now uses an explicit stack for AND nodes. The uint and EC paths have a depth limit.