### PR TITLE
syntax: ensure parsing preserves address space information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 #### Fixes
 - Fixed stack overflow in the precompile prover's `translate_truthy`, `translate_uint`, and `translate_ec` by converting them from recursive to iterative post-order traversals. Programs with many `LOGDEFERRED` calls no longer crash ([#3626](https://github.com/0xMiden/miden-vm/issues/3626)).
+- Fixed issue where parsing of pointer types dropped address space information ([#3790](https://github.com/0xMiden/miden-vm/pull/3790)).
 
 ## v0.31.1 (2026-09-04)
 

--- a/crates/assembly-syntax/src/ast/type.rs
+++ b/crates/assembly-syntax/src/ast/type.rs
@@ -376,7 +376,7 @@ impl TypeExpr {
             TypeExpr::Ptr(ty) => Ok(ty
                 .pointee
                 .resolve_template_with_depth(resolver, depth + 1)?
-                .map(TypeTemplate::ptr)),
+                .map(|pointee| TypeTemplate::ptr_in(ty.address_space(), pointee))),
             TypeExpr::Struct(t) => {
                 let mut fields = Vec::with_capacity(t.fields.len());
                 for field in t.fields.iter() {

--- a/crates/assembly/src/tests/type_resolution.rs
+++ b/crates/assembly/src/tests/type_resolution.rs
@@ -4,6 +4,59 @@
 use super::*;
 
 #[test]
+fn pointer_address_spaces_survive_package_round_trip() -> TestResult {
+    use miden_assembly_syntax::ast::types::{AddressSpace, PointerType, Type};
+    use miden_mast_package::{Package, PackageExport};
+
+    let context = TestContext::new();
+    let module = context.parse_module(source_file!(
+        &context,
+        r#"
+        namespace lib::pointers
+
+        pub proc write(
+            explicit: ptr<u32, addrspace(felt)>,
+            implicit: ptr<u32>,
+            bytes: ptr<u32, addrspace(byte)>,
+            nested: ptr<ptr<u32, addrspace(felt)>, addrspace(byte)>
+        ) -> ptr<u32, addrspace(felt)>
+            nop
+        end
+        "#
+    ))?;
+
+    let package = context.assemble_library("lib", None, module, [])?;
+    let decoded = Package::read_from_bytes(&package.to_bytes()).expect("package should decode");
+    let element_ptr =
+        Type::Ptr(PointerType::new_with_address_space(Type::U32, AddressSpace::Element).into());
+    let byte_ptr =
+        Type::Ptr(PointerType::new_with_address_space(Type::U32, AddressSpace::Byte).into());
+    let nested_ptr = Type::Ptr(
+        PointerType::new_with_address_space(element_ptr.clone(), AddressSpace::Byte).into(),
+    );
+
+    for package in [&package, &decoded] {
+        let signature = package
+            .manifest
+            .exports()
+            .find_map(|export| match export {
+                PackageExport::Procedure(proc) if proc.path.to_string().ends_with("write") => {
+                    proc.signature.as_ref()
+                },
+                _ => None,
+            })
+            .expect("write should be exported with a signature");
+
+        assert_eq!(
+            signature.params(),
+            &[element_ptr.clone(), element_ptr.clone(), byte_ptr.clone(), nested_ptr.clone()]
+        );
+        assert_eq!(signature.results(), core::slice::from_ref(&element_ptr));
+    }
+    Ok(())
+}
+
+#[test]
 fn variadic_procedure_signatures_resolve() -> TestResult {
     use miden_assembly_syntax::ast::types::Type;
     use miden_mast_package::PackageExport;


### PR DESCRIPTION
This patch fixes a bug in `miden-assembly-syntax` where it would drop a pointer type's parsed address space.

During type resolution in `TypeExpr::resolve_type_with_depth`, it resolves a pointer through `PointerType::new(pointee)`, which defaults to `AddressSpace::Byte`, discarding the parsed `addrspace(..)`. The AST accessor `PointerType::address_space()` defaults an *unannotated* pointer to `Element`, so the two halves
disagree even for `ptr<u32>`. Consequence: every pointer in an assembled package manifest reports
byte space, so the compiler cannot learn from a typed signature that a parameter is an element
address, and therefore cannot insert the byte-to-element conversion the design relies on.

This is a critical blocker for binding generation in the compiler, so it is based against `main` so it can go out ASAP in a patch release. I have another PR which adds missing type signatures to the core lib which I'll open after this one, which is similarly a blocker for the compiler, and is based on `main` - both should go out together.