### PR TITLE
test: verify default state for initialized MerkleStore

### DIFF
--- a/crates/crypto/src/merkle/store/tests.rs
+++ b/crates/crypto/src/merkle/store/tests.rs
@@ -990,3 +990,11 @@ fn deserialize_rejects_truncated_payload() {
     let result = MerkleStore::read_from_bytes(&bytes);
     assert!(matches!(result, Err(DeserializationError::UnexpectedEOF)));
 }
+
+#[test]
+fn test_empty_merkle_store_operations() {
+    let store = MerkleStore::new();
+
+    // MerkleStore varsayılan boş alt ağaç köklerini içerir
+    assert!(!store.nodes.is_empty(), "Yeni oluşturulan MerkleStore varsayılan kökleri içermelidir");
+}


### PR DESCRIPTION
### Summary
Adds a unit test to check the initial state of a newly created `MerkleStore`.

### Changes
- Added `test_empty_merkle_store_operations` test case to `crates/crypto/src/merkle/store/tests.rs`.
- Verified that `store.nodes` contains default empty subtree roots upon initialization.