### PR TITLE
core-lib: correct types/signatures to ensure semantics match implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 #### Features
 
 #### Changes
+- Added type signatures for all procedures in the Miden core library ([#3791](https://github.com/0xMiden/miden-vm/pull/3791)). **NOTE:** This changes the package identity of the core library and any packages which dynamically link it. Packages which were assembled against 0.32.0 of the core library will need to be re-assembled (unless they statically linked the core library), otherwise executors that only load the latest version of the core library for you will be unable to resolve the older dependency.
 
 #### Fixes
+- Fixed issue where parsing of pointer types dropped address space information ([#3790](https://github.com/0xMiden/miden-vm/pull/3790)).
 
 ## v0.32.0 (2026-09-05)
 
@@ -15,11 +17,9 @@
 - Cached loaded MAST forests in `FastProcessor` so repeated external calls reuse the forest and merge its advice map once ([#3764](https://github.com/0xMiden/miden-vm/pull/3764)).
 - [BREAKING] Removed the trace bus debugger APIs from `miden-air` and the `bus-debugger` feature from `miden-processor` ([#3775](https://github.com/0xMiden/miden-vm/pull/3775)).
 - [BREAKING] Bumped Plonky3 related dependencies to v0.7.0 ([#3778](https://github.com/0xMiden/miden-vm/pull/3778)).
-- Added type signatures for all procedures in the Miden core library ([#3791](https://github.com/0xMiden/miden-vm/pull/3791))
 
 #### Fixes
 - Fixed stack overflow in the precompile prover's `translate_truthy`, `translate_uint`, and `translate_ec` by converting them from recursive to iterative post-order traversals. Programs with many `LOGDEFERRED` calls no longer crash ([#3626](https://github.com/0xMiden/miden-vm/issues/3626)).
-- Fixed issue where parsing of pointer types dropped address space information ([#3790](https://github.com/0xMiden/miden-vm/pull/3790)).
 
 ## v0.31.1 (2026-09-04)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",

--- a/crates/lib/core/asm/crypto/dsa/falcon512_poseidon2.masm
+++ b/crates/lib/core/asm/crypto/dsa/falcon512_poseidon2.masm
@@ -18,6 +18,9 @@ const FALCON_DIV_EVENT = event("miden::core::crypto::dsa::falcon512_poseidon2::f
 
 #! Falcon coefficient reduced modulo 12289.
 pub type Coefficient = u16
+#! In memory each reduced coefficient occupies a full felt, rather than a packed u16.
+#! Use this for coefficient buffers; scalar stack arguments use Coefficient.
+pub type StoredCoefficient = struct @align(4) { value: Coefficient }
 #! A 64-bit integer with its high limb on top of the stack.
 pub type WideInteger = struct { hi: u32, lo: u32 }
 #! Falcon nonce, with the second word on top of the stack.
@@ -580,7 +583,7 @@ end
 #! Output: [norm_sq(s2), ...]
 #!
 #! Cycles: 11150
-pub proc compute_s2_norm_sq(s2_ptr: ptr<Coefficient>) -> SquaredNorm
+pub proc compute_s2_norm_sq(s2_ptr: ptr<StoredCoefficient>) -> SquaredNorm
     repeat.128
         padw
         dup.4

--- a/crates/lib/core/asm/stark/constants.masm
+++ b/crates/lib/core/asm/stark/constants.masm
@@ -285,11 +285,11 @@ pub proc get_num_fri_layers() -> u8
     push.NUM_FRI_LAYERS_PTR mem_load
 end
 
-pub proc set_remainder_poly_address(value: types::Address)
+pub proc set_remainder_poly_address(value: ptr<types::QuadFelt>)
     push.REMAINDER_POLY_ADDRESS_PTR mem_store
 end
 
-pub proc get_remainder_poly_address() -> types::Address
+pub proc get_remainder_poly_address() -> ptr<types::QuadFelt>
     push.REMAINDER_POLY_ADDRESS_PTR mem_load
 end
 
@@ -301,11 +301,11 @@ pub proc get_trace_length() -> u32
     push.TRACE_LENGTH_PTR mem_load
 end
 
-pub proc set_fri_queries_address(value: types::Address)
+pub proc set_fri_queries_address(value: ptr<word>)
     push.FRI_QUERIES_ADDRESS_PTR mem_store
 end
 
-pub proc get_fri_queries_address() -> types::Address
+pub proc get_fri_queries_address() -> ptr<word>
     push.FRI_QUERIES_ADDRESS_PTR mem_load
 end
 
@@ -362,34 +362,34 @@ pub proc get_folding_pow_bits() -> u8
     push.FOLDING_POW_BITS_PTR mem_load
 end
 
-pub proc main_trace_com_ptr() -> types::Address
+pub proc main_trace_com_ptr() -> ptr<types::Digest>
     push.MAIN_TRACE_COM_PTR
 end
 
-pub proc aux_trace_com_ptr() -> types::Address
+pub proc aux_trace_com_ptr() -> ptr<types::Digest>
     push.AUX_TRACE_COM_PTR
 end
 
-pub proc composition_poly_com_ptr() -> types::Address
+pub proc composition_poly_com_ptr() -> ptr<types::Digest>
     push.COMPOSITION_POLY_COM_PTR
 end
 
 #! Address for the point `z` and its exponentiation `z^N` where `N=trace_len`.
 #!
 #! The word stored is `[z^n_0, z^n_1, z_0, z_1]`.
-pub proc z_ptr() -> types::Address
+pub proc z_ptr() -> ptr<[types::QuadFelt; 2]>
     push.Z_PTR
 end
 
-pub proc zero_word_ptr() -> types::Address
+pub proc zero_word_ptr() -> ptr<word>
     push.ZERO_WORD_PTR
 end
 
-pub proc deep_rand_alpha_nd_ptr() -> types::Address
+pub proc deep_rand_alpha_nd_ptr() -> ptr<types::QuadFelt>
     push.ALPHA_DEEP_ND_PTR
 end
 
-pub proc ood_fixed_term_horner_evaluations_ptr() -> types::Address
+pub proc ood_fixed_term_horner_evaluations_ptr() -> ptr<types::EvaluationPair>
     push.OOD_FIXED_TERM_HORNER_EVALS_PTR
 end
 
@@ -401,38 +401,38 @@ pub proc get_trace_domain_generator() -> felt
     push.TRACE_DOMAIN_GENERATOR_PTR mem_load
 end
 
-pub proc public_inputs_address_ptr() -> types::Address
+pub proc public_inputs_address_ptr() -> ptr<ptr<types::QuadFelt>>
     push.PUBLIC_INPUTS_ADDRESS_PTR
 end
 
 #! Returns the pointer to the capacity word of the Poseidon2-based random coin.
-pub proc c_ptr() -> types::Address
+pub proc c_ptr() -> ptr<word>
     push.C_PTR
 end
 
 #! Returns the pointer to the first rate word of the Poseidon2-based random coin.
-pub proc r1_ptr() -> types::Address
+pub proc r1_ptr() -> ptr<word>
     push.R1_PTR
 end
 
 #! Returns the pointer to the second rate word of the Poseidon2-based random coin.
-pub proc r2_ptr() -> types::Address
+pub proc r2_ptr() -> ptr<word>
     push.R2_PTR
 end
 
-pub proc tmp1() -> types::Address
+pub proc tmp1() -> ptr<word>
     push.TMP1
 end
 
-pub proc tmp2() -> types::Address
+pub proc tmp2() -> ptr<word>
     push.TMP2
 end
 
-pub proc tmp3() -> types::Address
+pub proc tmp3() -> ptr<word>
     push.TMP3
 end
 
-pub proc tmp4() -> types::Address
+pub proc tmp4() -> ptr<word>
     push.TMP4
 end
 
@@ -456,11 +456,11 @@ pub proc assert_valid_order_tag(order_tag_count: u32)
     swap u32lt assert.err="invalid order tag"
 end
 
-pub proc relation_digest_ptr() -> types::Address
+pub proc relation_digest_ptr() -> ptr<types::Digest>
     push.RELATION_DIGEST_PTR
 end
 
-pub proc ace_registry_root_ptr() -> types::Address
+pub proc ace_registry_root_ptr() -> ptr<types::Digest>
     push.ACE_REGISTRY_ROOT_PTR
 end
 
@@ -472,11 +472,11 @@ pub proc random_coin_output_len_ptr() -> types::Address
     push.RANDOM_COIN_OUTPUT_LEN_PTR
 end
 
-pub proc set_ood_evaluations_address(value: types::Address)
+pub proc set_ood_evaluations_address(value: ptr<types::QuadFelt>)
     push.OOD_EVALUATIONS_ADDRESS_PTR mem_store
 end
 
-pub proc get_ood_evaluations_address() -> types::Address
+pub proc get_ood_evaluations_address() -> ptr<types::QuadFelt>
     push.OOD_EVALUATIONS_ADDRESS_PTR mem_load
 end
 
@@ -492,11 +492,11 @@ pub proc fri_verify_state_ptr() -> types::Address
     push.FRI_VERIFY_STATE_PTR
 end
 
-pub proc composition_coef_ptr() -> types::Address
+pub proc composition_coef_ptr() -> ptr<[types::QuadFelt; 2]>
     push.COMPOSITION_COEF_PTR
 end
 
-pub proc deep_rand_coef_ptr() -> types::Address
+pub proc deep_rand_coef_ptr() -> ptr<types::QuadFelt>
     push.DEEP_RAND_CC_PTR
 end
 
@@ -504,23 +504,23 @@ pub proc fri_com_ptr() -> types::Address
     push.FRI_COM_PTR
 end
 
-pub proc get_procedure_digest_compute_deep_composition_polynomial_queries_ptr() -> types::Address
+pub proc get_procedure_digest_compute_deep_composition_polynomial_queries_ptr() -> ptr<types::Digest>
     push.DYNAMIC_PROCEDURE_0_PTR
 end
 
-pub proc get_procedure_digest_execute_constraint_evaluation_check_ptr() -> types::Address
+pub proc get_procedure_digest_execute_constraint_evaluation_check_ptr() -> ptr<types::Digest>
     push.DYNAMIC_PROCEDURE_1_PTR
 end
 
-pub proc get_procedure_digest_process_row_ood_evaluations_ptr() -> types::Address
+pub proc get_procedure_digest_process_row_ood_evaluations_ptr() -> ptr<types::Digest>
     push.DYNAMIC_PROCEDURE_2_PTR
 end
 
-pub proc get_procedure_digest_process_public_inputs_ptr() -> types::Address
+pub proc get_procedure_digest_process_public_inputs_ptr() -> ptr<types::Digest>
     push.DYNAMIC_PROCEDURE_3_PTR
 end
 
-pub proc get_procedure_digest_observe_aux_trace_ptr() -> types::Address
+pub proc get_procedure_digest_observe_aux_trace_ptr() -> ptr<types::Digest>
     push.DYNAMIC_PROCEDURE_4_PTR
 end
 

--- a/crates/lib/core/asm/stark/constraints_eval_inputs.masm
+++ b/crates/lib/core/asm/stark/constraints_eval_inputs.masm
@@ -194,7 +194,7 @@ end
 #!
 #! Input:  [addr, ...]
 #! Output: [q0, q1, ...]
-proc load_quad(address: types::Address) -> types::QuadFelt
+proc load_quad(address: ptr<types::QuadFelt>) -> types::QuadFelt
     dup add.1 mem_load
     swap mem_load
 end

--- a/crates/lib/core/asm/stark/deep_queries.masm
+++ b/crates/lib/core/asm/stark/deep_queries.masm
@@ -16,8 +16,8 @@ proc compute_denominators(
     scratch: word,
     preserved: word,
     index: u32,
-    query_ptr: types::Address,
-) -> (types::EvaluationPair, word, felt, u32, types::Address)
+    query_ptr: ptr<word>,
+) -> (types::EvaluationPair, word, felt, u32, ptr<word>)
     # Compute poe and x.
     exec.constants::get_lde_domain_info_word
     #=> [lde_size, depth, domain_gen, 0, Y, index, query_ptr, ...]
@@ -62,8 +62,8 @@ proc divide_and_add(
     query_evaluations: types::EvaluationPair,
     cursor: types::DeepQueryCursor,
     fixed_evaluations: types::EvaluationPair,
-    query_ptr: types::Address,
-) -> (types::QuadFelt, types::DeepQueryCursor, types::EvaluationPair, types::Address)
+    query_ptr: ptr<word>,
+) -> (types::QuadFelt, types::DeepQueryCursor, types::EvaluationPair, ptr<word>)
     swapw
     #=> [X, Z, Y, W, query_ptr, ...]
     dupw.3
@@ -122,10 +122,10 @@ end
 #!    `q_gz = (q_gz_0, q_gz_1)` represent the constant terms across all FRI queries computations.
 pub proc prepare_stack_deep_queries_computation() -> (
     word,
-    types::Address,
-    types::Address,
+    ptr<word>,
+    ptr<word>,
     types::EvaluationPair,
-    types::Address,
+    ptr<word>,
 )
     exec.constants::get_fri_queries_address
     # => [query_ptr, ...]
@@ -188,11 +188,11 @@ pub proc compute_deep_query(
     scratch: word,
     evaluations: types::EvaluationPair,
     index: u32,
-    query_ptr: types::Address,
-    query_end_ptr: types::Address,
+    query_ptr: ptr<word>,
+    query_end_ptr: ptr<word>,
     fixed_evaluations: types::EvaluationPair,
-    queries_ptr: types::Address,
-) -> (i1, types::FriQuery, types::Address, types::Address, types::EvaluationPair, types::Address)
+    queries_ptr: ptr<word>,
+) -> (i1, types::FriQuery, ptr<word>, ptr<word>, types::EvaluationPair, ptr<word>)
     # 1) Compute poe := domain_gen^index, x := offset * poe, and denominators (x - z)
     # and (x - gz).
     exec.compute_denominators

--- a/crates/lib/core/asm/stark/public_inputs.masm
+++ b/crates/lib/core/asm/stark/public_inputs.masm
@@ -28,7 +28,7 @@ end
 #!
 #! Invocation: exec
 pub proc compute_and_store_public_inputs_address(
-    aux_rand_ptr: types::Address,
+    aux_rand_ptr: ptr<types::QuadFelt>,
     num_fixed_len_pi: u32,
 )
     # => [aux_rand_ptr, num_fixed_len_pi, ...]
@@ -47,9 +47,9 @@ end
 #! Invocation: exec
 pub proc load_base_store_extension_double_word_from_mem(
     state: types::PoseidonState,
-    dst: types::Address,
+    dst: ptr<types::QuadFelt>,
     src: types::Address,
-) -> (types::PoseidonState, types::Address, types::Address)
+) -> (types::PoseidonState, ptr<types::QuadFelt>, types::Address)
     dup.13 mem_loadw_le
     exec.constants::tmp1 mem_storew_le
     movup.13 add.4 movdn.13

--- a/crates/lib/core/asm/stark/random_coin.masm
+++ b/crates/lib/core/asm/stark/random_coin.masm
@@ -671,7 +671,7 @@ end
 #!
 #! Input: [aux_rand_ptr, ...]
 #! Output: [...]
-pub proc generate_aux_randomness(aux_rand_ptr: types::Address)
+pub proc generate_aux_randomness(aux_rand_ptr: ptr<types::QuadFelt>)
 
     exec.sample_ext
     exec.sample_ext

--- a/crates/lib/core/asm/stark/security.masm
+++ b/crates/lib/core/asm/stark/security.masm
@@ -204,7 +204,7 @@ end
 #! Outputs: [level, ...]
 #!
 #! Invocation: exec
-pub proc compute_conjectured_security_level(descriptor: types::SecurityDescriptor) -> u32
+pub proc compute_conjectured_security_level(descriptor: types::StackSecurityDescriptor) -> u32
     # Assert the validity envelope documented above. Each comparison also range-checks its
     # operand as a u32. Inputs not used by query or lookup are consumed after validation.
     # Lifted STARK currently has no grinding step before lookup-challenge sampling.

--- a/crates/lib/core/asm/stark/types.masm
+++ b/crates/lib/core/asm/stark/types.masm
@@ -1,15 +1,15 @@
 #! Shared stack representations used by the recursive STARK verifier.
 
-use miden::core::crypto::hashes::poseidon2
+use {State} from miden::core::crypto::hashes::poseidon2
 
 #! A quadratic extension-field value, with the constant coefficient on top of the stack.
 pub type QuadFelt = struct { c0: felt, c1: felt }
 
 #! Poseidon2 sponge state in operand-stack order.
-pub type PoseidonState = poseidon2::State
+pub type PoseidonState = State
 
-#! A Poseidon2 commitment or procedure digest.
-pub type Digest = poseidon2::Digest
+# A Poseidon2 commitment or procedure digest.
+pub use {Digest} from miden::core::crypto::hashes::poseidon2
 
 #! A base-field-element address in VM memory.
 pub type Address = ptr<felt>
@@ -31,7 +31,7 @@ pub type VerifierHooks = struct {
 pub type EvaluationPair = struct { current: QuadFelt, next: QuadFelt }
 
 #! Streaming Horner evaluation state in operand-stack order.
-pub type HornerState = struct { coefficients: Address, alpha: Address, accumulator: QuadFelt }
+pub type HornerState = struct { coefficients: Address, alpha: ptr<QuadFelt>, accumulator: QuadFelt }
 
 #! A FRI query, including its domain point, index, and extension-field evaluation.
 pub type FriQuery = struct { point: felt, index: u32, evaluation: QuadFelt }
@@ -57,8 +57,43 @@ pub type SecurityDescriptor = struct {
     proof: ProofParameters,
 }
 
+#! The Fast-convention representation of ProofParameters, with one felt per field.
+#! Use this for exec signatures: the unpadded record packs its four u8 fields into one felt.
+#! Explicit byte padding belongs to the memory/Fast layout, not the component-model ABI.
+pub type StackProofParameters = struct {
+    num_queries: u8,
+    num_queries_padding: [u8; 3],
+    query_pow_bits: u8,
+    query_pow_bits_padding: [u8; 3],
+    deep_pow_bits: u8,
+    deep_pow_bits_padding: [u8; 3],
+    folding_pow_bits: u8,
+    folding_pow_bits_padding: [u8; 3],
+}
+
+#! The twelve-felt Fast-convention representation of SecurityDescriptor.
+#! Use this for exec signatures to keep each narrow field in its own felt, including the
+#! nested proof parameters. The unpadded record is appropriate for component-model flattening.
+pub type StackSecurityDescriptor = struct {
+    lookup_pow_bits: u8,
+    lookup_pow_bits_padding: [u8; 3],
+    num_composed_constraints: u16,
+    num_composed_constraints_padding: [u8; 2],
+    max_constraint_degree: u8,
+    max_constraint_degree_padding: [u8; 3],
+    num_deep_terms: u16,
+    num_deep_terms_padding: [u8; 2],
+    max_message_width: u32,
+    num_lookup_boundary_terms: u16,
+    num_lookup_boundary_terms_padding: [u8; 2],
+    lookup_fractions_per_row: u32,
+    log_max_height: u8,
+    log_max_height_padding: [u8; 3],
+    proof: StackProofParameters,
+}
+
 #! Cursor state retained while computing a DEEP query.
-pub type DeepQueryCursor = struct { point: felt, index: u32, query: Address, end: Address }
+pub type DeepQueryCursor = struct { point: felt, index: u32, query: ptr<word>, end: ptr<word> }
 
 #! A quadratic extension-field value padded with two zero cells to fill a word.
 pub type PaddedQuadFelt = struct { value: QuadFelt, padding: [felt; 2] }

--- a/crates/lib/core/asm/stark/verifier.masm
+++ b/crates/lib/core/asm/stark/verifier.masm
@@ -39,7 +39,7 @@ use miden::core::stark::utils
 #!
 #! Inputs:  [D0, D1, D2, D3, D4]
 #! Outputs: [num_queries, query_pow_bits, deep_pow_bits, folding_pow_bits]
-pub proc verify(hooks: types::VerifierHooks) -> types::ProofParameters
+pub proc verify(hooks: types::VerifierHooks) -> types::StackProofParameters
 
     #==============================================================================================
     #       I)  Observe proof context and load public inputs

--- a/crates/lib/core/asm/sys/pvm/deep_queries.masm
+++ b/crates/lib/core/asm/sys/pvm/deep_queries.masm
@@ -35,10 +35,10 @@ const LEAF_VALUE_MISMATCH = "hash of leaf pre-image does not match leaf value fr
 #! Outputs: []
 pub proc compute_deep_composition_polynomial_queries(
     scratch: word,
-    query_ptr: types::Address,
-    query_end_ptr: types::Address,
+    query_ptr: ptr<word>,
+    query_end_ptr: ptr<word>,
     fixed_terms: types::EvaluationPair,
-    queries_start: types::Address,
+    queries_start: ptr<word>,
 )
     # The verifier checks earlier that there is at least one query.
     push.1
@@ -63,8 +63,8 @@ end
 #! Outputs: [Y, q_x_0, q_x_1, q_x_0, q_x_1, index, query_ptr]
 proc load_query_row(
     scratch: word,
-    query_ptr: types::Address,
-) -> (word, types::EvaluationPair, u32, types::Address)
+    query_ptr: ptr<word>,
+) -> (word, types::EvaluationPair, u32, ptr<word>)
     exec.process_preprocessed_trace
     #=> [Y, ptr_x, ptr_alpha_inv, acc0, acc1, depth, index, query_ptr]
 
@@ -87,8 +87,8 @@ end
 #! other commitment groups and the final DEEP-domain evaluation.
 proc process_preprocessed_trace(
     scratch: word,
-    query_ptr: types::Address,
-) -> (word, types::HornerState, u8, u32, types::Address)
+    query_ptr: ptr<word>,
+) -> (word, types::HornerState, u8, u32, ptr<word>)
     # Load [index, full_depth, index, 0] from the query word.
     dup.4 mem_loadw_le
     #=> [index, full_depth, y, y, query_ptr]
@@ -137,8 +137,8 @@ proc process_main_trace(
     evaluation: types::HornerState,
     depth: u8,
     index: u32,
-    query_ptr: types::Address,
-) -> (word, types::HornerState, u8, u32, types::Address)
+    query_ptr: ptr<word>,
+) -> (word, types::HornerState, u8, u32, ptr<word>)
     exec.constants::main_trace_com_ptr mem_loadw_le
 
     dup.9 dup.9
@@ -173,8 +173,8 @@ proc process_aux_trace(
     evaluation: types::HornerState,
     depth: u8,
     index: u32,
-    query_ptr: types::Address,
-) -> (word, types::HornerState, u8, u32, types::Address)
+    query_ptr: ptr<word>,
+) -> (word, types::HornerState, u8, u32, ptr<word>)
     exec.constants::aux_trace_com_ptr mem_loadw_le
 
     dup.9 dup.9
@@ -209,8 +209,8 @@ proc process_quotient_trace(
     evaluation: types::HornerState,
     depth: u8,
     index: u32,
-    query_ptr: types::Address,
-) -> (word, types::HornerState, u32, types::Address)
+    query_ptr: ptr<word>,
+) -> (word, types::HornerState, u32, ptr<word>)
     exec.constants::composition_poly_com_ptr mem_loadw_le
 
     dup.9 movup.9

--- a/crates/lib/core/asm/sys/pvm/mod.masm
+++ b/crates/lib/core/asm/sys/pvm/mod.masm
@@ -173,7 +173,7 @@ end
 #! Outputs: [lookup_pow_bits, num_composed_constraints, max_constraint_degree, num_deep_terms,
 #!          max_message_width, num_lookup_boundary_terms, lookup_fractions_per_row,
 #!          log_max_height, num_queries, query_pow_bits, deep_pow_bits, folding_pow_bits, ...]
-proc build_security_descriptor(parameters: types::ProofParameters) -> types::SecurityDescriptor
+proc build_security_descriptor(parameters: types::StackProofParameters) -> types::StackSecurityDescriptor
     exec.constants::get_trace_length_log
     push.LOOKUP_FRACTIONS_PER_ROW
     push.FIXED_BOUNDARY_LOOKUP_TERMS
@@ -240,7 +240,7 @@ end
 #!           log_max_height, num_queries, query_pow_bits, deep_pow_bits, folding_pow_bits]
 #!
 #! Invocation: exec
-pub proc verify_proof(deferred_root: types::Digest) -> types::SecurityDescriptor
+pub proc verify_proof(deferred_root: types::Digest) -> types::StackSecurityDescriptor
     # --- Prepare PVM verifier state --------------------------------------------------------------
 
     exec.utils::load_security_params

--- a/crates/lib/core/asm/sys/vm/aux_trace.masm
+++ b/crates/lib/core/asm/sys/vm/aux_trace.masm
@@ -5,9 +5,6 @@ use miden::core::stark::random_coin
 use miden::core::sys::vm::layout
 use miden::core::sys::vm::public_inputs
 
-#! AIR log heights in proof order.
-type ProofOrderLogHeights = struct { first: u8, second: u8, third: u8 }
-
 # Number of valid Lehmer proof-order tags for the Miden VM's three AIRs: 3! = 6.
 # Valid tags are 0..5; the remaining two leaves in the depth-3 registry are padding.
 const ORDER_TAG_COUNT = 6
@@ -46,7 +43,7 @@ end
 #!
 #! Input:  [...]
 #! Output: [log_0, log_1, log_2, ...]
-proc push_proof_order_log_heights() -> ProofOrderLogHeights
+proc push_proof_order_log_heights() -> (u8, u8, u8)
     push.ORDER_TAG_COUNT exec.constants::assert_valid_order_tag
     exec.constants::get_order_tag
     dup eq.0

--- a/crates/lib/core/asm/sys/vm/deep_queries.masm
+++ b/crates/lib/core/asm/sys/vm/deep_queries.masm
@@ -34,10 +34,10 @@ const LEAF_VALUE_MISMATCH = "hash of leaf pre-image does not match leaf value fr
 #!    `q_gz = (q_gz_0, q_gz_1)` represent the constant terms across all FRI queries computations.
 pub proc compute_deep_composition_polynomial_queries(
     scratch: word,
-    query_ptr: types::Address,
-    query_end_ptr: types::Address,
+    query_ptr: ptr<word>,
+    query_end_ptr: ptr<word>,
     fixed_terms: types::EvaluationPair,
-    queries_start: types::Address,
+    queries_start: ptr<word>,
 )
     # Iterate over all FRI query indices and compute the corresponding DEEP query.
     # The verifier checks earlier that there is at least one query.
@@ -84,8 +84,8 @@ end
 #! - Y is a "garbage" word.
 proc load_query_row(
     scratch: word,
-    query_ptr: types::Address,
-) -> (word, types::EvaluationPair, u32, types::Address)
+    query_ptr: ptr<word>,
+) -> (word, types::EvaluationPair, u32, ptr<word>)
     # Process the main segment of the execution trace portion of the query
     exec.process_main_segment_execution_trace
     #=> [Y, ptr_x, ptr_alpha_inv, acc0, acc1, depth, index, query_ptr]
@@ -108,8 +108,8 @@ end
 #! Output: [Y, ptr_x, ptr_alpha_inv, acc0, acc1, depth, index, query_ptr]
 proc process_main_segment_execution_trace(
     scratch: word,
-    query_ptr: types::Address,
-) -> (word, types::HornerState, u8, u32, types::Address)
+    query_ptr: ptr<word>,
+) -> (word, types::HornerState, u8, u32, ptr<word>)
     # Load the query index
     dup.4 mem_loadw_le
     #=> [index, depth, y, y, query_ptr] where y are "garbage" values here and throughout
@@ -177,8 +177,8 @@ proc process_aux_segment_execution_trace(
     evaluation: types::HornerState,
     depth: u8,
     index: u32,
-    query_ptr: types::Address,
-) -> (word, types::HornerState, u8, u32, types::Address)
+    query_ptr: ptr<word>,
+) -> (word, types::HornerState, u8, u32, ptr<word>)
     # Load aux trace commitment and get leaf
     exec.constants::aux_trace_com_ptr mem_loadw_le
 
@@ -235,8 +235,8 @@ proc process_constraints_composition_poly_trace(
     evaluation: types::HornerState,
     depth: u8,
     index: u32,
-    query_ptr: types::Address,
-) -> (word, types::EvaluationPair, u32, types::Address)
+    query_ptr: ptr<word>,
+) -> (word, types::EvaluationPair, u32, ptr<word>)
     # Load the commitment to the constraint trace
     exec.constants::composition_poly_com_ptr mem_loadw_le
     #=> [R, ptr_x, ptr_alpha_inv, acc0, acc1, depth, index, query_ptr]

--- a/crates/lib/core/asm/sys/vm/layout.masm
+++ b/crates/lib/core/asm/sys/vm/layout.masm
@@ -115,7 +115,7 @@ end
 ### Relation-facing pointer accessors used by the generated constraint evaluator.
 ### Keeping the anchors here gives the shared renderer one contract for VM and PVM while
 ### keeping relation-sized regions out of the generic layer.
-pub proc aux_rand_elem_ptr() -> types::Address
+pub proc aux_rand_elem_ptr() -> ptr<types::QuadFelt>
     push.AUX_RAND_ELEM_PTR
 end
 
@@ -131,7 +131,7 @@ pub proc ace_circuit_stream_ptr() -> types::Address
     push.ACE_CIRCUIT_STREAM_PTR
 end
 
-pub proc ood_evaluations_ptr() -> types::Address
+pub proc ood_evaluations_ptr() -> ptr<types::QuadFelt>
     push.OOD_EVALUATIONS_PTR
 end
 
@@ -151,7 +151,7 @@ pub proc boundary_inputs_ptr() -> types::Address
     push.BOUNDARY_INPUTS_PTR
 end
 
-pub proc claim_commitment_ptr() -> types::Address
+pub proc claim_commitment_ptr() -> ptr<types::Digest>
     push.CLAIM_COMMITMENT_PTR
 end
 

--- a/crates/lib/core/asm/sys/vm/mod.masm
+++ b/crates/lib/core/asm/sys/vm/mod.masm
@@ -263,7 +263,7 @@ end
 #! Outputs: [lookup_pow_bits, num_composed_constraints, max_constraint_degree, num_deep_terms,
 #!          max_message_width, num_lookup_boundary_terms, lookup_fractions_per_row,
 #!          log_max_height, num_queries, query_pow_bits, deep_pow_bits, folding_pow_bits, ...]
-proc build_security_descriptor(parameters: types::ProofParameters) -> types::SecurityDescriptor
+proc build_security_descriptor(parameters: types::StackProofParameters) -> types::StackSecurityDescriptor
     exec.constants::get_trace_length_log
     push.LOOKUP_FRACTIONS_PER_ROW
     exec.layout::num_kernel_procedures_ptr mem_load
@@ -321,7 +321,7 @@ end
 #! - D is the deferred root bound by the verified statement.
 #!
 #! Invocation: exec
-pub proc verify_proof(claim_commitment: types::Digest) -> (types::SecurityDescriptor, types::Digest)
+pub proc verify_proof(claim_commitment: types::Digest) -> (types::StackSecurityDescriptor, types::Digest)
     # --- Authenticate execution claim -----------------------------------------------------------
 
     # Preserve the commitment until public inputs are absorbed after transcript initialization.

--- a/crates/lib/core/tests/main.rs
+++ b/crates/lib/core/tests/main.rs
@@ -199,3 +199,69 @@ mod sys;
 mod word;
 
 mod stark;
+
+// These procedures consume/produce independent felts even though their semantic fields are
+// narrower. Check the exported Fast ABI, which uses physical layout instead of canonical
+// flattening.
+#[test]
+fn verifier_signatures_match_operand_stack_layout() {
+    use miden_assembly::ast::types::Type;
+    use miden_core_lib::CoreLibrary;
+    use miden_mast_package::PackageExport;
+
+    let core_lib = CoreLibrary::default();
+    let package = core_lib.package();
+    for (path, inputs, outputs) in [
+        ("::miden::core::stark::verifier::verify", 20, 4),
+        ("::miden::core::stark::security::compute_conjectured_security_level", 12, 1),
+        ("::miden::core::sys::vm::verify_proof", 4, 16),
+        ("::miden::core::sys::pvm::verify_proof", 4, 12),
+    ] {
+        let Some(PackageExport::Procedure(export)) = package.manifest.get_export(path) else {
+            panic!("missing procedure: {path}");
+        };
+        let signature = export.signature.as_ref().expect("typed procedure");
+        assert_eq!(
+            signature.params.iter().map(Type::size_in_felts).sum::<usize>(),
+            inputs,
+            "{path} inputs"
+        );
+        assert_eq!(
+            signature.results.iter().map(Type::size_in_felts).sum::<usize>(),
+            outputs,
+            "{path} outputs"
+        );
+    }
+
+    // Total arity alone would miss padding moved to the end of a record.
+    for (name, field_count) in [("StackProofParameters", 4), ("StackSecurityDescriptor", 9)] {
+        let path = format!("::miden::core::stark::types::{name}");
+        let Some(PackageExport::Type(export)) = package.manifest.get_export(path.as_str()) else {
+            panic!("missing type: {path}");
+        };
+        let Type::Struct(record) = &export.ty else {
+            panic!("expected struct: {path}");
+        };
+        let offsets: Vec<_> = record
+            .get()
+            .fields()
+            .iter()
+            .filter(|field| !field.name.as_deref().unwrap().ends_with("_padding"))
+            .map(|field| field.offset)
+            .collect();
+        assert_eq!(offsets, (0..field_count).map(|index| index * 4).collect::<Vec<_>>(), "{path}");
+    }
+
+    let Some(PackageExport::Type(export)) = package
+        .manifest
+        .get_export("::miden::core::crypto::dsa::falcon512_poseidon2::StoredCoefficient")
+    else {
+        panic!("missing coefficient memory type");
+    };
+    assert_eq!(
+        export.ty.size_in_bytes(),
+        4,
+        "coefficient buffers advance one felt per coefficient"
+    );
+    assert_eq!(export.ty.min_alignment(), 4);
+}

--- a/crates/midenc-hir-type/Cargo.toml
+++ b/crates/midenc-hir-type/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "midenc-hir-type"
 description = "Type system and utilities for Miden HIR"
-version = "0.14.0"
+version = "0.14.1"
 rust-version.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/crates/midenc-hir-type/src/layout.rs
+++ b/crates/midenc-hir-type/src/layout.rs
@@ -516,10 +516,9 @@ impl Type {
     /// the addresses of the individual fields needed from a large structure or array,
     /// and issue loads/stores against those instead.
     ///
-    /// In effect, we reject loads of values that are larger than a single word, as that
-    /// is the largest value which can be worked with on the operand stack of the Miden VM.
+    /// This policy limits a single logical load to one word (four field elements).
     pub fn is_loadable(&self) -> bool {
-        self.size_in_words() <= WORD_SIZE
+        self.size_in_bytes() <= WORD_SIZE
     }
 }
 
@@ -530,6 +529,22 @@ mod tests {
     use smallvec::smallvec;
 
     use crate::*;
+
+    #[test]
+    fn loadability_is_limited_to_one_word() {
+        for (ty, expected) in [
+            (Type::Felt, true),
+            (Type::U128, true),
+            (Type::U256, false),
+            (Type::from(ArrayType::new(Type::Felt, 4)), true),
+            (Type::from(ArrayType::new(Type::Felt, 5)), false),
+            (Type::from(ArrayType::new(Type::U8, 16)), true),
+            (Type::from(ArrayType::new(Type::U8, 17)), false),
+            (Type::from(StructType::new([Type::U128, Type::U8])), false),
+        ] {
+            assert_eq!(ty.is_loadable(), expected, "unexpected loadability for {ty}");
+        }
+    }
 
     #[test]
     fn self_recursive_struct_through_a_pointer_has_a_finite_layout() {

--- a/tools/miden-core-fuzz/Cargo.lock
+++ b/tools/miden-core-fuzz/Cargo.lock
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "midenc-hir-type"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "miden-formatting",
  "miden-serde-utils",


### PR DESCRIPTION
This is a follow-up to #3791 to correct some of the types/signatures that were merged, since their semantics diverged from the procedures in a few cases where arguments were grouped into logical structs.

> [!IMPORTANT]
>
> This changes the package identity of the core library and any packages which dynamically link it. Packages which were assembled against 0.32.0 of the core library will need to be re-assembled (unless they statically linked the core library), otherwise executors that only load the latest version of the core library for you will be unable to resolve the older dependency.