### PR TITLE
feat: Cache loaded MastForests in the FastProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 #### Changes
 
+- Cached loaded MAST forests in `FastProcessor` so repeated external calls reuse the forest and merge its advice map once ([#1949](https://github.com/0xMiden/miden-vm/issues/1949)).
+- [BREAKING] Removed the unused `SmtForest` type from `miden-crypto`. Use `LargeSmtForest` for shared SMT storage ([#3746](https://github.com/0xMiden/miden-vm/pull/3746)).
+- [BREAKING] Split precompile AIR and verification code from `miden-precompiles-prover` into `miden-precompiles-air` and `miden-precompiles-verifier`. Verifier users no longer build prover-only trace and witness code. Existing PVM proof bytes remain compatible ([#3734](https://github.com/0xMiden/miden-vm/pull/3734)).
 - Split the assembly crate's monolithic `tests.rs` into thematic modules under `crates/assembly/src/tests/` ([#3379](https://github.com/0xMiden/miden-vm/pull/3379)).
 - [BREAKING] Split precompile AIR and verification code from `miden-precompiles-prover` into `miden-precompiles-air` and `miden-precompiles-verifier`. Verifier users no longer build prover-only trace and witness code. Existing PVM proof bytes remain compatible ([#3734](https://github.com/0xMiden/miden-vm/pull/3734)).
 - [BREAKING] Removed the unused `SmtForest` type from `miden-crypto`. Use `LargeSmtForest` for shared SMT storage ([#3746](https://github.com/0xMiden/miden-vm/pull/3746)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## v0.32.0 (Unreleased)
 
+
+#### Features
+
+#### Changes
+
+- Cached loaded MAST forests in `FastProcessor` so repeated external calls reuse the forest and merge its advice map once ([#3764](https://github.com/0xMiden/miden-vm/pull/3764)).
+
+#### Fixes
+
 ## v0.31.0 (2026-09-02)
 
 #### Features
@@ -11,9 +20,7 @@
 
 #### Changes
 
-- Cached loaded MAST forests in `FastProcessor` so repeated external calls reuse the forest and merge its advice map once ([#1949](https://github.com/0xMiden/miden-vm/issues/1949)).
-- [BREAKING] Removed the unused `SmtForest` type from `miden-crypto`. Use `LargeSmtForest` for shared SMT storage ([#3746](https://github.com/0xMiden/miden-vm/pull/3746)).
-- [BREAKING] Split precompile AIR and verification code from `miden-precompiles-prover` into `miden-precompiles-air` and `miden-precompiles-verifier`. Verifier users no longer build prover-only trace and witness code. Existing PVM proof bytes remain compatible ([#3734](https://github.com/0xMiden/miden-vm/pull/3734)).
+- Cached loaded MAST forests in `FastProcessor` so repeated external calls reuse the forest and merge its advice map once ([#3764](https://github.com/0xMiden/miden-vm/pull/3764)).
 - Split the assembly crate's monolithic `tests.rs` into thematic modules under `crates/assembly/src/tests/` ([#3379](https://github.com/0xMiden/miden-vm/pull/3379)).
 - [BREAKING] Split precompile AIR and verification code from `miden-precompiles-prover` into `miden-precompiles-air` and `miden-precompiles-verifier`. Verifier users no longer build prover-only trace and witness code. Existing PVM proof bytes remain compatible ([#3734](https://github.com/0xMiden/miden-vm/pull/3734)).
 - [BREAKING] Removed the unused `SmtForest` type from `miden-crypto`. Use `LargeSmtForest` for shared SMT storage ([#3746](https://github.com/0xMiden/miden-vm/pull/3746)).

--- a/processor/src/fast/execution_api.rs
+++ b/processor/src/fast/execution_api.rs
@@ -20,6 +20,7 @@ use super::{
 use crate::PrecompileWitness;
 use crate::{
     ExecutionError, ExecutionOutput, ExecutionWitness, Host, LoadedMastForest, Stopper, SyncHost,
+    advice::AdviceError,
     continuation_stack::{Continuation, ContinuationStack, SourceInlineCallContext},
     errors::{
         MapExecErr, MapExecErrNoCtx, PackageSourceDebugContext, malformed_mast_forest_with_context,
@@ -1195,18 +1196,23 @@ impl FastProcessor {
         ),
         ExecutionError,
     > {
-        let loaded_mast_forest = host.get_mast_forest(&node_digest).ok_or_else(|| {
-            match (package_debug_info, source_node_id) {
-                (Some(debug_info), Some(source_node_id)) => {
-                    crate::errors::procedure_not_found_with_package_source_context(
-                        node_digest,
-                        PackageSourceDebugContext::new(debug_info, source_node_id),
-                        host,
-                    )
-                },
-                _ => crate::errors::procedure_not_found_with_context(node_digest),
-            }
-        })?;
+        let cached = self.loaded_mast_forests.get(&node_digest).cloned();
+        let was_cached = cached.is_some();
+        let loaded_mast_forest = match cached {
+            Some(mast_forest) => mast_forest,
+            None => host.get_mast_forest(&node_digest).ok_or_else(|| {
+                match (package_debug_info, source_node_id) {
+                    (Some(debug_info), Some(source_node_id)) => {
+                        crate::errors::procedure_not_found_with_package_source_context(
+                            node_digest,
+                            PackageSourceDebugContext::new(debug_info, source_node_id),
+                            host,
+                        )
+                    },
+                    _ => crate::errors::procedure_not_found_with_context(node_digest),
+                }
+            })?,
+        };
         let mast_forest = loaded_mast_forest.mast_forest().clone();
 
         let root_id = mast_forest.find_procedure_root(node_digest).ok_or_else(|| {
@@ -1219,7 +1225,10 @@ impl FastProcessor {
             malformed_mast_forest_with_context(node_digest, context, host)
         })?;
 
-        self.advice.extend_map(mast_forest.advice_map()).map_exec_err()?;
+        if !was_cached {
+            self.cache_loaded_mast_forest(&loaded_mast_forest);
+        }
+        self.merge_mast_forest_advice(&mast_forest).map_exec_err()?;
         let (loaded_package_debug_info, loaded_source_node_id) =
             Self::loaded_package_source_context(
                 &loaded_mast_forest,
@@ -1246,20 +1255,26 @@ impl FastProcessor {
         ),
         ExecutionError,
     > {
-        let loaded_mast_forest = if let Some(mast_forest) = host.get_mast_forest(&node_digest).await
-        {
-            mast_forest
-        } else {
-            return Err(match (package_debug_info, source_node_id) {
-                (Some(debug_info), Some(source_node_id)) => {
-                    crate::errors::procedure_not_found_with_package_source_context(
-                        node_digest,
-                        PackageSourceDebugContext::new(debug_info, source_node_id),
-                        host,
-                    )
-                },
-                _ => crate::errors::procedure_not_found_with_context(node_digest),
-            });
+        let cached = self.loaded_mast_forests.get(&node_digest).cloned();
+        let was_cached = cached.is_some();
+        let loaded_mast_forest = match cached {
+            Some(mast_forest) => mast_forest,
+            None => {
+                if let Some(mast_forest) = host.get_mast_forest(&node_digest).await {
+                    mast_forest
+                } else {
+                    return Err(match (package_debug_info, source_node_id) {
+                        (Some(debug_info), Some(source_node_id)) => {
+                            crate::errors::procedure_not_found_with_package_source_context(
+                                node_digest,
+                                PackageSourceDebugContext::new(debug_info, source_node_id),
+                                host,
+                            )
+                        },
+                        _ => crate::errors::procedure_not_found_with_context(node_digest),
+                    });
+                }
+            },
         };
         let mast_forest = loaded_mast_forest.mast_forest().clone();
 
@@ -1273,7 +1288,10 @@ impl FastProcessor {
             malformed_mast_forest_with_context(node_digest, context, host)
         })?;
 
-        self.advice.extend_map(mast_forest.advice_map()).map_exec_err()?;
+        if !was_cached {
+            self.cache_loaded_mast_forest(&loaded_mast_forest);
+        }
+        self.merge_mast_forest_advice(&mast_forest).map_exec_err()?;
         let (loaded_package_debug_info, loaded_source_node_id) =
             Self::loaded_package_source_context(
                 &loaded_mast_forest,
@@ -1282,6 +1300,23 @@ impl FastProcessor {
             )?;
 
         Ok((root_id, mast_forest, loaded_package_debug_info, loaded_source_node_id))
+    }
+
+    fn cache_loaded_mast_forest(&mut self, loaded_mast_forest: &LoadedMastForest) {
+        for procedure_digest in loaded_mast_forest.mast_forest().local_procedure_digests() {
+            self.loaded_mast_forests.insert(procedure_digest, loaded_mast_forest.clone());
+        }
+    }
+
+    fn merge_mast_forest_advice(&mut self, mast_forest: &MastForest) -> Result<(), AdviceError> {
+        let commitment = mast_forest.commitment();
+        if self.merged_mast_forests.contains(&commitment) {
+            return Ok(());
+        }
+
+        self.advice.extend_map(mast_forest.advice_map())?;
+        self.merged_mast_forests.insert(commitment);
+        Ok(())
     }
 
     fn loaded_package_source_context(

--- a/processor/src/fast/execution_api.rs
+++ b/processor/src/fast/execution_api.rs
@@ -1304,7 +1304,9 @@ impl FastProcessor {
 
     fn cache_loaded_mast_forest(&mut self, loaded_mast_forest: &LoadedMastForest) {
         for procedure_digest in loaded_mast_forest.mast_forest().local_procedure_digests() {
-            self.loaded_mast_forests.insert(procedure_digest, loaded_mast_forest.clone());
+            self.loaded_mast_forests
+                .entry(procedure_digest)
+                .or_insert_with(|| loaded_mast_forest.clone());
         }
     }
 

--- a/processor/src/fast/mod.rs
+++ b/processor/src/fast/mod.rs
@@ -1,4 +1,10 @@
-use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
+use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
 use core::{cmp::min, ops::ControlFlow};
 
 use miden_air::{Felt, trace::RowIndex};
@@ -15,7 +21,8 @@ use miden_mast_package::{
 };
 
 use crate::{
-    AdviceInputs, AdviceProvider, ContextId, ExecutionError, ExecutionOptions, ProcessorState,
+    AdviceInputs, AdviceProvider, ContextId, ExecutionError, ExecutionOptions, LoadedMastForest,
+    ProcessorState,
     advice::AdviceError,
     continuation_stack::{Continuation, ContinuationStack},
     errors::MapExecErrNoCtx,
@@ -122,6 +129,12 @@ pub struct FastProcessor {
 
     /// The advice provider to be used during execution.
     advice: AdviceProvider,
+
+    /// MAST forests loaded during this execution, indexed by their local procedure digests.
+    loaded_mast_forests: BTreeMap<Word, LoadedMastForest>,
+
+    /// Commitments of MAST forests whose advice maps have been merged into the advice provider.
+    merged_mast_forests: BTreeSet<Word>,
 
     /// A map from (context_id, word_address) to the word stored starting at that memory location.
     memory: Memory,
@@ -276,6 +289,8 @@ impl FastProcessor {
 
         Ok(Self {
             advice: AdviceProvider::new(advice_inputs, &options)?,
+            loaded_mast_forests: BTreeMap::new(),
+            merged_mast_forests: BTreeSet::new(),
             stack,
             stack_top_idx,
             stack_bot_idx: stack_top_idx - MIN_STACK_DEPTH,

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -4,7 +4,7 @@ use alloc::{
     sync::Arc,
     vec,
 };
-use core::{assert_matches, str::FromStr};
+use core::{assert_matches, cell::Cell, str::FromStr};
 
 use miden_air::trace::MIN_TRACE_LEN;
 use miden_assembly::{
@@ -40,7 +40,7 @@ use super::*;
 use crate::{
     AdviceInputs, BaseHost, DefaultHost, LoadedMastForest, ProcessorState, ProgramExecutor,
     SyncHost,
-    advice::AdviceMutation,
+    advice::{AdviceMap, AdviceMutation},
     event::EventError,
     operation::OperationError,
     processor::{StackInterface, SystemInterface},
@@ -1510,6 +1510,60 @@ struct MalformedExternalHost {
     loaded_mast_forest: LoadedMastForest,
 }
 
+struct CountingMastForestHost {
+    mast_forests: Vec<LoadedMastForest>,
+    lookup_count: Cell<usize>,
+}
+
+impl CountingMastForestHost {
+    fn new(mast_forests: impl IntoIterator<Item = Arc<MastForest>>) -> Self {
+        Self {
+            mast_forests: mast_forests.into_iter().map(LoadedMastForest::new).collect(),
+            lookup_count: Cell::new(0),
+        }
+    }
+
+    fn lookup_count(&self) -> usize {
+        self.lookup_count.get()
+    }
+}
+
+impl BaseHost for CountingMastForestHost {
+    fn get_label_and_source_file(
+        &self,
+        _location: &Location,
+    ) -> (SourceSpan, Option<Arc<SourceFile>>) {
+        (SourceSpan::UNKNOWN, None)
+    }
+}
+
+impl SyncHost for CountingMastForestHost {
+    fn get_mast_forest(&self, node_digest: &Word) -> Option<LoadedMastForest> {
+        self.lookup_count.set(self.lookup_count.get() + 1);
+        self.mast_forests
+            .iter()
+            .find(|loaded| loaded.mast_forest().find_procedure_root(*node_digest).is_some())
+            .cloned()
+    }
+
+    fn on_event(&mut self, _process: &ProcessorState) -> Result<Vec<AdviceMutation>, EventError> {
+        Ok(Vec::new())
+    }
+}
+
+fn program_calling_external_procedures(procedure_digests: [Word; 2]) -> Program {
+    let mut forest = MastForest::new();
+    let first = ExternalNodeBuilder::new(procedure_digests[0])
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let second = ExternalNodeBuilder::new(procedure_digests[1])
+        .add_to_forest(&mut forest)
+        .unwrap();
+    let root = JoinNodeBuilder::new([first, second]).add_to_forest(&mut forest).unwrap();
+    forest.make_root(root);
+    Program::new(forest.into(), root)
+}
+
 impl BaseHost for MalformedExternalHost {
     fn get_label_and_source_file(
         &self,
@@ -1529,6 +1583,78 @@ impl SyncHost for MalformedExternalHost {
     fn on_event(&mut self, _process: &ProcessorState) -> Result<Vec<AdviceMutation>, EventError> {
         Ok(Vec::new())
     }
+}
+
+#[test]
+fn caches_all_procedures_and_advice_from_a_loaded_mast_forest() {
+    let mut mast_forest = MastForest::new();
+    let first = BasicBlockNodeBuilder::new(vec![Operation::Noop])
+        .add_to_forest(&mut mast_forest)
+        .unwrap();
+    let second = BasicBlockNodeBuilder::new(vec![Operation::Incr])
+        .add_to_forest(&mut mast_forest)
+        .unwrap();
+    mast_forest.make_root(first);
+    mast_forest.make_root(second);
+    let procedure_digests = [mast_forest[first].digest(), mast_forest[second].digest()];
+    let advice_key = Word::from([ONE, ZERO, ZERO, ZERO]);
+    let mast_forest =
+        Arc::new(mast_forest.with_advice_map(AdviceMap::from_iter([(advice_key, vec![ONE])])));
+    let forest_commitment = mast_forest.commitment();
+    let program = program_calling_external_procedures(procedure_digests);
+    let mut host = CountingMastForestHost::new([mast_forest]);
+    let mut processor = FastProcessor::new(StackInputs::default());
+
+    processor.execute_mut_sync(&program, &mut host).unwrap();
+
+    assert_eq!(host.lookup_count(), 1);
+    assert_eq!(processor.loaded_mast_forests.len(), 2);
+    assert!(
+        procedure_digests
+            .iter()
+            .all(|digest| { processor.loaded_mast_forests.contains_key(digest) })
+    );
+    assert_eq!(processor.merged_mast_forests.len(), 1);
+    assert!(processor.merged_mast_forests.contains(&forest_commitment));
+    assert!(processor.advice.contains_map_key(&advice_key));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn caches_advice_from_distinct_mast_forests() {
+    let first_advice_key = Word::from([ONE, ZERO, ZERO, ZERO]);
+    let second_advice_key = Word::from([ZERO, ONE, ZERO, ZERO]);
+
+    let mut first_forest = MastForest::new();
+    let first_root = BasicBlockNodeBuilder::new(vec![Operation::Noop])
+        .add_to_forest(&mut first_forest)
+        .unwrap();
+    first_forest.make_root(first_root);
+    let first_digest = first_forest[first_root].digest();
+    let first_forest = Arc::new(
+        first_forest.with_advice_map(AdviceMap::from_iter([(first_advice_key, vec![ONE])])),
+    );
+
+    let mut second_forest = MastForest::new();
+    let second_root = BasicBlockNodeBuilder::new(vec![Operation::Incr])
+        .add_to_forest(&mut second_forest)
+        .unwrap();
+    second_forest.make_root(second_root);
+    let second_digest = second_forest[second_root].digest();
+    let second_forest = Arc::new(
+        second_forest.with_advice_map(AdviceMap::from_iter([(second_advice_key, vec![ONE])])),
+    );
+
+    let program = program_calling_external_procedures([first_digest, second_digest]);
+    let mut host = CountingMastForestHost::new([first_forest, second_forest]);
+    let mut processor = FastProcessor::new(StackInputs::default());
+
+    processor.execute_mut(&program, &mut host).await.unwrap();
+
+    assert_eq!(host.lookup_count(), 2);
+    assert_eq!(processor.loaded_mast_forests.len(), 2);
+    assert_eq!(processor.merged_mast_forests.len(), 2);
+    assert!(processor.advice.contains_map_key(&first_advice_key));
+    assert!(processor.advice.contains_map_key(&second_advice_key));
 }
 
 #[test]

--- a/processor/src/fast/tests/mod.rs
+++ b/processor/src/fast/tests/mod.rs
@@ -1658,6 +1658,44 @@ async fn caches_advice_from_distinct_mast_forests() {
 }
 
 #[test]
+fn preserves_first_cached_forest_for_a_shared_procedure() {
+    let mut first_forest = MastForest::new();
+    let shared_root = BasicBlockNodeBuilder::new(vec![Operation::Noop])
+        .add_to_forest(&mut first_forest)
+        .unwrap();
+    let first_unique_root = BasicBlockNodeBuilder::new(vec![Operation::Incr])
+        .add_to_forest(&mut first_forest)
+        .unwrap();
+    first_forest.make_root(shared_root);
+    first_forest.make_root(first_unique_root);
+    let shared_digest = first_forest[shared_root].digest();
+    let first_unique_digest = first_forest[first_unique_root].digest();
+    let first_forest = Arc::new(first_forest);
+    let first_commitment = first_forest.commitment();
+
+    let mut second_forest = MastForest::new();
+    let second_shared_root = BasicBlockNodeBuilder::new(vec![Operation::Noop])
+        .add_to_forest(&mut second_forest)
+        .unwrap();
+    let second_unique_root = BasicBlockNodeBuilder::new(vec![Operation::Neg])
+        .add_to_forest(&mut second_forest)
+        .unwrap();
+    second_forest.make_root(second_shared_root);
+    second_forest.make_root(second_unique_root);
+    let second_unique_digest = second_forest[second_unique_root].digest();
+    let second_forest = Arc::new(second_forest);
+
+    let program = program_calling_external_procedures([first_unique_digest, second_unique_digest]);
+    let mut host = CountingMastForestHost::new([first_forest, second_forest]);
+    let mut processor = FastProcessor::new(StackInputs::default());
+
+    processor.execute_mut_sync(&program, &mut host).unwrap();
+
+    let cached_shared_forest = processor.loaded_mast_forests.get(&shared_digest).unwrap();
+    assert_eq!(cached_shared_forest.mast_forest().commitment(), first_commitment);
+}
+
+#[test]
 fn package_source_debug_missing_external_preserves_external_source_span() {
     let (program, package_debug_info, mut host, _, expected_span, source_file) =
         missing_external_package_source_debug_fixture();


### PR DESCRIPTION
Closes [#1949](https://github.com/0xMiden/miden-vm/issues/1949).

`FastProcessor` still asked the host for the same MAST forest on each external call. This was the part left open when [#1953 removed the old cache](https://github.com/0xMiden/miden-vm/pull/1953#issuecomment-3052971764).

This change adds a cache for one execution, keyed by every [local procedure digest](https://github.com/0xMiden/miden-vm/blob/727dfec86b1cd574e3c6828c5f06dcb858c45512/core/src/mast/mod.rs#L561-L569). Sync and async calls use the cache before asking the host. The first forest stored for a digest stays in place.

`FastProcessor` tracks merged advice maps by the [forest commitment that binds the advice map](https://github.com/0xMiden/miden-vm/blob/727dfec86b1cd574e3c6828c5f06dcb858c45512/core/src/mast/mod.rs#L612-L628). It records the commitment only after the merge succeeds.

Tests cover one host lookup for two procedures in one forest. They also cover separate advice maps and shared procedure digests.