### PR TITLE
Ci: check MASM release compatibility by boundary

### DIFF
--- a/.github/actions/workspace-release/action.yml
+++ b/.github/actions/workspace-release/action.yml
@@ -63,7 +63,7 @@ runs:
         chmod +x scripts/check-msrv.sh
         ./scripts/check-msrv.sh
 
-    - name: Check MASM procedure root stability
+    - name: Check MASM release compatibility
       if: ${{ inputs.mode == 'dry-run' && (github.ref == 'refs/heads/main' || github.base_ref == 'main') }}
       shell: bash
       run: |

--- a/scripts/check-masm-export-digests.rs
+++ b/scripts/check-masm-export-digests.rs
@@ -6,16 +6,14 @@ edition = "2024"
 [dependencies]
 miden-assembly-current = { package = "miden-assembly", path = "../crates/assembly" }
 miden-assembly-syntax-current = { package = "miden-assembly-syntax", path = "../crates/assembly-syntax" }
-miden-core-lib-current = { package = "miden-core-lib", path = "../crates/lib/core" }
 miden-mast-package-current = { package = "miden-mast-package", path = "../crates/mast-package" }
 miden-package-registry-current = { package = "miden-package-registry", path = "../crates/package-registry", features = ["resolver"] }
 
 # The release wrapper rewrites these tags to the latest release tag on main.
