### PR TITLE
perf(crypto): native runtime optimizations for Eidos compression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,13 +65,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - backend: SSE2
+            target_features: -avx2,-avx512f,-avx512vl
+            required_cpu_features: sse2
+            forbidden_target_features: avx2 avx512f avx512vl
           - backend: AVX2
-            target_features: +avx2,-avx512f
+            target_features: +avx2,-avx512f,-avx512vl
             required_cpu_features: avx2
-            forbidden_target_features: avx512f
-          - backend: AVX-512
-            target_features: +avx2,+avx512f
-            required_cpu_features: avx2 avx512f
+            forbidden_target_features: avx512f avx512vl
+          - backend: AVX-512F/VL
+            target_features: +avx2,+avx512f,+avx512vl
+            required_cpu_features: avx2 avx512f avx512vl
             forbidden_target_features: ""
     env:
       RUSTFLAGS: -C target-feature=${{ matrix.target_features }}
@@ -110,7 +114,7 @@ jobs:
         uses: taiki-e/install-action@b6b84cf49ebfe0176417bdce007c624f0db37f20 # v2.86.2
         with:
           tool: cargo-nextest
-      - name: Verify selected Rust backend
+      - name: Verify configured Rust target features
         env:
           FORBIDDEN_TARGET_FEATURES: ${{ matrix.forbidden_target_features }}
           REQUIRED_TARGET_FEATURES: ${{ matrix.required_cpu_features }}
@@ -132,9 +136,21 @@ jobs:
               exit 1
             fi
           done
-          echo "Selected Eidos backend: ${{ matrix.backend }}"
+          echo "Configured Eidos target: ${{ matrix.backend }}"
+      - name: Check every miden-crypto target with the configured target features
+        # `cfg(test)` keeps otherwise-gated helpers alive, so the plain library build has to be
+        # checked on its own: once with runtime dispatch (`std`) and once with compile-time backend
+        # selection (`no_std`).
+        env:
+          RUSTFLAGS: -D warnings -C target-feature=${{ matrix.target_features }}
+        run: |
+          cargo check -p miden-crypto --all-targets
+          cargo check -p miden-crypto --lib --no-default-features
       - name: Run Eidos backend equivalence and vector tests
-        run: cargo nextest run --profile ci -p miden-crypto --lib --no-tests=fail 'hash::eidos::'
+        # Disabling the crate's `std` feature makes target features select the exact backend. The
+        # default-feature crypto job above exercises runtime CPU dispatch and checks each x86-64
+        # backend directly on the runner's CPU.
+        run: cargo nextest run --profile ci -p miden-crypto --lib --no-default-features --no-tests=fail 'hash::eidos::'
 
   doc-tests:
     name: doc-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [BREAKING] Added Eidos hashing with typed domain separation, including Eidos-backed IES, random-coin, and length-bound LMCS implementations; existing Poseidon2 variants remain available.
 
