### PR TITLE
chore: Reduce local test artifact duplication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,8 @@ lto = true
 [profile.test-dev]
 inherits = "dev"
 opt-level = 1
-debug = true
+# Keep line-level information for backtraces without embedding full DWARF in every test binary.
+debug = 1
 debug-assertions = true
 overflow-checks = true
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ ALL_FEATURES             := --all-features
 
 # Workspace-wide test features
 WORKSPACE_TEST_FEATURES  := concurrent,testing,executable,registry-tools
-FAST_TEST_FEATURES       := concurrent,testing
 MIDEN_CRYPTO_FUZZ_TARGETS := smt word merkle merkle_store smt_serde partial_smt mmr crypto aead signatures
 MIDEN_SERDE_UTILS_FUZZ_TARGETS := primitives collections string vint64 goldilocks budgeted
 MIDEN_STARK_TEST_PACKAGES := -p miden-lifted-air -p miden-lifted-stark -p miden-stateful-hasher -p miden-stark-transcript
@@ -214,8 +213,9 @@ test-docs: ## Run documentation tests (cargo test - nextest doesn't support doct
 
 .PHONY: test-fast
 test-fast: ## Runs fast tests (excludes all CLI tests and proptests)
+	# Keep this feature set aligned with `test` so both targets reuse the same test binaries.
 	$(MAKE) core-test \
-		FEATURES="$(FAST_TEST_FEATURES)" \
+		FEATURES="$(WORKSPACE_TEST_FEATURES)" \
 		EXPR="-E 'not test(#*proptest) and not test(cli_)'"
 
 .PHONY: test-skip-proptests


### PR DESCRIPTION
Local test builds currently retain full DWARF information in every linked test executable. The `test-fast` and `test` targets also use different feature sets, which makes Cargo keep two hashed copies of much of the test suite when developers run both commands.

This PR changes the `test-dev` profile from full debug information to limited debug information with `debug = 1`. File and line information remains available for backtraces, while variable and type-level DWARF is omitted. It also gives `test-fast` the workspace test feature set used by `test`, allowing both commands to reuse one set of binaries.

## Measurements

Measurements were taken on an AMD Ryzen 9 9950X with Rust 1.96.1. Each clean comparison used an empty `CARGO_TARGET_DIR` and ran `make test-build` with the normal workspace test features. Times are single local samples that indicate the likely direction of change.

| Configuration | Build time | Target size | Extensionless files |
| --- | ---: | ---: | ---: |
| Full debug information | 392.2 s | 32 GiB | 31.2 GB |
| `debug = 1` | 341.2 s | 25 GiB | 23.6 GB |
| Difference | 51.0 s faster | 7 GiB smaller | 7.6 GB smaller |

The reduced-debug build was 13% faster and used 22% less disk space. Inspection with `readelf` confirmed that the resulting test binaries still contain `.debug_line`, `.debug_info`, and symbol sections.

The feature alignment has a larger effect on the common sequential workflow:

| Step | Cargo compile time | Test time | Added bytes |
| --- | ---: | ---: | ---: |
| Clean `make test-fast` | 5m 43s | 60.6 s | 25 GiB total |
| Warm `make test` | 0.14 s | 47.1 s | 0 |

Before this change, running `make test-fast` followed by `make test` grew the `test-dev` directory to 57 GiB. The second command alone added about 27 GiB because its feature set produced another collection of hashed test binaries. After this change, the second command added zero bytes. 