### PR TITLE
refactor: mark ParsingError as non_exhaustive (closes 0xMiden#3816)

### DIFF
--- a/crates/assembly-syntax/src/parser/error.rs
+++ b/crates/assembly-syntax/src/parser/error.rs
@@ -91,6 +91,7 @@ impl fmt::Display for BinErrorKind {
 // PARSING ERROR
 // ================================================================================================
 
+#[non_exhaustive]
 #[derive(Debug, Default, thiserror::Error, Diagnostic)]
 #[repr(u8)]
 pub enum ParsingError {


### PR DESCRIPTION
Reopens the work from #3818, which was auto-closed by the bot. Same single-line change.