### PR TITLE
fix(ci): handle placeholder crates in release checks

### DIFF
--- a/.github/workflows/workspace-dry-run.yml
+++ b/.github/workflows/workspace-dry-run.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
 
       - name: Build MASM packages

--- a/scripts/check-masm-root-stability.sh
+++ b/scripts/check-masm-root-stability.sh
@@ -46,8 +46,6 @@ latest_release_tag_on_head() {
 
 parse_version "$workspace_version" current
 
-git -C "$repo_root" fetch --tags origin
-
 baseline_tag="$(latest_release_tag_on_head)"
 if [[ -z "$baseline_tag" ]]; then
     echo "No release tag found on the current branch history; skipping MASM root stability check"

--- a/scripts/check-package-release-plan.sh
+++ b/scripts/check-package-release-plan.sh
@@ -159,8 +159,15 @@ else
         local_version="${semver_local_versions[$i]}"
         latest_version="${semver_latest_versions[$i]}"
 
-        echo "Checking semver for $package v$local_version against published v$latest_version"
         baseline_commit="$(baseline_commit_for "$package" "$latest_version" || true)"
+        if [[ -z "$baseline_commit" ]] &&
+            ! published_package_has_library_target "$package" "$latest_version"; then
+            echo "Skipping semver for $package because published v$latest_version has no library target."
+            would_publish+=("$package v$local_version (latest published: $latest_version)")
+            continue
+        fi
+
+        echo "Checking semver for $package v$local_version against published v$latest_version"
         if run_semver_check "$package" "$latest_version" "$workspace_root" "$baseline_commit"; then
             would_publish+=("$package v$local_version (latest published: $latest_version)")
         else

--- a/scripts/lib/release-plan-common.sh
+++ b/scripts/lib/release-plan-common.sh
@@ -54,6 +54,47 @@ download_published_crate() {
     esac
 }
 
+published_package_has_library_target() {
+    local package="$1"
+    local version="$2"
+    local archive="$RELEASE_PLAN_TMPDIR/published-crates/$package-$version.crate"
+    local source_dir="$RELEASE_PLAN_TMPDIR/published-sources/$package-$version"
+    local manifest_path="$source_dir/$package-$version/Cargo.toml"
+    local published_metadata
+
+    check_command "tar"
+
+    mkdir -p "$(dirname "$archive")" "$source_dir"
+    if [[ ! -f "$archive" ]]; then
+        download_published_crate "$package" "$version" "$archive"
+    fi
+
+    if ! tar -xzf "$archive" -C "$source_dir"; then
+        echo "ERROR: could not extract published archive for $package v$version" >&2
+        exit 1
+    fi
+
+    if [[ ! -f "$manifest_path" ]]; then
+        echo "ERROR: published archive for $package v$version has no Cargo.toml" >&2
+        exit 1
+    fi
+
+    if ! published_metadata="$(
+        cargo metadata --manifest-path "$manifest_path" --no-deps --format-version 1
+    )"; then
+        echo "ERROR: could not read package metadata for published $package v$version" >&2
+        exit 1
+    fi
+
+    printf '%s' "$published_metadata" |
+        jq -e --arg package "$package" '
+          .packages[]
+          | select(.name == $package)
+          | .targets[]
+          | select(.kind | index("lib") or index("rlib"))
+        ' >/dev/null
+}
+
 latest_published_version() {
     local package="$1"
     local body_file="$RELEASE_PLAN_TMPDIR/${package}.latest.json"


### PR DESCRIPTION
#3766 has two failed release checks. Its build and test jobs pass.

The root cause of the [package version failure](https://github.com/0xMiden/miden-vm/actions/runs/33693806838/job/100458224997) is two `0.0.0` crates on crates.io. They hold the names `miden-precompiles-air` and `miden-precompiles-verifier` for this project. Each crate is a small program with no Rust library. `cargo-semver-checks` compares public Rust code between _library_ releases, so it cannot use either crate as the older release.

The package check now skips this comparison when the published crate has no library. Major releases with a library still run `cargo-semver-checks`.

The root cause of the [release dry run failure](https://github.com/0xMiden/miden-vm/actions/runs/33693809496/job/100458232857) is a Git tag fetch that runs _after_ checkout. Checkout does not keep a login for later Git commands, so the fetch fails.

The workflow now fetches tags during checkout. The MASM root check uses those local tags.