-miden-assembly-previous = { package = "miden-assembly", git = "https://github.com/0xMiden/miden-vm", tag = "v0.29.0" }
-miden-assembly-syntax-previous = { package = "miden-assembly-syntax", git = "https://github.com/0xMiden/miden-vm", tag = "v0.29.0" }
-miden-core-lib-previous = { package = "miden-core-lib", git = "https://github.com/0xMiden/miden-vm", tag = "v0.29.0" }
-miden-mast-package-previous = { package = "miden-mast-package", git = "https://github.com/0xMiden/miden-vm", tag = "v0.29.0" }
-miden-package-registry-previous = { package = "miden-package-registry", git = "https://github.com/0xMiden/miden-vm", tag = "v0.29.0", features = ["resolver"] }
+miden-assembly-previous = { package = "miden-assembly", git = "https://github.com/0xMiden/miden-vm", tag = "v0.32.0" }
+miden-assembly-syntax-previous = { package = "miden-assembly-syntax", git = "https://github.com/0xMiden/miden-vm", tag = "v0.32.0" }
+miden-mast-package-previous = { package = "miden-mast-package", git = "https://github.com/0xMiden/miden-vm", tag = "v0.32.0" }
+miden-package-registry-previous = { package = "miden-package-registry", git = "https://github.com/0xMiden/miden-vm", tag = "v0.32.0", features = ["resolver"] }
 ---
 
 use std::{
@@ -25,7 +23,31 @@ use std::{
     process,
 };
 
+// Release compatibility has four separate boundaries. Executable compatibility protects
+// exported procedure paths and MAST digests. Fast ABI compatibility protects the number of input
+// and output felts consumed by previously published Fast procedures. Source compatibility reports
+// changes to published nominal signatures, exported types, and source attributes. It is advisory
+// during a release because a patch may preserve the Fast ABI without preserving source syntax.
+// Package compatibility prevents one semantic version from identifying two dependency commitments
+// and reports when old serialized dependents require the previous package to remain archived.
+
 type Exports = BTreeMap<String, ExportInfo>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PackageInfo {
+    name: String,
+    version: String,
+    exports: Exports,
+    commitments: PackageCommitments,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PackageCommitments {
+    interface: String,
+    mast_forest: String,
+    code: String,
+    dependency: String,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ExportInfo {
@@ -37,7 +59,14 @@ enum ExportInfo {
 struct ProcedureInfo {
     digest: String,
     signature: Option<String>,
+    fast_abi: Option<FastAbiInfo>,
     abi_attributes: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FastAbiInfo {
+    inputs: usize,
+    outputs: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -56,12 +85,92 @@ impl ExportInfo {
 
 impl ProcedureInfo {
     fn describe(&self) -> String {
-        let Self { digest, signature, abi_attributes } = self;
+        let Self {
+            digest,
+            signature,
+            fast_abi,
+            abi_attributes,
+        } = self;
         format!(
-            "procedure digest={digest}, signature={}, abi_attributes={}",
+            "procedure digest={digest}, signature={}, fast_abi={}, abi_attributes={}",
             signature.as_deref().unwrap_or("None"),
+            fast_abi
+                .as_ref()
+                .map(FastAbiInfo::describe)
+                .unwrap_or_else(|| "None".to_string()),
             format_attributes(abi_attributes),
         )
+    }
+}
+
+impl FastAbiInfo {
+    fn describe(&self) -> String {
+        format!("{} input felts, {} output felts", self.inputs, self.outputs)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Check {
+    All,
+    Executable,
+    FastAbi,
+    Source,
+    Package,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Diagnostic {
+    Error,
+    Warning,
+}
+
+impl Diagnostic {
+    fn annotation(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+        }
+    }
+}
+
+impl Check {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "all" => Ok(Self::All),
+            "executable" => Ok(Self::Executable),
+            "fast-abi" => Ok(Self::FastAbi),
+            "source" => Ok(Self::Source),
+            "package" => Ok(Self::Package),
+            _ => Err(format!("unknown compatibility check '{value}'\n{}", usage())),
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Executable => "Executable compatibility",
+            Self::FastAbi => "Fast ABI compatibility",
+            Self::Source => "Source compatibility",
+            Self::Package => "Package compatibility",
+        }
+    }
+
+    fn consequence(self) -> &'static str {
+        match self {
+            Self::All => "all compatibility checks run",
+            Self::Executable => {
+                "old compiled callers resolve the same paths to the same executable MAST roots"
+            },
+            Self::FastAbi => {
+                "old compiled Fast callers provide and receive the same number of felts"
+            },
+            Self::Source => {
+                "reports whether released MASM source continues to type-check without changes"
+            },
+            Self::Package => {
+                "one semantic version identifies one dependency commitment; older commitments must remain archived"
+            },
+        }
     }
 }
 
@@ -92,123 +201,291 @@ fn main() {
 
 fn run() -> Result<(), String> {
     let mut args = env::args().skip(1);
-    let previous_input = args.next().map(PathBuf::from).ok_or_else(usage)?;
+    let first = args.next().ok_or_else(usage)?;
+    let (check, previous_input) = if first == "--check" {
+        let check = args.next().ok_or_else(usage)?;
+        let previous = args.next().map(PathBuf::from).ok_or_else(usage)?;
+        (Check::parse(&check)?, previous)
+    } else {
+        (Check::All, PathBuf::from(first))
+    };
     let current_input = args.next().map(PathBuf::from).ok_or_else(usage)?;
     if args.next().is_some() {
         return Err(usage());
     }
 
-    let previous = previous::collect_exports(&previous_input)?;
-    let current = current::collect_exports(&current_input)?;
-    compare_exports(previous, current)
+    let previous = previous::collect_package(&previous_input)?;
+    let current = current::collect_package(&current_input)?;
+    compare_compatibility(check, &previous, &current)
 }
 
 fn usage() -> String {
-    "usage: check-masm-export-digests.rs <previous-miden-project.toml|previous-project-dir> <current-miden-project.toml|current-project-dir>".to_string()
+    "usage: check-masm-export-digests.rs [--check all|executable|fast-abi|source|package] <previous-miden-project.toml|previous-project-dir> <current-miden-project.toml|current-project-dir>".to_string()
 }
 
-fn compare_exports(previous: Exports, current: Exports) -> Result<(), String> {
+fn compare_compatibility(
+    check: Check,
+    previous: &PackageInfo,
+    current: &PackageInfo,
+) -> Result<(), String> {
+    let release_check = check == Check::All;
+    let checks = match check {
+        Check::All => vec![Check::Executable, Check::FastAbi, Check::Source, Check::Package],
+        selected => vec![selected],
+    };
+    let mut failed = Vec::new();
+
+    for selected in checks {
+        println!("::group::{}", selected.label());
+        println!("Consequence: {}", selected.consequence());
+        let result = match selected {
+            Check::Executable => compare_executable(&previous.exports, &current.exports),
+            Check::FastAbi => compare_fast_abi(&previous.exports, &current.exports),
+            Check::Source => compare_source(
+                &previous.exports,
+                &current.exports,
+                if release_check {
+                    Diagnostic::Warning
+                } else {
+                    Diagnostic::Error
+                },
+            ),
+            Check::Package => compare_package(previous, current),
+            Check::All => unreachable!("all expands to individual checks"),
+        };
+        println!("::endgroup::");
+        if result.is_err() && selected == Check::Source && release_check {
+            println!(
+                "::notice::source compatibility changed; source changes do not block this release"
+            );
+        } else if result.is_err() {
+            failed.push(selected.label());
+        }
+    }
+
+    if failed.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("compatibility checks failed: {}", failed.join(", ")))
+    }
+}
+
+fn compare_executable(previous: &Exports, current: &Exports) -> Result<(), String> {
     let mut status = Ok(());
+    let mut checked = 0usize;
+    for (name, previous_export) in previous {
+        let ExportInfo::Procedure(previous_procedure) = previous_export else {
+            continue;
+        };
+        checked += 1;
+        match current.get(name) {
+            Some(ExportInfo::Procedure(current_procedure))
+                if previous_procedure.digest == current_procedure.digest => {},
+            Some(ExportInfo::Procedure(current_procedure)) => {
+                println!(
+                    "::error::executable digest changed for {name}: previous={}, current={}",
+                    previous_procedure.digest, current_procedure.digest,
+                );
+                status = Err("executable exports changed".to_string());
+            },
+            Some(current_export) => {
+                println!(
+                    "::error::executable export kind changed for {name}: previous={}, current={}",
+                    previous_export.describe(),
+                    current_export.describe(),
+                );
+                status = Err("executable exports changed".to_string());
+            },
+            None => {
+                println!("::error::executable export removed: {name}");
+                status = Err("executable exports changed".to_string());
+            },
+        }
+    }
+    println!("checked {checked} previously published procedure digests");
+    status
+}
+
+fn compare_fast_abi(previous: &Exports, current: &Exports) -> Result<(), String> {
+    let mut status = Ok(());
+    let mut checked = 0usize;
+    for (name, previous_export) in previous {
+        let ExportInfo::Procedure(previous_procedure) = previous_export else {
+            continue;
+        };
+        let Some(previous_abi) = &previous_procedure.fast_abi else {
+            continue;
+        };
+        checked += 1;
+        match current.get(name) {
+            Some(ExportInfo::Procedure(current_procedure))
+                if current_procedure.fast_abi.as_ref() == Some(previous_abi) => {},
+            Some(ExportInfo::Procedure(current_procedure)) => {
+                let current_abi = current_procedure
+                    .fast_abi
+                    .as_ref()
+                    .map(FastAbiInfo::describe)
+                    .unwrap_or_else(|| "not Fast".to_string());
+                println!(
+                    "::error::Fast ABI changed for {name}: previous={}, current={current_abi}",
+                    previous_abi.describe(),
+                );
+                status = Err("Fast ABI changed".to_string());
+            },
+            _ => {
+                println!("::error::Fast ABI export removed: {name}");
+                status = Err("Fast ABI changed".to_string());
+            },
+        }
+    }
+    println!("checked {checked} previously published Fast procedure layouts");
+    status
+}
+
+fn compare_source(
+    previous: &Exports,
+    current: &Exports,
+    diagnostic: Diagnostic,
+) -> Result<(), String> {
+    let mut status = Ok(());
+    let mut added = 0usize;
     let export_names = previous.keys().chain(current.keys()).cloned().collect::<BTreeSet<_>>();
 
     for name in export_names {
         match (previous.get(&name), current.get(&name)) {
             (Some(previous_export), Some(current_export)) if previous_export == current_export => {
-                println!("{name} {}", current_export.describe());
             },
-            (Some(previous_export), Some(current_export)) => {
-                if compare_export(&name, previous_export, current_export) {
-                    status = Err("exports changed".to_string());
+            (Some(ExportInfo::Procedure(previous)), Some(ExportInfo::Procedure(current))) => {
+                if compare_source_procedure(&name, previous, current, diagnostic) {
+                    status = Err("source exports changed".to_string());
                 }
             },
-            (Some(previous_export), None) => {
-                eprintln!(
-                    "::error::export removed: {name} previous={}",
-                    previous_export.describe()
-                );
-                status = Err("procedure exports changed".to_string());
-            },
-            (None, Some(current_export)) => match current_export {
-                ExportInfo::Procedure(_) => {
+            (Some(ExportInfo::Type(previous)), Some(ExportInfo::Type(current))) => {
+                if canonicalize_type_string(&previous.ty) != canonicalize_type_string(&current.ty) {
                     println!(
-                        "::notice::export added: {name} current={}",
-                        current_export.describe()
+                        "::{}::source type changed for {name}: previous={}, current={}",
+                        diagnostic.annotation(),
+                        previous.ty,
+                        current.ty,
                     );
-                },
-                ExportInfo::Type(_) => {
-                    println!("{name} {}", current_export.describe());
-                },
+                    status = Err("source exports changed".to_string());
+                }
+            },
+            (Some(previous_export), Some(current_export)) => {
+                println!(
+                    "::{}::source export kind changed for {name}: previous={}, current={}",
+                    diagnostic.annotation(),
+                    previous_export.describe(),
+                    current_export.describe(),
+                );
+                status = Err("source exports changed".to_string());
+            },
+            (Some(previous_export), None) => {
+                println!(
+                    "::{}::source export removed: {name} previous={}",
+                    diagnostic.annotation(),
+                    previous_export.describe(),
+                );
+                status = Err("source exports changed".to_string());
+            },
+            (None, Some(_)) => {
+                added += 1;
             },
             (None, None) => unreachable!("name came from at least one side"),
         }
     }
-
+    if added > 0 {
+        println!("::notice::{added} source exports added; additions are source-compatible");
+    }
     status
 }
 
-fn compare_export(name: &str, previous: &ExportInfo, current: &ExportInfo) -> bool {
-    match (previous, current) {
-        (ExportInfo::Procedure(previous), ExportInfo::Procedure(current)) => {
-            compare_procedure(name, previous, current)
-        },
-        (ExportInfo::Type(previous), ExportInfo::Type(current)) => {
-            if canonicalize_type_string(&previous.ty) == canonicalize_type_string(&current.ty) {
-                false
-            } else {
-                eprintln!(
-                    "::error::exported type changed for {name}: previous={}, current={}",
-                    previous.ty, current.ty,
-                );
-                true
-            }
-        },
-        _ => {
-            eprintln!(
-                "::error::export kind changed for {name}: previous={}, current={}",
-                previous.describe(),
-                current.describe(),
-            );
-            true
-        },
-    }
-}
-
-fn compare_procedure(name: &str, previous: &ProcedureInfo, current: &ProcedureInfo) -> bool {
+fn compare_source_procedure(
+    name: &str,
+    previous: &ProcedureInfo,
+    current: &ProcedureInfo,
+    diagnostic: Diagnostic,
+) -> bool {
     let mut changed = false;
-
-    if previous.digest != current.digest {
-        eprintln!(
-            "::error::export digest changed for {name}: previous={}, current={}",
-            previous.digest, current.digest,
-        );
-        changed = true;
-    }
 
     if previous.signature.is_some()
         && canonicalize_type_string(previous.signature.as_deref().unwrap_or(""))
             != canonicalize_type_string(current.signature.as_deref().unwrap_or(""))
     {
-        eprintln!(
-            "::error::export signature changed for {name}: previous={}, current={}",
+        println!(
+            "::{}::source signature changed for {name}: previous={}, current={}",
+            diagnostic.annotation(),
             previous.signature.as_deref().unwrap_or("None"),
             current.signature.as_deref().unwrap_or("None"),
         );
         changed = true;
     }
 
-    // Adding ABI metadata is non-breaking; removing or changing previously published ABI metadata
-    // is not.
+    // Adding source metadata is compatible. Removing or changing published metadata is not.
     for (attr, previous_value) in &previous.abi_attributes {
         let current_value = current.abi_attributes.get(attr).map(String::as_str).unwrap_or("None");
         if previous_value != current_value {
-            eprintln!(
-                "::error::export ABI attribute changed for {name}: {attr} previous={previous_value}, current={current_value}",
+            println!(
+                "::{}::source attribute changed for {name}: {attr} previous={previous_value}, current={current_value}",
+                diagnostic.annotation(),
             );
             changed = true;
         }
     }
 
     changed
+}
+
+fn compare_package(previous: &PackageInfo, current: &PackageInfo) -> Result<(), String> {
+    let mut status = Ok(());
+    if previous.name != current.name {
+        println!(
+            "::error::package name changed: previous={}, current={}",
+            previous.name, current.name,
+        );
+        status = Err("package identity changed".to_string());
+    }
+
+    report_commitment("interface", &previous.commitments.interface, &current.commitments.interface);
+    report_commitment(
+        "MAST forest",
+        &previous.commitments.mast_forest,
+        &current.commitments.mast_forest,
+    );
+    report_commitment("code", &previous.commitments.code, &current.commitments.code);
+    report_commitment(
+        "dependency",
+        &previous.commitments.dependency,
+        &current.commitments.dependency,
+    );
+
+    if previous.commitments.dependency != current.commitments.dependency {
+        if previous.version == current.version {
+            println!(
+                "::error::package dependency commitment changed without a version change: package={} version={} previous={}, current={}",
+                current.name,
+                current.version,
+                previous.commitments.dependency,
+                current.commitments.dependency,
+            );
+            status = Err("package version identifies two dependency commitments".to_string());
+        } else {
+            println!(
+                "::notice::package dependency commitment changed with version {} -> {}; serialized dependents remain loadable only while the {} {} package is archived",
+                previous.version, current.version, previous.name, previous.version,
+            );
+        }
+    }
+
+    status
+}
+
+fn report_commitment(label: &str, previous: &str, current: &str) {
+    if previous == current {
+        println!("{label} commitment unchanged: {current}");
+    } else {
+        println!("::notice::{label} commitment changed: previous={previous}, current={current}");
+    }
 }
 
 fn is_abi_attribute(name: &str) -> bool {
@@ -223,9 +500,9 @@ fn is_abi_attribute(name: &str) -> bool {
 /// `StructType` derives `PartialEq`/`Hash` over the (now populated) name field. This helper strips
 /// the `name :` prefix from each struct field so such deltas compare equal.
 ///
-/// It deliberately preserves everything that *is* part of the ABI: field types, field count, field
-/// order, struct names, `repr` attributes (`@packed`, etc.), and all non-struct
-/// syntax. Only the leading `ident :` of a struct field is removed.
+/// It deliberately preserves the nominal source contract: field types, field count, field order,
+/// struct names, `repr` attributes (`@packed`, etc.), and all non-struct syntax. Only the leading
+/// `ident :` of a struct field is removed.
 fn canonicalize_type_string(value: &str) -> String {
     normalize(&strip_field_labels(value))
 }
@@ -391,24 +668,84 @@ mod tests {
         ExportInfo::Procedure(ProcedureInfo {
             digest: digest.to_string(),
             signature: None,
+            fast_abi: None,
             abi_attributes: BTreeMap::new(),
         })
     }
 
     #[test]
     fn compare_exports_allows_added_procedure() {
-        let previous = Exports::new();
+        let previous = PackageInfo::for_test(Exports::new());
         let current = Exports::from([("new_proc".to_string(), procedure("0x01"))]);
+        let current = PackageInfo::for_test(current);
 
-        assert_eq!(compare_exports(previous, current), Ok(()));
+        assert_eq!(compare_compatibility(Check::All, &previous, &current), Ok(()));
     }
 
     #[test]
     fn compare_exports_rejects_changed_procedure() {
         let previous = Exports::from([("existing_proc".to_string(), procedure("0x01"))]);
         let current = Exports::from([("existing_proc".to_string(), procedure("0x02"))]);
+        let previous = PackageInfo::for_test(previous);
+        let current = PackageInfo::for_test(current);
 
-        assert!(compare_exports(previous, current).is_err());
+        assert!(compare_compatibility(Check::All, &previous, &current).is_err());
+    }
+
+    #[test]
+    fn fast_abi_compares_total_felt_widths() {
+        let old = ProcedureInfo {
+            digest: "0x01".to_string(),
+            signature: Some("extern \"fast\" fn(u32, u32)".to_string()),
+            fast_abi: Some(FastAbiInfo { inputs: 2, outputs: 0 }),
+            abi_attributes: BTreeMap::new(),
+        };
+        let new = ProcedureInfo {
+            digest: "0x01".to_string(),
+            signature: Some("extern \"fast\" fn(struct pair {u32, u32})".to_string()),
+            fast_abi: Some(FastAbiInfo { inputs: 2, outputs: 0 }),
+            abi_attributes: BTreeMap::new(),
+        };
+        let previous = Exports::from([("p".to_string(), ExportInfo::Procedure(old))]);
+        let current = Exports::from([("p".to_string(), ExportInfo::Procedure(new))]);
+
+        assert_eq!(compare_fast_abi(&previous, &current), Ok(()));
+        assert!(compare_source(&previous, &current, Diagnostic::Error).is_err());
+    }
+
+    #[test]
+    fn release_allows_source_only_changes() {
+        let old = ProcedureInfo {
+            digest: "0x01".to_string(),
+            signature: Some("extern \"fast\" fn(u32, u32)".to_string()),
+            fast_abi: Some(FastAbiInfo { inputs: 2, outputs: 0 }),
+            abi_attributes: BTreeMap::new(),
+        };
+        let new = ProcedureInfo {
+            digest: "0x01".to_string(),
+            signature: Some("extern \"fast\" fn(struct pair {u32, u32})".to_string()),
+            fast_abi: Some(FastAbiInfo { inputs: 2, outputs: 0 }),
+            abi_attributes: BTreeMap::new(),
+        };
+        let previous =
+            PackageInfo::for_test(Exports::from([("p".to_string(), ExportInfo::Procedure(old))]));
+        let current =
+            PackageInfo::for_test(Exports::from([("p".to_string(), ExportInfo::Procedure(new))]));
+
+        assert_eq!(compare_compatibility(Check::All, &previous, &current), Ok(()));
+        assert!(compare_compatibility(Check::Source, &previous, &current).is_err());
+    }
+
+    #[test]
+    fn package_change_requires_a_new_version() {
+        let previous = PackageInfo::for_test(Exports::new());
+        let mut current = previous.clone();
+        current.commitments.dependency = "0x02".to_string();
+
+        assert!(compare_package(&previous, &current).is_err());
+
+        current.version = "0.1.1".to_string();
+        assert_eq!(compare_package(&previous, &current), Ok(()));
     }
 
     #[test]
@@ -520,16 +857,32 @@ mod tests {
     }
 }
 
+#[cfg(test)]
+impl PackageInfo {
+    fn for_test(exports: Exports) -> Self {
+        Self {
+            name: "test".to_string(),
+            version: "0.1.0".to_string(),
+            exports,
+            commitments: PackageCommitments {
+                interface: "0x01".to_string(),
+                mast_forest: "0x01".to_string(),
+                code: "0x01".to_string(),
+                dependency: "0x01".to_string(),
+            },
+        }
+    }
+}
+
 mod current {
     use miden_assembly_current::{Assembler, ProjectTargetSelector};
     use miden_assembly_syntax_current::prettier::PrettyPrint;
-    use miden_core_lib_current::CoreLibrary;
     use miden_mast_package_current::{Package, PackageExport};
-    use miden_package_registry_current::{InMemoryPackageRegistry, PackageCache};
+    use miden_package_registry_current::InMemoryPackageRegistry;
 
     use super::*;
 
-    pub fn collect_exports(input: &Path) -> Result<Exports, String> {
+    pub fn collect_package(input: &Path) -> Result<PackageInfo, String> {
         let mut store = InMemoryPackageRegistry::default();
         let mut project =
             Assembler::default().for_project_at_path(input, &mut store).map_err(|err| {
@@ -540,11 +893,11 @@ mod current {
                 format!("current: failed to assemble project '{}': {err}", input.display())
             })?;
 
-        collect_package_exports(package.as_ref())
+        collect_package_info(package.as_ref())
     }
 
-    fn collect_package_exports(package: &Package) -> Result<Exports, String> {
-        Ok(package
+    fn collect_package_info(package: &Package) -> Result<PackageInfo, String> {
+        let exports = package
             .manifest
             .exports()
             .filter_map(|export| match export {
@@ -553,6 +906,16 @@ mod current {
                     ExportInfo::Procedure(ProcedureInfo {
                         digest: procedure.digest.to_string(),
                         signature: procedure.signature.as_ref().map(PrettyPrint::to_pretty_string),
+                        fast_abi: procedure.signature.as_ref().and_then(|signature| {
+                            (signature.abi.to_string() == "fast").then(|| FastAbiInfo {
+                                inputs: signature.params.iter().map(|ty| ty.size_in_felts()).sum(),
+                                outputs: signature
+                                    .results
+                                    .iter()
+                                    .map(|ty| ty.size_in_felts())
+                                    .sum(),
+                            })
+                        }),
                         abi_attributes: procedure
                             .attributes
                             .iter()
@@ -567,20 +930,33 @@ mod current {
                 )),
                 PackageExport::Constant(_) => None,
             })
-            .collect())
+            .collect();
+        Ok(PackageInfo {
+            name: package.name.to_string(),
+            version: package.version.to_string(),
+            exports,
+            commitments: PackageCommitments {
+                interface: package
+                    .interface_commitment()
+                    .map_err(|err| err.to_string())?
+                    .to_string(),
+                mast_forest: package.mast_forest_commitment().to_string(),
+                code: package.code_commitment().to_string(),
+                dependency: package.dependency_commitment().to_string(),
+            },
+        })
     }
 }
 
 mod previous {
     use miden_assembly_previous::{Assembler, ProjectTargetSelector};
     use miden_assembly_syntax_previous::prettier::PrettyPrint;
-    use miden_core_lib_previous::CoreLibrary;
     use miden_mast_package_previous::{Package, PackageExport};
-    use miden_package_registry_previous::{InMemoryPackageRegistry, PackageCache};
+    use miden_package_registry_previous::InMemoryPackageRegistry;
 
     use super::*;
 
-    pub fn collect_exports(input: &Path) -> Result<Exports, String> {
+    pub fn collect_package(input: &Path) -> Result<PackageInfo, String> {
         let mut store = InMemoryPackageRegistry::default();
         let mut project =
             Assembler::default().for_project_at_path(input, &mut store).map_err(|err| {
@@ -591,11 +967,11 @@ mod previous {
                 format!("previous: failed to assemble project '{}': {err}", input.display())
             })?;
 
-        collect_package_exports(package.as_ref())
+        collect_package_info(package.as_ref())
     }
 
-    fn collect_package_exports(package: &Package) -> Result<Exports, String> {
-        Ok(package
+    fn collect_package_info(package: &Package) -> Result<PackageInfo, String> {
+        let exports = package
             .manifest
             .exports()
             .filter_map(|export| match export {
@@ -604,6 +980,16 @@ mod previous {
                     ExportInfo::Procedure(ProcedureInfo {
                         digest: procedure.digest.to_string(),
                         signature: procedure.signature.as_ref().map(PrettyPrint::to_pretty_string),
+                        fast_abi: procedure.signature.as_ref().and_then(|signature| {
+                            (signature.abi.to_string() == "fast").then(|| FastAbiInfo {
+                                inputs: signature.params.iter().map(|ty| ty.size_in_felts()).sum(),
+                                outputs: signature
+                                    .results
+                                    .iter()
+                                    .map(|ty| ty.size_in_felts())
+                                    .sum(),
+                            })
+                        }),
                         abi_attributes: procedure
                             .attributes
                             .iter()
@@ -618,6 +1004,20 @@ mod previous {
                 )),
                 PackageExport::Constant(_) => None,
             })
-            .collect())
+            .collect();
+        Ok(PackageInfo {
+            name: package.name.to_string(),
+            version: package.version.to_string(),
+            exports,
+            commitments: PackageCommitments {
+                interface: package
+                    .interface_commitment()
+                    .map_err(|err| err.to_string())?
+                    .to_string(),
+                mast_forest: package.mast_forest_commitment().to_string(),
+                code: package.code_commitment().to_string(),
+                dependency: package.dependency_commitment().to_string(),
+            },
+        })
     }
 }

--- a/scripts/check-masm-root-stability.sh
+++ b/scripts/check-masm-root-stability.sh
@@ -105,11 +105,11 @@ for project in "${projects[@]}"; do
         continue
     fi
 
-    echo "Checking MASM root stability for $relative_project against $baseline_tag"
+    echo "Checking MASM release compatibility for $relative_project against $baseline_tag"
     RUSTC_WRAPPER= rustup run nightly cargo -Zscript \
         "$check_script" \
         "$baseline_project" \
         "$current_project"
 done
 
-echo "MASM procedure roots are stable against $baseline_tag"
+echo "MASM release compatibility checks passed against $baseline_tag"


### PR DESCRIPTION
The MASM release check now reports four compatibility boundaries separately.

- Executable changes fail when a published path, export kind, or MAST root changes. 
- Fast ABI changes fail when a published Fast procedure changes its input or output felt count. 
- Source changes warn without stopping a release. --check source remains strict for nominal signatures, exported types, and source attributes. 
- The package check fails when the package name changes or one version maps to two dependency commitments. A new version may have a new commitment. Old serialized assets still require the old package by version and commitment.

This lets v0.32.1 ship from current main. It preserves executable and Fast ABI compatibility while changing source metadata and the package dependency commitment.

<details>
  <summary>Results against v0.32.0</summary>
#3791 kept all 500 published procedure roots but changed three Fast layouts. PR #3803 restored them before [merging into main](https://github.com/0xMiden/miden-vm/commit/58c7a6c6b3fb066d8743692a60d4c0b575a15264). Current main keeps all 500 roots and 112 Fast layouts. The source check reports 36 changes and 50 additions. The interface, MAST forest, and code commitments remain unchanged. The dependency commitment changes from `0xf5fb…f83a` to `0x6a9149…a841`.
</details>