### PR TITLE
ci: catch release version errors before builds

### DIFF
--- a/.github/workflows/package-version-gate.yml
+++ b/.github/workflows/package-version-gate.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: ""
         type: string
+      allow_existing:
+        description: "Allow crate versions that already exist on crates.io."
+        required: false
+        default: true
+        type: boolean
   workflow_dispatch:
     inputs:
       packages:
@@ -27,6 +32,11 @@ on:
         required: false
         default: ""
         type: string
+      allow_existing:
+        description: "Allow crate versions that already exist on crates.io."
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.event_name }} @ ${{ inputs.ref || github.ref }} @ ${{ inputs.packages || '' }}"
@@ -52,6 +62,7 @@ jobs:
         run: cargo install cargo-semver-checks --version 0.49.0 --locked
 
       - name: Check package versions
-        run: scripts/check-package-release-plan.sh "$PACKAGE_VERSION_GATE_PACKAGES"
+        run: scripts/check-package-release-plan.sh "--allow-existing=$PACKAGE_VERSION_GATE_ALLOW_EXISTING" "$PACKAGE_VERSION_GATE_PACKAGES"
         env:
           PACKAGE_VERSION_GATE_PACKAGES: ${{ inputs.packages || '' }}
+          PACKAGE_VERSION_GATE_ALLOW_EXISTING: ${{ github.event_name == 'push' || inputs.allow_existing }}

--- a/.github/workflows/release-metadata.yml
+++ b/.github/workflows/release-metadata.yml
@@ -1,0 +1,24 @@
+name: Release metadata
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+      - next
+
+jobs:
+  release-metadata:
+    name: check release metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check release metadata
+        run: scripts/check-release-metadata.sh "${{ github.event.pull_request.base.sha }}"

--- a/.github/workflows/workspace-publish.yml
+++ b/.github/workflows/workspace-publish.yml
@@ -22,9 +22,9 @@ on:
         default: ""
         type: string
       allow_existing:
-        description: "Exclude crate versions that already exist on crates.io."
+        description: "Resume a partial publish after checking existing crates."
         required: false
-        default: true
+        default: false
         type: boolean
       skip_package_version_gate:
         description: "Skip the package version gate. Use only for manual release recovery after maintainers verify the release plan."
@@ -78,6 +78,7 @@ jobs:
     with:
       ref: ${{ needs.prepare-release.outputs.sha }}
       packages: ${{ github.event.inputs.packages || '' }}
+      allow_existing: ${{ github.event_name == 'release' || inputs.allow_existing }}
 
   create-draft:
     name: create draft release
@@ -252,7 +253,7 @@ jobs:
           mode: "publish"
           verify-main-head: "true"
           packages: ${{ github.event.inputs.packages || '' }}
