### PR TITLE
fix: expose precompile state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Features
 
 - [BREAKING] Added a conjectured security estimator for the main VM and the precompiles VM ([#3688](https://github.com/0xMiden/miden-vm/pull/3688)).
+- Added `has_precompiles()` to `ExecutionWitness` and `ExecutionProof` so callers can check for precompile work without consuming the witness or inspecting proof variants ([#3757](https://github.com/0xMiden/miden-vm/pull/3757)).
 
 #### Changes
 

--- a/core/src/proof.rs
+++ b/core/src/proof.rs
@@ -239,6 +239,11 @@ impl ExecutionProof {
         matches!(self, Self::Complete { .. })
     }
 
+    /// Returns whether this proof contains precompile work.
+    pub const fn has_precompiles(&self) -> bool {
+        matches!(self, Self::Deferred { .. } | Self::Complete { precompile: Some(_), .. })
+    }
+
     /// Transitions a deferred proof to complete by attaching a precompile proof.
     pub fn complete(self, precompile: PrecompileProof) -> Result<Self, ExecutionProofError> {
         let Self::Deferred { vm, .. } = self else {
@@ -456,6 +461,28 @@ mod tests {
         assert_eq!(ExecutionProof::read_from(&mut reader).unwrap(), deferred);
         assert_eq!(ExecutionProof::read_from(&mut reader).unwrap(), complete);
         assert!(!reader.has_more_bytes());
+    }
+
+    #[test]
+    fn execution_proof_reports_precompile_state() {
+        let (precompile_wire, wire_root) = wire();
+        let deferred = ExecutionProof::Deferred {
+            vm: vm_proof(wire_root),
+            precompile: precompile_wire,
+        };
+        assert!(deferred.has_precompiles());
+
+        let complete_without_precompile = ExecutionProof::Complete {
+            vm: vm_proof(TRUE_DIGEST),
+            precompile: None,
+        };
+        assert!(!complete_without_precompile.has_precompiles());
+
+        let complete_with_precompile = ExecutionProof::Complete {
+            vm: vm_proof(root(1)),
+            precompile: Some(precompile_proof(&[root(1)])),
+        };
+        assert!(complete_with_precompile.has_precompiles());
     }
 
     #[test]

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -97,6 +97,11 @@ impl ExecutionWitness {
         self.vm.claim()
     }
 
+    /// Returns whether this witness contains precompile work.
+    pub const fn has_precompiles(&self) -> bool {
+        self.precompile.is_some()
+    }
+
     /// Consumes this witness and returns its supported low-level proving components.
     ///
     /// The [`VmWitness`] can be passed to [`build_trace`]. The optional [`PrecompileWitness`] is
@@ -501,16 +506,28 @@ mod wire_tests {
     use super::{Deserializable, ExecutionWitness, Serializable};
     use crate::{DefaultHost, FastProcessor, StackInputs};
 
-    fn deferred_witness_bytes() -> alloc::vec::Vec<u8> {
+    fn execution_witness(source: &str) -> ExecutionWitness {
         let program = Assembler::default()
-            .assemble_program("program", "begin log_deferred end")
+            .assemble_program("program", source)
             .expect("program should compile")
             .unwrap_program();
         let mut host = DefaultHost::default();
-        let witness = FastProcessor::new(StackInputs::default())
+        FastProcessor::new(StackInputs::default())
             .execute_for_proving_sync(&program, &mut host)
-            .expect("execution should produce a witness");
-        witness.to_bytes()
+            .expect("execution should produce a witness")
+    }
+
+    fn deferred_witness_bytes() -> alloc::vec::Vec<u8> {
+        execution_witness("begin log_deferred end").to_bytes()
+    }
+
+    #[test]
+    fn witness_reports_precompile_state() {
+        let plain = execution_witness("begin push.1 drop end");
+        assert!(!plain.has_precompiles());
+
+        let deferred = execution_witness("begin log_deferred end");
+        assert!(deferred.has_precompiles());
     }
 
     #[test]


### PR DESCRIPTION
`ExecutionWitness` only exposes its precompile state through the consuming `into_parts` method. `ExecutionProof::is_complete()` cannot tell a proof without precompile work from one that includes a completed precompile proof. Protocol callers need one check for both types.

This adds `has_precompiles()` to `ExecutionWitness` and `ExecutionProof.` The proof helper returns true for deferred proofs and complete proofs with a precompile proof.

Closes https://github.com/0xMiden/miden-vm/issues/3755.