### PR TITLE
fix(crypto): report the serialized size of NodeIndex, not its in-memory size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Fixes
 
+- Fixed `SubtreeKey::get_size_hint()` over-reporting the serialized length by 7 bytes, and gave `NodeIndex` the `Serializable::get_size_hint()` it was missing ([#PRNUM](https://github.com/0xMiden/miden-vm/pull/PRNUM)).
 - Fixed `PartialMmr::from_parts()` and deserialization so they reject tracked leaves without complete authentication paths ([#3809](https://github.com/0xMiden/miden-vm/pull/3809)).
 - Fixed `PartialMmr::track()` panicking when a leaf position did not belong to the tree selected by its authentication path ([#3804](https://github.com/0xMiden/miden-vm/pull/3804)).
 - Fixed 46 `\begin{cases}...\end{cases}` blocks in the assembly instruction reference and stack design docs that were missing the `\\` row separator between cases, which broke KaTeX rendering ([#3650](https://github.com/0xMiden/miden-vm/issues/3650)).

--- a/crates/crypto/src/merkle/index.rs
+++ b/crates/crypto/src/merkle/index.rs
@@ -206,6 +206,12 @@ impl Serializable for NodeIndex {
         target.write_u8(self.depth);
         target.write_u64(self.position);
     }
+
+    fn get_size_hint(&self) -> usize {
+        // `size_of::<NodeIndex>()` is 16: `position` forces 8-byte alignment, so the `u8` depth is
+        // followed by 7 bytes of padding that never reach the wire.
+        size_of::<u8>() + size_of::<u64>()
+    }
 }
 
 impl Deserializable for NodeIndex {
@@ -357,5 +363,14 @@ mod tests {
 
         // depth 63, position 0: scalar = 2^63
         assert_eq!(NodeIndex::make(63, 0).to_scalar_index().unwrap(), 1u64 << 63);
+    }
+
+    proptest! {
+        #[test]
+        fn node_index_size_hint_matches_serialized_len(index in node_index()) {
+            let bytes = index.to_bytes();
+            prop_assert_eq!(bytes.len(), index.get_size_hint());
+            prop_assert_eq!(index, NodeIndex::read_from_bytes(&bytes).unwrap());
+        }
     }
 }

--- a/crates/crypto/src/merkle/smt/large_forest/backend/persistent/keys.rs
+++ b/crates/crypto/src/merkle/smt/large_forest/backend/persistent/keys.rs
@@ -60,7 +60,7 @@ impl Serializable for SubtreeKey {
     }
 
     fn get_size_hint(&self) -> usize {
-        size_of::<LineageId>() + size_of::<NodeIndex>()
+        self.lineage.get_size_hint() + self.index.get_size_hint()
     }
 }
 
@@ -70,5 +70,39 @@ impl Deserializable for SubtreeKey {
         let index = NodeIndex::read_from(source)?;
 
         Ok(Self { lineage, index })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::merkle::smt::large_forest::root::LineageId;
+
+    /// `size_of::<NodeIndex>()` includes alignment padding the wire format never carries, so the
+    /// hint has to come from the parts' own hints.
+    #[test]
+    fn subtree_key_size_hint_matches_serialized_len() {
+        let key = SubtreeKey {
+            lineage: LineageId::new([7; 32]),
+            index: NodeIndex::new(8, 42).unwrap(),
+        };
+
+        let bytes = key.to_bytes();
+
+        assert_eq!(bytes.len(), key.get_size_hint());
+        assert_eq!(key, SubtreeKey::read_from_bytes(&bytes).unwrap());
+    }
+
+    #[test]
+    fn leaf_key_size_hint_matches_serialized_len() {
+        let key = LeafKey {
+            lineage: LineageId::new([7; 32]),
+            index: 42,
+        };
+
+        let bytes = key.to_bytes();
+
+        assert_eq!(bytes.len(), key.get_size_hint());
+        assert_eq!(key, LeafKey::read_from_bytes(&bytes).unwrap());
     }
 }


### PR DESCRIPTION
## Describe your changes

`SubtreeKey::get_size_hint()` reports 48 bytes for a key that serializes to 41.

```rust
// crates/crypto/src/merkle/smt/large_forest/backend/persistent/keys.rs
fn get_size_hint(&self) -> usize {
    size_of::<LineageId>() + size_of::<NodeIndex>()
}
```

`NodeIndex` is `{ depth: u8, position: u64 }`, so `position` forces 8-byte alignment and `size_of::<NodeIndex>()` is 16 — but the wire form is `write_u8` + `write_u64`, i.e. 9 bytes. `LeafKey`, directly above it in the same file, is correct precisely because it sums `size_of::<u64>()` for a field it really does write as a `u64`.

The root cause is one level down: `NodeIndex` never implemented `get_size_hint()`, so it returned the trait default of 0 and callers reached for `size_of` instead. This gives `NodeIndex` its real serialized size and composes `SubtreeKey`'s hint from its parts' hints, so the two cannot drift apart again.

Measured on `next` at b36ffc6 before the fix:

| type | wire | `get_size_hint()` | |
|---|---|---|---|
| `NodeIndex` | 9 | 0 | missing impl |
| `SubtreeKey` | 41 | 48 | over by 7 |
| `LeafKey` | 40 | 40 | correct |
| `TreeMetadata` | 48 | 48 | correct |

`size_of::<NodeIndex>()` = 16, `size_of::<LineageId>()` = 32.

I checked the other `get_size_hint()` bodies that use `size_of::` — the rest are primitives (`u8`/`u16`/`u32`/`u64`/`u128`/`bool`), where the in-memory and serialized sizes agree, and `TreeMetadata`'s composite sum is correct. `SubtreeKey` was the only one off.

The contract these tests assert is the one the repo already relies on elsewhere: `smt/full/mod.rs:692` and `:731` and `field/src/word/tests.rs:33` all assert `bytes.len() == get_size_hint()`.

## Verification

Reverting only the two source changes and keeping the new tests:

```
leaf_key_size_hint_matches_serialized_len    ... ok
subtree_key_size_hint_matches_serialized_len ... FAILED   left: 41  right: 48
node_index_size_hint_matches_serialized_len  ... FAILED
```

`LeafKey` passing in both directions is deliberate — it keeps the new tests from being change detectors.

With the fix: `cargo test -p miden-crypto --features persistent-forest --lib` → **782 passed, 0 failed**; `cargo test -p miden-crypto --lib` (default features) → **742 passed, 0 failed**; `cargo +nightly fmt --all --check` clean.

One note on lint: `cargo +nightly clippy -p miden-crypto --all-targets` with `-D warnings` fails on two `needless_range_loop`s in `smt/large/subtree/mod.rs:668` and `smt/large_forest/root.rs:51`. Both reproduce identically on an unmodified `next`, so they are not from this change — `make clippy` pins `+stable`, which is presumably why CI is green.

## Checklist before requesting a review
- [x] Repo forked and branch created from `next` according to naming convention.
- [x] Commit messages and codestyle follow [conventions](../CONTRIBUTING.md).
- [x] Commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [ ] Relevant issues are linked in the PR description. — N/A: found by inspection, no existing issue (searched for `SubtreeKey get_size_hint`, `get_size_hint NodeIndex`, `size_hint serialized length`).
- [x] Tests added for new functionality.
- [x] Documentation/comments updated according to changes.
- [x] Updated `CHANGELOG.md`
