### PR TITLE
syntax: infer callconv attribute from protocol abi attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Changes
 - Added type signatures for all procedures in the Miden core library ([#3791](https://github.com/0xMiden/miden-vm/pull/3791)). **NOTE:** This changes the package identity of the core library and any packages which dynamically link it. Packages which were assembled against 0.32.0 of the core library will need to be re-assembled (unless they statically linked the core library), otherwise executors that only load the latest version of the core library for you will be unable to resolve the older dependency.
+- Automatically infer procedure calling convention from known protocol ABI attributes ([#3802](https://github.com/0xMiden/miden-vm/pull/3802))
 
 #### Fixes
 - Fixed issue where parsing of pointer types dropped address space information ([#3790](https://github.com/0xMiden/miden-vm/pull/3790)).

--- a/crates/assembly-syntax/src/ast/tests.rs
+++ b/crates/assembly-syntax/src/ast/tests.rs
@@ -7,7 +7,7 @@ use pretty_assertions::assert_eq;
 use crate::{
     Felt, PathBuf, assert_diagnostic, assert_diagnostic_lines,
     ast::{types::Type, *},
-    parser::{IntValue, WordValue},
+    parser::{IntValue, PushValue, WordValue},
     regex, source_file,
     testing::SyntaxTestContext,
 };
@@ -1847,4 +1847,227 @@ end
     );
     assert_eq!(context.parse_forms(source)?, forms);
     Ok(())
+}
+
+#[test]
+fn test_implied_call_convention() -> Result<(), Report> {
+    let context = SyntaxTestContext::new();
+    let source = source_file!(
+        &context,
+        r#"
+@account_procedure
+pub proc foo() -> i1
+    push.1
+end
+"#
+    );
+
+    let Form::Procedure(mut proc) = typed_export!(
+        foo,
+        0,
+        function_ty!( => TypeExpr::Primitive(Span::unknown(Type::I1))),
+        block!(inst!(Push(PushValue::Int(IntValue::U8(1)).into())))
+    ) else {
+        unreachable!()
+    };
+    proc.signature_mut().unwrap().cc = types::CallConv::ComponentModel;
+    let proc = Form::Procedure(proc.with_attributes([Attribute::Marker(id!(account_procedure))]));
+    let forms = module!(proc);
+    assert_eq!(context.parse_forms(source)?, forms);
+    Ok(())
+}
+
+#[test]
+fn test_protocol_abi_attribute_forms_imply_calling_convention() -> Result<(), Report> {
+    for name in ["account_procedure", "auth_script", "note_script", "transaction_script"] {
+        for metadata in ["", "(value)", "(role = \"custom\")"] {
+            let context = SyntaxTestContext::new();
+            let source = source_file!(
+                &context,
+                format!("@{name}{metadata}\npub proc foo() -> i1\n    push.1\nend\n")
+            );
+            let forms = context.parse_forms(source)?;
+            let Form::Procedure(proc) = &forms[0] else {
+                panic!("expected procedure")
+            };
+            assert_eq!(proc.signature().unwrap().cc, types::CallConv::ComponentModel);
+            assert_eq!(
+                proc.attributes().get(name).unwrap().to_string(),
+                format!("@{name}{metadata}")
+            );
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_protocol_abi_matching_callconv_in_either_order() -> Result<(), Report> {
+    for name in ["account_procedure", "auth_script", "note_script", "transaction_script"] {
+        for metadata in ["", "(value)", "(role = \"custom\")"] {
+            let abi = format!("@{name}{metadata}");
+            let cc = r#"@callconv("component-model")"#;
+            for annotations in [format!("{abi}\n{cc}"), format!("{cc}\n{abi}")] {
+                let context = SyntaxTestContext::new();
+                let source = source_file!(
+                    &context,
+                    format!("{annotations}\npub proc foo() -> i1\n    push.1\nend\n")
+                );
+                let forms = context.parse_forms(source)?;
+                let Form::Procedure(proc) = &forms[0] else {
+                    panic!("expected procedure")
+                };
+                assert_eq!(proc.signature().unwrap().cc, types::CallConv::ComponentModel);
+                assert!(proc.attributes().has(name));
+                assert!(!proc.attributes().has("callconv"));
+            }
+        }
+    }
+    Ok(())
+}
+
+#[test]
+fn test_protocol_abi_conflicting_callconv_in_either_order() {
+    for name in ["account_procedure", "auth_script", "note_script", "transaction_script"] {
+        for metadata in ["", "(value)", "(role = \"custom\")"] {
+            let abi = format!("@{name}{metadata}");
+            for cc in [r#"@callconv("C")"#, "@callconv(fast)"] {
+                for annotations in [format!("{abi}\n{cc}"), format!("{cc}\n{abi}")] {
+                    let context = SyntaxTestContext::new();
+                    let source = source_file!(
+                        &context,
+                        format!("{annotations}\npub proc foo() -> i1\n    push.1\nend\n")
+                    );
+                    let error = context.parse_forms(source).expect_err(&annotations);
+                    assert_diagnostic!(
+                        error,
+                        "@callconv conflicts with convention implied by other attribute"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_protocol_abi_conflicting_attribute_forms_are_rejected() {
+    for first in ["account_procedure", "auth_script", "note_script", "transaction_script"] {
+        for second in ["account_procedure", "auth_script", "note_script", "transaction_script"] {
+            if first == second {
+                continue;
+            }
+            for first_meta in ["", "(value)", "(role = \"custom\")"] {
+                for second_meta in ["", "(value)", "(role = \"custom\")"] {
+                    let context = SyntaxTestContext::new();
+                    let annotations = format!("@{first}{first_meta}\n@{second}{second_meta}");
+                    let source = source_file!(
+                        &context,
+                        format!("{annotations}\npub proc foo() -> i1\n    push.1\nend\n")
+                    );
+                    let error = context.parse_forms(source).expect_err(&annotations);
+                    assert_diagnostic!(error, "a different ABI was previously specified");
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_protocol_abi_key_value_attributes_can_merge() -> Result<(), Report> {
+    let context = SyntaxTestContext::new();
+    let source = source_file!(
+        &context,
+        r#"
+@auth_script(role = "custom")
+@auth_script(version = 1)
+pub proc foo() -> i1
+    push.1
+end
+"#
+    );
+    let forms = context.parse_forms(source)?;
+    let Form::Procedure(proc) = &forms[0] else {
+        panic!("expected procedure")
+    };
+    assert_eq!(proc.signature().unwrap().cc, types::CallConv::ComponentModel);
+    assert_eq!(
+        proc.attributes().get("auth_script").unwrap().to_string(),
+        r#"@auth_script(role = "custom", version = 1)"#
+    );
+    Ok(())
+}
+
+#[test]
+fn test_conflicting_implied_calling_convention_is_rejected() {
+    let context = SyntaxTestContext::new();
+    let source = source_file!(
+        &context,
+        r#"
+@account_procedure
+@callconv("C")
+proc foo() -> i1
+    push.1
+end
+
+begin
+    exec.foo
+end
+"#
+    );
+
+    let error = context
+        .parse_program_source_file(source)
+        .expect_err("expected diagnostic to be raised, but parsing succeeded");
+
+    assert_diagnostic_lines!(
+        error,
+        "conflicting attributes for procedure definition",
+        regex!(r#",-\[test[\d]+:2:1\]"#),
+        "1 |",
+        "2 | @account_procedure",
+        "  : ^^^^^^^^^|^^^^^^^^",
+        "  :          `-- this attribute implies @callconv(\"component-model\")",
+        "3 | @callconv(\"C\")",
+        "  : ^^^^^^^|^^^^^^",
+        "  :        `-- conflict occurs because @callconv conflicts with convention implied by other attribute",
+        "4 | proc foo() -> i1",
+        "  `----"
+    );
+}
+
+#[test]
+fn test_conflicting_protocol_abi_is_rejected() {
+    let context = SyntaxTestContext::new();
+    let source = source_file!(
+        &context,
+        r#"
+@account_procedure
+@note_script
+proc foo() -> i1
+    push.1
+end
+
+begin
+    exec.foo
+end
+"#
+    );
+
+    let error = context
+        .parse_program_source_file(source)
+        .expect_err("expected diagnostic to be raised, but parsing succeeded");
+
+    assert_diagnostic_lines!(
+        error,
+        "conflicting attributes for procedure definition",
+        regex!(r#",-\[test[\d]+:2:1\]"#),
+        "1 |",
+        "2 | @account_procedure",
+        "  : ^^^^^^^^^|^^^^^^^^",
+        "  :          `-- this attribute already specifies the protocol ABI for this procedure",
+        "3 | @note_script",
+        "  : ^^^^^^|^^^^^",
+        "  :       `-- this attribute specifies the protocol ABI of this procedure, but a different ABI was previously specified",
+        "4 | proc foo() -> i1",
+        "  `----"
+    );
 }

--- a/crates/assembly-syntax/src/parser/cst/forms.rs
+++ b/crates/assembly-syntax/src/parser/cst/forms.rs
@@ -472,6 +472,10 @@ fn lower_procedure(
     Ok(ast::Form::Procedure(proc))
 }
 
+/// Protocol ABI attributes imply the component-model calling convention, regardless of their form.
+const PROTOCOL_ABI_ATTRIBUTES: &[&str] =
+    &["account_procedure", "auth_script", "note_script", "transaction_script"];
+
 /// Applies lowered attributes to a procedure while preserving legacy attribute semantics.
 ///
 /// This is responsible for duplicate detection, `@callconv` validation, `@locals` validation, and
@@ -482,11 +486,21 @@ fn apply_procedure_attributes(
     annotations: Vec<ast::Attribute>,
 ) -> Result<(), ParsingError> {
     let mut cc = None;
+    let mut callconv_span = None;
+    let mut protocol_abi_span = None;
     let mut num_locals = None;
     {
         let attributes = procedure.attributes_mut();
 
         for attr in annotations {
+            if PROTOCOL_ABI_ATTRIBUTES.contains(&attr.name()) && !attributes.has(attr.name()) {
+                let span = attr.span();
+                if let Some(prev) = protocol_abi_span {
+                    return Err(ParsingError::ConflictingProtocolAbiAttribute { span, prev });
+                }
+                protocol_abi_span = Some(span);
+            }
+
             match attr {
                 ast::Attribute::KeyValue(kv) => match attributes.entry(kv.id()) {
                     ast::AttributeSetEntry::Vacant(entry) => {
@@ -522,6 +536,7 @@ fn apply_procedure_attributes(
                     },
                 },
                 ast::Attribute::List(list) if list.name() == "callconv" && list.len() == 1 => {
+                    let span = list.span;
                     match attributes.entry(list.id()) {
                         ast::AttributeSetEntry::Vacant(entry) => {
                             let valid_cc = match &list.as_slice()[0] {
@@ -533,13 +548,12 @@ fn apply_procedure_attributes(
                                 },
                                 _ => None,
                             };
+                            callconv_span = Some(span);
                             if let Some(valid_cc) = valid_cc {
                                 cc = Some(valid_cc);
                                 entry.insert(ast::Attribute::List(list));
                             } else {
-                                return Err(ParsingError::UnrecognizedCallConv {
-                                    span: list.span(),
-                                });
+                                return Err(ParsingError::UnrecognizedCallConv { span });
                             }
                         },
                         ast::AttributeSetEntry::Occupied(entry) => {
@@ -619,6 +633,17 @@ fn apply_procedure_attributes(
         if cc.is_some() {
             attributes.remove("callconv");
         }
+    }
+
+    // Resolve the convention after collecting attributes so annotation order is irrelevant.
+    if let Some(attr_span) = protocol_abi_span {
+        if cc.is_some_and(|cc| cc != ast::types::CallConv::ComponentModel) {
+            return Err(ParsingError::CallConvAttributeConflict {
+                cc_span: callconv_span.expect("callconv was set without associated span"),
+                attr_span,
+            });
+        }
+        cc = Some(ast::types::CallConv::ComponentModel);
     }
 
     if let Some(num_locals) = num_locals {

--- a/crates/assembly-syntax/src/parser/error.rs
+++ b/crates/assembly-syntax/src/parser/error.rs
@@ -270,6 +270,26 @@ pub enum ParsingError {
         #[label("previously defined here")]
         prev: SourceSpan,
     },
+    #[error("conflicting attributes for procedure definition")]
+    #[diagnostic()]
+    CallConvAttributeConflict {
+        #[label(
+            "conflict occurs because @callconv conflicts with convention implied by other attribute"
+        )]
+        cc_span: SourceSpan,
+        #[label("this attribute implies @callconv(\"component-model\")")]
+        attr_span: SourceSpan,
+    },
+    #[error("conflicting attributes for procedure definition")]
+    #[diagnostic()]
+    ConflictingProtocolAbiAttribute {
+        #[label(
+            "this attribute specifies the protocol ABI of this procedure, but a different ABI was previously specified"
+        )]
+        span: SourceSpan,
+        #[label("this attribute already specifies the protocol ABI for this procedure")]
+        prev: SourceSpan,
+    },
     #[error("conflicting key-value attributes for procedure definition")]
     #[diagnostic()]
     AttributeKeyValueConflict {

--- a/scripts/check-masm-export-digests.rs
+++ b/scripts/check-masm-export-digests.rs
@@ -212,7 +212,10 @@ fn compare_procedure(name: &str, previous: &ProcedureInfo, current: &ProcedureIn
 }
 
 fn is_abi_attribute(name: &str) -> bool {
-    matches!(name, "auth_script" | "callconv")
+    matches!(
+        name,
+        "account_procedure" | "auth_script" | "callconv" | "note_script" | "transaction_script"
+    )
 }
 
 /// Compare a pretty-printed signature or type string ignoring struct field labels.


### PR DESCRIPTION
This PR infers (and validates) `@callconv` for procedures when known protocol ABI attributes are specified (i.e. `account_procedure`, `auth_script`, `note_script`, `transaction_script`).

It accepts:

- Explicitly specified callconv and protocol ABI when they align
- Eliding callconv when protocol ABI is specified

It rejects:
- Conflicting callconv and protocol ABI attributes
- Conflicting protocol ABI attributes