### PR TITLE
feat: prepare v0.31.1 with public security types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Changes
 
-- Re-exported the security estimator types used in public proof APIs so downstream callers can name them through Miden crates.
+- Re-exported the security estimator types used in public proof APIs so downstream callers can name them through Miden crates ([#3774](https://github.com/0xMiden/miden-vm/pull/3774)).
 
 #### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.31.1 (Unreleased)
+
+#### Features
+
+#### Changes
+
+- Re-exported the security estimator types used in public proof APIs so downstream callers can name them through Miden crates.
+
+#### Fixes
+
 ## v0.31.0 (2026-09-02)
 
 #### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2046,7 +2046,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-constraint-compiler",
  "miden-core",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "insta",
  "miden-ace-codegen",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "env_logger",
  "insta",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "env_logger",
  "log",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "miden-bench"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "clap",
  "miden-lifted-stark",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "miden-constraint-compiler"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "criterion",
  "derive_more",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "criterion",
  "env_logger",
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core-lib-codegen"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-core",
  "miden-precompiles",
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "assert_matches",
  "blake3",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-field",
  "quote",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-smt-codspeed-bench"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-crypto",
@@ -2306,7 +2306,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-wycheproof-tests"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "ed25519-dalek",
  "hex",
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [[package]]
 name = "miden-format"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "clap",
  "miden-assembly-syntax-cst",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-field",
  "p3-air 0.6.3",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "criterion",
  "miden-lifted-air",
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "codspeed-criterion-compat",
  "hashbrown 0.17.1",
@@ -2483,7 +2483,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry-local"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "clap",
  "miden-assembly-syntax",
@@ -2514,7 +2514,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles-air"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles-prover"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "k256",
  "miden-air",
@@ -2558,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles-verifier"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "insta",
  "miden-ace-codegen",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "hashbrown 0.17.1",
  "insta",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "miden-prover"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-air",
  "miden-assembly",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-field 0.6.3",
  "p3-goldilocks",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-challenger",
  "p3-field 0.6.3",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-bn254",
  "p3-field 0.6.3",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "miden-test-serialization-macros"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "proc-macro2",
  "proptest",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "miden-test-utils"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "env_logger",
  "miden-air",
@@ -2715,7 +2715,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-serde-utils",
  "miden-test-serialization-macros",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "lock_api",
  "loom",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "miden-verifier"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-air",
  "miden-core",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-blake3-bench"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "clap",
  "codspeed-criterion-compat",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-precompiles-bench"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-core",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "miden-vm-synthetic-bench"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "codspeed-criterion-compat",
  "miden-assembly",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ rust-version = "1.96.1"
 # Private workspace members inherit this version. Publishable crates keep their
 # own package versions so release tooling can publish only the crates selected
 # for a release.
-version = "0.31.0"
+version = "0.31.1"
 
 [profile.optimized]
 inherits = "release"

--- a/air/Cargo.toml
+++ b/air/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-air"
-version = "0.31.0"
+version = "0.31.1"
 description = "Algebraic intermediate representation of Miden VM processor"
 documentation = "https://docs.rs/miden-air"
 readme = "README.md"

--- a/air/src/security.rs
+++ b/air/src/security.rs
@@ -6,13 +6,11 @@
 
 use miden_core::field::{BasedVectorSpace, PrimeField64, QuadFelt};
 use miden_crypto::{hash::poseidon2::Poseidon2, stark::pcs::PcsParams};
-use p3_security::{
-    budget::{
-        AirShape, InstanceShape, LookupShape, ProtocolParams, SecurityReport, SecurityTerm,
-        report::LOOKUP_LABEL,
-    },
-    fixed,
+/// Security-estimation types used by verified Miden proofs.
+pub use p3_security::budget::{
+    AirShape, InstanceShape, LookupShape, ProtocolParams, SecurityReport, SecurityTerm,
 };
+use p3_security::{budget::report::LOOKUP_LABEL, fixed};
 
 use crate::{
     AIRS, ConstraintCounts, ConstraintDegrees, Felt, MidenAir, config,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.31.0"
+version = "0.31.1"
 description = "Miden VM core components"
 documentation = "https://docs.rs/miden-core"
 readme = "README.md"

--- a/crates/ace-codegen/Cargo.toml
+++ b/crates/ace-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-ace-codegen"
-version = "0.31.0"
+version = "0.31.1"
 description = "ACE circuit codegen for Plonky3-based Miden AIRs."
 documentation = "https://docs.rs/miden-ace-codegen"
 readme = "README.md"

--- a/crates/assembly-syntax-cst/Cargo.toml
+++ b/crates/assembly-syntax-cst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax-cst"
-version = "0.31.0"
+version = "0.31.1"
 description = "Lossless concrete syntax tree support for the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax-cst"
 readme = "README.md"

--- a/crates/assembly-syntax/Cargo.toml
+++ b/crates/assembly-syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly-syntax"
-version = "0.31.0"
+version = "0.31.1"
 description = "Parsing and semantic analysis of the Miden Assembly language"
 documentation = "https://docs.rs/miden-assembly-syntax"
 readme = "README.md"

--- a/crates/assembly/Cargo.toml
+++ b/crates/assembly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-assembly"
-version = "0.31.0"
+version = "0.31.1"
 description = "Miden VM assembly language"
 documentation = "https://docs.rs/miden-assembly"
 readme = "README.md"

--- a/crates/crypto-derive/Cargo.toml
+++ b/crates/crypto-derive/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "miden-crypto-derive"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.31.0"
+version = "0.31.1"
 
 [lib]
 doctest    = false

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-crypto"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.31.0"
+version = "0.31.1"
 
 [[bin]]
 bench             = false

--- a/crates/debug-types/Cargo.toml
+++ b/crates/debug-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-debug-types"
-version = "0.31.0"
+version = "0.31.1"
 description = "Core source-level debugging information types used throughout the Miden toolchain"
 documentation = "https://docs.rs/miden-debug-types"
 readme = "README.md"

--- a/crates/field/Cargo.toml
+++ b/crates/field/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-field"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.31.0"
+version = "0.31.1"
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/lib/core/Cargo.toml
+++ b/crates/lib/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core-lib"
-version = "0.31.0"
+version = "0.31.1"
 description = "Miden VM core library"
 documentation = "https://docs.rs/miden-core-lib"
 readme = "README.md"

--- a/crates/lib/core/asm/miden-project.toml
+++ b/crates/lib/core/asm/miden-project.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-core"
-version = "0.31.0"
+version = "0.31.1"
 
 [lib]
 namespace = "miden::core"

--- a/crates/lifted-air/Cargo.toml
+++ b/crates/lifted-air/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-lifted-air"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.31.0"
+version = "0.31.1"
 
 [lib]
 doctest = true

--- a/crates/lifted-stark/Cargo.toml
+++ b/crates/lifted-stark/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-lifted-stark"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.31.0"
+version = "0.31.1"
 
 [lib]
 doctest = false

--- a/crates/mast-package/Cargo.toml
+++ b/crates/mast-package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-mast-package"
-version = "0.31.0"
+version = "0.31.1"
 description = "Package containing a compiled Miden MAST artifact with declared dependencies and exports"
 documentation = "https://docs.rs/miden-mast-package"
 readme = "README.md"

--- a/crates/miden-constraint-compiler/Cargo.toml
+++ b/crates/miden-constraint-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-constraint-compiler"
-version = "0.31.0"
+version = "0.31.1"
 description = "Constraint compiler for Plonky3-based Miden AIRs."
 documentation = "https://docs.rs/miden-constraint-compiler"
 readme = "README.md"

--- a/crates/miden-format/Cargo.toml
+++ b/crates/miden-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-format"
-version = "0.31.0"
+version = "0.31.1"
 description = "Formatter for the Miden Assembly language"
 documentation = "https://docs.rs/miden-format"
 readme = "README.md"

--- a/crates/package-registry-local/Cargo.toml
+++ b/crates/package-registry-local/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry-local"
-version = "0.31.0"
+version = "0.31.1"
 description = "Filesystem-backed local package registry for Miden packages"
 documentation = "https://docs.rs/miden-package-registry-local"
 readme = "README.md"

--- a/crates/package-registry/Cargo.toml
+++ b/crates/package-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-package-registry"
-version = "0.31.0"
+version = "0.31.1"
 description = "Package registry interfaces and dependency resolution for Miden packages"
 documentation = "https://docs.rs/miden-package-registry"
 readme = "README.md"

--- a/crates/precompiles-air/src/security.rs
+++ b/crates/precompiles-air/src/security.rs
@@ -1,14 +1,17 @@
 //! Conjectured security level computation for the precompile chiplet stack.
 //!
 //! The chiplet stack proves a different statement from the VM and therefore has its own AIR shape.
-//! Both statements use the round-budget formulas in [`p3_security::budget`] and the same challenge
-//! field. Their recursive verifiers both use Poseidon2. Native verification derives alignment and
-//! collision resistance from the commitment scheme used for each proof.
+//! Both statements use the same round-budget formulas and challenge field. Their recursive
+//! verifiers both use Poseidon2. Native verification derives alignment and collision resistance
+//! from the commitment scheme used for each proof.
 //!
 //! [`AIR_SHAPE`] stores the relation shape used by the security calculation, while
 //! `air_shape_matches_symbolic` checks it against the shape obtained from the chiplet AIRs.
 
-pub use miden_air::security::ProofSecurityParameters;
+pub use miden_air::security::{
+    AirShape, InstanceShape, LookupShape, ProofSecurityParameters, ProtocolParams, SecurityReport,
+    SecurityTerm,
+};
 use miden_air::security::{CHALLENGE_FIELD_BITS, COLLISION_RESISTANCE, COMMITMENT_ALIGNMENT};
 use miden_core::{
     Felt,
@@ -16,13 +19,7 @@ use miden_core::{
 };
 use miden_crypto::stark::pcs::PcsParams;
 use miden_lifted_air::{BaseAir, ConstraintCounts, ConstraintDegrees, LiftedAir};
-use p3_security::{
-    budget::{
-        AirShape, InstanceShape, LookupShape, ProtocolParams, SecurityReport, SecurityTerm,
-        report::LOOKUP_LABEL,
-    },
-    fixed,
-};
+use p3_security::{budget::report::LOOKUP_LABEL, fixed};
 
 use crate::{
     ChipletAir,

--- a/crates/precompiles-verifier/src/lib.rs
+++ b/crates/precompiles-verifier/src/lib.rs
@@ -8,7 +8,10 @@ pub use miden_core::{
     deferred::DeferredRoot,
     proof::{HashFunction, StarkProof},
 };
-pub use miden_precompiles_air::security::ProofSecurityParameters;
+pub use miden_precompiles_air::security::{
+    AirShape, InstanceShape, LookupShape, ProofSecurityParameters, ProtocolParams, SecurityReport,
+    SecurityTerm,
+};
 
 #[cfg(any(test, feature = "std"))]
 pub(crate) mod ace;

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-project"
-version = "0.31.0"
+version = "0.31.1"
 description = "Interface for working with Miden projects"
 documentation = "https://docs.rs/miden-project"
 readme = "README.md"

--- a/crates/serde-utils/Cargo.toml
+++ b/crates/serde-utils/Cargo.toml
@@ -10,7 +10,7 @@ name                   = "miden-serde-utils"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.31.0"
+version = "0.31.1"
 
 [features]
 default = ["std"]

--- a/crates/stark-transcript/Cargo.toml
+++ b/crates/stark-transcript/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-stark-transcript"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.31.0"
+version = "0.31.1"
 
 [lib]
 doctest = false

--- a/crates/stateful-hasher/Cargo.toml
+++ b/crates/stateful-hasher/Cargo.toml
@@ -7,7 +7,7 @@ name                   = "miden-stateful-hasher"
 readme.workspace       = true
 repository.workspace   = true
 rust-version.workspace = true
-version = "0.31.0"
+version = "0.31.1"
 
 [lib]
 doctest = false

--- a/crates/test-serialization-macros/Cargo.toml
+++ b/crates/test-serialization-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-test-serialization-macros"
-version = "0.31.0"
+version = "0.31.1"
 description = "Proc macros for serialization round-trip testing in Miden VM"
 readme = "README.md"
 categories = ["development-tools::testing", "no-std"]

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-test-utils"
-version = "0.31.0"
+version = "0.31.1"
 description = "Test utilities for Miden VM programs"
 readme = "README.md"
 categories = ["development-tools::testing", "no-std"]

--- a/crates/utils-core-derive/Cargo.toml
+++ b/crates/utils-core-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-core-derive"
-version = "0.31.0"
+version = "0.31.1"
 description = "Proc macro to derive enum dispatch trait implementations on miden-core structs"
 readme = "README.md"
 categories = ["development-tools::procedural-macro-helpers", "no-std"]

--- a/crates/utils-diagnostics/Cargo.toml
+++ b/crates/utils-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-diagnostics"
-version = "0.31.0"
+version = "0.31.1"
 description = "Diagnostic infrastructure used in the Miden assembler and VM"
 documentation = "https://docs.rs/miden-utils-diagnostics"
 readme = "README.md"

--- a/crates/utils-indexing/Cargo.toml
+++ b/crates/utils-indexing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-indexing"
-version = "0.31.0"
+version = "0.31.1"
 description = "Type-safe u32-indexed vector utilities for Miden"
 readme = "README.md"
 categories = ["development-tools", "no-std"]

--- a/crates/utils-sync/Cargo.toml
+++ b/crates/utils-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-utils-sync"
-version = "0.31.0"
+version = "0.31.1"
 description = "no-std compatible locking primitives for the Miden project"
 documentation = "https://docs.rs/miden-utils-sync"
 readme = "README.md"

--- a/miden-vm/Cargo.toml
+++ b/miden-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-vm"
-version = "0.31.0"
+version = "0.31.1"
 description = "Miden virtual machine"
 documentation = "https://docs.rs/miden-vm"
 readme = "README.md"

--- a/miden-vm/src/lib.rs
+++ b/miden-vm/src/lib.rs
@@ -28,7 +28,8 @@ pub use miden_processor::{
 };
 pub use miden_prover::{InputError, Prover, ProverError, StackOutputs, Word, prove_sync};
 pub use miden_verifier::{
-    ProofSecurityParameters, VerificationError, VerificationOutcome, Verifier,
+    AirShape, InstanceShape, LookupShape, ProofSecurityParameters, ProtocolParams, SecurityReport,
+    SecurityTerm, VerificationError, VerificationOutcome, Verifier,
 };
 
 /// Hydrates a passive deferred-state wire using the standard bundled precompile registry.

--- a/miden-vm/tests/security_reexports.rs
+++ b/miden-vm/tests/security_reexports.rs
@@ -1,0 +1,15 @@
+use miden_vm::{
+    AirShape, InstanceShape, LookupShape, ProofSecurityParameters, ProtocolParams, SecurityReport,
+    SecurityTerm,
+};
+
+#[test]
+fn security_types_are_available_through_the_vm_crate() {
+    let _: Option<AirShape> = None;
+    let _: Option<InstanceShape> = None;
+    let _: Option<LookupShape> = None;
+    let _: Option<ProofSecurityParameters> = None;
+    let _: Option<ProtocolParams> = None;
+    let _: Option<SecurityReport> = None;
+    let _: Option<SecurityTerm> = None;
+}

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-processor"
-version = "0.31.0"
+version = "0.31.1"
 description = "Miden VM processor"
 documentation = "https://docs.rs/miden-processor"
 readme = "README.md"

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-prover"
-version = "0.31.0"
+version = "0.31.1"
 description = "Miden VM prover"
 documentation = "https://docs.rs/miden-prover"
 readme = "README.md"

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -742,7 +742,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miden-ace-codegen"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-constraint-compiler",
  "miden-core",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "miden-air"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-ace-codegen",
  "miden-core",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "log",
  "miden-assembly-syntax",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "log",
  "miden-assembly-syntax-cst",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "miden-assembly-syntax-cst"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-debug-types",
  "miden-rowan",
@@ -810,7 +810,7 @@ dependencies = [
 
 [[package]]
 name = "miden-constraint-compiler"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "miden-core"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "derive_more",
  "log",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "blake3",
  "cc",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "miden-debug-types"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "memchr",
  "miden-crypto",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-air 0.6.3",
  "p3-challenger",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "miden-mast-package"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "hashbrown",
  "miden-assembly-syntax",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "miden-package-registry"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "miden-precompiles"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-core",
  "miden-crypto",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "miden-processor"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "hashbrown",
  "itertools",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "miden-project"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-assembly-syntax",
  "miden-core",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-field 0.6.3",
  "p3-goldilocks",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-challenger",
  "p3-field 0.6.3",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-field 0.6.3",
  "p3-symmetric",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-core-derive"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-diagnostics"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-debug-types",
  "miden-miette",
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-indexing"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-serde-utils",
  "proptest",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "miden-utils-sync"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "lock_api",
  "loom",

--- a/tools/miden-crypto-fuzz/Cargo.lock
+++ b/tools/miden-crypto-fuzz/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "blake3",
  "cc",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "miden-crypto-derive"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "quote",
  "syn 2.0.119",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "miden-field"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-serde-utils",
  "num-bigint 0.5.1",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-air"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-air",
  "p3-challenger",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "miden-lifted-stark"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "miden-lifted-air",
  "miden-stark-transcript",
@@ -619,7 +619,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-field",
  "p3-goldilocks",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stark-transcript"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-challenger",
  "p3-field",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "miden-stateful-hasher"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-field",
  "p3-symmetric",

--- a/tools/miden-serde-utils-fuzz/Cargo.lock
+++ b/tools/miden-serde-utils-fuzz/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "miden-serde-utils"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "p3-field",
  "p3-goldilocks",

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miden-verifier"
-version = "0.31.0"
+version = "0.31.1"
 description = "Miden VM execution verifier"
 documentation = "https://docs.rs/miden-verifier"
 readme = "README.md"

--- a/verifier/src/lib.rs
+++ b/verifier/src/lib.rs
@@ -37,7 +37,10 @@ mod exports {
     }
 }
 pub use exports::*;
-pub use miden_air::security::ProofSecurityParameters;
+pub use miden_air::security::{
+    AirShape, InstanceShape, LookupShape, ProofSecurityParameters, ProtocolParams, SecurityReport,
+    SecurityTerm,
+};
 
 pub mod recursive;
 


### PR DESCRIPTION
Miden VM normally reexports the P3 types used in its public APIs. Callers can then use a Miden path and get the exact type version that Miden expects. The proof security API in 0.31.0 was an exception. It returned types from `p3-security` 0.7.0-rc.1 without reexporting them.

Callers had to add `p3-security` to their own `Cargo.toml` to write a type annotation or build one of those values. This exposed a version split that Miden normally hides. Miden's field and AIR APIs use P3 0.6.3, while `p3-security` brings in the P3 0.7.0 release candidates. Rust treats types from those two versions as different types.

This patch reexports the six security budget types through each Miden verifier layer to the `miden-vm` crate root. Callers can name the returned types through the Miden crate they already use. Existing APIs and proof bytes stay the same.

This patch does not align the two P3 version families. The duplicate dependency and `cargo deny` failure remain tracked in [#3773](https://github.com/0xMiden/miden-vm/issues/3773) (and can only be resolved by a p3 0.7.0 release).

<details>
<summary>Which P3 version should callers use?</summary>

For a field or AIR type passed to Miden, callers should use the type reexported by the matching Miden crate. Those types come from P3 0.6.3.

For a security budget type returned by Miden, callers can now use the new Miden reexport. Those types come from `p3-security` 0.7.0-rc.1.

Code that depends on P3 directly must use the version expected at each API boundary. A type from P3 0.7.0-rc.1 cannot replace the same named type from P3 0.6.3. The [v0.31.0 dependency table](https://github.com/0xMiden/miden-vm/blob/v0.31.0/Cargo.toml#L181-L203) shows both version families, and the [security result fields](https://github.com/0xMiden/miden-vm/blob/v0.31.0/air/src/security.rs#L29-L41) show the types that lacked a Miden path.

</details>