+#### Changes
+
+- Accelerated `miden-crypto` Eidos hashing and proof-of-work grinding with a fixed 16-lane logical batch and runtime x86-64 SIMD dispatch ([#3782](https://github.com/0xMiden/miden-vm/pull/3782)).
+
 ## v0.32.0 (2026-09-05)
 
 #### Changes

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -26,6 +26,11 @@ required-features = ["std"]
 
 [[bench]]
 harness           = false
+name              = "eidos_challenger"
+required-features = ["std"]
+
+[[bench]]
+harness           = false
 name              = "hash"
 required-features = ["std"]
 

--- a/crates/crypto/benches/eidos_challenger.rs
+++ b/crates/crypto/benches/eidos_challenger.rs
@@ -1,0 +1,62 @@
+use std::hint::black_box;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use miden_crypto::{
+    Felt, Word, field::PrimeField64, hash::eidos::EidosChallenger, parallel::*,
+    stark::challenger::GrindingChallenger,
+};
+
+const CASES: [(usize, usize); 4] = [(4, 0), (12, 0), (17, 0), (12, 7)];
+
+fn challenger_with_buffer(buffer_len: usize) -> EidosChallenger {
+    let mut challenger = EidosChallenger::new(Word::new([
+        Felt::new_unchecked(1),
+        Felt::new_unchecked(2),
+        Felt::new_unchecked(3),
+        Felt::new_unchecked(4),
+    ]));
+    for value in 0..buffer_len {
+        challenger.observe_felt(Felt::new_unchecked(100 + value as u64));
+    }
+    challenger
+}
+
+fn grind_unbatched(challenger: &mut EidosChallenger, bits: usize) -> Felt {
+    let witness = (0..Felt::ORDER_U64)
+        .into_par_iter()
+        .map(Felt::new_unchecked)
+        .find_any(|&witness| challenger.clone().check_witness(bits, witness))
+        .expect("failed to find proof-of-work witness");
+
+    assert!(challenger.check_witness(bits, witness));
+    witness
+}
+
+fn eidos_grinding(c: &mut Criterion) {
+    let mut group = c.benchmark_group("eidos-grinding");
+
+    for (bits, buffer_len) in CASES {
+        let input = format!("bits-{bits}-buffer-{buffer_len}");
+        let challenger = challenger_with_buffer(buffer_len);
+
+        group.bench_function(BenchmarkId::new("packed", &input), |b| {
+            b.iter_batched(
+                || challenger.clone(),
+                |mut challenger| black_box(challenger.grind(bits)),
+                BatchSize::SmallInput,
+            )
+        });
+        group.bench_function(BenchmarkId::new("unbatched", &input), |b| {
+            b.iter_batched(
+                || challenger.clone(),
+                |mut challenger| black_box(grind_unbatched(&mut challenger, bits)),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(eidos_challenger_benches, eidos_grinding);
+criterion_main!(eidos_challenger_benches);

--- a/crates/crypto/src/hash/eidos/challenger.rs
+++ b/crates/crypto/src/hash/eidos/challenger.rs
@@ -10,7 +10,9 @@ use p3_challenger::{
 };
 use p3_symmetric::{Hash, MerkleCap};
 
-use super::{BLOCK_LEN, DIGEST_WIDTH, Eidos};
+use super::{
+    BLOCK_LEN, DIGEST_WIDTH, Eidos, PACKED_LANES, PackedBlock, PackedChainingValue, PackedFelt,
+};
 use crate::{
     Felt, Word, ZERO,
     field::{BasedVectorSpace, PrimeField64},
@@ -330,15 +332,79 @@ impl GrindingChallenger for EidosChallenger {
             return ZERO;
         }
 
-        let witness = (0..Felt::ORDER_U64)
+        let mask = (1u64 << bits) - 1;
+        let cv = self.cv;
+        let buffer = self.buffer;
+        let buffer_len = self.buffer_len;
+        let num_batches = Felt::ORDER_U64.div_ceil(PACKED_LANES as u64);
+
+        // Every candidate shares the same pre-witness challenger snapshot (`observe_felt` always
+        // forces absorbing mode first, so this only ever replays that branch); only the witness
+        // lane varies. One packed compression pass therefore checks `PACKED_LANES` candidates.
+        let witness = (0..num_batches)
             .into_par_iter()
-            .map(Felt::new_unchecked)
-            .find_any(|&witness| self.clone().check_witness(bits, witness))
+            .map(|batch| {
+                let base = batch * PACKED_LANES as u64;
+                let candidates: PackedFelt = core::array::from_fn(|lane| {
+                    let candidate = base + lane as u64;
+                    // Lanes beyond the field order can never satisfy the PoW check; repeat the
+                    // last in-range candidate so every lane stays a canonical field element.
+                    Felt::new_unchecked(candidate.min(Felt::ORDER_U64 - 1))
+                });
+                let accepted = check_witness_packed(cv, buffer, buffer_len, candidates, mask);
+                (0..PACKED_LANES).find(|&lane| accepted[lane]).map(|lane| candidates[lane])
+            })
+            .find_any(Option::is_some)
+            .flatten()
             .expect("failed to find proof-of-work witness");
 
         assert!(self.check_witness(bits, witness));
         witness
     }
+}
+
+/// Runs the equivalent of `EidosChallenger::check_witness` for `PACKED_LANES` independent
+/// candidate witnesses in one packed compression pass, given a fixed pre-witness challenger
+/// snapshot `(cv, buffer, buffer_len)`.
+///
+/// `observe_felt` always calls `enter_absorbing_mode` first, so absorbing the witness and
+/// sampling the check bits only ever exercises the `Absorbing` branch of `refill_output_word`;
+/// this mirrors that exact sequence with `Felt` replaced by `PackedFelt` throughout.
+fn check_witness_packed(
+    cv: Word,
+    buffer: [Felt; BLOCK_LEN],
+    buffer_len: usize,
+    witnesses: PackedFelt,
+    mask: u64,
+) -> [bool; PACKED_LANES] {
+    debug_assert!(buffer_len < BLOCK_LEN);
+
+    // observe_felt: append the witness at the next free buffer slot.
+    let mut packed_buffer: PackedBlock = core::array::from_fn(|slot| {
+        use core::cmp::Ordering;
+        match slot.cmp(&buffer_len) {
+            Ordering::Less => [buffer[slot]; PACKED_LANES],
+            Ordering::Equal => witnesses,
+            Ordering::Greater => [ZERO; PACKED_LANES],
+        }
+    });
+    let mut packed_cv: PackedChainingValue = core::array::from_fn(|i| [cv[i]; PACKED_LANES]);
+    let mut packed_len = buffer_len + 1;
+
+    // compress_pending_buffer: an untagged compression only if the witness filled the buffer.
+    if packed_len == BLOCK_LEN {
+        packed_cv = Eidos::compress_packed(packed_cv, packed_buffer);
+        packed_buffer = [[ZERO; PACKED_LANES]; BLOCK_LEN];
+        packed_len = 0;
+    }
+
+    // refill_output_word (Absorbing branch): tagged compression producing the fresh output word.
+    let tag = transition_tag(packed_len);
+    packed_cv[3] = packed_cv[3].map(|word| word + tag);
+    let output = Eidos::compress_packed(packed_cv, packed_buffer);
+
+    // sample_felt then sample_bits: the first sample off a freshly refilled word is output[0].
+    core::array::from_fn(|lane| (output[0][lane].as_canonical_u64() & mask) == 0)
 }
 
 impl CanFinalizeDigest for EidosChallenger {
@@ -619,5 +685,68 @@ mod tests {
         assert_eq!(row[6..14], [9, 10, 0, 0, 0, 0, 0, 0]);
         assert_eq!(row[14], 2);
         assert_eq!(row[15..20], [0, 0, 0, 0, 0]);
+    }
+
+    /// `check_witness_packed` must agree, lane by lane, with the scalar `check_witness` default
+    /// implementation run on an independently cloned challenger, for every pre-witness buffer
+    /// state it can be called with (`buffer_len` in `0..BLOCK_LEN`, covering both the case where
+    /// the witness fills the buffer and the case where it doesn't).
+    #[test]
+    fn check_witness_packed_matches_scalar_check_witness_across_buffer_lengths() {
+        let bits_values = [1usize, 8, 20];
+
+        for buffer_len in 0..BLOCK_LEN {
+            let mut challenger = EidosChallenger::new(word([5, 6, 7, 8]));
+            for i in 0..buffer_len {
+                challenger.observe_felt(felt(100 + i as u64));
+            }
+            assert_eq!(challenger.buffer_len, buffer_len);
+
+            let witnesses: PackedFelt = core::array::from_fn(|lane| felt(1_000_000 + lane as u64));
+
+            for &bits in &bits_values {
+                let mask = (1u64 << bits) - 1;
+                let accepted = check_witness_packed(
+                    challenger.cv,
+                    challenger.buffer,
+                    challenger.buffer_len,
+                    witnesses,
+                    mask,
+                );
+
+                for lane in 0..PACKED_LANES {
+                    let mut scalar = challenger.clone();
+                    let expected = scalar.check_witness(bits, witnesses[lane]);
+                    assert_eq!(
+                        accepted[lane], expected,
+                        "lane {lane} mismatch at buffer_len={buffer_len}, bits={bits}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// `grind` must find a witness from every possible pre-grind buffer state, and that witness
+    /// must independently satisfy `check_witness` on a challenger cloned from the pre-grind
+    /// state (not just the internal assertion `grind` already performs on `self`).
+    #[test]
+    fn grind_finds_a_valid_witness_from_every_buffer_state() {
+        let bits = 4;
+
+        for buffer_len in 0..BLOCK_LEN {
+            let mut challenger = EidosChallenger::new(word([1, 2, 3, 4]));
+            for i in 0..buffer_len {
+                challenger.observe_felt(felt(200 + i as u64));
+            }
+            let pre_grind = challenger.clone();
+
+            let witness = challenger.grind(bits);
+
+            let mut verifier = pre_grind;
+            assert!(
+                verifier.check_witness(bits, witness),
+                "witness from buffer_len={buffer_len} failed independent verification"
+            );
+        }
     }
 }

--- a/crates/crypto/src/hash/eidos/challenger.rs
+++ b/crates/crypto/src/hash/eidos/challenger.rs
@@ -336,21 +336,14 @@ impl GrindingChallenger for EidosChallenger {
         let cv = self.cv;
         let buffer = self.buffer;
         let buffer_len = self.buffer_len;
-        let num_batches = Felt::ORDER_U64.div_ceil(PACKED_LANES as u64);
 
         // Every candidate shares the same pre-witness challenger snapshot (`observe_felt` always
         // forces absorbing mode first, so this only ever replays that branch); only the witness
         // lane varies. One packed compression pass therefore checks `PACKED_LANES` candidates.
-        let witness = (0..num_batches)
+        let witness = (0..WITNESS_BATCHES)
             .into_par_iter()
             .map(|batch| {
-                let base = batch * PACKED_LANES as u64;
-                let candidates: PackedFelt = core::array::from_fn(|lane| {
-                    let candidate = base + lane as u64;
-                    // Lanes beyond the field order can never satisfy the PoW check; repeat the
-                    // last in-range candidate so every lane stays a canonical field element.
-                    Felt::new_unchecked(candidate.min(Felt::ORDER_U64 - 1))
-                });
+                let candidates = witness_batch(batch);
                 let accepted = check_witness_packed(cv, buffer, buffer_len, candidates, mask);
                 (0..PACKED_LANES).find(|&lane| accepted[lane]).map(|lane| candidates[lane])
             })
@@ -361,6 +354,22 @@ impl GrindingChallenger for EidosChallenger {
         assert!(self.check_witness(bits, witness));
         witness
     }
+}
+
+/// Number of `PACKED_LANES`-wide candidate batches that cover every canonical field element.
+const WITNESS_BATCHES: u64 = Felt::ORDER_U64.div_ceil(PACKED_LANES as u64);
+
+#[inline]
+fn witness_batch(batch: u64) -> PackedFelt {
+    debug_assert!(batch < WITNESS_BATCHES);
+
+    let base = batch * PACKED_LANES as u64;
+    core::array::from_fn(|lane| {
+        let candidate = base + lane as u64;
+        // No canonical candidate exists beyond the field order. Repeat the last in-range
+        // candidate so every lane stays a canonical field element.
+        Felt::new_unchecked(candidate.min(Felt::ORDER_U64 - 1))
+    })
 }
 
 /// Runs the equivalent of `EidosChallenger::check_witness` for `PACKED_LANES` independent
@@ -687,6 +696,20 @@ mod tests {
         assert_eq!(row[15..20], [0, 0, 0, 0, 0]);
     }
 
+    #[test]
+    fn witness_batches_cover_the_field_boundary_canonically() {
+        let first = witness_batch(0).map(|candidate| candidate.as_canonical_u64());
+        assert_eq!(first, core::array::from_fn(|lane| lane as u64));
+
+        let penultimate =
+            witness_batch(WITNESS_BATCHES - 2).map(|candidate| candidate.as_canonical_u64());
+        let penultimate_base = Felt::ORDER_U64 - 1 - PACKED_LANES as u64;
+        assert_eq!(penultimate, core::array::from_fn(|lane| penultimate_base + lane as u64));
+
+        let last = witness_batch(WITNESS_BATCHES - 1).map(|candidate| candidate.as_canonical_u64());
+        assert_eq!(last, [Felt::ORDER_U64 - 1; PACKED_LANES]);
+    }
+
     /// `check_witness_packed` must agree, lane by lane, with the scalar `check_witness` default
     /// implementation run on an independently cloned challenger, for every pre-witness buffer
     /// state it can be called with (`buffer_len` in `0..BLOCK_LEN`, covering both the case where
@@ -738,15 +761,26 @@ mod tests {
             for i in 0..buffer_len {
                 challenger.observe_felt(felt(200 + i as u64));
             }
-            let pre_grind = challenger.clone();
-
-            let witness = challenger.grind(bits);
-
-            let mut verifier = pre_grind;
-            assert!(
-                verifier.check_witness(bits, witness),
-                "witness from buffer_len={buffer_len} failed independent verification"
-            );
+            assert_grind_matches_independent_check(challenger, bits);
         }
+    }
+
+    #[test]
+    fn grind_from_squeezing_state_matches_independent_check() {
+        let mut challenger = EidosChallenger::new(word([1, 2, 3, 4]));
+        challenger.observe_felt(felt(200));
+        let _ = challenger.sample_felt();
+        assert_eq!(challenger.mode, EidosChallengerMode::Squeezing);
+        assert_ne!(challenger.output_len, 0);
+
+        assert_grind_matches_independent_check(challenger, 4);
+    }
+
+    fn assert_grind_matches_independent_check(mut challenger: EidosChallenger, bits: usize) {
+        let mut verifier = challenger.clone();
+        let witness = challenger.grind(bits);
+
+        assert!(verifier.check_witness(bits, witness));
+        assert_eq!(snapshot(&challenger), snapshot(&verifier));
     }
 }

--- a/crates/crypto/src/hash/eidos/compression.rs
+++ b/crates/crypto/src/hash/eidos/compression.rs
@@ -5,6 +5,8 @@
 //! elements are accepted in the input CV; only the output CV is placed in Eidos's 252-bit packed
 //! subspace.
 
+#[cfg(all(target_arch = "x86_64", feature = "std"))]
+use super::primitive::cpu;
 use super::{
     BLOCK_LEN, DIGEST_WIDTH, PACKED_LANES, PackedBlock, PackedChainingValue,
     PackedU32ChainingValue, encoding, primitive::CompressionCore,
@@ -83,10 +85,21 @@ pub(super) fn compress_packed_u64_block(
     cv: &PackedU32ChainingValue,
     block: &[[u64; PACKED_LANES]; BLOCK_LEN],
 ) -> PackedU32ChainingValue {
-    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
-    let block = avx512_u64_adapter::unpack_block(*block);
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
+    let block = if cpu::has_avx512f() {
+        // SAFETY: `cpu::has_avx512f` confirmed AVX-512F support on the running CPU.
+        unsafe { avx512_u64_adapter::unpack_block(block) }
+    } else {
+        encoding::encode_packed_u64_block(*block)
+    };
 
-    #[cfg(not(all(target_arch = "x86_64", target_feature = "avx512f")))]
+    #[cfg(all(target_arch = "x86_64", not(feature = "std"), target_feature = "avx512f"))]
+    let block = {
+        // SAFETY: AVX-512F is enabled crate-wide in this configuration.
+        unsafe { avx512_u64_adapter::unpack_block(block) }
+    };
+
+    #[cfg(not(all(target_arch = "x86_64", any(feature = "std", target_feature = "avx512f"))))]
     let block = encoding::encode_packed_u64_block(*block);
 
     compress_cv_packed(cv, &block)
@@ -96,18 +109,29 @@ pub(super) fn compress_packed_u64_block(
 pub(super) fn pack_packed_u64_cv(
     cv: &PackedU32ChainingValue,
 ) -> [[u64; PACKED_LANES]; DIGEST_WIDTH] {
-    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
     {
-        avx512_u64_adapter::pack_cv(*cv)
+        if cpu::has_avx512f() {
+            // SAFETY: `cpu::has_avx512f` confirmed AVX-512F support on the running CPU.
+            unsafe { avx512_u64_adapter::pack_cv(cv) }
+        } else {
+            encoding::pack_cv_to_packed_u64s(*cv)
+        }
     }
 
-    #[cfg(not(all(target_arch = "x86_64", target_feature = "avx512f")))]
+    #[cfg(all(target_arch = "x86_64", not(feature = "std"), target_feature = "avx512f"))]
+    {
+        // SAFETY: AVX-512F is enabled crate-wide in this configuration.
+        unsafe { avx512_u64_adapter::pack_cv(cv) }
+    }
+
+    #[cfg(not(all(target_arch = "x86_64", any(feature = "std", target_feature = "avx512f"))))]
     {
         encoding::pack_cv_to_packed_u64s(*cv)
     }
 }
 
-#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+#[cfg(all(target_arch = "x86_64", any(feature = "std", target_feature = "avx512f")))]
 mod avx512_u64_adapter {
     use core::arch::x86_64::*;
 
@@ -118,25 +142,23 @@ mod avx512_u64_adapter {
     const _: () = assert!(LANES == 16, "the AVX-512 adapter requires sixteen packed lanes");
 
     #[inline]
-    pub(super) fn unpack_block(block: [[u64; LANES]; BLOCK_LEN]) -> [[u32; LANES]; 16] {
+    #[target_feature(enable = "avx512f")]
+    pub(super) unsafe fn unpack_block(block: &[[u64; LANES]; BLOCK_LEN]) -> [[u32; LANES]; 16] {
         let mut output = [[0u32; LANES]; 16];
 
         for (element, values) in block.iter().enumerate() {
             for half in 0..2 {
                 let lane_offset = half * HALF_LANES;
-                // SAFETY: this module is compiled only with AVX-512F enabled. `lane_offset` is
-                // either 0 or 8, so the unaligned eight-u64 load remains within `values`.
+                // SAFETY: this function requires AVX-512F. `lane_offset` is either 0 or 8, so the
+                // unaligned eight-u64 load remains within `values`.
                 let packed = unsafe {
                     _mm512_loadu_si512(values.as_ptr().add(lane_offset).cast::<__m512i>())
                 };
-                // SAFETY: these AVX-512F operations only transform the loaded register. Signed
-                // narrowing is intentional: both conversions retain the low 32 bits.
-                let (lo, hi) = unsafe {
-                    (
-                        _mm512_cvtepi64_epi32(packed),
-                        _mm512_cvtepi64_epi32(_mm512_srli_epi64::<32>(packed)),
-                    )
-                };
+                // Signed narrowing is intentional: both conversions retain the low 32 bits.
+                let (lo, hi) = (
+                    _mm512_cvtepi64_epi32(packed),
+                    _mm512_cvtepi64_epi32(_mm512_srli_epi64::<32>(packed)),
+                );
 
                 // SAFETY: `lane_offset` is either 0 or 8, so each unaligned eight-u32 store
                 // remains within its sixteen-element output row.
@@ -157,10 +179,10 @@ mod avx512_u64_adapter {
     }
 
     #[inline]
-    pub(super) fn pack_cv(cv: [[u32; LANES]; 8]) -> [[u64; LANES]; DIGEST_WIDTH] {
+    #[target_feature(enable = "avx512f")]
+    pub(super) unsafe fn pack_cv(cv: &[[u32; LANES]; 8]) -> [[u64; LANES]; DIGEST_WIDTH] {
         let mut output = [[0u64; LANES]; DIGEST_WIDTH];
-        // SAFETY: this module is compiled only with AVX-512F enabled.
-        let high_mask = unsafe { _mm512_set1_epi64(super::encoding::ODD_LANE_MASK as i64) };
+        let high_mask = _mm512_set1_epi64(super::encoding::ODD_LANE_MASK as i64);
 
         for word in 0..DIGEST_WIDTH {
             for half in 0..2 {
@@ -173,13 +195,10 @@ mod avx512_u64_adapter {
                 let hi32 = unsafe {
                     _mm256_loadu_si256(cv[2 * word + 1].as_ptr().add(lane_offset).cast::<__m256i>())
                 };
-                // SAFETY: these AVX-512F operations only transform registers. The high word is
-                // masked to preserve the canonical 63-bit field-element encoding.
-                let packed = unsafe {
-                    let lo64 = _mm512_cvtepu32_epi64(lo32);
-                    let hi64 = _mm512_and_si512(_mm512_cvtepu32_epi64(hi32), high_mask);
-                    _mm512_or_si512(lo64, _mm512_slli_epi64::<32>(hi64))
-                };
+                // Mask the high word to preserve the canonical 63-bit field-element encoding.
+                let lo64 = _mm512_cvtepu32_epi64(lo32);
+                let hi64 = _mm512_and_si512(_mm512_cvtepu32_epi64(hi32), high_mask);
+                let packed = _mm512_or_si512(lo64, _mm512_slli_epi64::<32>(hi64));
 
                 // SAFETY: `lane_offset` is either 0 or 8, so the unaligned eight-u64 store
                 // remains within its sixteen-element output row.
@@ -274,13 +293,20 @@ mod tests {
         }
     }
 
-    #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+    #[cfg(all(target_arch = "x86_64", any(feature = "std", target_feature = "avx512f")))]
     #[test]
     fn avx512_u64_adapter_matches_generic_layout() {
+        #[cfg(feature = "std")]
+        if !cpu::has_avx512f() {
+            std::eprintln!("skipped: the running CPU lacks AVX-512F");
+            return;
+        }
+
         for batch in 0..32 {
             let block = mixed_packed_u64_block(batch);
             assert_eq!(
-                avx512_u64_adapter::unpack_block(block),
+                // SAFETY: AVX-512F is either enabled crate-wide or checked above at runtime.
+                unsafe { avx512_u64_adapter::unpack_block(&block) },
                 encoding::encode_packed_u64_block(block),
                 "AVX-512 input adapter diverged in batch {batch}",
             );
@@ -288,7 +314,8 @@ mod tests {
             let cv =
                 array::from_fn(|word| array::from_fn(|lane| mixed_u64(batch, word, lane) as u32));
             assert_eq!(
-                avx512_u64_adapter::pack_cv(cv),
+                // SAFETY: AVX-512F is either enabled crate-wide or checked above at runtime.
+                unsafe { avx512_u64_adapter::pack_cv(&cv) },
                 encoding::pack_cv_to_packed_u64s(cv),
                 "AVX-512 output adapter diverged in batch {batch}",
             );

--- a/crates/crypto/src/hash/eidos/compression.rs
+++ b/crates/crypto/src/hash/eidos/compression.rs
@@ -18,8 +18,8 @@ pub(super) fn compress_cv(cv: [u32; 8], block: [u32; 16]) -> [u32; 8] {
 
 #[inline]
 pub(super) fn compress_cv_packed(
-    cv: PackedU32ChainingValue,
-    block: [[u32; PACKED_LANES]; 16],
+    cv: &PackedU32ChainingValue,
+    block: &[[u32; PACKED_LANES]; 16],
 ) -> PackedU32ChainingValue {
     CompressionCore::compress_packed_native(cv, block)
 }
@@ -47,18 +47,20 @@ pub(super) fn compress_felt_block_for_test(
 
 #[inline]
 pub(super) fn compress_packed_felt_cv(
-    cv: PackedChainingValue,
-    block: PackedBlock,
+    cv: &PackedChainingValue,
+    block: &PackedBlock,
 ) -> PackedChainingValue {
-    encoding::pack_cv_to_felts(compress_packed_felt_block(encoding::unpack_packed_cv(cv), block))
+    let cv = encoding::unpack_packed_cv(*cv);
+    encoding::pack_cv_to_felts(compress_packed_felt_block(&cv, block))
 }
 
 #[inline]
 pub(super) fn compress_packed_felt_block(
-    cv: PackedU32ChainingValue,
-    block: PackedBlock,
+    cv: &PackedU32ChainingValue,
+    block: &PackedBlock,
 ) -> PackedU32ChainingValue {
-    compress_cv_packed(cv, encoding::encode_packed_felt_block(block))
+    let block = encoding::encode_packed_felt_block(*block);
+    compress_cv_packed(cv, &block)
 }
 
 #[inline]
@@ -68,38 +70,40 @@ pub(super) fn compress_u64_cv(cv: [u32; 8], block: [u64; BLOCK_LEN]) -> [u32; 8]
 
 #[inline]
 pub(super) fn compress_packed_u64_cv(
-    cv: [[u64; PACKED_LANES]; DIGEST_WIDTH],
-    block: [[u64; PACKED_LANES]; BLOCK_LEN],
+    cv: &[[u64; PACKED_LANES]; DIGEST_WIDTH],
+    block: &[[u64; PACKED_LANES]; BLOCK_LEN],
 ) -> [[u64; PACKED_LANES]; DIGEST_WIDTH] {
-    pack_packed_u64_cv(compress_packed_u64_block(encoding::unpack_packed_u64_cv(cv), block))
+    let cv = encoding::unpack_packed_u64_cv(*cv);
+    let cv = compress_packed_u64_block(&cv, block);
+    pack_packed_u64_cv(&cv)
 }
 
 #[inline]
 pub(super) fn compress_packed_u64_block(
-    cv: PackedU32ChainingValue,
-    block: [[u64; PACKED_LANES]; BLOCK_LEN],
+    cv: &PackedU32ChainingValue,
+    block: &[[u64; PACKED_LANES]; BLOCK_LEN],
 ) -> PackedU32ChainingValue {
     #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
-    let block = avx512_u64_adapter::unpack_block(block);
+    let block = avx512_u64_adapter::unpack_block(*block);
 
     #[cfg(not(all(target_arch = "x86_64", target_feature = "avx512f")))]
-    let block = encoding::encode_packed_u64_block(block);
+    let block = encoding::encode_packed_u64_block(*block);
 
-    compress_cv_packed(cv, block)
+    compress_cv_packed(cv, &block)
 }
 
 #[inline]
 pub(super) fn pack_packed_u64_cv(
-    cv: PackedU32ChainingValue,
+    cv: &PackedU32ChainingValue,
 ) -> [[u64; PACKED_LANES]; DIGEST_WIDTH] {
     #[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
     {
-        avx512_u64_adapter::pack_cv(cv)
+        avx512_u64_adapter::pack_cv(*cv)
     }
 
     #[cfg(not(all(target_arch = "x86_64", target_feature = "avx512f")))]
     {
-        encoding::pack_cv_to_packed_u64s(cv)
+        encoding::pack_cv_to_packed_u64s(*cv)
     }
 }
 
@@ -255,7 +259,7 @@ mod tests {
         let cv = super::super::framing::init_packed_u64_cv(0, [0; 3]);
         for batch in 0..32 {
             let block = mixed_packed_u64_block(batch);
-            let packed = compress_packed_u64_cv(cv, block);
+            let packed = compress_packed_u64_cv(&cv, &block);
 
             for lane in 0..PACKED_LANES {
                 let scalar_cv = array::from_fn(|word| cv[word][lane]);

--- a/crates/crypto/src/hash/eidos/construction.rs
+++ b/crates/crypto/src/hash/eidos/construction.rs
@@ -48,7 +48,7 @@ impl Eidos {
     /// Each lane is independent. Like [`Self::compress`], this adds no message framing.
     #[inline]
     pub fn compress_packed(cv: PackedChainingValue, block: PackedBlock) -> PackedChainingValue {
-        compression::compress_packed_felt_cv(cv, block)
+        compression::compress_packed_felt_cv(&cv, &block)
     }
 
     /// Return all sixteen raw XOF output lanes for one complete block.
@@ -295,7 +295,7 @@ where
         len,
         framing::init_packed_u32_cv(GENERIC_FELT_TAG, [len_u32, 0, 0]),
         [Felt::ZERO; PACKED_LANES],
-        compression::compress_packed_felt_block,
+        |cv, block| compression::compress_packed_felt_block(&cv, &block),
     );
     encoding::pack_cv_to_felts(cv)
 }
@@ -310,9 +310,9 @@ where
         len,
         framing::init_packed_u32_cv(GENERIC_FELT_TAG, [len_u32, 0, 0]),
         [0; PACKED_LANES],
-        compression::compress_packed_u64_block,
+        |cv, block| compression::compress_packed_u64_block(&cv, &block),
     );
-    compression::pack_packed_u64_cv(cv)
+    compression::pack_packed_u64_cv(&cv)
 }
 
 impl CryptographicHasher<Felt, [Felt; DIGEST_WIDTH]> for Eidos {

--- a/crates/crypto/src/hash/eidos/construction.rs
+++ b/crates/crypto/src/hash/eidos/construction.rs
@@ -43,7 +43,7 @@ impl Eidos {
         compression::compress_felt_block(cv, block)
     }
 
-    /// Compress one complete block in each native packed lane.
+    /// Compress one complete block in each packed lane.
     ///
     /// Each lane is independent. Like [`Self::compress`], this adds no message framing.
     #[inline]
@@ -110,7 +110,7 @@ impl Eidos {
         encoding::output_cv_to_word(framing::init_cv(tag.as_u32(), params))
     }
 
-    /// Construct the same one-parameter initial chaining word in every native packed lane.
+    /// Construct the same one-parameter initial chaining word in every packed lane.
     ///
     /// The interpretation of `param0` is defined by the registered domain.
     #[inline]
@@ -205,7 +205,7 @@ impl Eidos {
         encoding::output_cv_to_word(MERKLE_NODE_INIT_CV)
     }
 
-    /// Compress two packed digest words as reserved Merkle inner nodes in every native packed lane.
+    /// Compress two packed digest words as reserved Merkle inner nodes in every packed lane.
     ///
     /// This is the packed equivalent of [`Self::merge`].
     #[inline]

--- a/crates/crypto/src/hash/eidos/encoding.rs
+++ b/crates/crypto/src/hash/eidos/encoding.rs
@@ -184,8 +184,16 @@ pub(super) fn encode_packed_felt_block<const LANES: usize>(
     })
 }
 
+/// Generic lane layout for packed `u64` blocks.
+///
+/// Under `std` this stays live on x86_64 as the runtime fallback next to the AVX-512 adapter, so
+/// the gate must not follow `target_feature` alone.
 #[inline]
-#[cfg(any(test, not(all(target_arch = "x86_64", target_feature = "avx512f"))))]
+#[cfg(any(
+    test,
+    feature = "std",
+    not(all(target_arch = "x86_64", target_feature = "avx512f"))
+))]
 pub(super) fn encode_packed_u64_block<const LANES: usize>(
     block: [[u64; LANES]; BLOCK_LEN],
 ) -> [[u32; LANES]; 16] {

--- a/crates/crypto/src/hash/eidos/lmcs.rs
+++ b/crates/crypto/src/hash/eidos/lmcs.rs
@@ -84,7 +84,7 @@ impl PseudoCompressionFunction<PackedDigest, COMPRESSION_INPUTS> for EidosLmcsCo
             input[1][2],
             input[1][3],
         ];
-        compression::compress_packed_u64_cv(framing::init_packed_u64_cv(0, [0; 3]), block)
+        compression::compress_packed_u64_cv(&framing::init_packed_u64_cv(0, [0; 3]), &block)
     }
 }
 
@@ -132,7 +132,7 @@ impl StatefulHasher<PackedFelt, PackedDigest> for EidosLmcsHasher {
             input,
             [Felt::ZERO; PACKED_LANES],
             |cv, block| {
-                compression::compress_cv_packed(cv, encoding::encode_packed_felt_block(block))
+                compression::compress_cv_packed(&cv, &encoding::encode_packed_felt_block(block))
             },
         );
         *state = encoding::pack_cv_to_packed_u64s(cv);
@@ -259,7 +259,7 @@ mod tests {
             &packed_state,
         );
         for lane in 0..PACKED_LANES {
-            assert_eq!(unpack_digest_lane(packed, lane), expected);
+            assert_eq!(unpack_digest_lane(&packed, lane), expected);
         }
     }
 
@@ -468,13 +468,13 @@ mod tests {
         let expected = eidos_hash_two_digests(left, right);
         assert_eq!(actual, expected);
 
-        let left_packed = pack_digest_lanes(array::from_fn(|lane| digest_from_seed(100 + lane)));
-        let right_packed = pack_digest_lanes(array::from_fn(|lane| digest_from_seed(200 + lane)));
+        let left_packed = pack_digest_lanes(&array::from_fn(|lane| digest_from_seed(100 + lane)));
+        let right_packed = pack_digest_lanes(&array::from_fn(|lane| digest_from_seed(200 + lane)));
         let actual_packed = compressor.compress([left_packed, right_packed]);
 
         for (lane, _) in left_packed[0].iter().enumerate() {
-            let left_lane = unpack_digest_lane(left_packed, lane);
-            let right_lane = unpack_digest_lane(right_packed, lane);
+            let left_lane = unpack_digest_lane(&left_packed, lane);
+            let right_lane = unpack_digest_lane(&right_packed, lane);
             let expected_lane = eidos_hash_two_digests(left_lane, right_lane);
 
             for word in 0..DIGEST_WIDTH {
@@ -518,11 +518,11 @@ mod tests {
             .map(|value| value.as_canonical_u64())
     }
 
-    fn pack_digest_lanes(lanes: [Digest; PACKED_LANES]) -> PackedDigest {
+    fn pack_digest_lanes(lanes: &[Digest; PACKED_LANES]) -> PackedDigest {
         array::from_fn(|word| array::from_fn(|lane| lanes[lane][word]))
     }
 
-    fn unpack_digest_lane(digest: PackedDigest, lane: usize) -> Digest {
+    fn unpack_digest_lane(digest: &PackedDigest, lane: usize) -> Digest {
         array::from_fn(|word| digest[word][lane])
     }
 }

--- a/crates/crypto/src/hash/eidos/mod.rs
+++ b/crates/crypto/src/hash/eidos/mod.rs
@@ -37,13 +37,14 @@ pub const BLOCK_LEN: usize = 8;
 /// Number of felts in an Eidos digest.
 pub const DIGEST_WIDTH: usize = 4;
 
-/// Number of independent Eidos inputs processed by the selected native packed backend.
+/// Number of independent Eidos inputs in one logical packed batch.
 ///
-/// The width is selected at compile time from the target features. Callers should always process
-/// tails by repeating a real lane and discarding the duplicate outputs.
+/// The logical width is fixed across targets. Backends with narrower SIMD registers process the
+/// batch in independent sub-batches. Callers should fill tails by repeating a real lane and
+/// discard the duplicate outputs.
 pub const PACKED_LANES: usize = primitive::PACKED_LANES;
 
-/// One packed base-field element, with one independent value per native SIMD lane.
+/// One packed base-field element, with one independent value per logical packed lane.
 pub type PackedFelt = [crate::Felt; PACKED_LANES];
 
 /// Lane-oriented chaining value retained between packed compression calls.
@@ -51,14 +52,14 @@ pub type PackedFelt = [crate::Felt; PACKED_LANES];
 /// Packing into field elements is reserved for API boundaries.
 type PackedU32ChainingValue = [[u32; PACKED_LANES]; 8];
 
-/// One packed Eidos chaining value, with one independent CV per native SIMD lane.
+/// One packed Eidos chaining value, with one independent CV per logical packed lane.
 ///
 /// Raw compression accepts arbitrary canonical field elements here; callers must not assume that
 /// an input CV already lies in Eidos's 252-bit output subspace.
 pub type PackedChainingValue = [PackedFelt; DIGEST_WIDTH];
 
-/// One packed Eidos digest, with one independent digest per native SIMD lane.
+/// One packed Eidos digest, with one independent digest per logical packed lane.
 pub type PackedDigest = PackedChainingValue;
 
-/// One packed Eidos message block, with one independent block per native SIMD lane.
+/// One packed Eidos message block, with one independent block per logical packed lane.
 pub type PackedBlock = [PackedFelt; BLOCK_LEN];

--- a/crates/crypto/src/hash/eidos/primitive.rs
+++ b/crates/crypto/src/hash/eidos/primitive.rs
@@ -92,8 +92,8 @@ impl CompressionCore {
     /// Apply compression to the build's selected native packed lane width.
     #[inline]
     pub(super) fn compress_packed_native(
-        cv: [[u32; PACKED_LANES]; 8],
-        block: [[u32; PACKED_LANES]; 16],
+        cv: &[[u32; PACKED_LANES]; 8],
+        block: &[[u32; PACKED_LANES]; 16],
     ) -> [[u32; PACKED_LANES]; 8] {
         let mut cv_new = blake3_schedule::compress_packed_native(cv, block);
         apply_packed_output_mask(&mut cv_new);
@@ -415,7 +415,7 @@ mod tests {
         let packed_block: [[u32; LANES]; 16] =
             core::array::from_fn(|word| core::array::from_fn(|lane| blocks[lane][word]));
         let portable = CompressionCore::compress_packed(packed_cv, packed_block);
-        let native = CompressionCore::compress_packed_native(packed_cv, packed_block);
+        let native = CompressionCore::compress_packed_native(&packed_cv, &packed_block);
 
         for lane in 0..LANES {
             let scalar = CompressionCore::compress(cvs[lane], blocks[lane]);

--- a/crates/crypto/src/hash/eidos/primitive.rs
+++ b/crates/crypto/src/hash/eidos/primitive.rs
@@ -221,6 +221,32 @@ mod tests {
         assert_eq!(CompressionCore::compress_raw(cv, block), expected);
     }
 
+    /// `compress_raw`/`compress_raw_xof` dispatch to an architecture- and (on x86_64, under the
+    /// `std` feature) runtime-CPU-selected backend; this checks every reachable backend against
+    /// the portable scalar reference over many pseudo-random inputs, not just the single fixed
+    /// vector above.
+    #[test]
+    fn compress_raw_and_xof_match_scalar_reference_over_random_inputs() {
+        let mut state = 0x243f_6a88_85a3_08d3u64;
+        let mut next_u32 = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state as u32
+        };
+
+        for _ in 0..10_000 {
+            let cv: [u32; 8] = core::array::from_fn(|_| next_u32());
+            let block: [u32; 16] = core::array::from_fn(|_| next_u32());
+
+            let expected_raw = reference_core_with_p(cv, block, [IV[4], IV[5], IV[6], IV[7]]);
+            assert_eq!(CompressionCore::compress_raw(cv, block), expected_raw);
+
+            let expected_xof = reference_core_xof_with_p(cv, block, [IV[4], IV[5], IV[6], IV[7]]);
+            assert_eq!(CompressionCore::compress_raw_xof(cv, block), expected_xof);
+        }
+    }
+
     #[test]
     fn xof_reference_matches_official_blake3_compress_xof() {
         let cv = TEST_CV;

--- a/crates/crypto/src/hash/eidos/primitive.rs
+++ b/crates/crypto/src/hash/eidos/primitive.rs
@@ -9,6 +9,8 @@ mod blake3_schedule;
 
 pub(super) const IV: [u32; 8] = blake3_schedule::IV;
 pub(super) const PACKED_LANES: usize = blake3_schedule::PACKED_LANES;
+#[cfg(all(target_arch = "x86_64", feature = "std"))]
+pub(super) use blake3_schedule::cpu;
 
 use super::encoding::ODD_LANE_MASK;
 
@@ -89,7 +91,7 @@ impl CompressionCore {
         cv_new
     }
 
-    /// Apply compression to the build's selected native packed lane width.
+    /// Apply compression to one logical packed batch using the selected native backend.
     #[inline]
     pub(super) fn compress_packed_native(
         cv: &[[u32; PACKED_LANES]; 8],
@@ -221,10 +223,8 @@ mod tests {
         assert_eq!(CompressionCore::compress_raw(cv, block), expected);
     }
 
-    /// `compress_raw`/`compress_raw_xof` dispatch to an architecture- and (on x86_64, under the
-    /// `std` feature) runtime-CPU-selected backend; this checks every reachable backend against
-    /// the portable scalar reference over many pseudo-random inputs, not just the single fixed
-    /// vector above.
+    /// Checks the selected raw and XOF paths against the portable scalar reference over many
+    /// pseudo-random inputs, not just the single fixed vector above.
     #[test]
     fn compress_raw_and_xof_match_scalar_reference_over_random_inputs() {
         let mut state = 0x243f_6a88_85a3_08d3u64;

--- a/crates/crypto/src/hash/eidos/primitive/blake3_schedule.rs
+++ b/crates/crypto/src/hash/eidos/primitive/blake3_schedule.rs
@@ -32,42 +32,173 @@ const MSG_SCHEDULE: [[usize; 16]; ROUNDS] = [
     [11, 15, 5, 0, 1, 9, 8, 6, 14, 10, 2, 12, 3, 4, 7, 13],
 ];
 
-/// Lane count for the selected raw compression backend.
+/// Fixed logical width of a packed compression batch.
 ///
-/// Backend selection is compile-time only. A native x86 build can use
-/// `-C target-cpu=native`, or explicit target features such as `+avx2` or `+avx512f`.
-pub(super) const PACKED_LANES: usize = native_backend::LANES;
+/// This is independent of any particular SIMD backend. Every backend below fills a 16-lane
+/// batch using as many physical-width calls as its vector registers need: one call of 16 for
+/// AVX-512, two calls of 8 for AVX2, four calls of 4 for SSE2 or NEON. A stable logical width
+/// keeps `PackedFelt` and friends the same public type regardless of which physical backend
+/// ends up selected.
+pub(super) const PACKED_LANES: usize = 16;
 
-#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+/// Splits a `PACKED_LANES`-wide batch into `PACKED_LANES / W` sub-batches of width `W`, applies
+/// `f` to each, and reassembles the results.
+#[cfg(any(
+    all(target_arch = "x86_64", feature = "std"),
+    all(target_arch = "x86_64", not(target_feature = "avx512f")),
+    all(target_arch = "aarch64", target_feature = "neon"),
+))]
+#[inline]
+fn compress_via_sub_batches<const W: usize>(
+    cv: [[u32; PACKED_LANES]; 8],
+    block: [[u32; PACKED_LANES]; 16],
+    f: impl Fn([[u32; W]; 8], [[u32; W]; 16]) -> [[u32; W]; 8],
+) -> [[u32; PACKED_LANES]; 8] {
+    let mut out = [[0u32; PACKED_LANES]; 8];
+    for chunk in 0..(PACKED_LANES / W) {
+        let base = chunk * W;
+        let sub_cv: [[u32; W]; 8] =
+            array::from_fn(|word| array::from_fn(|lane| cv[word][base + lane]));
+        let sub_block: [[u32; W]; 16] =
+            array::from_fn(|word| array::from_fn(|lane| block[word][base + lane]));
+        let sub_out = f(sub_cv, sub_block);
+        for (word, sub_word) in out.iter_mut().zip(sub_out) {
+            word[base..base + W].copy_from_slice(&sub_word);
+        }
+    }
+    out
+}
+
+/// Backend selection: on x86_64 with the `std` feature, the physical SIMD tier (AVX-512, AVX2,
+/// or SSE2) is detected once at runtime and cached, so an off-the-shelf build picks up whatever
+/// the host CPU actually supports. Without `std` (or off x86_64), selection falls back to
+/// `target_feature` cfg, exactly as before: a native build needs `-C target-cpu=native` or an
+/// explicit `+avx2`/`+avx512f` to get past the SSE2/NEON baseline.
+#[cfg(all(target_arch = "x86_64", feature = "std"))]
 mod native_backend {
-    pub(super) const LANES: usize = 16;
+    use once_cell::sync::Lazy;
 
-    #[inline(always)]
-    pub(super) fn compress(cv: [[u32; LANES]; 8], block: [[u32; LANES]; 16]) -> [[u32; LANES]; 8] {
-        super::x86_64_avx512::compress_packed_16(cv, block)
+    use super::{PACKED_LANES, compress_via_sub_batches, x86_64_avx2, x86_64_avx512, x86_64_sse2};
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum Tier {
+        Avx512,
+        Avx2,
+        Sse2,
+    }
+
+    fn detect() -> Tier {
+        if std::is_x86_feature_detected!("avx512f") {
+            Tier::Avx512
+        } else if std::is_x86_feature_detected!("avx2") {
+            Tier::Avx2
+        } else {
+            Tier::Sse2
+        }
+    }
+
+    static TIER: Lazy<Tier> = Lazy::new(detect);
+
+    #[inline]
+    pub(super) fn compress(
+        cv: [[u32; PACKED_LANES]; 8],
+        block: [[u32; PACKED_LANES]; 16],
+    ) -> [[u32; PACKED_LANES]; 8] {
+        match *TIER {
+            Tier::Avx512 => {
+                // SAFETY: `TIER` only reports `Avx512` after `is_x86_feature_detected!("avx512f")`
+                // returned true for the running CPU.
+                unsafe { x86_64_avx512::compress_packed_16(cv, block) }
+            },
+            Tier::Avx2 => compress_via_sub_batches::<8>(cv, block, |cv, block| {
+                // SAFETY: `TIER` only reports `Avx2` after `is_x86_feature_detected!("avx2")`
+                // returned true for the running CPU.
+                unsafe { x86_64_avx2::compress_packed_8(cv, block) }
+            }),
+            Tier::Sse2 => compress_via_sub_batches::<4>(cv, block, |cv, block| {
+                // SAFETY: SSE2 is part of the x86_64 architectural baseline.
+                unsafe { x86_64_sse2::compress_packed_4(cv, block) }
+            }),
+        }
     }
 }
 
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2", not(target_feature = "avx512f")))]
+#[cfg(all(target_arch = "x86_64", not(feature = "std"), target_feature = "avx512f"))]
 mod native_backend {
-    pub(super) const LANES: usize = 8;
+    use super::PACKED_LANES;
 
     #[inline(always)]
-    pub(super) fn compress(cv: [[u32; LANES]; 8], block: [[u32; LANES]; 16]) -> [[u32; LANES]; 8] {
-        super::x86_64_avx2::compress_packed_8(cv, block)
+    pub(super) fn compress(
+        cv: [[u32; PACKED_LANES]; 8],
+        block: [[u32; PACKED_LANES]; 16],
+    ) -> [[u32; PACKED_LANES]; 8] {
+        // SAFETY: this module only compiles when `target_feature = "avx512f"` is enabled
+        // crate-wide (e.g. via `-C target-cpu=native` or `-C target-feature=+avx512f`).
+        unsafe { super::x86_64_avx512::compress_packed_16(cv, block) }
     }
 }
 
-#[cfg(not(any(
-    all(target_arch = "x86_64", target_feature = "avx2"),
-    all(target_arch = "x86_64", target_feature = "avx512f"),
-)))]
+#[cfg(all(
+    target_arch = "x86_64",
+    not(feature = "std"),
+    target_feature = "avx2",
+    not(target_feature = "avx512f")
+))]
 mod native_backend {
-    pub(super) const LANES: usize = 4;
+    use super::{PACKED_LANES, compress_via_sub_batches};
 
     #[inline(always)]
-    pub(super) fn compress(cv: [[u32; LANES]; 8], block: [[u32; LANES]; 16]) -> [[u32; LANES]; 8] {
-        super::compress_packed_4(cv, block)
+    pub(super) fn compress(
+        cv: [[u32; PACKED_LANES]; 8],
+        block: [[u32; PACKED_LANES]; 16],
+    ) -> [[u32; PACKED_LANES]; 8] {
+        compress_via_sub_batches::<8>(cv, block, |cv, block| {
+            // SAFETY: this module only compiles when `target_feature = "avx2"` is enabled
+            // crate-wide (e.g. via `-C target-cpu=native` or `-C target-feature=+avx2`).
+            unsafe { super::x86_64_avx2::compress_packed_8(cv, block) }
+        })
+    }
+}
+
+#[cfg(all(
+    target_arch = "x86_64",
+    not(feature = "std"),
+    not(target_feature = "avx2"),
+    not(target_feature = "avx512f")
+))]
+mod native_backend {
+    use super::{PACKED_LANES, compress_via_sub_batches};
+
+    #[inline(always)]
+    pub(super) fn compress(
+        cv: [[u32; PACKED_LANES]; 8],
+        block: [[u32; PACKED_LANES]; 16],
+    ) -> [[u32; PACKED_LANES]; 8] {
+        compress_via_sub_batches::<4>(cv, block, |cv, block| {
+            // SAFETY: SSE2 is part of the x86_64 architectural baseline.
+            unsafe { super::x86_64_sse2::compress_packed_4(cv, block) }
+        })
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+mod native_backend {
+    use super::PACKED_LANES;
+
+    #[inline(always)]
+    pub(super) fn compress(
+        cv: [[u32; PACKED_LANES]; 8],
+        block: [[u32; PACKED_LANES]; 16],
+    ) -> [[u32; PACKED_LANES]; 8] {
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            super::compress_via_sub_batches::<4>(cv, block, super::neon::compress_packed_4)
+        }
+
+        #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+        {
+            super::compress_packed(cv, block)
+        }
     }
 }
 
@@ -228,29 +359,6 @@ pub(super) fn compress_packed<const LANES: usize>(
     array::from_fn(|i| xor_packed(v[i], v[i + 8]))
 }
 
-/// Applies the raw BLAKE3 schedule to four independent lanes.
-#[cfg(not(all(target_arch = "x86_64", any(target_feature = "avx2", target_feature = "avx512f"))))]
-#[inline]
-pub(super) fn compress_packed_4(cv: [[u32; 4]; 8], block: [[u32; 4]; 16]) -> [[u32; 4]; 8] {
-    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-    {
-        neon::compress_packed_4(cv, block)
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    {
-        x86_64_sse2::compress_packed_4(cv, block)
-    }
-
-    #[cfg(any(
-        all(target_arch = "aarch64", not(target_feature = "neon")),
-        not(any(target_arch = "aarch64", target_arch = "x86_64")),
-    ))]
-    {
-        compress_packed(cv, block)
-    }
-}
-
 /// Applies the raw BLAKE3 schedule to the build's selected native lane width.
 #[inline]
 pub(super) fn compress_packed_native(
@@ -263,9 +371,10 @@ pub(super) fn compress_packed_native(
 #[cfg(target_arch = "x86_64")]
 #[rustfmt::skip]
 macro_rules! define_x86_packed_compress {
-    ($name:ident, $lanes:literal) => {
-        #[inline(always)]
-        pub(super) fn $name(
+    ($(#[$attr:meta])* $name:ident, $lanes:literal) => {
+        $(#[$attr])*
+        #[inline]
+        pub(super) unsafe fn $name(
             cv: [[u32; $lanes]; 8],
             block: [[u32; $lanes]; 16],
         ) -> [[u32; $lanes]; 8] {
@@ -414,7 +523,7 @@ macro_rules! define_x86_packed_compress {
 
 #[cfg(all(
     target_arch = "x86_64",
-    not(any(target_feature = "avx2", target_feature = "avx512f"))
+    any(feature = "std", not(any(target_feature = "avx2", target_feature = "avx512f")))
 ))]
 mod x86_64_sse2 {
     use core::arch::x86_64::*;
@@ -471,7 +580,10 @@ mod x86_64_sse2 {
     define_x86_packed_compress!(compress_packed_4, 4);
 }
 
-#[cfg(all(target_arch = "x86_64", target_feature = "avx2", not(target_feature = "avx512f")))]
+#[cfg(all(
+    target_arch = "x86_64",
+    any(feature = "std", all(target_feature = "avx2", not(target_feature = "avx512f")))
+))]
 mod x86_64_avx2 {
     use core::arch::x86_64::*;
 
@@ -504,9 +616,17 @@ mod x86_64_avx2 {
         unsafe { _mm256_xor_si256(a, b) }
     }
 
+    /// Rotate each 32-bit lane right by 16 bits via a single byte shuffle: this is cheaper than
+    /// the shift-or sequence because the rotation amount is byte-aligned.
     #[inline(always)]
     fn rotr16(x: __m256i) -> __m256i {
-        unsafe { _mm256_or_si256(_mm256_srli_epi32::<16>(x), _mm256_slli_epi32::<16>(x)) }
+        unsafe {
+            let mask = _mm256_setr_epi8(
+                2, 3, 0, 1, 6, 7, 4, 5, 10, 11, 8, 9, 14, 15, 12, 13, 2, 3, 0, 1, 6, 7, 4, 5, 10,
+                11, 8, 9, 14, 15, 12, 13,
+            );
+            _mm256_shuffle_epi8(x, mask)
+        }
     }
 
     #[inline(always)]
@@ -514,9 +634,16 @@ mod x86_64_avx2 {
         unsafe { _mm256_or_si256(_mm256_srli_epi32::<12>(x), _mm256_slli_epi32::<20>(x)) }
     }
 
+    /// Rotate each 32-bit lane right by 8 bits via a single byte shuffle (see [`rotr16`]).
     #[inline(always)]
     fn rotr8(x: __m256i) -> __m256i {
-        unsafe { _mm256_or_si256(_mm256_srli_epi32::<8>(x), _mm256_slli_epi32::<24>(x)) }
+        unsafe {
+            let mask = _mm256_setr_epi8(
+                1, 2, 3, 0, 5, 6, 7, 4, 9, 10, 11, 8, 13, 14, 15, 12, 1, 2, 3, 0, 5, 6, 7, 4, 9,
+                10, 11, 8, 13, 14, 15, 12,
+            );
+            _mm256_shuffle_epi8(x, mask)
+        }
     }
 
     #[inline(always)]
@@ -524,10 +651,14 @@ mod x86_64_avx2 {
         unsafe { _mm256_or_si256(_mm256_srli_epi32::<7>(x), _mm256_slli_epi32::<25>(x)) }
     }
 
-    define_x86_packed_compress!(compress_packed_8, 8);
+    define_x86_packed_compress!(
+        #[target_feature(enable = "avx2")]
+        compress_packed_8,
+        8
+    );
 }
 
-#[cfg(all(target_arch = "x86_64", target_feature = "avx512f"))]
+#[cfg(all(target_arch = "x86_64", any(feature = "std", target_feature = "avx512f")))]
 mod x86_64_avx512 {
     use core::arch::x86_64::*;
 
@@ -580,7 +711,11 @@ mod x86_64_avx512 {
         unsafe { _mm512_ror_epi32::<7>(x) }
     }
 
-    define_x86_packed_compress!(compress_packed_16, 16);
+    define_x86_packed_compress!(
+        #[target_feature(enable = "avx512f")]
+        compress_packed_16,
+        16
+    );
 }
 
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]

--- a/crates/crypto/src/hash/eidos/primitive/blake3_schedule.rs
+++ b/crates/crypto/src/hash/eidos/primitive/blake3_schedule.rs
@@ -5,7 +5,16 @@
 //! `primitive.rs` and `framing.rs`. The local schedule accepts batches of caller-supplied chaining
 //! values and message blocks and exposes the raw CV and XOF folds required by Eidos.
 
+#[cfg(any(
+    test,
+    not(target_arch = "x86_64"),
+    feature = "std",
+    not(target_feature = "avx512f")
+))]
 use core::array;
+
+#[cfg(target_arch = "x86_64")]
+mod row_x86;
 
 /// BLAKE3 IV.
 pub(super) const IV: [u32; 8] = [
@@ -19,9 +28,11 @@ pub(super) const IV: [u32; 8] = [
     0x5be0_cd19,
 ];
 
+#[cfg(any(test, not(target_arch = "x86_64")))]
 const ROUNDS: usize = 7;
 
 /// BLAKE3 message-word schedule for the compression rounds.
+#[cfg(any(test, not(target_arch = "x86_64")))]
 const MSG_SCHEDULE: [[usize; 16]; ROUNDS] = [
     [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
     [2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8],
@@ -203,6 +214,7 @@ mod native_backend {
 }
 
 #[inline(always)]
+#[cfg(any(test, not(target_arch = "x86_64")))]
 fn g(v: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, x: u32, y: u32) {
     v[a] = v[a].wrapping_add(v[b]).wrapping_add(x);
     v[d] = (v[d] ^ v[a]).rotate_right(16);
@@ -270,6 +282,7 @@ fn g_packed<const LANES: usize>(
 }
 
 #[inline(always)]
+#[cfg(any(test, not(target_arch = "x86_64")))]
 fn permuted_state_with_parameter_words(
     cv: [u32; 8],
     block: [u32; 16],
@@ -296,14 +309,30 @@ fn permuted_state_with_parameter_words(
 
 /// Returns the raw eight-word CV fold with Eidos compression's fixed parameter words.
 pub(super) fn compress_raw(cv: [u32; 8], block: [u32; 16]) -> [u32; 8] {
-    let v = permuted_state_with_parameter_words(cv, block, [IV[4], IV[5], IV[6], IV[7]]);
-    array::from_fn(|i| v[i] ^ v[i + 8])
+    #[cfg(target_arch = "x86_64")]
+    {
+        row_x86::compress_raw(&cv, &block)
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        let v = permuted_state_with_parameter_words(cv, block, [IV[4], IV[5], IV[6], IV[7]]);
+        array::from_fn(|i| v[i] ^ v[i + 8])
+    }
 }
 
 /// Returns the raw 16-word XOF fold with Eidos compression's fixed parameter words.
 pub(super) fn compress_raw_xof(cv: [u32; 8], block: [u32; 16]) -> [u32; 16] {
-    let v = permuted_state_with_parameter_words(cv, block, [IV[4], IV[5], IV[6], IV[7]]);
-    array::from_fn(|i| if i < 8 { v[i] ^ v[i + 8] } else { v[i] ^ cv[i - 8] })
+    #[cfg(target_arch = "x86_64")]
+    {
+        row_x86::compress_raw_xof(&cv, &block)
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        let v = permuted_state_with_parameter_words(cv, block, [IV[4], IV[5], IV[6], IV[7]]);
+        array::from_fn(|i| if i < 8 { v[i] ^ v[i + 8] } else { v[i] ^ cv[i - 8] })
+    }
 }
 
 #[cfg(test)]

--- a/crates/crypto/src/hash/eidos/primitive/blake3_schedule.rs
+++ b/crates/crypto/src/hash/eidos/primitive/blake3_schedule.rs
@@ -213,6 +213,45 @@ mod native_backend {
     }
 }
 
+/// Runtime dispatch for `row_x86`'s single-block path: `compress_pre` keeps up to 13 live
+/// 128-bit vectors, which spills under the legacy 16-register SSE/AVX file on a default build
+/// (measured ~30-37% slower than with a wider register file available). AVX-512VL's EVEX
+/// encoding reaches XMM16-31 even for plain 128-bit operations, eliminating those spills with
+/// the exact same instructions — so, like `native_backend` above, this is detected once at
+/// runtime and cached under the `std` feature. Without `std` (or off x86_64), selection falls
+/// back to `target_feature` cfg.
+#[cfg(all(target_arch = "x86_64", feature = "std"))]
+mod row_dispatch {
+    use once_cell::sync::Lazy;
+
+    use super::row_x86;
+
+    static HAS_AVX512VL: Lazy<bool> = Lazy::new(|| {
+        std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl")
+    });
+
+    #[inline]
+    pub(super) fn compress_raw(cv: &[u32; 8], block: &[u32; 16]) -> [u32; 8] {
+        if *HAS_AVX512VL {
+            // SAFETY: `HAS_AVX512VL` only true after `is_x86_feature_detected!` confirmed both
+            // "avx512f" and "avx512vl" for the running CPU.
+            unsafe { row_x86::compress_raw_avx512vl(cv, block) }
+        } else {
+            row_x86::compress_raw(cv, block)
+        }
+    }
+
+    #[inline]
+    pub(super) fn compress_raw_xof(cv: &[u32; 8], block: &[u32; 16]) -> [u32; 16] {
+        if *HAS_AVX512VL {
+            // SAFETY: see `compress_raw` above.
+            unsafe { row_x86::compress_raw_xof_avx512vl(cv, block) }
+        } else {
+            row_x86::compress_raw_xof(cv, block)
+        }
+    }
+}
+
 #[inline(always)]
 #[cfg(any(test, not(target_arch = "x86_64")))]
 fn g(v: &mut [u32; 16], a: usize, b: usize, c: usize, d: usize, x: u32, y: u32) {
@@ -309,7 +348,20 @@ fn permuted_state_with_parameter_words(
 
 /// Returns the raw eight-word CV fold with Eidos compression's fixed parameter words.
 pub(super) fn compress_raw(cv: [u32; 8], block: [u32; 16]) -> [u32; 8] {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
+    {
+        row_dispatch::compress_raw(&cv, &block)
+    }
+
+    #[cfg(all(target_arch = "x86_64", not(feature = "std"), target_feature = "avx512vl"))]
+    {
+        // SAFETY: this module only compiles when `target_feature = "avx512vl"` (and its
+        // prerequisite `"avx512f"`) are enabled crate-wide (e.g. via `-C target-cpu=native` or
+        // explicit `+avx512f,+avx512vl`).
+        unsafe { row_x86::compress_raw_avx512vl(&cv, &block) }
+    }
+
+    #[cfg(all(target_arch = "x86_64", not(feature = "std"), not(target_feature = "avx512vl")))]
     {
         row_x86::compress_raw(&cv, &block)
     }
@@ -323,7 +375,18 @@ pub(super) fn compress_raw(cv: [u32; 8], block: [u32; 16]) -> [u32; 8] {
 
 /// Returns the raw 16-word XOF fold with Eidos compression's fixed parameter words.
 pub(super) fn compress_raw_xof(cv: [u32; 8], block: [u32; 16]) -> [u32; 16] {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
+    {
+        row_dispatch::compress_raw_xof(&cv, &block)
+    }
+
+    #[cfg(all(target_arch = "x86_64", not(feature = "std"), target_feature = "avx512vl"))]
+    {
+        // SAFETY: see `compress_raw` above.
+        unsafe { row_x86::compress_raw_xof_avx512vl(&cv, &block) }
+    }
+
+    #[cfg(all(target_arch = "x86_64", not(feature = "std"), not(target_feature = "avx512vl")))]
     {
         row_x86::compress_raw_xof(&cv, &block)
     }

--- a/crates/crypto/src/hash/eidos/primitive/blake3_schedule.rs
+++ b/crates/crypto/src/hash/eidos/primitive/blake3_schedule.rs
@@ -61,8 +61,8 @@ pub(super) const PACKED_LANES: usize = 16;
 ))]
 #[inline]
 fn compress_via_sub_batches<const W: usize>(
-    cv: [[u32; PACKED_LANES]; 8],
-    block: [[u32; PACKED_LANES]; 16],
+    cv: &[[u32; PACKED_LANES]; 8],
+    block: &[[u32; PACKED_LANES]; 16],
     f: impl Fn([[u32; W]; 8], [[u32; W]; 16]) -> [[u32; W]; 8],
 ) -> [[u32; PACKED_LANES]; 8] {
     let mut out = [[0u32; PACKED_LANES]; 8];
@@ -112,14 +112,14 @@ mod native_backend {
 
     #[inline]
     pub(super) fn compress(
-        cv: [[u32; PACKED_LANES]; 8],
-        block: [[u32; PACKED_LANES]; 16],
+        cv: &[[u32; PACKED_LANES]; 8],
+        block: &[[u32; PACKED_LANES]; 16],
     ) -> [[u32; PACKED_LANES]; 8] {
         match *TIER {
             Tier::Avx512 => {
                 // SAFETY: `TIER` only reports `Avx512` after `is_x86_feature_detected!("avx512f")`
                 // returned true for the running CPU.
-                unsafe { x86_64_avx512::compress_packed_16(cv, block) }
+                unsafe { x86_64_avx512::compress_packed_16(*cv, *block) }
             },
             Tier::Avx2 => compress_via_sub_batches::<8>(cv, block, |cv, block| {
                 // SAFETY: `TIER` only reports `Avx2` after `is_x86_feature_detected!("avx2")`
@@ -140,12 +140,12 @@ mod native_backend {
 
     #[inline(always)]
     pub(super) fn compress(
-        cv: [[u32; PACKED_LANES]; 8],
-        block: [[u32; PACKED_LANES]; 16],
+        cv: &[[u32; PACKED_LANES]; 8],
+        block: &[[u32; PACKED_LANES]; 16],
     ) -> [[u32; PACKED_LANES]; 8] {
         // SAFETY: this module only compiles when `target_feature = "avx512f"` is enabled
         // crate-wide (e.g. via `-C target-cpu=native` or `-C target-feature=+avx512f`).
-        unsafe { super::x86_64_avx512::compress_packed_16(cv, block) }
+        unsafe { super::x86_64_avx512::compress_packed_16(*cv, *block) }
     }
 }
 
@@ -160,8 +160,8 @@ mod native_backend {
 
     #[inline(always)]
     pub(super) fn compress(
-        cv: [[u32; PACKED_LANES]; 8],
-        block: [[u32; PACKED_LANES]; 16],
+        cv: &[[u32; PACKED_LANES]; 8],
+        block: &[[u32; PACKED_LANES]; 16],
     ) -> [[u32; PACKED_LANES]; 8] {
         compress_via_sub_batches::<8>(cv, block, |cv, block| {
             // SAFETY: this module only compiles when `target_feature = "avx2"` is enabled
@@ -182,8 +182,8 @@ mod native_backend {
 
     #[inline(always)]
     pub(super) fn compress(
-        cv: [[u32; PACKED_LANES]; 8],
-        block: [[u32; PACKED_LANES]; 16],
+        cv: &[[u32; PACKED_LANES]; 8],
+        block: &[[u32; PACKED_LANES]; 16],
     ) -> [[u32; PACKED_LANES]; 8] {
         compress_via_sub_batches::<4>(cv, block, |cv, block| {
             // SAFETY: SSE2 is part of the x86_64 architectural baseline.
@@ -198,8 +198,8 @@ mod native_backend {
 
     #[inline(always)]
     pub(super) fn compress(
-        cv: [[u32; PACKED_LANES]; 8],
-        block: [[u32; PACKED_LANES]; 16],
+        cv: &[[u32; PACKED_LANES]; 8],
+        block: &[[u32; PACKED_LANES]; 16],
     ) -> [[u32; PACKED_LANES]; 8] {
         #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
         {
@@ -208,7 +208,7 @@ mod native_backend {
 
         #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
         {
-            super::compress_packed(cv, block)
+            super::compress_packed(*cv, *block)
         }
     }
 }
@@ -454,8 +454,8 @@ pub(super) fn compress_packed<const LANES: usize>(
 /// Applies the raw BLAKE3 schedule to the build's selected native lane width.
 #[inline]
 pub(super) fn compress_packed_native(
-    cv: [[u32; PACKED_LANES]; 8],
-    block: [[u32; PACKED_LANES]; 16],
+    cv: &[[u32; PACKED_LANES]; 8],
+    block: &[[u32; PACKED_LANES]; 16],
 ) -> [[u32; PACKED_LANES]; 8] {
     native_backend::compress(cv, block)
 }

--- a/crates/crypto/src/hash/eidos/primitive/blake3_schedule.rs
+++ b/crates/crypto/src/hash/eidos/primitive/blake3_schedule.rs
@@ -45,7 +45,7 @@ const MSG_SCHEDULE: [[usize; 16]; ROUNDS] = [
 
 /// Fixed logical width of a packed compression batch.
 ///
-/// This is independent of any particular SIMD backend. Every backend below fills a 16-lane
+/// This is independent of any particular SIMD backend. Each SIMD backend fills a 16-lane
 /// batch using as many physical-width calls as its vector registers need: one call of 16 for
 /// AVX-512, two calls of 8 for AVX2, four calls of 4 for SSE2 or NEON. A stable logical width
 /// keeps `PackedFelt` and friends the same public type regardless of which physical backend
@@ -55,6 +55,7 @@ pub(super) const PACKED_LANES: usize = 16;
 /// Splits a `PACKED_LANES`-wide batch into `PACKED_LANES / W` sub-batches of width `W`, applies
 /// `f` to each, and reassembles the results.
 #[cfg(any(
+    test,
     all(target_arch = "x86_64", feature = "std"),
     all(target_arch = "x86_64", not(target_feature = "avx512f")),
     all(target_arch = "aarch64", target_feature = "neon"),
@@ -80,56 +81,61 @@ fn compress_via_sub_batches<const W: usize>(
     out
 }
 
+/// Runtime CPU feature queries shared by every x86_64 dispatch site under `std`.
+///
+/// The standard library caches runtime feature detection results. Keeping the queries here means
+/// the packed backend, the row-wise variant, and the AVX-512 `u64` lane adapter all key off the
+/// same predicates.
+#[cfg(all(target_arch = "x86_64", feature = "std"))]
+pub(crate) mod cpu {
+    /// AVX-512F selects the 16-lane packed backend and the AVX-512 `u64` lane adapter.
+    #[inline]
+    pub(crate) fn has_avx512f() -> bool {
+        std::is_x86_feature_detected!("avx512f")
+    }
+
+    /// AVX-512VL on top of AVX-512F selects the row-wise variant that can use XMM16-31.
+    #[inline]
+    pub(crate) fn has_avx512vl() -> bool {
+        has_avx512f() && std::is_x86_feature_detected!("avx512vl")
+    }
+
+    /// AVX2 selects the 8-lane packed backend when AVX-512F is unavailable.
+    #[inline]
+    pub(crate) fn has_avx2() -> bool {
+        std::is_x86_feature_detected!("avx2")
+    }
+}
+
 /// Backend selection: on x86_64 with the `std` feature, the physical SIMD tier (AVX-512, AVX2,
-/// or SSE2) is detected once at runtime and cached, so an off-the-shelf build picks up whatever
-/// the host CPU actually supports. Without `std` (or off x86_64), selection falls back to
+/// or SSE2) is chosen at runtime through `cpu`, so an off-the-shelf build picks up whatever the
+/// host CPU actually supports. Without `std` (or off x86_64), selection falls back to
 /// `target_feature` cfg, exactly as before: a native build needs `-C target-cpu=native` or an
 /// explicit `+avx2`/`+avx512f` to get past the SSE2/NEON baseline.
 #[cfg(all(target_arch = "x86_64", feature = "std"))]
 mod native_backend {
-    use once_cell::sync::Lazy;
-
-    use super::{PACKED_LANES, compress_via_sub_batches, x86_64_avx2, x86_64_avx512, x86_64_sse2};
-
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    enum Tier {
-        Avx512,
-        Avx2,
-        Sse2,
-    }
-
-    fn detect() -> Tier {
-        if std::is_x86_feature_detected!("avx512f") {
-            Tier::Avx512
-        } else if std::is_x86_feature_detected!("avx2") {
-            Tier::Avx2
-        } else {
-            Tier::Sse2
-        }
-    }
-
-    static TIER: Lazy<Tier> = Lazy::new(detect);
+    use super::{
+        PACKED_LANES, compress_via_sub_batches, cpu, x86_64_avx2, x86_64_avx512, x86_64_sse2,
+    };
 
     #[inline]
     pub(super) fn compress(
         cv: &[[u32; PACKED_LANES]; 8],
         block: &[[u32; PACKED_LANES]; 16],
     ) -> [[u32; PACKED_LANES]; 8] {
-        match *TIER {
-            Tier::Avx512 => {
-                // SAFETY: `TIER` only reports `Avx512` after `is_x86_feature_detected!("avx512f")`
-                // returned true for the running CPU.
-                unsafe { x86_64_avx512::compress_packed_16(*cv, *block) }
-            },
-            Tier::Avx2 => compress_via_sub_batches::<8>(cv, block, |cv, block| {
-                // SAFETY: `TIER` only reports `Avx2` after `is_x86_feature_detected!("avx2")`
-                // returned true for the running CPU.
+        if cpu::has_avx512f() {
+            // SAFETY: `cpu::has_avx512f` confirmed AVX-512F support on the running CPU.
+            unsafe { x86_64_avx512::compress_packed_16(*cv, *block) }
+        } else if cpu::has_avx2() {
+            compress_via_sub_batches::<8>(cv, block, |cv, block| {
+                // SAFETY: `cpu::has_avx2` confirmed AVX2 support on the running CPU.
                 unsafe { x86_64_avx2::compress_packed_8(cv, block) }
-            }),
-            Tier::Sse2 => compress_via_sub_batches::<4>(cv, block, |cv, block| {
+            })
+        } else {
+            compress_via_sub_batches::<4>(cv, block, |cv, block| {
                 // SAFETY: SSE2 is part of the x86_64 architectural baseline.
                 unsafe { x86_64_sse2::compress_packed_4(cv, block) }
-            }),
+            })
         }
     }
 }
@@ -213,28 +219,17 @@ mod native_backend {
     }
 }
 
-/// Runtime dispatch for `row_x86`'s single-block path: `compress_pre` keeps up to 13 live
-/// 128-bit vectors, which spills under the legacy 16-register SSE/AVX file on a default build
-/// (measured ~30-37% slower than with a wider register file available). AVX-512VL's EVEX
-/// encoding reaches XMM16-31 even for plain 128-bit operations, eliminating those spills with
-/// the exact same instructions — so, like `native_backend` above, this is detected once at
-/// runtime and cached under the `std` feature. Without `std` (or off x86_64), selection falls
-/// back to `target_feature` cfg.
+/// Selects the baseline SSE2 or AVX-512F/VL row implementation at runtime under `std` through
+/// `cpu`. Without `std`, target features select the implementation at compile time.
 #[cfg(all(target_arch = "x86_64", feature = "std"))]
 mod row_dispatch {
-    use once_cell::sync::Lazy;
-
-    use super::row_x86;
-
-    static HAS_AVX512VL: Lazy<bool> = Lazy::new(|| {
-        std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl")
-    });
+    use super::{cpu, row_x86};
 
     #[inline]
     pub(super) fn compress_raw(cv: &[u32; 8], block: &[u32; 16]) -> [u32; 8] {
-        if *HAS_AVX512VL {
-            // SAFETY: `HAS_AVX512VL` only true after `is_x86_feature_detected!` confirmed both
-            // "avx512f" and "avx512vl" for the running CPU.
+        if cpu::has_avx512vl() {
+            // SAFETY: `cpu::has_avx512vl` confirmed AVX-512F and AVX-512VL support on the running
+            // CPU.
             unsafe { row_x86::compress_raw_avx512vl(cv, block) }
         } else {
             row_x86::compress_raw(cv, block)
@@ -243,7 +238,7 @@ mod row_dispatch {
 
     #[inline]
     pub(super) fn compress_raw_xof(cv: &[u32; 8], block: &[u32; 16]) -> [u32; 16] {
-        if *HAS_AVX512VL {
+        if cpu::has_avx512vl() {
             // SAFETY: see `compress_raw` above.
             unsafe { row_x86::compress_raw_xof_avx512vl(cv, block) }
         } else {
@@ -451,7 +446,7 @@ pub(super) fn compress_packed<const LANES: usize>(
     array::from_fn(|i| xor_packed(v[i], v[i + 8]))
 }
 
-/// Applies the raw BLAKE3 schedule to the build's selected native lane width.
+/// Applies the raw BLAKE3 schedule to one logical packed batch using the selected native backend.
 #[inline]
 pub(super) fn compress_packed_native(
     cv: &[[u32; PACKED_LANES]; 8],
@@ -1005,5 +1000,139 @@ mod neon {
             store(xor(v6, v14)),
             store(xor(v7, v15)),
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// xorshift64 stream for backend equivalence inputs.
+    fn next_u32(state: &mut u64) -> u32 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        *state as u32
+    }
+
+    fn random_packed<const W: usize>(state: &mut u64) -> ([[u32; W]; 8], [[u32; W]; 16]) {
+        let cv = array::from_fn(|_| array::from_fn(|_| next_u32(state)));
+        let block = array::from_fn(|_| array::from_fn(|_| next_u32(state)));
+        (cv, block)
+    }
+
+    /// `compress_via_sub_batches` must split, process, and reassemble lanes without mixing them,
+    /// whatever physical width the backend uses.
+    #[test]
+    fn sub_batches_reassemble_lanes_in_order() {
+        let mut state = 0x1234_5678_9abc_def0u64;
+        let (cv, block) = random_packed::<PACKED_LANES>(&mut state);
+        let expected = compress_packed::<PACKED_LANES>(cv, block);
+
+        assert_eq!(compress_via_sub_batches::<4>(&cv, &block, compress_packed::<4>), expected);
+        assert_eq!(compress_via_sub_batches::<8>(&cv, &block, compress_packed::<8>), expected);
+        assert_eq!(compress_via_sub_batches::<16>(&cv, &block, compress_packed::<16>), expected);
+    }
+
+    /// Each x86_64 backend is checked directly rather than through the runtime dispatcher, so one
+    /// AVX-512 host exercises every tier a default `std` build can select.
+    #[cfg(all(target_arch = "x86_64", feature = "std"))]
+    mod x86_64_backends {
+        use super::*;
+
+        const PARAMETER_WORDS: [u32; 4] = [IV[4], IV[5], IV[6], IV[7]];
+
+        fn assert_packed_backend_matches_reference<const W: usize>(
+            backend: impl Fn([[u32; W]; 8], [[u32; W]; 16]) -> [[u32; W]; 8],
+        ) {
+            let mut state = 0x9e37_79b9_7f4a_7c15u64;
+            for _ in 0..512 {
+                let (cv, block) = random_packed::<W>(&mut state);
+                let out = backend(cv, block);
+                for lane in 0..W {
+                    let cv_lane: [u32; 8] = array::from_fn(|word| cv[word][lane]);
+                    let block_lane: [u32; 16] = array::from_fn(|word| block[word][lane]);
+                    let expected =
+                        compress_raw_with_parameter_words(cv_lane, block_lane, PARAMETER_WORDS);
+                    let actual: [u32; 8] = array::from_fn(|word| out[word][lane]);
+                    assert_eq!(actual, expected, "lane {lane} diverged");
+                }
+            }
+        }
+
+        fn assert_row_variant_matches_reference(
+            raw: impl Fn(&[u32; 8], &[u32; 16]) -> [u32; 8],
+            xof: impl Fn(&[u32; 8], &[u32; 16]) -> [u32; 16],
+        ) {
+            let mut state = 0x0123_4567_89ab_cdefu64;
+            for _ in 0..2048 {
+                let cv: [u32; 8] = array::from_fn(|_| next_u32(&mut state));
+                let block: [u32; 16] = array::from_fn(|_| next_u32(&mut state));
+                assert_eq!(
+                    raw(&cv, &block),
+                    compress_raw_with_parameter_words(cv, block, PARAMETER_WORDS)
+                );
+                assert_eq!(
+                    xof(&cv, &block),
+                    compress_raw_xof_with_parameter_words(cv, block, PARAMETER_WORDS)
+                );
+            }
+        }
+
+        #[test]
+        fn sse2_packed_backend_matches_reference() {
+            assert_packed_backend_matches_reference::<4>(|cv, block| {
+                // SAFETY: SSE2 is part of the x86_64 architectural baseline.
+                unsafe { x86_64_sse2::compress_packed_4(cv, block) }
+            });
+        }
+
+        #[test]
+        fn avx2_packed_backend_matches_reference() {
+            if !cpu::has_avx2() {
+                std::eprintln!("skipped: the running CPU lacks AVX2");
+                return;
+            }
+            assert_packed_backend_matches_reference::<8>(|cv, block| {
+                // SAFETY: `cpu::has_avx2` confirmed AVX2 support on the running CPU.
+                unsafe { x86_64_avx2::compress_packed_8(cv, block) }
+            });
+        }
+
+        #[test]
+        fn avx512_packed_backend_matches_reference() {
+            if !cpu::has_avx512f() {
+                std::eprintln!("skipped: the running CPU lacks AVX-512F");
+                return;
+            }
+            assert_packed_backend_matches_reference::<16>(|cv, block| {
+                // SAFETY: `cpu::has_avx512f` confirmed AVX-512F support on the running CPU.
+                unsafe { x86_64_avx512::compress_packed_16(cv, block) }
+            });
+        }
+
+        #[test]
+        fn sse2_row_variant_matches_reference() {
+            assert_row_variant_matches_reference(row_x86::compress_raw, row_x86::compress_raw_xof);
+        }
+
+        #[test]
+        fn avx512vl_row_variant_matches_reference() {
+            if !cpu::has_avx512vl() {
+                std::eprintln!("skipped: the running CPU lacks AVX-512VL");
+                return;
+            }
+            assert_row_variant_matches_reference(
+                |cv, block| {
+                    // SAFETY: `cpu::has_avx512vl` confirmed AVX-512F and AVX-512VL support on the
+                    // running CPU.
+                    unsafe { row_x86::compress_raw_avx512vl(cv, block) }
+                },
+                |cv, block| {
+                    // SAFETY: see above.
+                    unsafe { row_x86::compress_raw_xof_avx512vl(cv, block) }
+                },
+            );
+        }
     }
 }

--- a/crates/crypto/src/hash/eidos/primitive/blake3_schedule/row_x86.rs
+++ b/crates/crypto/src/hash/eidos/primitive/blake3_schedule/row_x86.rs
@@ -1,0 +1,243 @@
+//! Row-wise (diagonalized) single-block BLAKE3 compression for x86_64.
+//!
+//! Ported from the `blake3` crate's `rust_sse2::compress_pre` (the pure-Rust SSE2 backend,
+//! MIT/Apache-2.0/CC0), adapted to Eidos's fixed parameter-word tail
+//! (`v[12..16] = IV[4..8]`, no counter/block_len/flags) and to a `[u32; 16]` message block
+//! instead of raw bytes. Keeping one G-function row per 128-bit vector and diagonalizing via
+//! shuffles (instead of one scalar 32-bit lane per `g` call) does the same seven rounds in
+//! roughly a quarter of the vector instructions of the portable loop in `super`.
+//!
+//! SSE2 is part of the x86_64 architectural baseline, so every function here runs
+//! unconditionally on x86_64 with no runtime feature check.
+
+use core::arch::x86_64::*;
+
+use super::IV;
+
+#[inline(always)]
+unsafe fn loadu(src: *const u32) -> __m128i {
+    unsafe { _mm_loadu_si128(src.cast()) }
+}
+
+#[inline(always)]
+unsafe fn storeu(src: __m128i, dest: *mut u32) {
+    unsafe { _mm_storeu_si128(dest.cast(), src) }
+}
+
+#[inline(always)]
+unsafe fn add(a: __m128i, b: __m128i) -> __m128i {
+    unsafe { _mm_add_epi32(a, b) }
+}
+
+#[inline(always)]
+unsafe fn xor(a: __m128i, b: __m128i) -> __m128i {
+    unsafe { _mm_xor_si128(a, b) }
+}
+
+#[inline(always)]
+unsafe fn set4(a: u32, b: u32, c: u32, d: u32) -> __m128i {
+    unsafe { _mm_setr_epi32(a as i32, b as i32, c as i32, d as i32) }
+}
+
+#[inline(always)]
+unsafe fn rot16(a: __m128i) -> __m128i {
+    unsafe { _mm_or_si128(_mm_srli_epi32(a, 16), _mm_slli_epi32(a, 32 - 16)) }
+}
+
+#[inline(always)]
+unsafe fn rot12(a: __m128i) -> __m128i {
+    unsafe { _mm_or_si128(_mm_srli_epi32(a, 12), _mm_slli_epi32(a, 32 - 12)) }
+}
+
+#[inline(always)]
+unsafe fn rot8(a: __m128i) -> __m128i {
+    unsafe { _mm_or_si128(_mm_srli_epi32(a, 8), _mm_slli_epi32(a, 32 - 8)) }
+}
+
+#[inline(always)]
+unsafe fn rot7(a: __m128i) -> __m128i {
+    unsafe { _mm_or_si128(_mm_srli_epi32(a, 7), _mm_slli_epi32(a, 32 - 7)) }
+}
+
+#[inline(always)]
+unsafe fn g1(
+    row0: &mut __m128i,
+    row1: &mut __m128i,
+    row2: &mut __m128i,
+    row3: &mut __m128i,
+    m: __m128i,
+) {
+    unsafe {
+        *row0 = add(add(*row0, m), *row1);
+        *row3 = xor(*row3, *row0);
+        *row3 = rot16(*row3);
+        *row2 = add(*row2, *row3);
+        *row1 = xor(*row1, *row2);
+        *row1 = rot12(*row1);
+    }
+}
+
+#[inline(always)]
+unsafe fn g2(
+    row0: &mut __m128i,
+    row1: &mut __m128i,
+    row2: &mut __m128i,
+    row3: &mut __m128i,
+    m: __m128i,
+) {
+    unsafe {
+        *row0 = add(add(*row0, m), *row1);
+        *row3 = xor(*row3, *row0);
+        *row3 = rot8(*row3);
+        *row2 = add(*row2, *row3);
+        *row1 = xor(*row1, *row2);
+        *row1 = rot7(*row1);
+    }
+}
+
+macro_rules! mm_shuffle {
+    ($z:expr, $y:expr, $x:expr, $w:expr) => {
+        ($z << 6) | ($y << 4) | ($x << 2) | $w
+    };
+}
+
+macro_rules! shuffle2 {
+    ($a:expr, $b:expr, $c:expr) => {
+        _mm_castps_si128(_mm_shuffle_ps(_mm_castsi128_ps($a), _mm_castsi128_ps($b), $c))
+    };
+}
+
+// Note the optimization here of leaving row1 as the unrotated row, rather than row0. All the
+// message loads below are adjusted to compensate. See
+// https://github.com/sneves/blake2-avx2/pull/4.
+#[inline(always)]
+unsafe fn diagonalize(row0: &mut __m128i, row2: &mut __m128i, row3: &mut __m128i) {
+    unsafe {
+        *row0 = _mm_shuffle_epi32(*row0, mm_shuffle!(2, 1, 0, 3));
+        *row3 = _mm_shuffle_epi32(*row3, mm_shuffle!(1, 0, 3, 2));
+        *row2 = _mm_shuffle_epi32(*row2, mm_shuffle!(0, 3, 2, 1));
+    }
+}
+
+#[inline(always)]
+unsafe fn undiagonalize(row0: &mut __m128i, row2: &mut __m128i, row3: &mut __m128i) {
+    unsafe {
+        *row0 = _mm_shuffle_epi32(*row0, mm_shuffle!(0, 3, 2, 1));
+        *row3 = _mm_shuffle_epi32(*row3, mm_shuffle!(1, 0, 3, 2));
+        *row2 = _mm_shuffle_epi32(*row2, mm_shuffle!(2, 1, 0, 3));
+    }
+}
+
+#[inline(always)]
+unsafe fn blend_epi16(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
+    unsafe {
+        let bits = _mm_set_epi16(0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01);
+        let mut mask = _mm_set1_epi16(imm8 as i16);
+        mask = _mm_and_si128(mask, bits);
+        mask = _mm_cmpeq_epi16(mask, bits);
+        _mm_or_si128(_mm_and_si128(mask, b), _mm_andnot_si128(mask, a))
+    }
+}
+
+/// Row-wise diagonalized permutation, adapted from `blake3::rust_sse2::compress_pre`.
+///
+/// Returns `[row0, row1, row2, row3] = [v[0..4], v[4..8], v[8..12], v[12..16]]` of the standard
+/// BLAKE3 permuted state after all seven rounds, with Eidos's fixed parameter-word tail
+/// (`v[12..16] = IV[4..8]`, matching `super::permuted_state_with_parameter_words`).
+#[inline(always)]
+unsafe fn compress_pre(cv: &[u32; 8], block: &[u32; 16]) -> [__m128i; 4] {
+    unsafe {
+        let row0 = &mut loadu(cv.as_ptr());
+        let row1 = &mut loadu(cv.as_ptr().add(4));
+        let row2 = &mut set4(IV[0], IV[1], IV[2], IV[3]);
+        let row3 = &mut set4(IV[4], IV[5], IV[6], IV[7]);
+
+        let mut m0 = loadu(block.as_ptr());
+        let mut m1 = loadu(block.as_ptr().add(4));
+        let mut m2 = loadu(block.as_ptr().add(8));
+        let mut m3 = loadu(block.as_ptr().add(12));
+
+        let mut t0;
+        let mut t1;
+        let mut t2;
+        let mut t3;
+        let mut tt;
+
+        // Round 1 permutes the message words from the original input order into the groups
+        // that get mixed in parallel.
+        t0 = shuffle2!(m0, m1, mm_shuffle!(2, 0, 2, 0));
+        g1(row0, row1, row2, row3, t0);
+        t1 = shuffle2!(m0, m1, mm_shuffle!(3, 1, 3, 1));
+        g2(row0, row1, row2, row3, t1);
+        diagonalize(row0, row2, row3);
+        t2 = shuffle2!(m2, m3, mm_shuffle!(2, 0, 2, 0));
+        t2 = _mm_shuffle_epi32(t2, mm_shuffle!(2, 1, 0, 3));
+        g1(row0, row1, row2, row3, t2);
+        t3 = shuffle2!(m2, m3, mm_shuffle!(3, 1, 3, 1));
+        t3 = _mm_shuffle_epi32(t3, mm_shuffle!(2, 1, 0, 3));
+        g2(row0, row1, row2, row3, t3);
+        undiagonalize(row0, row2, row3);
+        m0 = t0;
+        m1 = t1;
+        m2 = t2;
+        m3 = t3;
+
+        // Rounds 2-7 apply a fixed permutation to the message words produced by the round
+        // before, so the same shuffle sequence repeats.
+        for _ in 0..6 {
+            t0 = shuffle2!(m0, m1, mm_shuffle!(3, 1, 1, 2));
+            t0 = _mm_shuffle_epi32(t0, mm_shuffle!(0, 3, 2, 1));
+            g1(row0, row1, row2, row3, t0);
+            t1 = shuffle2!(m2, m3, mm_shuffle!(3, 3, 2, 2));
+            tt = _mm_shuffle_epi32(m0, mm_shuffle!(0, 0, 3, 3));
+            t1 = blend_epi16(tt, t1, 0xcc);
+            g2(row0, row1, row2, row3, t1);
+            diagonalize(row0, row2, row3);
+            t2 = _mm_unpacklo_epi64(m3, m1);
+            tt = blend_epi16(t2, m2, 0xc0);
+            t2 = _mm_shuffle_epi32(tt, mm_shuffle!(1, 3, 2, 0));
+            g1(row0, row1, row2, row3, t2);
+            t3 = _mm_unpackhi_epi32(m1, m3);
+            tt = _mm_unpacklo_epi32(m2, t3);
+            t3 = _mm_shuffle_epi32(tt, mm_shuffle!(0, 1, 3, 2));
+            g2(row0, row1, row2, row3, t3);
+            undiagonalize(row0, row2, row3);
+            m0 = t0;
+            m1 = t1;
+            m2 = t2;
+            m3 = t3;
+        }
+
+        [*row0, *row1, *row2, *row3]
+    }
+}
+
+/// Returns the raw eight-word CV fold with Eidos compression's fixed parameter words:
+/// `out[i] = v[i] ^ v[i + 8]`.
+#[inline]
+pub(super) fn compress_raw(cv: &[u32; 8], block: &[u32; 16]) -> [u32; 8] {
+    unsafe {
+        let [row0, row1, row2, row3] = compress_pre(cv, block);
+        let mut out = [0u32; 8];
+        storeu(xor(row0, row2), out.as_mut_ptr());
+        storeu(xor(row1, row3), out.as_mut_ptr().add(4));
+        out
+    }
+}
+
+/// Returns the raw sixteen-word XOF fold with Eidos compression's fixed parameter words:
+/// `out[i] = v[i] ^ v[i + 8]` for `i < 8`, `out[i] = v[i] ^ cv[i - 8]` for `i >= 8`.
+#[inline]
+pub(super) fn compress_raw_xof(cv: &[u32; 8], block: &[u32; 16]) -> [u32; 16] {
+    unsafe {
+        let [row0, row1, row2, row3] = compress_pre(cv, block);
+        let cv_row0 = loadu(cv.as_ptr());
+        let cv_row1 = loadu(cv.as_ptr().add(4));
+        let mut out = [0u32; 16];
+        storeu(xor(row0, row2), out.as_mut_ptr());
+        storeu(xor(row1, row3), out.as_mut_ptr().add(4));
+        storeu(xor(row2, cv_row0), out.as_mut_ptr().add(8));
+        storeu(xor(row3, cv_row1), out.as_mut_ptr().add(12));
+        out
+    }
+}

--- a/crates/crypto/src/hash/eidos/primitive/blake3_schedule/row_x86.rs
+++ b/crates/crypto/src/hash/eidos/primitive/blake3_schedule/row_x86.rs
@@ -7,8 +7,18 @@
 //! shuffles (instead of one scalar 32-bit lane per `g` call) does the same seven rounds in
 //! roughly a quarter of the vector instructions of the portable loop in `super`.
 //!
-//! SSE2 is part of the x86_64 architectural baseline, so every function here runs
-//! unconditionally on x86_64 with no runtime feature check.
+//! SSE2 is part of the x86_64 architectural baseline, so the plain `compress_raw`/
+//! `compress_raw_xof` below run unconditionally on x86_64 with no runtime feature check.
+//!
+//! `compress_pre` keeps up to 13 `__m128i` values alive at once (`row0..row3`, `m0..m3`,
+//! `t0..t3`, `tt`), which exceeds the 16-register legacy SSE/AVX file once ABI and spill
+//! bookkeeping are accounted for, forcing real stack spills on a default (non
+//! `target-cpu=native`) build — measured at ~30-37% slower than with a wider register file
+//! available. AVX-512VL's EVEX encoding reaches XMM16-31 even for plain 128-bit operations, so
+//! the `_avx512vl` variants below are the exact same logic (generated from one macro body, so
+//! there is no copy-paste divergence risk) recompiled with that attribute purely for the wider
+//! register file — no wider vectors, no different instructions selected by us. `avx512f` is
+//! AVX-512VL's prerequisite.
 
 use core::arch::x86_64::*;
 
@@ -144,100 +154,177 @@ unsafe fn blend_epi16(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 /// Returns `[row0, row1, row2, row3] = [v[0..4], v[4..8], v[8..12], v[12..16]]` of the standard
 /// BLAKE3 permuted state after all seven rounds, with Eidos's fixed parameter-word tail
 /// (`v[12..16] = IV[4..8]`, matching `super::permuted_state_with_parameter_words`).
-#[inline(always)]
-unsafe fn compress_pre(cv: &[u32; 8], block: &[u32; 16]) -> [__m128i; 4] {
-    unsafe {
-        let row0 = &mut loadu(cv.as_ptr());
-        let row1 = &mut loadu(cv.as_ptr().add(4));
-        let row2 = &mut set4(IV[0], IV[1], IV[2], IV[3]);
-        let row3 = &mut set4(IV[4], IV[5], IV[6], IV[7]);
+///
+/// Generated twice (see module docs): a plain variant with no feature requirement beyond SSE2,
+/// and an `avx512f,avx512vl`-attributed variant that is bit-for-bit the same logic, recompiled
+/// for the wider register file. Both bodies come from this one macro, so they cannot diverge.
+macro_rules! define_compress_pre {
+    ($(#[$attr:meta])* $name:ident) => {
+        $(#[$attr])*
+        #[inline]
+        unsafe fn $name(cv: &[u32; 8], block: &[u32; 16]) -> [__m128i; 4] {
+            unsafe {
+                let row0 = &mut loadu(cv.as_ptr());
+                let row1 = &mut loadu(cv.as_ptr().add(4));
+                let row2 = &mut set4(IV[0], IV[1], IV[2], IV[3]);
+                let row3 = &mut set4(IV[4], IV[5], IV[6], IV[7]);
 
-        let mut m0 = loadu(block.as_ptr());
-        let mut m1 = loadu(block.as_ptr().add(4));
-        let mut m2 = loadu(block.as_ptr().add(8));
-        let mut m3 = loadu(block.as_ptr().add(12));
+                let mut m0 = loadu(block.as_ptr());
+                let mut m1 = loadu(block.as_ptr().add(4));
+                let mut m2 = loadu(block.as_ptr().add(8));
+                let mut m3 = loadu(block.as_ptr().add(12));
 
-        let mut t0;
-        let mut t1;
-        let mut t2;
-        let mut t3;
-        let mut tt;
+                let mut t0;
+                let mut t1;
+                let mut t2;
+                let mut t3;
+                let mut tt;
 
-        // Round 1 permutes the message words from the original input order into the groups
-        // that get mixed in parallel.
-        t0 = shuffle2!(m0, m1, mm_shuffle!(2, 0, 2, 0));
-        g1(row0, row1, row2, row3, t0);
-        t1 = shuffle2!(m0, m1, mm_shuffle!(3, 1, 3, 1));
-        g2(row0, row1, row2, row3, t1);
-        diagonalize(row0, row2, row3);
-        t2 = shuffle2!(m2, m3, mm_shuffle!(2, 0, 2, 0));
-        t2 = _mm_shuffle_epi32(t2, mm_shuffle!(2, 1, 0, 3));
-        g1(row0, row1, row2, row3, t2);
-        t3 = shuffle2!(m2, m3, mm_shuffle!(3, 1, 3, 1));
-        t3 = _mm_shuffle_epi32(t3, mm_shuffle!(2, 1, 0, 3));
-        g2(row0, row1, row2, row3, t3);
-        undiagonalize(row0, row2, row3);
-        m0 = t0;
-        m1 = t1;
-        m2 = t2;
-        m3 = t3;
+                // Round 1 permutes the message words from the original input order into the
+                // groups that get mixed in parallel.
+                t0 = shuffle2!(m0, m1, mm_shuffle!(2, 0, 2, 0));
+                g1(row0, row1, row2, row3, t0);
+                t1 = shuffle2!(m0, m1, mm_shuffle!(3, 1, 3, 1));
+                g2(row0, row1, row2, row3, t1);
+                diagonalize(row0, row2, row3);
+                t2 = shuffle2!(m2, m3, mm_shuffle!(2, 0, 2, 0));
+                t2 = _mm_shuffle_epi32(t2, mm_shuffle!(2, 1, 0, 3));
+                g1(row0, row1, row2, row3, t2);
+                t3 = shuffle2!(m2, m3, mm_shuffle!(3, 1, 3, 1));
+                t3 = _mm_shuffle_epi32(t3, mm_shuffle!(2, 1, 0, 3));
+                g2(row0, row1, row2, row3, t3);
+                undiagonalize(row0, row2, row3);
+                m0 = t0;
+                m1 = t1;
+                m2 = t2;
+                m3 = t3;
 
-        // Rounds 2-7 apply a fixed permutation to the message words produced by the round
-        // before, so the same shuffle sequence repeats.
-        for _ in 0..6 {
-            t0 = shuffle2!(m0, m1, mm_shuffle!(3, 1, 1, 2));
-            t0 = _mm_shuffle_epi32(t0, mm_shuffle!(0, 3, 2, 1));
-            g1(row0, row1, row2, row3, t0);
-            t1 = shuffle2!(m2, m3, mm_shuffle!(3, 3, 2, 2));
-            tt = _mm_shuffle_epi32(m0, mm_shuffle!(0, 0, 3, 3));
-            t1 = blend_epi16(tt, t1, 0xcc);
-            g2(row0, row1, row2, row3, t1);
-            diagonalize(row0, row2, row3);
-            t2 = _mm_unpacklo_epi64(m3, m1);
-            tt = blend_epi16(t2, m2, 0xc0);
-            t2 = _mm_shuffle_epi32(tt, mm_shuffle!(1, 3, 2, 0));
-            g1(row0, row1, row2, row3, t2);
-            t3 = _mm_unpackhi_epi32(m1, m3);
-            tt = _mm_unpacklo_epi32(m2, t3);
-            t3 = _mm_shuffle_epi32(tt, mm_shuffle!(0, 1, 3, 2));
-            g2(row0, row1, row2, row3, t3);
-            undiagonalize(row0, row2, row3);
-            m0 = t0;
-            m1 = t1;
-            m2 = t2;
-            m3 = t3;
+                // Rounds 2-7 apply a fixed permutation to the message words produced by the
+                // round before, so the same shuffle sequence repeats.
+                for _ in 0..6 {
+                    t0 = shuffle2!(m0, m1, mm_shuffle!(3, 1, 1, 2));
+                    t0 = _mm_shuffle_epi32(t0, mm_shuffle!(0, 3, 2, 1));
+                    g1(row0, row1, row2, row3, t0);
+                    t1 = shuffle2!(m2, m3, mm_shuffle!(3, 3, 2, 2));
+                    tt = _mm_shuffle_epi32(m0, mm_shuffle!(0, 0, 3, 3));
+                    t1 = blend_epi16(tt, t1, 0xcc);
+                    g2(row0, row1, row2, row3, t1);
+                    diagonalize(row0, row2, row3);
+                    t2 = _mm_unpacklo_epi64(m3, m1);
+                    tt = blend_epi16(t2, m2, 0xc0);
+                    t2 = _mm_shuffle_epi32(tt, mm_shuffle!(1, 3, 2, 0));
+                    g1(row0, row1, row2, row3, t2);
+                    t3 = _mm_unpackhi_epi32(m1, m3);
+                    tt = _mm_unpacklo_epi32(m2, t3);
+                    t3 = _mm_shuffle_epi32(tt, mm_shuffle!(0, 1, 3, 2));
+                    g2(row0, row1, row2, row3, t3);
+                    undiagonalize(row0, row2, row3);
+                    m0 = t0;
+                    m1 = t1;
+                    m2 = t2;
+                    m3 = t3;
+                }
+
+                [*row0, *row1, *row2, *row3]
+            }
         }
-
-        [*row0, *row1, *row2, *row3]
-    }
+    };
 }
+
+define_compress_pre!(
+    #[cfg(any(feature = "std", not(target_feature = "avx512vl")))]
+    compress_pre
+);
+define_compress_pre!(
+    #[cfg(any(feature = "std", target_feature = "avx512vl"))]
+    #[target_feature(enable = "avx512f,avx512vl")]
+    compress_pre_avx512vl
+);
 
 /// Returns the raw eight-word CV fold with Eidos compression's fixed parameter words:
 /// `out[i] = v[i] ^ v[i + 8]`.
-#[inline]
-pub(super) fn compress_raw(cv: &[u32; 8], block: &[u32; 16]) -> [u32; 8] {
-    unsafe {
-        let [row0, row1, row2, row3] = compress_pre(cv, block);
-        let mut out = [0u32; 8];
-        storeu(xor(row0, row2), out.as_mut_ptr());
-        storeu(xor(row1, row3), out.as_mut_ptr().add(4));
-        out
-    }
+///
+/// Generated twice (see module docs): a plain SSE2 variant needing no runtime feature check, and
+/// an `avx512f,avx512vl`-attributed variant for a wider register file.
+macro_rules! define_compress_raw {
+    ($(#[$attr:meta])* $name:ident, $compress_pre:ident) => {
+        $(#[$attr])*
+        #[inline]
+        pub(super) unsafe fn $name(cv: &[u32; 8], block: &[u32; 16]) -> [u32; 8] {
+            unsafe {
+                let [row0, row1, row2, row3] = $compress_pre(cv, block);
+                let mut out = [0u32; 8];
+                storeu(xor(row0, row2), out.as_mut_ptr());
+                storeu(xor(row1, row3), out.as_mut_ptr().add(4));
+                out
+            }
+        }
+    };
 }
+
+define_compress_raw!(
+    #[cfg(any(feature = "std", not(target_feature = "avx512vl")))]
+    compress_raw_impl,
+    compress_pre
+);
+define_compress_raw!(
+    #[cfg(any(feature = "std", target_feature = "avx512vl"))]
+    #[target_feature(enable = "avx512f,avx512vl")]
+    compress_raw_avx512vl,
+    compress_pre_avx512vl
+);
 
 /// Returns the raw sixteen-word XOF fold with Eidos compression's fixed parameter words:
 /// `out[i] = v[i] ^ v[i + 8]` for `i < 8`, `out[i] = v[i] ^ cv[i - 8]` for `i >= 8`.
+///
+/// Generated twice (see module docs): a plain SSE2 variant needing no runtime feature check, and
+/// an `avx512f,avx512vl`-attributed variant for a wider register file.
+macro_rules! define_compress_raw_xof {
+    ($(#[$attr:meta])* $name:ident, $compress_pre:ident) => {
+        $(#[$attr])*
+        #[inline]
+        pub(super) unsafe fn $name(cv: &[u32; 8], block: &[u32; 16]) -> [u32; 16] {
+            unsafe {
+                let [row0, row1, row2, row3] = $compress_pre(cv, block);
+                let cv_row0 = loadu(cv.as_ptr());
+                let cv_row1 = loadu(cv.as_ptr().add(4));
+                let mut out = [0u32; 16];
+                storeu(xor(row0, row2), out.as_mut_ptr());
+                storeu(xor(row1, row3), out.as_mut_ptr().add(4));
+                storeu(xor(row2, cv_row0), out.as_mut_ptr().add(8));
+                storeu(xor(row3, cv_row1), out.as_mut_ptr().add(12));
+                out
+            }
+        }
+    };
+}
+
+define_compress_raw_xof!(
+    #[cfg(any(feature = "std", not(target_feature = "avx512vl")))]
+    compress_raw_xof_impl,
+    compress_pre
+);
+define_compress_raw_xof!(
+    #[cfg(any(feature = "std", target_feature = "avx512vl"))]
+    #[target_feature(enable = "avx512f,avx512vl")]
+    compress_raw_xof_avx512vl,
+    compress_pre_avx512vl
+);
+
+/// Returns the raw eight-word CV fold with Eidos compression's fixed parameter words. Needs no
+/// runtime feature check: SSE2 is part of the x86_64 architectural baseline.
+#[cfg(any(feature = "std", not(target_feature = "avx512vl")))]
+#[inline]
+pub(super) fn compress_raw(cv: &[u32; 8], block: &[u32; 16]) -> [u32; 8] {
+    // SAFETY: SSE2 is part of the x86_64 architectural baseline.
+    unsafe { compress_raw_impl(cv, block) }
+}
+
+/// Returns the raw sixteen-word XOF fold with Eidos compression's fixed parameter words. Needs no
+/// runtime feature check: SSE2 is part of the x86_64 architectural baseline.
+#[cfg(any(feature = "std", not(target_feature = "avx512vl")))]
 #[inline]
 pub(super) fn compress_raw_xof(cv: &[u32; 8], block: &[u32; 16]) -> [u32; 16] {
-    unsafe {
-        let [row0, row1, row2, row3] = compress_pre(cv, block);
-        let cv_row0 = loadu(cv.as_ptr());
-        let cv_row1 = loadu(cv.as_ptr().add(4));
-        let mut out = [0u32; 16];
-        storeu(xor(row0, row2), out.as_mut_ptr());
-        storeu(xor(row1, row3), out.as_mut_ptr().add(4));
-        storeu(xor(row2, cv_row0), out.as_mut_ptr().add(8));
-        storeu(xor(row3, cv_row1), out.as_mut_ptr().add(12));
-        out
-    }
+    // SAFETY: SSE2 is part of the x86_64 architectural baseline.
+    unsafe { compress_raw_xof_impl(cv, block) }
 }

--- a/crates/crypto/src/hash/eidos/primitive/blake3_schedule/row_x86.rs
+++ b/crates/crypto/src/hash/eidos/primitive/blake3_schedule/row_x86.rs
@@ -1,24 +1,15 @@
 //! Row-wise (diagonalized) single-block BLAKE3 compression for x86_64.
 //!
-//! Ported from the `blake3` crate's `rust_sse2::compress_pre` (the pure-Rust SSE2 backend,
-//! MIT/Apache-2.0/CC0), adapted to Eidos's fixed parameter-word tail
-//! (`v[12..16] = IV[4..8]`, no counter/block_len/flags) and to a `[u32; 16]` message block
-//! instead of raw bytes. Keeping one G-function row per 128-bit vector and diagonalizing via
-//! shuffles (instead of one scalar 32-bit lane per `g` call) does the same seven rounds in
-//! roughly a quarter of the vector instructions of the portable loop in `super`.
+//! Adapted from the `blake3` crate's `rust_sse2::compress_pre` (MIT/Apache-2.0/CC0). It applies
+//! Eidos's fixed parameter-word tail (`v[12..16] = IV[4..8]`, without counter, block length, or
+//! flags) to a `[u32; 16]` message block using four diagonalized 128-bit rows.
 //!
 //! SSE2 is part of the x86_64 architectural baseline, so the plain `compress_raw`/
 //! `compress_raw_xof` below run unconditionally on x86_64 with no runtime feature check.
 //!
-//! `compress_pre` keeps up to 13 `__m128i` values alive at once (`row0..row3`, `m0..m3`,
-//! `t0..t3`, `tt`), which exceeds the 16-register legacy SSE/AVX file once ABI and spill
-//! bookkeeping are accounted for, forcing real stack spills on a default (non
-//! `target-cpu=native`) build — measured at ~30-37% slower than with a wider register file
-//! available. AVX-512VL's EVEX encoding reaches XMM16-31 even for plain 128-bit operations, so
-//! the `_avx512vl` variants below are the exact same logic (generated from one macro body, so
-//! there is no copy-paste divergence risk) recompiled with that attribute purely for the wider
-//! register file — no wider vectors, no different instructions selected by us. `avx512f` is
-//! AVX-512VL's prerequisite.
+//! The AVX-512F/VL-targeted variant uses the same algorithm with access to XMM16-31, reducing
+//! register spills without changing the logical width. Both variants are emitted from the same
+//! macro body. `avx512f` is AVX-512VL's prerequisite.
 
 use core::arch::x86_64::*;
 
@@ -155,9 +146,8 @@ unsafe fn blend_epi16(a: __m128i, b: __m128i, imm8: i32) -> __m128i {
 /// BLAKE3 permuted state after all seven rounds, with Eidos's fixed parameter-word tail
 /// (`v[12..16] = IV[4..8]`, matching `super::permuted_state_with_parameter_words`).
 ///
-/// Generated twice (see module docs): a plain variant with no feature requirement beyond SSE2,
-/// and an `avx512f,avx512vl`-attributed variant that is bit-for-bit the same logic, recompiled
-/// for the wider register file. Both bodies come from this one macro, so they cannot diverge.
+/// The macro emits a baseline SSE2 variant and an `avx512f,avx512vl`-targeted variant from the
+/// same body.
 macro_rules! define_compress_pre {
     ($(#[$attr:meta])* $name:ident) => {
         $(#[$attr])*


### PR DESCRIPTION
## Summary

Native-runtime perf work on Eidos compression:

- Runtime CPU dispatch for packed compression (AVX-512/AVX2/SSE2, detected once under `std`) + pshufb rot16/rot8 on the AVX2 tier.
- Row-wise (diagonalized) SSE2 single-block compression, ported from `blake3`'s own `rust_sse2::compress_pre`, replacing the scalar loop behind `Eidos::hash`/`merge`/`hash_elements` and the challenger's observe/squeeze on x86_64.
- Batched PoW grinding: 16 candidates per packed compression instead of one scalar clone+compress per candidate.
- AVX-512VL register-file widening: the row-wise compressor keeps ~13 `__m128i` values live at once, which spills under the legacy 16-register SSE/AVX file. Same logic recompiled with `avx512f,avx512vl` (EVEX reaches XMM16-31 even for 128-bit ops) eliminates the spills, runtime-dispatched the same way as the packed tier.

An aarch64/NEON row-wise attempt was tried and reverted — correct (verified against the scalar reference over 10k random inputs + frozen vectors) but 45-95% *slower* than the portable scalar loop on real hardware, so not included.

## Benchmark results

`cargo bench -p miden-crypto --bench hash -- eidos`, default build (no `RUSTFLAGS`), against this branch's base:

- aarch64 (Apple Silicon, native): no change — expected, this work is x86_64-only.
- x86_64 (AWS c8i.32xlarge, Intel Xeon 6975P-C, real hardware, default build):

  | benchmark | change |
  |---|---|
  | `hash-eidos-merge` | **−24.2%** |
  | `hash-eidos-felt/hash_elements/1` | **−19.9%** |
  | `hash-eidos-felt/hash_elements/100` | **−24.3%** time / +32.1% throughput |
  | `hash-eidos-felt/hash_elements/1000` | **−24.7%** time / +32.7% throughput |

## Test plan

- [x] Full crate test suite (900+ tests) on aarch64 native and x86_64 (Rosetta + real c8i hardware)
- [x] `compress_raw`/`compress_raw_xof` checked against the scalar reference over 10k random inputs, plus existing frozen test vectors
- [x] New packed-grind logic checked lane-by-lane against the scalar `check_witness` default impl across every pre-witness buffer state
- [x] clippy clean across std/no_std × baseline/AVX2/AVX-512VL/NEON/wasm32