### PR TITLE
fix(syntax): preserve `ParsingError` compatiblity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Automatically infer procedure calling convention from known protocol ABI attributes ([#3802](https://github.com/0xMiden/miden-vm/pull/3802))
 
 #### Fixes
+- Preserved the public `ParsingError` enum layout while adding protocol ABI attribute checks ([#3802](https://github.com/0xMiden/miden-vm/pull/3802)).
 - Fixed issue where parsing of pointer types dropped address space information ([#3790](https://github.com/0xMiden/miden-vm/pull/3790)).
 
 ## v0.32.0 (2026-09-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Automatically infer procedure calling convention from known protocol ABI attributes ([#3802](https://github.com/0xMiden/miden-vm/pull/3802))
 
 #### Fixes
-- Preserved the public `ParsingError` enum layout while adding protocol ABI attribute checks ([#3802](https://github.com/0xMiden/miden-vm/pull/3802)).
+- Preserved the public `ParsingError` enum layout while adding protocol ABI attribute checks ([#3812](https://github.com/0xMiden/miden-vm/pull/3812)).
 - Fixed issue where parsing of pointer types dropped address space information ([#3790](https://github.com/0xMiden/miden-vm/pull/3790)).
 
 ## v0.32.0 (2026-09-05)

--- a/crates/assembly-syntax/src/ast/tests.rs
+++ b/crates/assembly-syntax/src/ast/tests.rs
@@ -1938,10 +1938,7 @@ fn test_protocol_abi_conflicting_callconv_in_either_order() {
                         format!("{annotations}\npub proc foo() -> i1\n    push.1\nend\n")
                     );
                     let error = context.parse_forms(source).expect_err(&annotations);
-                    assert_diagnostic!(
-                        error,
-                        "@callconv conflicts with convention implied by other attribute"
-                    );
+                    assert_diagnostic!(error, "this attribute conflicts with another attribute");
                 }
             }
         }
@@ -1964,7 +1961,7 @@ fn test_protocol_abi_conflicting_attribute_forms_are_rejected() {
                         format!("{annotations}\npub proc foo() -> i1\n    push.1\nend\n")
                     );
                     let error = context.parse_forms(source).expect_err(&annotations);
-                    assert_diagnostic!(error, "a different ABI was previously specified");
+                    assert_diagnostic!(error, "this attribute conflicts with another attribute");
                 }
             }
         }
@@ -2025,10 +2022,10 @@ end
         "1 |",
         "2 | @account_procedure",
         "  : ^^^^^^^^^|^^^^^^^^",
-        "  :          `-- this attribute implies @callconv(\"component-model\")",
+        "  :          `-- conflicting attribute here",
         "3 | @callconv(\"C\")",
         "  : ^^^^^^^|^^^^^^",
-        "  :        `-- conflict occurs because @callconv conflicts with convention implied by other attribute",
+        "  :        `-- this attribute conflicts with another attribute",
         "4 | proc foo() -> i1",
         "  `----"
     );
@@ -2063,10 +2060,10 @@ end
         "1 |",
         "2 | @account_procedure",
         "  : ^^^^^^^^^|^^^^^^^^",
-        "  :          `-- this attribute already specifies the protocol ABI for this procedure",
+        "  :          `-- conflicting attribute here",
         "3 | @note_script",
         "  : ^^^^^^|^^^^^",
-        "  :       `-- this attribute specifies the protocol ABI of this procedure, but a different ABI was previously specified",
+        "  :       `-- this attribute conflicts with another attribute",
         "4 | proc foo() -> i1",
         "  `----"
     );

--- a/crates/assembly-syntax/src/parser/cst/forms.rs
+++ b/crates/assembly-syntax/src/parser/cst/forms.rs
@@ -496,7 +496,7 @@ fn apply_procedure_attributes(
             if PROTOCOL_ABI_ATTRIBUTES.contains(&attr.name()) && !attributes.has(attr.name()) {
                 let span = attr.span();
                 if let Some(prev) = protocol_abi_span {
-                    return Err(ParsingError::ConflictingProtocolAbiAttribute { span, prev });
+                    return Err(ParsingError::AttributeConflict { span, prev });
                 }
                 protocol_abi_span = Some(span);
             }
@@ -638,9 +638,9 @@ fn apply_procedure_attributes(
     // Resolve the convention after collecting attributes so annotation order is irrelevant.
     if let Some(attr_span) = protocol_abi_span {
         if cc.is_some_and(|cc| cc != ast::types::CallConv::ComponentModel) {
-            return Err(ParsingError::CallConvAttributeConflict {
-                cc_span: callconv_span.expect("callconv was set without associated span"),
-                attr_span,
+            return Err(ParsingError::AttributeConflict {
+                span: callconv_span.expect("callconv was set without associated span"),
+                prev: attr_span,
             });
         }
         cc = Some(ast::types::CallConv::ComponentModel);

--- a/crates/assembly-syntax/src/parser/error.rs
+++ b/crates/assembly-syntax/src/parser/error.rs
@@ -263,31 +263,9 @@ pub enum ParsingError {
     #[error("conflicting attributes for procedure definition")]
     #[diagnostic()]
     AttributeConflict {
-        #[label(
-            "conflict occurs because an attribute with the same name has already been defined"
-        )]
+        #[label("this attribute conflicts with another attribute")]
         span: SourceSpan,
-        #[label("previously defined here")]
-        prev: SourceSpan,
-    },
-    #[error("conflicting attributes for procedure definition")]
-    #[diagnostic()]
-    CallConvAttributeConflict {
-        #[label(
-            "conflict occurs because @callconv conflicts with convention implied by other attribute"
-        )]
-        cc_span: SourceSpan,
-        #[label("this attribute implies @callconv(\"component-model\")")]
-        attr_span: SourceSpan,
-    },
-    #[error("conflicting attributes for procedure definition")]
-    #[diagnostic()]
-    ConflictingProtocolAbiAttribute {
-        #[label(
-            "this attribute specifies the protocol ABI of this procedure, but a different ABI was previously specified"
-        )]
-        span: SourceSpan,
-        #[label("this attribute already specifies the protocol ABI for this procedure")]
+        #[label("conflicting attribute here")]
         prev: SourceSpan,
     },
     #[error("conflicting key-value attributes for procedure definition")]


### PR DESCRIPTION
#3802 added two variants to the public, exhaustive `ParsingError` enum. The new variants break exhaustive matches and shift the numeric values of 15 later variants because the enum uses  `#[repr(u8)]`. The package version gate (https://github.com/0xMiden/miden-vm/actions/runs/34324505029) correctly blocks the 0.32.1 release.
  
Both new conflict paths now use the existing `AttributeConflict variant`. The parser still rejects conflicting protocol ABI and calling convention attributes. The public enum layout remains compatible with 0.32.0.