### PR TITLE
feat: add synchronous partial proving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Features
 
-- Added `prove_partial_sync` for synchronous VM proving that leaves precompile work deferred ([protocol#3835](https://github.com/0xMiden/protocol/issues/3835)).
+- Added `prove_partial_sync` for synchronous VM proving that leaves precompile work deferred ([#3815](https://github.com/0xMiden/miden-vm/pull/3815); [protocol#3835](https://github.com/0xMiden/protocol/issues/3835)).
 
 #### Changes
 - Added type signatures for all procedures in the Miden core library ([#3791](https://github.com/0xMiden/miden-vm/pull/3791)). **NOTE:** This changes the package identity of the core library and any packages which dynamically link it. Packages which were assembled against 0.32.0 of the core library will need to be re-assembled (unless they statically linked the core library), otherwise executors that only load the latest version of the core library for you will be unable to resolve the older dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Features
 
+- Added `prove_partial_sync` for synchronous VM proving that leaves precompile work deferred ([protocol#3835](https://github.com/0xMiden/protocol/issues/3835)).
+
 #### Changes
 - Added type signatures for all procedures in the Miden core library ([#3791](https://github.com/0xMiden/miden-vm/pull/3791)). **NOTE:** This changes the package identity of the core library and any packages which dynamically link it. Packages which were assembled against 0.32.0 of the core library will need to be re-assembled (unless they statically linked the core library), otherwise executors that only load the latest version of the core library for you will be unable to resolve the older dependency.
 - Automatically infer procedure calling convention from known protocol ABI attributes ([#3802](https://github.com/0xMiden/miden-vm/pull/3802))

--- a/miden-vm/src/lib.rs
+++ b/miden-vm/src/lib.rs
@@ -26,7 +26,9 @@ pub use miden_processor::{
     ProgramExecutor, ProgramInfo, StackInputs, SyncHost, VmWitness, ZERO, advice, crypto, field,
     operation::Operation, serde, trace, trace::VmTrace, utils,
 };
-pub use miden_prover::{InputError, Prover, ProverError, StackOutputs, Word, prove_sync};
+pub use miden_prover::{
+    InputError, Prover, ProverError, StackOutputs, Word, prove_partial_sync, prove_sync,
+};
 pub use miden_verifier::{
     AirShape, InstanceShape, LookupShape, ProofSecurityParameters, ProtocolParams, SecurityReport,
     SecurityTerm, VerificationError, VerificationOutcome, Verifier,

--- a/miden-vm/tests/integration/prove_verify.rs
+++ b/miden-vm/tests/integration/prove_verify.rs
@@ -264,7 +264,7 @@ mod prover_api_lifecycle {
         DefaultHost, ExecutionClaim, ExecutionOptions, ExecutionProof, ExecutionWitness,
         FastProcessor, HashFunction, PrecompileProof, PrecompileStatus, PrecompileWitness, Program,
         Prover, StackInputs, StackOutputs, StarkProof, VerificationError, Verifier,
-        advice::AdviceInputs, precompile_witness_from_wire, prove_sync,
+        advice::AdviceInputs, precompile_witness_from_wire, prove_partial_sync, prove_sync,
     };
 
     use super::minimum_conjectured_security_level;
@@ -292,7 +292,7 @@ mod prover_api_lifecycle {
         )
     }
 
-    fn u256_witness(value: u64) -> ExecutionWitness {
+    fn u256_program(value: u64) -> Program {
         let precompile_id = precompile_id("uint256");
         let value_tag = Tag::precompile(
             precompile_id,
@@ -335,7 +335,11 @@ mod prover_api_lifecycle {
             word_literal(equality_tag.as_word().into()),
         );
 
-        execute(&assemble(&source))
+        assemble(&source)
+    }
+
+    fn u256_witness(value: u64) -> ExecutionWitness {
+        execute(&u256_program(value))
     }
 
     fn assert_complete(
@@ -392,6 +396,34 @@ mod prover_api_lifecycle {
         // proofs instead of requiring byte-identical encodings.
         assert_complete(&program, stack_inputs, buffered_outputs, &buffered_proof);
         assert_complete(&program, stack_inputs, overlapped_outputs, &overlapped_proof);
+    }
+
+    #[test]
+    fn configured_prove_partial_sync_defers_precompile_work() {
+        let program = u256_program(1);
+        let stack_inputs = StackInputs::default();
+        let prover = Prover::new().with_hash_fn(HashFunction::Blake3_256);
+
+        for overlapped_trace_build in [false, true] {
+            let mut host = DefaultHost::default();
+            let (stack_outputs, proof) = prove_partial_sync(
+                &prover,
+                &program,
+                stack_inputs,
+                AdviceInputs::default(),
+                &mut host,
+                ExecutionOptions::default().with_overlapped_trace_build(overlapped_trace_build),
+            )
+            .expect("partial execute-and-prove should succeed");
+
+            assert!(matches!(proof.precompile(), PrecompileStatus::Deferred(_)));
+            let claim =
+                ExecutionClaim::from_program_info(program.to_info(), stack_inputs, stack_outputs);
+            let outcome = Verifier::new()
+                .verify(&claim, &proof)
+                .expect("partial execution proof should verify");
+            assert_eq!(outcome.outstanding_precompile_root(), Some(proof.vm().precompile_root));
+        }
     }
 
     #[test]

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -34,7 +34,7 @@ pub use miden_processor::{
     FutureMaybeSend, Host, InputError, PrecompileWitness, ProgramInfo, StackInputs, StackOutputs,
     SyncHost, VmWitness, Word, advice::AdviceInputs, crypto, field, serde, utils,
 };
-pub use prover::{Prover, ProverError, prove_sync};
+pub use prover::{Prover, ProverError, prove_partial_sync, prove_sync};
 
 // STARK PROOF GENERATION
 // ================================================================================================

--- a/prover/src/prover.rs
+++ b/prover/src/prover.rs
@@ -65,14 +65,8 @@ impl Prover {
     pub fn prove(&self, witness: ExecutionWitness) -> Result<ExecutionProof, ProverError> {
         let (vm_witness, precompile_witness) = witness.into_parts();
         let vm = self.prove_vm(vm_witness)?;
-        let Some(precompile_witness) = precompile_witness else {
-            return Ok(ExecutionProof::new(vm, PrecompileStatus::Empty));
-        };
-        let precompile = precompile_witness
-            .state()
-            .to_wire()
-            .expect("execution witness state must have canonical deferred wire");
-        Ok(ExecutionProof::new(vm, PrecompileStatus::Deferred(precompile)))
+        let precompile = Self::defer_precompile(precompile_witness.as_ref());
+        Ok(ExecutionProof::new(vm, precompile))
     }
 
     /// Proves a complete execution witness entirely in memory.
@@ -127,6 +121,27 @@ impl Prover {
             None => PrecompileStatus::Empty,
         };
         Ok(ExecutionProof::new(vm, precompile))
+    }
+
+    #[cfg(feature = "std")]
+    fn prove_partial_trace(
+        &self,
+        trace: VmTrace,
+        precompile: Option<&PrecompileWitness>,
+    ) -> Result<ExecutionProof, ProverError> {
+        let vm = self.prove_vm_trace(trace)?;
+        Ok(ExecutionProof::new(vm, Self::defer_precompile(precompile)))
+    }
+
+    fn defer_precompile(witness: Option<&PrecompileWitness>) -> PrecompileStatus {
+        let Some(witness) = witness else {
+            return PrecompileStatus::Empty;
+        };
+        let wire = witness
+            .state()
+            .to_wire()
+            .expect("execution witness state must have canonical deferred wire");
+        PrecompileStatus::Deferred(wire)
     }
 
     /// Proves a fully materialized VM trace.
@@ -262,6 +277,50 @@ pub fn prove_sync(
     };
     let stack_outputs = *witness.claim().stack_outputs();
     let proof = prover.prove_full(witness).map_err(ProverError::into_execution_error)?;
+    Ok((stack_outputs, proof))
+}
+
+/// Executes a program and proves only its VM trace synchronously.
+///
+/// If execution authenticates deferred precompile work, the returned proof carries its passive
+/// wire for later hydration and proving.
+#[tracing::instrument(name = "prove_program_partial_sync", skip_all)]
+pub fn prove_partial_sync(
+    prover: &Prover,
+    program: &Program,
+    stack_inputs: StackInputs,
+    advice_inputs: AdviceInputs,
+    host: &mut impl SyncHost,
+    execution_options: ExecutionOptions,
+) -> Result<(StackOutputs, ExecutionProof), ExecutionError> {
+    #[cfg(feature = "std")]
+    let overlapped_trace_build = execution_options.overlapped_trace_build();
+    let processor = FastProcessor::new_with_options(stack_inputs, advice_inputs, execution_options)
+        .map_err(ExecutionError::advice_error_no_context)?;
+
+    #[cfg(feature = "std")]
+    if overlapped_trace_build {
+        let (trace, precompile) = {
+            let _span = tracing::info_span!("execute_miden_vm").entered();
+            processor.execute_and_build_trace_sync(
+                program,
+                host,
+                prover.max_prover_memory_bytes(),
+            )?
+        };
+        let stack_outputs = *trace.stack_outputs();
+        let proof = prover
+            .prove_partial_trace(trace, precompile.as_ref())
+            .map_err(ProverError::into_execution_error)?;
+        return Ok((stack_outputs, proof));
+    }
+
+    let witness = {
+        let _span = tracing::info_span!("execute_miden_vm").entered();
+        processor.execute_for_proving_sync(program, host)?
+    };
+    let stack_outputs = *witness.claim().stack_outputs();
+    let proof = prover.prove(witness).map_err(ProverError::into_execution_error)?;
     Ok((stack_outputs, proof))
 }
 


### PR DESCRIPTION
`prove_partial_sync` runs the VM synchronously and leaves precompile work deferred.

`LocalTransactionProver` can use this function without changing the meaning of `prove_sync`.

The test covers buffered and overlapped trace building with a U256 precompile.

This API is needed to fix 0xmiden/protocol#3835