### PR TITLE
fix: harden ExecutionWitness deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 #### Fixes
 
+- Hardened `ExecutionWitness` byte decoding with an input-sized budget, exact canonical payload checks, and an explicit trusted reader for sparse replay data ([#3303](https://github.com/0xMiden/miden-vm/issues/3303)).
 - [BREAKING] Limited bare `exp` to 63 exponent bits. It now lowers to `exp.u63` (72 cycles) and fails for exponents greater than or equal to `2^63`. Existing MAST artifacts containing the previous bare-`exp` lowering must be reassembled to use the new bound ([#3712](https://github.com/0xMiden/miden-vm/pull/3712)).
 
 ## v0.30.0 (2026-08-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 #### Fixes
 
-- Hardened `ExecutionWitness` byte decoding with an input-sized budget, exact canonical payload checks, and an explicit trusted reader for sparse replay data ([#3758](https://github.com/0xMiden/miden-vm/pull/3758)).
+- Hardened `ExecutionWitness` byte decoding with an input-sized budget and rejection of trailing bytes. Added an explicit trusted reader for sparse replay data ([#3758](https://github.com/0xMiden/miden-vm/pull/3758)).
 - [BREAKING] Limited bare `exp` to 63 exponent bits. It now lowers to `exp.u63` (72 cycles) and fails for exponents greater than or equal to `2^63`. Existing MAST artifacts containing the previous bare-`exp` lowering must be reassembled to use the new bound ([#3712](https://github.com/0xMiden/miden-vm/pull/3712)).
 
 ## v0.30.0 (2026-08-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 #### Fixes
 
-- Hardened `ExecutionWitness` byte decoding with an input-sized budget, exact canonical payload checks, and an explicit trusted reader for sparse replay data ([#3303](https://github.com/0xMiden/miden-vm/issues/3303)).
+- Hardened `ExecutionWitness` byte decoding with an input-sized budget, exact canonical payload checks, and an explicit trusted reader for sparse replay data ([#3758](https://github.com/0xMiden/miden-vm/pull/3758)).
 - [BREAKING] Limited bare `exp` to 63 exponent bits. It now lowers to `exp.u63` (72 cycles) and fails for exponents greater than or equal to `2^63`. Existing MAST artifacts containing the previous bare-`exp` lowering must be reassembled to use the new bound ([#3712](https://github.com/0xMiden/miden-vm/pull/3712)).
 
 ## v0.30.0 (2026-08-26)

--- a/core/src/deferred/wire.rs
+++ b/core/src/deferred/wire.rs
@@ -26,7 +26,7 @@ use crate::{
     Felt, ZERO,
     serde::{
         BudgetedReader, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
-        SliceReader,
+        SliceReader, read_bounded_len,
     },
 };
 
@@ -567,7 +567,8 @@ impl Serializable for DeferredStateWire {
 
 impl Deserializable for DeferredStateWire {
     fn read_from<R: ByteReader>(source: &mut R) -> Result<Self, DeserializationError> {
-        let entry_count = source.read_usize()?;
+        let entry_count =
+            read_bounded_len(source, "deferred wire entry", WireEntry::min_serialized_size())?;
         if entry_count > MAX_WIRE_ENTRIES {
             return Err(DeserializationError::InvalidValue(format!(
                 "deferred wire contains {entry_count} entries, maximum is {MAX_WIRE_ENTRIES}"
@@ -868,6 +869,21 @@ mod tests {
     fn wire_rejects_over_budget_entry_count() {
         assert!(
             DeferredStateWire::read_from_bytes(&encoded_entry_count(MAX_WIRE_ENTRIES + 1)).is_err()
+        );
+    }
+
+    #[test]
+    fn wire_rejects_entry_count_exceeding_remaining_input_before_allocation() {
+        let err = DeferredStateWire::read_from_bytes(&encoded_entry_count(MAX_WIRE_ENTRIES))
+            .expect_err("entry count without entry bytes should be rejected");
+        let DeserializationError::InvalidValue(message) = err else {
+            panic!("unexpected error: {err:?}");
+        };
+        assert!(
+            message.contains("deferred wire entry count")
+                && (message.contains("exceeds budget")
+                    || message.contains("exceeds remaining input")),
+            "unexpected error: {message}"
         );
     }
 

--- a/miden-vm/tests/integration/prove_verify.rs
+++ b/miden-vm/tests/integration/prove_verify.rs
@@ -542,10 +542,7 @@ mod execution_witness_serialization {
         DefaultHost, FastProcessor, HostLibrary, StackInputs, advice::AdviceInputs,
         trace::build_trace,
     };
-    use miden_prover::{
-        HashFunction, Prover,
-        serde::{Deserializable, Serializable},
-    };
+    use miden_prover::{HashFunction, Prover, serde::Serializable};
     #[cfg(feature = "arbitrary")]
     use miden_utils_testing::proptest::prelude::*;
     use miden_verifier::Verifier;
@@ -618,9 +615,8 @@ mod execution_witness_serialization {
         witness: ExecutionWitness,
     ) {
         let bytes = witness.to_bytes();
-        let budget = bytes.len().saturating_mul(4);
-        ExecutionWitness::read_from_bytes_with_budget(&bytes, budget)
-            .expect("witness seed should decode within the fuzzing budget");
+        ExecutionWitness::read_from_bytes(&bytes)
+            .expect("witness seed should pass adversarial byte-slice decoding");
         std::fs::write(corpus_dir.join(name), bytes).expect("witness seed should be writable");
     }
 
@@ -655,15 +651,8 @@ mod execution_witness_serialization {
 
             let expected_claim = witness.claim();
             let witness_bytes = witness.to_bytes();
-            let witness_budget = witness_bytes
-                .len()
-                .checked_mul(4)
-                .expect("generated witness budget should fit usize");
-            let restored = ExecutionWitness::read_from_bytes_with_budget(
-                &witness_bytes,
-                witness_budget,
-            )
-            .expect("generated witness should round trip");
+            let restored = ExecutionWitness::read_from_bytes(&witness_bytes)
+                .expect("generated witness should round trip");
 
             prop_assert_eq!(restored.claim(), expected_claim);
             prop_assert_eq!(restored.to_bytes(), witness_bytes);
@@ -732,11 +721,8 @@ mod execution_witness_serialization {
             original_trace.public_inputs().to_air_inputs()
         );
 
-        let witness_budget =
-            witness_bytes.len().checked_mul(4).expect("test input budget overflow");
-        let restored_witness =
-            ExecutionWitness::read_from_bytes_with_budget(&witness_bytes, witness_budget)
-                .expect("execution witness round trip");
+        let restored_witness = ExecutionWitness::read_from_bytes(&witness_bytes)
+            .expect("execution witness round trip");
         let proof = Prover::new()
             .with_hash_fn(HashFunction::Blake3_256)
             .prove(restored_witness)

--- a/processor/src/continuation_stack.rs
+++ b/processor/src/continuation_stack.rs
@@ -533,6 +533,10 @@ impl Deserializable for Continuation<MastForestId> {
             },
         }
     }
+
+    fn min_serialized_size() -> usize {
+        u8::min_serialized_size() + MastNodeId::min_serialized_size()
+    }
 }
 
 // `source_node_ids` is deliberately *not* serialized: those indices point into a package's

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -555,7 +555,7 @@ mod wire_tests {
     use miden_core::deferred::TRUE_DIGEST;
 
     use super::{ExecutionWitness, Serializable};
-    use crate::{DefaultHost, FastProcessor, StackInputs};
+    use crate::{DefaultHost, FastProcessor, StackInputs, mast::MastNodeId};
 
     fn execution_witness(source: &str) -> ExecutionWitness {
         let program = Assembler::default()
@@ -568,8 +568,12 @@ mod wire_tests {
             .expect("execution should produce a witness")
     }
 
+    fn deferred_witness() -> ExecutionWitness {
+        execution_witness("begin log_deferred end")
+    }
+
     fn deferred_witness_bytes() -> alloc::vec::Vec<u8> {
-        execution_witness("begin log_deferred end").to_bytes()
+        deferred_witness().to_bytes()
     }
 
     #[test]
@@ -613,6 +617,27 @@ mod wire_tests {
             ExecutionWitness::read_from_bytes_trusted(&bytes).is_ok(),
             "the explicit trusted reader should preserve the old permissive behavior"
         );
+    }
+
+    #[test]
+    fn witness_wire_accepts_large_minimally_encoded_continuation_stack() {
+        let mut witness = deferred_witness();
+        let continuation = &mut witness
+            .vm
+            .trace_replay_mut()
+            .core_trace_contexts
+            .first_mut()
+            .expect("witness should contain a trace fragment")
+            .continuation;
+        for _ in 0..4096 {
+            continuation.push_start_node(MastNodeId::from(0));
+        }
+
+        let bytes = witness.to_bytes();
+        let restored = ExecutionWitness::read_from_bytes(&bytes)
+            .expect("valid witness should fit its input-proportional allocation budget");
+
+        assert_eq!(restored.to_bytes(), bytes);
     }
 
     #[test]

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -116,10 +116,9 @@ impl ExecutionWitness {
     /// Decodes one execution witness from a potentially adversarial byte slice.
     ///
     /// The reader applies an input-proportional limit to byte consumption and collection
-    /// preallocation, rejects trailing bytes, and requires the payload to use the canonical
-    /// encoding produced by [`Serializable::to_bytes`]. These checks establish safe transport
-    /// syntax. They do not prove that the sparse MAST replay is a subset of a particular source
-    /// forest because the witness wire does not carry such a proof.
+    /// preallocation, then rejects trailing bytes. These checks establish safe transport syntax.
+    /// They do not prove that the sparse MAST replay is a subset of a particular source forest
+    /// because the witness wire does not carry such a proof.
     ///
     /// Use [`Self::read_from_bytes_trusted`] for bytes retained inside a trusted prover system.
     #[track_caller]
@@ -133,12 +132,6 @@ impl ExecutionWitness {
                 "extra bytes after execution witness payload".into(),
             ));
         }
-        if witness.to_bytes() != bytes {
-            return Err(DeserializationError::InvalidValue(
-                "execution witness bytes are not canonically encoded".into(),
-            ));
-        }
-
         Ok(witness)
     }
 

--- a/processor/src/trace/mod.rs
+++ b/processor/src/trace/mod.rs
@@ -9,7 +9,10 @@ use miden_air::{
 use miden_core::{
     deferred::{DeferredState, DeferredStateWire, Digest, TRUE_DIGEST},
     program::ExecutionClaim,
-    serde::{ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable},
+    serde::{
+        BudgetedReader, ByteReader, ByteWriter, Deserializable, DeserializationError, Serializable,
+        SliceReader,
+    },
 };
 
 use crate::{
@@ -109,7 +112,51 @@ impl ExecutionWitness {
     pub fn into_parts(self) -> (VmWitness, Option<PrecompileWitness>) {
         (self.vm, self.precompile)
     }
+
+    /// Decodes one execution witness from a potentially adversarial byte slice.
+    ///
+    /// The reader applies an input-proportional limit to byte consumption and collection
+    /// preallocation, rejects trailing bytes, and requires the payload to use the canonical
+    /// encoding produced by [`Serializable::to_bytes`]. These checks establish safe transport
+    /// syntax. They do not prove that the sparse MAST replay is a subset of a particular source
+    /// forest because the witness wire does not carry such a proof.
+    ///
+    /// Use [`Self::read_from_bytes_trusted`] for bytes retained inside a trusted prover system.
+    #[track_caller]
+    pub fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
+        let budget = bytes.len().saturating_mul(EXECUTION_WITNESS_BYTE_READ_BUDGET_MULTIPLIER);
+        let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
+        let witness = <Self as Deserializable>::read_from(&mut reader)?;
+
+        if reader.has_more_bytes() {
+            return Err(DeserializationError::InvalidValue(
+                "extra bytes after execution witness payload".into(),
+            ));
+        }
+        if witness.to_bytes() != bytes {
+            return Err(DeserializationError::InvalidValue(
+                "execution witness bytes are not canonically encoded".into(),
+            ));
+        }
+
+        Ok(witness)
+    }
+
+    /// Decodes execution witness bytes retained inside a trusted prover system.
+    ///
+    /// This preserves the original permissive byte-slice behavior. It trusts sparse MAST replay
+    /// hashes, accepts trailing bytes, and uses a replay-sized byte budget. Use
+    /// [`Self::read_from_bytes`] for bytes received across a trust boundary.
+    #[track_caller]
+    pub fn read_from_bytes_trusted(bytes: &[u8]) -> Result<Self, DeserializationError> {
+        let budget = bytes.len().saturating_mul(EXECUTION_WITNESS_BYTE_READ_BUDGET_MULTIPLIER);
+        let mut reader = BudgetedReader::new(SliceReader::new(bytes), budget);
+        <Self as Deserializable>::read_from(&mut reader)
+    }
 }
+
+/// Covers nested replay length checks while keeping untrusted work proportional to input size.
+const EXECUTION_WITNESS_BYTE_READ_BUDGET_MULTIPLIER: usize = 4;
 
 /// Current wire format version for [`ExecutionWitness`] serialization.
 ///
@@ -176,6 +223,10 @@ impl Deserializable for ExecutionWitness {
             },
         };
         Ok(Self { vm, precompile })
+    }
+
+    fn read_from_bytes(bytes: &[u8]) -> Result<Self, DeserializationError> {
+        ExecutionWitness::read_from_bytes(bytes)
     }
 }
 
@@ -503,7 +554,7 @@ mod wire_tests {
     use miden_assembly::Assembler;
     use miden_core::deferred::TRUE_DIGEST;
 
-    use super::{Deserializable, ExecutionWitness, Serializable};
+    use super::{ExecutionWitness, Serializable};
     use crate::{DefaultHost, FastProcessor, StackInputs};
 
     fn execution_witness(source: &str) -> ExecutionWitness {
@@ -543,6 +594,24 @@ mod wire_tests {
         assert!(
             format!("{err:?}").contains("unsupported execution witness wire version"),
             "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn witness_wire_rejects_trailing_bytes() {
+        let mut bytes = deferred_witness_bytes();
+        bytes.push(0);
+
+        let err = ExecutionWitness::read_from_bytes(&bytes)
+            .expect_err("witness payload with trailing bytes should be rejected");
+        assert!(
+            format!("{err:?}").contains("extra bytes after execution witness payload"),
+            "unexpected error: {err:?}"
+        );
+
+        assert!(
+            ExecutionWitness::read_from_bytes_trusted(&bytes).is_ok(),
+            "the explicit trusted reader should preserve the old permissive behavior"
         );
     }
 

--- a/tools/miden-core-fuzz/fuzz_targets/execution_witness_deserialize.rs
+++ b/tools/miden-core-fuzz/fuzz_targets/execution_witness_deserialize.rs
@@ -5,9 +5,8 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use miden_processor::{ExecutionWitness, serde::Deserializable};
+use miden_processor::ExecutionWitness;
 
 fuzz_target!(|data: &[u8]| {
-    let budget = data.len().saturating_mul(4);
-    let _ = ExecutionWitness::read_from_bytes_with_budget(data, budget);
+    let _ = ExecutionWitness::read_from_bytes(data);
 });


### PR DESCRIPTION
Closes #3303.

[#3314](https://github.com/0xMiden/miden-vm/pull/3314) changed the remote proving format to `ExecutionWitness`. This PR adds a bounded reader for witness bytes received from outside the prover.

The `ExecutionWitness` fuzz target now uses this reader. Tests cover invalid lengths and large valid continuation stacks.

Sparse MAST data cannot be checked against a source forest commitment, as agreed in [#3291](https://github.com/0xMiden/miden-vm/issues/3291#issuecomment-4897012906). The named trusted reader remains for witness bytes kept inside a trusted prover.