### PR TITLE
chore: Clean up v0.32.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 
-## v0.32.0 (Unreleased)
-
-#### Features
+## v0.32.0 (2026-09-05)
 
 #### Changes
 
@@ -15,13 +13,9 @@
 
 ## v0.31.1 (2026-09-04)
 
-#### Features
-
 #### Changes
 
 - Re-exported the security estimator types used in public proof APIs so downstream callers can name them through Miden crates ([#3774](https://github.com/0xMiden/miden-vm/pull/3774)).
-
-#### Fixes
 
 ## v0.31.0 (2026-09-02)
 


### PR DESCRIPTION
- Dates v0.32.0 as 2026-09-05.
- Removes empty sections from v0.31.1 and v0.32.0.