### PR TITLE
refactor: mark ParsingError as non_exhaustive (closes 0xMiden#3816)

### DIFF
--- a/crates/assembly-syntax/src/parser/error.rs
+++ b/crates/assembly-syntax/src/parser/error.rs
@@ -91,6 +91,7 @@ impl fmt::Display for BinErrorKind {
 // PARSING ERROR
 // ================================================================================================
 
+#[non_exhaustive]
 #[derive(Debug, Default, thiserror::Error, Diagnostic)]
 #[repr(u8)]
 pub enum ParsingError {


### PR DESCRIPTION
Marks the public `ParsingError` enum `#[non_exhaustive]`, the same pattern already used for `ExecutionError`. Right now it's exhaustive, so adding a variant is a breaking change for anyone matching on it downstream — which is exactly what happened in v0.32.1, where PR #3812 had to fall back to a generic variant instead of adding proper ones, just to avoid a silent breaking change in a patch release. This closes that gap going forward: new variants can be added freely, downstream just needs a wildcard arm. Verified with `cargo check --workspace --all-targets` and `cargo test -p miden-assembly-syntax` (270 passed) — nothing in the repo actually matches `ParsingError` exhaustively, so the change is a no-op internally. Closes #3816.
