### PR TITLE
fix(crypto): validate tracked PartialMmr paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Fixes
 
+- Fixed `PartialMmr::from_parts()` and deserialization so they reject tracked leaves without complete authentication paths ([#3809](https://github.com/0xMiden/miden-vm/pull/3809)).
 - Fixed `PartialMmr::track()` panicking when a leaf position did not belong to the tree selected by its authentication path ([#3804](https://github.com/0xMiden/miden-vm/pull/3804)).
 - Fixed 46 `\begin{cases}...\end{cases}` blocks in the assembly instruction reference and stack design docs that were missing the `\\` row separator between cases, which broke KaTeX rendering ([#3650](https://github.com/0xMiden/miden-vm/issues/3650)).
 

--- a/crates/crypto/src/merkle/mmr/partial.rs
+++ b/crates/crypto/src/merkle/mmr/partial.rs
@@ -104,11 +104,11 @@ impl PartialMmr {
     /// This constructor validates the consistency between peaks, nodes, and tracked_leaves:
     /// - All tracked leaf positions must be within forest bounds.
     /// - All tracked leaves must have their values in the nodes map.
+    /// - All tracked leaves must have complete authentication paths.
     /// - All node indices must be valid leaf or internal node positions within the forest.
     ///
     /// Note: This performs structural validation only. It does not verify that authentication
-    /// paths for tracked leaves are complete or that node values are cryptographically
-    /// consistent with the peaks.
+    /// paths for tracked leaves are cryptographically consistent with the peaks.
     ///
     /// # Errors
     /// Returns an error if the components are inconsistent.
@@ -147,7 +147,22 @@ impl PartialMmr {
         }
 
         let peaks = peaks.into();
-        Ok(Self { forest, peaks, nodes, tracked_leaves })
+        let partial_mmr = Self { forest, peaks, nodes, tracked_leaves };
+
+        // Validate that every tracked leaf has a complete authentication path.
+        for &pos in &partial_mmr.tracked_leaves {
+            match partial_mmr.open(pos) {
+                Ok(Some(_)) => {},
+                Ok(None) => {
+                    return Err(MmrError::InconsistentPartialMmr(format!(
+                        "tracked leaf at position {pos} has no authentication path"
+                    )));
+                },
+                Err(err) => return Err(err),
+            }
+        }
+
+        Ok(partial_mmr)
     }
 
     /// Returns a new [PartialMmr] instantiated from the specified components without validation.
@@ -1440,13 +1455,19 @@ mod tests {
         let result = PartialMmr::from_parts(peaks.clone(), BTreeMap::new(), tracked_no_value);
         assert!(result.is_err());
 
-        // Valid case: tracked leaf with its value in nodes
-        let mut nodes_with_leaf = BTreeMap::new();
-        let leaf_idx = InOrderIndex::from_leaf_pos(0);
-        nodes_with_leaf.insert(leaf_idx, int_to_node(0));
+        // Valid case: tracked leaf with its complete authentication path in nodes
+        let tracked_pos = 0;
+        let mut complete_partial = PartialMmr::from_peaks(peaks.clone());
+        complete_partial
+            .track(
+                tracked_pos,
+                mmr.get(tracked_pos).unwrap(),
+                mmr.open(tracked_pos).unwrap().path().merkle_path(),
+            )
+            .unwrap();
         let mut tracked_valid = BTreeSet::new();
-        tracked_valid.insert(0);
-        let result = PartialMmr::from_parts(peaks.clone(), nodes_with_leaf, tracked_valid);
+        tracked_valid.insert(tracked_pos);
+        let result = PartialMmr::from_parts(peaks.clone(), complete_partial.nodes, tracked_valid);
         assert!(result.is_ok());
 
         // Invalid case: node index out of bounds (leaf index)
@@ -1490,6 +1511,27 @@ mod tests {
         nodes_with_empty_forest.insert(InOrderIndex::from_leaf_pos(0), int_to_node(0));
         let result = PartialMmr::from_parts(empty_peaks, nodes_with_empty_forest, BTreeSet::new());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_parts_rejects_missing_ancestor_sibling() {
+        let mmr = Mmr::try_from_iter(LEAVES.iter().copied()).unwrap();
+        let peaks = mmr.peaks();
+        let tracked_pos = 0;
+        let mut partial_mmr = PartialMmr::from_peaks(peaks.clone());
+        partial_mmr
+            .track(
+                tracked_pos,
+                mmr.get(tracked_pos).unwrap(),
+                mmr.open(tracked_pos).unwrap().path().merkle_path(),
+            )
+            .unwrap();
+
+        let missing_sibling = InOrderIndex::from_leaf_pos(tracked_pos).parent().sibling();
+        assert!(partial_mmr.nodes.remove(&missing_sibling).is_some());
+
+        let result = PartialMmr::from_parts(peaks, partial_mmr.nodes, partial_mmr.tracked_leaves);
+        assert!(matches!(result, Err(MmrError::InconsistentPartialMmr(_))));
     }
 
     #[test]
@@ -1537,6 +1579,26 @@ mod tests {
 
         let result = PartialMmr::read_from_bytes(&bad_bytes);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialization_rejects_missing_ancestor_sibling() {
+        let mmr = Mmr::try_from_iter(LEAVES.iter().copied()).unwrap();
+        let tracked_pos = 0;
+        let mut partial_mmr = PartialMmr::from_peaks(mmr.peaks());
+        partial_mmr
+            .track(
+                tracked_pos,
+                mmr.get(tracked_pos).unwrap(),
+                mmr.open(tracked_pos).unwrap().path().merkle_path(),
+            )
+            .unwrap();
+
+        let missing_sibling = InOrderIndex::from_leaf_pos(tracked_pos).parent().sibling();
+        assert!(partial_mmr.nodes.remove(&missing_sibling).is_some());
+
+        let result = PartialMmr::read_from_bytes(&partial_mmr.to_bytes());
+        assert!(matches!(result, Err(DeserializationError::InvalidValue(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require every tracked leaf passed to `PartialMmr::from_parts` to produce `Ok(Some(_))` from `open(pos)`
- keep `from_parts_unchecked` unchanged
- reject direct construction and deserialization when an ancestor sibling is missing

## Rationale
`PartialMmr::is_tracked` documents that a tracked leaf has an authentication path, but the checked `from_parts` constructor did not enforce that. Bounds and node indices were validated while a tracked leaf could still lack the ancestor siblings needed for `open(pos)`, so callers could build a `PartialMmr` that violates its own tracking invariant. Validating paths at construction (and on deserialization) keeps the checked API honest; `from_parts_unchecked` remains available for trusted inputs.

Fixes #3784

Supersedes #3793, which was closed by the contribution-quality bot before the issue was assigned.

## Test plan
- [x] `cargo test -p miden-crypto from_parts`
- [x] `cargo test -p miden-crypto missing_ancestor_sibling`