-          allow_existing: ${{ github.event.inputs.allow_existing || 'true' }}
+          allow_existing: ${{ github.event_name == 'release' || inputs.allow_existing }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 

--- a/scripts/check-package-release-plan.sh
+++ b/scripts/check-package-release-plan.sh
@@ -20,6 +20,25 @@ trap 'rm -rf "$RELEASE_PLAN_TMPDIR"' EXIT
 metadata_json="$(cargo metadata --locked --no-deps --format-version 1)"
 workspace_root="$(printf '%s' "$metadata_json" | jq -r '.workspace_root')"
 selected_packages=()
+allow_existing=true
+check_semver=true
+package_arguments=()
+
+for argument in "$@"; do
+    case "$argument" in
+        --allow-existing=*) allow_existing="${argument#*=}" ;;
+        --skip-semver) check_semver=false ;;
+        *) package_arguments+=("$argument") ;;
+    esac
+done
+
+case "$allow_existing" in
+    true | false) ;;
+    *)
+        echo "ERROR: --allow-existing must be true or false" >&2
+        exit 2
+        ;;
+esac
 
 add_packages() {
     local item word
@@ -33,7 +52,9 @@ add_packages() {
     done
 }
 
-add_packages "$@"
+if [[ "${#package_arguments[@]}" -gt 0 ]]; then
+    add_packages "${package_arguments[@]}"
+fi
 selected_package_count="${#selected_packages[@]}"
 
 publishable_package_names="$(
@@ -92,7 +113,9 @@ while IFS=$'\t' read -r package local_version manifest_path; do
     fi
 
     if crate_version_exists "$package" "$local_version"; then
-        if package_archive_matches_published "$package" "$local_version" "$workspace_root"; then
+        if [[ "$allow_existing" == "false" ]]; then
+            version_errors+=("$package v$local_version already exists on crates.io")
+        elif package_archive_matches_published "$package" "$local_version" "$workspace_root"; then
             already_published+=("$package v$local_version (latest published: $latest_version)")
         else
             archive_status=$?
@@ -108,6 +131,11 @@ while IFS=$'\t' read -r package local_version manifest_path; do
     cmp="$(version_cmp "$local_version" "$latest_version")"
     if [[ "$cmp" -le 0 ]]; then
         version_errors+=("$package v$local_version is not newer than latest published v$latest_version")
+        continue
+    fi
+
+    if [[ "$check_semver" == "false" ]]; then
+        would_publish+=("$package v$local_version (latest published: $latest_version)")
         continue
     fi
 

--- a/scripts/check-release-metadata.sh
+++ b/scripts/check-release-metadata.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+base="${1:?usage: check-release-metadata.sh BASE_COMMIT}"
+
+package_version() {
+    local metadata="$1"
+    local package="$2"
+
+    printf '%s' "$metadata" |
+        jq -er --arg package "$package" '.packages[] | select(.name == $package) | .version'
+}
+
+release_line() {
+    local core="${1%%[-+]*}"
+    printf '%s\n' "${core%.*}"
+}
+
+metadata_json="$(cargo metadata --locked --no-deps --format-version 1)"
+worktree_root="$(mktemp -d)"
+base_worktree="$worktree_root/base"
+cleanup() {
+    git worktree remove --force "$base_worktree" >/dev/null 2>&1 || true
+    rmdir "$worktree_root" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+git worktree add --detach "$base_worktree" "$base" >/dev/null
+base_metadata_json="$(
+    cargo metadata --locked --no-deps --format-version 1 --manifest-path "$base_worktree/Cargo.toml"
+)"
+
+# miden-precompiles inherits workspace.package.version.
+current_workspace="$(package_version "$metadata_json" miden-precompiles)"
+base_workspace="$(package_version "$base_metadata_json" miden-precompiles)"
+
+if [[ "$current_workspace" != "$base_workspace" ]]; then
+    if git show-ref --verify --quiet "refs/tags/v$current_workspace"; then
+        echo "ERROR: v$current_workspace has already been released. Choose a newer workspace version." >&2
+        exit 1
+    fi
+
+    current_midenc="$(package_version "$metadata_json" midenc-hir-type)"
+    base_midenc="$(package_version "$base_metadata_json" midenc-hir-type)"
+
+    if [[ "$(release_line "$current_workspace")" != "$(release_line "$base_workspace")" && "$current_midenc" == "$base_midenc" ]]; then
+        echo "ERROR: $current_workspace starts a new release line. Bump midenc-hir-type from $base_midenc." >&2
+        exit 1
+    fi
+
+    if [[ "$current_midenc" != "$base_midenc" ]]; then
+        requirement="$(
+            printf '%s' "$metadata_json" |
+                jq -r '[.packages[].dependencies[] | select(.name == "midenc-hir-type") | .req] | unique[]'
+        )"
+        if [[ "$current_midenc" == *-* ]]; then
+            expected="$current_midenc"
+        else
+            expected="${current_midenc%.*}"
+        fi
+        if [[ "$requirement" != "^$expected" ]]; then
+            echo "ERROR: midenc-hir-type $current_midenc needs workspace requirement $expected, found ${requirement#^}." >&2
+            exit 1
+        fi
+    fi
+fi
+
+for manifest in \
+    tools/miden-core-fuzz/Cargo.toml \
+    tools/miden-crypto-fuzz/Cargo.toml \
+    tools/miden-serde-utils-fuzz/Cargo.toml; do
+    cargo metadata --locked --no-deps --format-version 1 --manifest-path "$manifest" >/dev/null
+done
+
+scripts/check-package-release-plan.sh --skip-semver


### PR DESCRIPTION
Learnings from v0.30.0

- [Release run 32917889592](https://github.com/0xMiden/miden-vm/actions/runs/32917889592) built every artifact before it found that `midenc-hir-type` 0.10.1 was already on crates.io.
- Pull requests now reject code changes that keep a released workspace version. When the workspace version changes, the check also covers `midenc-hir-type`, its dependency requirement, package versions, and lockfiles.
- Fresh releases now reject existing crate versions in the package gate. The gate runs _before_ artifact builds. Set `allow_existing` only to resume a partial publish.
